### PR TITLE
Declarative config module for ways-cli

### DIFF
--- a/docs/architecture/system/ADR-117-sensor-crate-extraction-and-feature-flags.md
+++ b/docs/architecture/system/ADR-117-sensor-crate-extraction-and-feature-flags.md
@@ -1,0 +1,140 @@
+---
+status: Draft
+date: 2026-04-10
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-113
+  - ADR-115
+---
+
+# ADR-117: Sensor Crate Extraction and Feature Flags
+
+## Context
+
+attend (ADR-113) ships with four built-in sensors: context, git, peers, and processes. These are compiled directly into the attend binary as modules under `src/sensors/`. The ScriptSensor runner (shipped in PR #4) provides an extensibility path for shell-script sensors, but built-in sensors have no separation from the orchestrator.
+
+This creates several problems:
+
+- **No isolation** — sensor code shares the same module tree as the tick loop, state management, and CLI. Changes to one sensor can break another through shared internal interfaces.
+- **No selective compilation** — a user who only wants git and context awareness still compiles peer discovery and process scanning. On constrained systems or custom builds, this matters.
+- **No clear trait contract** — the `Sensor` trait lives in `sensors/mod.rs` alongside the `SensorSlot` runtime scaffolding. The boundary between "what a sensor must implement" and "how the orchestrator runs it" is blurred.
+- **Future daemon model** — if attend becomes long-running (paralleling the direction noted for ways-cli), hot-reloading sensors or dynamically enabling them requires a cleaner separation than in-binary modules.
+
+Meanwhile, the workspace already demonstrates the crate extraction pattern: `agent-fmt` was extracted from ways-cli (PR #3) and is consumed by both tools. The same pattern applies here.
+
+## Decision
+
+Extract each built-in sensor into its own workspace crate. Introduce a `sensor-trait` crate that defines the `Sensor` trait, `Focus` struct, and supporting types. Wire sensors into attend via Cargo feature flags.
+
+### Workspace Structure
+
+```
+tools/
+  agent-fmt/           # shared terminal formatting
+  sensor-trait/        # Sensor trait, Focus, SensorSlot
+  sensor-git/          # GitSensor
+  sensor-context/      # ContextSensor
+  sensor-peers/        # PeerSensor
+  sensor-processes/    # ProcessSensor
+  attend/              # orchestrator — depends on sensor crates via features
+  ways-cli/            # ways CLI
+```
+
+### Trait Crate
+
+`sensor-trait` defines the contract between attend and any sensor:
+
+```rust
+pub trait Sensor: Send {
+    fn name(&self) -> &str;
+    fn poll(&mut self, focus: &Focus) -> Vec<(f64, String)>;
+    fn emission_threshold(&self) -> f64;
+    fn base_interval(&self) -> Duration;
+    fn min_interval(&self) -> Duration;
+    fn export_state(&self) -> Vec<(String, String)> { Vec::new() }
+    fn import_state(&mut self, _state: &[(String, String)]) {}
+}
+```
+
+The `Send` bound prepares for the daemon model where sensors may run on separate threads. `Focus` and `SensorSlot` also move to this crate since they define how the orchestrator interacts with sensors.
+
+### Feature Flags
+
+attend's `Cargo.toml`:
+
+```toml
+[features]
+default = ["sensor-git", "sensor-context", "sensor-peers", "sensor-processes"]
+sensor-git = ["dep:sensor-git"]
+sensor-context = ["dep:sensor-context"]
+sensor-peers = ["dep:sensor-peers"]
+sensor-processes = ["dep:sensor-processes"]
+```
+
+The orchestrator uses `#[cfg(feature = "sensor-git")]` guards around sensor registration. A minimal build with `--no-default-features` compiles only the orchestrator + script sensor runner.
+
+### Two Sensor Paths
+
+This ADR formalizes the two-path model that emerged from PR #4:
+
+| Path | Implementation | Performance | Extensibility | Compilation |
+|------|---------------|-------------|---------------|-------------|
+| **Crate sensors** | Rust, compiled in | Native | Requires recompile | Feature-flagged |
+| **Script sensors** | Shell, external | Process fork per poll | No recompile | Config-driven |
+
+Both paths are controlled by the same declarative config (ADR-115). A crate sensor and a script sensor with the same name: the crate sensor wins (compiled-in takes precedence). This allows a script sensor to prototype behavior that later graduates to a crate sensor.
+
+### Config as Control Plane
+
+The `attend.yaml` config (ADR-115) controls all sensors uniformly:
+
+```yaml
+sensors:
+  git:
+    interval: 30
+    threshold: 2.0
+  -processes:            # disable a built-in sensor
+  +disk-pressure:        # add a script sensor
+    script: scripts/check-disk.sh
+    interval: 120
+```
+
+Disabling a crate sensor via config (`-processes`) means it's never instantiated at runtime even though the code is compiled in. Disabling via feature flag (`--no-default-features`) means the code isn't compiled at all. Config is the user-facing control plane; features are the build-time control plane.
+
+## Consequences
+
+### Positive
+
+- **Clear contracts** — `sensor-trait` is the documented interface. Any crate implementing `Sensor` can be wired into attend.
+- **Selective builds** — custom attend binaries for constrained environments.
+- **Isolation** — sensor bugs don't leak across module boundaries. Each sensor has its own dependency tree.
+- **Testability** — sensors can be unit-tested in isolation against a mock `Focus`.
+- **Graduation path** — script sensor → crate sensor is a defined workflow: prototype in shell, promote to Rust when performance matters.
+- **Daemon-ready** — `Send` bound and crate isolation prepare for concurrent sensor polling.
+
+### Negative
+
+- **More crates** — workspace goes from 3 to 7 members. Cargo handles this well but it's more manifests to maintain.
+- **Cross-crate changes** — modifying the `Sensor` trait requires updating all sensor crates. Mitigated by keeping the trait stable and small.
+- **Initial migration effort** — moving existing sensor code is mechanical but touches every sensor file.
+
+### Neutral
+
+- **No behavioral change** — the default feature set compiles all sensors, reproducing current behavior exactly.
+- **ScriptSensor stays in attend** — it's part of the orchestrator (runs any script), not a specific sensor implementation.
+- **Config format unchanged** — ADR-115's config works identically before and after extraction.
+
+## Implementation Plan
+
+1. Create `sensor-trait` crate with `Sensor`, `Focus`, `SensorSlot`, `AdaptiveInterval`, `DeltaAccumulator`
+2. Create `sensor-git` crate, move `sensors/git.rs` content, depend on `sensor-trait`
+3. Create `sensor-context` crate, move `sensors/context.rs`
+4. Create `sensor-peers` crate, move `sensors/peer.rs` (largest, has signal reading)
+5. Create `sensor-processes` crate, move `sensors/process.rs`
+6. Update attend `Cargo.toml` with feature flags, `#[cfg]` guards in sensor registration
+7. Update `sensors/mod.rs` to re-export from crates (compatibility shim, removable later)
+8. Verify `make lint`, `make attend-rebuild`, all existing behavior preserved
+9. Test minimal build: `cargo build -p attend --no-default-features`
+10. Update CI workflow to test both default and minimal feature sets

--- a/tools/ways-cli/src/agents/mod.rs
+++ b/tools/ways-cli/src/agents/mod.rs
@@ -43,18 +43,6 @@ pub fn resolve_language() -> String {
     "en".to_string()
 }
 
-/// Legacy: read output_language from ways.json directly.
-/// Kept for callers outside the config chain. Prefer config::global().language.
-fn _ways_json_language() -> Option<String> {
-    let config = crate::util::home_dir().join(".claude/ways.json");
-    let content = std::fs::read_to_string(config).ok()?;
-    let parsed: serde_json::Value = serde_json::from_str(&content).ok()?;
-    parsed
-        .get("output_language")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
-}
-
 /// Language config embedded at compile time from languages.json.
 pub const LANGUAGES_JSON: &str = include_str!("../../languages.json");
 

--- a/tools/ways-cli/src/agents/mod.rs
+++ b/tools/ways-cli/src/agents/mod.rs
@@ -15,17 +15,17 @@ pub trait AgentConfig {
 }
 
 /// Resolve output language with cascade:
-///   1. ways.json `output_language` (explicit override)
+///   1. Config language field (from ways.json / XDG config / project overlay)
 ///   2. Active agent's language setting
 ///   3. System locale ($LANG)
 ///   4. "en" fallback
+///
+/// config::global() — future migration: ctx.config.language
 pub fn resolve_language() -> String {
-    // 1. ways.json explicit override
-    let ways_lang = ways_json_language();
-    if let Some(lang) = ways_lang {
-        if lang != "auto" {
-            return normalize_language(&lang);
-        }
+    // 1. Config (layered: ways.json → XDG → project)
+    let cfg_lang = &crate::config::global().language;
+    if cfg_lang != "auto" {
+        return normalize_language(cfg_lang);
     }
 
     // 2. Agent config (currently only Claude Code)
@@ -43,8 +43,9 @@ pub fn resolve_language() -> String {
     "en".to_string()
 }
 
-/// Read output_language from ways.json.
-fn ways_json_language() -> Option<String> {
+/// Legacy: read output_language from ways.json directly.
+/// Kept for callers outside the config chain. Prefer config::global().language.
+fn _ways_json_language() -> Option<String> {
     let config = crate::util::home_dir().join(".claude/ways.json");
     let content = std::fs::read_to_string(config).ok()?;
     let parsed: serde_json::Value = serde_json::from_str(&content).ok()?;

--- a/tools/ways-cli/src/cmd/scan/candidates.rs
+++ b/tools/ways-cli/src/cmd/scan/candidates.rs
@@ -126,10 +126,13 @@ fn parse_candidate(id: &str, path: &Path, content: &str) -> Option<WayCandidate>
         files: get_fm_field(&fm, "files"),
         description: get_fm_field(&fm, "description").unwrap_or_default(),
         vocabulary: get_fm_field(&fm, "vocabulary").unwrap_or_default(),
+        // config::global() — future migration: ctx.config.bm25_threshold
         threshold: get_fm_field(&fm, "threshold")
             .and_then(|s| s.parse().ok())
-            .unwrap_or(2.0),
-        scope: get_fm_field(&fm, "scope").unwrap_or_else(|| "agent".to_string()),
+            .unwrap_or(crate::config::global().bm25_threshold),
+        // config::global() — future migration: ctx.config.default_scope
+        scope: get_fm_field(&fm, "scope")
+            .unwrap_or_else(|| crate::config::global().default_scope.clone()),
         when_project: get_when_field(&fm, "project"),
         when_file_exists: get_when_field(&fm, "file_exists"),
         trigger: get_fm_field(&fm, "trigger"),

--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -397,7 +397,8 @@ fn parent_threshold(way_id: &str, threshold: f64, session_id: &str) -> f64 {
     while let Some(idx) = path.rfind('/') {
         path = path[..idx].to_string();
         if session::way_is_shown(&path, session_id) {
-            return threshold * 0.8;
+            // config::global() — future migration: ctx.config.parent_threshold_multiplier
+            return threshold * crate::config::global().parent_threshold_multiplier;
         }
     }
     threshold

--- a/tools/ways-cli/src/cmd/status.rs
+++ b/tools/ways-cli/src/cmd/status.rs
@@ -9,8 +9,6 @@ use walkdir::WalkDir;
 pub fn run(json_output: bool) -> Result<()> {
     let xdg_cache = xdg_cache_dir().join("claude-ways/user");
     let ways_dir = home_dir().join(".claude/hooks/ways");
-    let ways_json = home_dir().join(".claude/ways.json");
-
     // Engine detection
     let way_embed = find_way_embed(&xdg_cache);
     let model_path = xdg_cache.join("minilm-l6-v2.gguf");
@@ -20,8 +18,8 @@ pub fn run(json_output: bool) -> Result<()> {
     let model_exists = model_path.is_file();
     let corpus_exists = corpus_path.is_file();
 
-    // Configured engine from ways.json
-    let configured = read_ways_json_engine(&ways_json);
+    // config::global() — future migration: ctx.config.matcher
+    let configured = crate::config::global().matcher.clone();
 
     // Active engine
     let engine = if way_embed.is_some() && model_exists && corpus_exists {
@@ -80,13 +78,8 @@ pub fn run(json_output: bool) -> Result<()> {
     // Output language
     let output_language = crate::agents::resolve_language();
 
-    // Disabled domains
-    let disabled: Vec<String> = std::fs::read_to_string(&ways_json)
-        .ok()
-        .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())
-        .and_then(|v| v["disabled"].as_array().cloned())
-        .map(|arr| arr.iter().filter_map(|v| v.as_str().map(|s| s.to_string())).collect())
-        .unwrap_or_default();
+    // config::global() — future migration: ctx.config.disabled_domains
+    let disabled = crate::config::global().disabled_domains.clone();
 
     if json_output {
         let output = json!({
@@ -204,14 +197,6 @@ fn find_way_embed(xdg_cache: &Path) -> Option<PathBuf> {
         return Some(bin);
     }
     None
-}
-
-fn read_ways_json_engine(path: &Path) -> String {
-    std::fs::read_to_string(path)
-        .ok()
-        .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())
-        .and_then(|v| v["semantic_engine"].as_str().map(|s| s.to_string()))
-        .unwrap_or_else(|| "auto".to_string())
 }
 
 fn count_ways(dir: &Path) -> (usize, usize) {

--- a/tools/ways-cli/src/config.rs
+++ b/tools/ways-cli/src/config.rs
@@ -1,0 +1,210 @@
+//! Declarative configuration for ways.
+//!
+//! Resolution order (later overrides earlier):
+//!   1. Built-in defaults
+//!   2. ~/.claude/ways.json (legacy, backward compat)
+//!   3. $XDG_CONFIG_HOME/ways/config.yaml (user scope)
+//!   4. $PROJECT/.claude/ways.yaml (project scope)
+
+use std::path::{Path, PathBuf};
+
+/// Ways configuration.
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Default BM25 threshold for ways without explicit threshold
+    pub bm25_threshold: f64,
+    /// Parent threshold multiplier (child threshold = parent * this)
+    pub parent_threshold_multiplier: f64,
+    /// Default scope for ways without explicit scope
+    pub default_scope: String,
+    /// Output language (e.g., "en", "ja", "auto")
+    pub language: String,
+    /// Disabled domains (e.g., ["ea", "itops"])
+    pub disabled_domains: Vec<String>,
+    /// Matcher preference: "auto", "embedding", "bm25"
+    pub matcher: String,
+    /// Corpus staleness threshold in seconds (rebuild if older)
+    pub corpus_stale_secs: u64,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            bm25_threshold: 2.0,
+            parent_threshold_multiplier: 0.8,
+            default_scope: "agent".to_string(),
+            language: "auto".to_string(),
+            disabled_domains: Vec::new(),
+            matcher: "auto".to_string(),
+            corpus_stale_secs: 3600,
+        }
+    }
+}
+
+impl Config {
+    /// Load config with full resolution chain.
+    pub fn load(project_dir: &str) -> Self {
+        let mut cfg = Config::default();
+
+        // Layer 1: legacy ways.json
+        let ways_json = home_dir().join(".claude/ways.json");
+        if let Ok(content) = std::fs::read_to_string(&ways_json) {
+            cfg.apply_ways_json(&content);
+        }
+
+        // Layer 2: XDG user config
+        let xdg_config = xdg_config_dir().join("ways/config.yaml");
+        if let Ok(content) = std::fs::read_to_string(&xdg_config) {
+            cfg.apply_yaml(&content);
+        }
+
+        // Layer 3: project overlay
+        let project_config = Path::new(project_dir).join(".claude/ways.yaml");
+        if let Ok(content) = std::fs::read_to_string(&project_config) {
+            cfg.apply_yaml(&content);
+        }
+
+        cfg
+    }
+
+    /// Apply values from legacy ways.json.
+    fn apply_ways_json(&mut self, content: &str) {
+        let v: serde_json::Value = match serde_json::from_str(content) {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+
+        if let Some(lang) = v.get("output_language").and_then(|v| v.as_str()) {
+            self.language = lang.to_string();
+        }
+
+        if let Some(disabled) = v.get("disabled").and_then(|v| v.as_array()) {
+            self.disabled_domains = disabled
+                .iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect();
+        }
+
+        if let Some(engine) = v.get("engine").and_then(|v| v.as_str()) {
+            self.matcher = engine.to_string();
+        }
+    }
+
+    /// Apply values from a YAML config file.
+    fn apply_yaml(&mut self, content: &str) {
+        let doc: serde_yaml::Value = match serde_yaml::from_str(content) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("[ways] config: parse error: {}", e);
+                return;
+            }
+        };
+
+        if let Some(v) = doc.get("language").and_then(|v| v.as_str()) {
+            self.language = v.to_string();
+        }
+        if let Some(v) = doc.get("matcher").and_then(|v| v.as_str()) {
+            self.matcher = v.to_string();
+        }
+        if let Some(v) = doc.get("bm25_threshold").and_then(|v| v.as_f64()) {
+            self.bm25_threshold = v;
+        }
+        if let Some(v) = doc.get("parent_threshold_multiplier").and_then(|v| v.as_f64()) {
+            self.parent_threshold_multiplier = v;
+        }
+        if let Some(v) = doc.get("default_scope").and_then(|v| v.as_str()) {
+            self.default_scope = v.to_string();
+        }
+        if let Some(v) = doc.get("corpus_stale_secs").and_then(|v| v.as_u64()) {
+            self.corpus_stale_secs = v;
+        }
+        if let Some(disabled) = doc.get("disabled_domains").and_then(|v| v.as_sequence()) {
+            self.disabled_domains = disabled
+                .iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect();
+        }
+    }
+
+    /// Initialize user config at XDG path.
+    pub fn init_user_config() -> PathBuf {
+        let path = xdg_config_dir().join("ways/config.yaml");
+        if path.exists() {
+            return path;
+        }
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        let content = "# ways configuration
+# User scope: $XDG_CONFIG_HOME/ways/config.yaml
+# Project scope: {project}/.claude/ways.yaml (layered on top)
+
+# language: en          # Output language (en, ja, auto)
+# matcher: auto         # Matching engine (auto, embedding, bm25)
+# bm25_threshold: 2.0   # Default BM25 score threshold
+# corpus_stale_secs: 3600  # Rebuild corpus if older than this
+# default_scope: agent  # Default scope for ways without explicit scope
+# disabled_domains: []  # Domains to disable (e.g., [ea, itops])
+";
+        std::fs::write(&path, content).ok();
+        path
+    }
+
+    /// Show the config file path.
+    pub fn config_path() -> String {
+        let xdg = xdg_config_dir().join("ways/config.yaml");
+        format!("user:    {}\nlegacy:  {}\nproject: $PROJECT/.claude/ways.yaml",
+            xdg.display(),
+            home_dir().join(".claude/ways.json").display())
+    }
+}
+
+fn home_dir() -> PathBuf {
+    crate::util::home_dir()
+}
+
+fn xdg_config_dir() -> PathBuf {
+    std::env::var("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| home_dir().join(".config"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_values() {
+        let cfg = Config::default();
+        assert_eq!(cfg.bm25_threshold, 2.0);
+        assert_eq!(cfg.language, "auto");
+        assert_eq!(cfg.matcher, "auto");
+        assert_eq!(cfg.default_scope, "agent");
+    }
+
+    #[test]
+    fn apply_yaml_overrides() {
+        let mut cfg = Config::default();
+        cfg.apply_yaml("language: ja\nbm25_threshold: 1.5\nmatcher: embedding");
+        assert_eq!(cfg.language, "ja");
+        assert_eq!(cfg.bm25_threshold, 1.5);
+        assert_eq!(cfg.matcher, "embedding");
+    }
+
+    #[test]
+    fn apply_ways_json() {
+        let mut cfg = Config::default();
+        cfg.apply_ways_json(r#"{"output_language":"de","disabled":["ea"],"engine":"bm25"}"#);
+        assert_eq!(cfg.language, "de");
+        assert_eq!(cfg.disabled_domains, vec!["ea"]);
+        assert_eq!(cfg.matcher, "bm25");
+    }
+
+    #[test]
+    fn yaml_overrides_json() {
+        let mut cfg = Config::default();
+        cfg.apply_ways_json(r#"{"output_language":"de"}"#);
+        cfg.apply_yaml("language: ja");
+        assert_eq!(cfg.language, "ja");
+    }
+}

--- a/tools/ways-cli/src/config.rs
+++ b/tools/ways-cli/src/config.rs
@@ -37,8 +37,6 @@ pub struct Config {
     pub disabled_domains: Vec<String>,
     /// Matcher preference: "auto", "embedding", "bm25"
     pub matcher: String,
-    /// Corpus staleness threshold in seconds (rebuild if older)
-    pub corpus_stale_secs: u64,
 }
 
 impl Default for Config {
@@ -50,7 +48,6 @@ impl Default for Config {
             language: "auto".to_string(),
             disabled_domains: Vec::new(),
             matcher: "auto".to_string(),
-            corpus_stale_secs: 3600,
         }
     }
 }
@@ -99,7 +96,11 @@ impl Config {
                 .collect();
         }
 
-        if let Some(engine) = v.get("engine").and_then(|v| v.as_str()) {
+        // Accept both field names: "engine" (new) and "semantic_engine" (legacy)
+        if let Some(engine) = v.get("engine")
+            .or_else(|| v.get("semantic_engine"))
+            .and_then(|v| v.as_str())
+        {
             self.matcher = engine.to_string();
         }
     }
@@ -129,9 +130,6 @@ impl Config {
         if let Some(v) = doc.get("default_scope").and_then(|v| v.as_str()) {
             self.default_scope = v.to_string();
         }
-        if let Some(v) = doc.get("corpus_stale_secs").and_then(|v| v.as_u64()) {
-            self.corpus_stale_secs = v;
-        }
         if let Some(disabled) = doc.get("disabled_domains").and_then(|v| v.as_sequence()) {
             self.disabled_domains = disabled
                 .iter()
@@ -156,7 +154,6 @@ impl Config {
 # language: en          # Output language (en, ja, auto)
 # matcher: auto         # Matching engine (auto, embedding, bm25)
 # bm25_threshold: 2.0   # Default BM25 score threshold
-# corpus_stale_secs: 3600  # Rebuild corpus if older than this
 # default_scope: agent  # Default scope for ways without explicit scope
 # disabled_domains: []  # Domains to disable (e.g., [ea, itops])
 ";

--- a/tools/ways-cli/src/config.rs
+++ b/tools/ways-cli/src/config.rs
@@ -7,6 +7,20 @@
 //!   4. $PROJECT/.claude/ways.yaml (project scope)
 
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+/// Global config, loaded once on first access.
+/// Access via `config::global()` — grep-friendly for future context refactor.
+static GLOBAL: LazyLock<Config> = LazyLock::new(|| {
+    let project_dir = std::env::var("CLAUDE_PROJECT_DIR")
+        .unwrap_or_else(|_| std::env::var("PWD").unwrap_or_else(|_| ".".to_string()));
+    Config::load(&project_dir)
+});
+
+/// Access the process-wide config. Every call site is a future `ctx.config` migration point.
+pub fn global() -> &'static Config {
+    &GLOBAL
+}
 
 /// Ways configuration.
 #[derive(Debug, Clone)]

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -527,6 +527,8 @@ fn main() -> Result<()> {
                 Ok(())
             }
             ConfigCommand::Show => {
+                // Intentionally loads fresh from disk (not config::global()) —
+                // diagnostic command should always reflect current file state
                 let project_dir = std::env::var("CLAUDE_PROJECT_DIR")
                     .unwrap_or_else(|_| std::env::var("PWD").unwrap_or_else(|_| ".".to_string()));
                 let cfg = config::Config::load(&project_dir);

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -4,6 +4,7 @@ use clap::{Parser, Subcommand};
 pub mod agents;
 mod bm25;
 mod cmd;
+pub mod config;
 mod frontmatter;
 mod scanner;
 pub mod session;
@@ -233,6 +234,11 @@ enum Commands {
         #[arg(long)]
         confirm: bool,
     },
+    /// Manage configuration (init/show/path)
+    Config {
+        #[command(subcommand)]
+        action: ConfigCommand,
+    },
     /// Tune embed_threshold values for locale stubs based on corpus similarity
     Tune {
         /// Ways root directory (default: ~/.claude/hooks/ways)
@@ -384,6 +390,16 @@ enum ShowCommand {
 }
 
 #[derive(Subcommand)]
+enum ConfigCommand {
+    /// Initialize user config at XDG path
+    Init,
+    /// Show resolved configuration
+    Show,
+    /// Show config file paths
+    Path,
+}
+
+#[derive(Subcommand)]
 enum GovernanceCommand {
     /// Coverage report (default)
     Report,
@@ -501,6 +517,24 @@ fn main() -> Result<()> {
             ShowCommand::Attend { signal, session } => {
                 let out = cmd::show::attend(&signal, &session)?;
                 if !out.is_empty() { print!("{out}"); }
+                Ok(())
+            }
+        },
+        Commands::Config { action } => match action {
+            ConfigCommand::Init => {
+                let path = config::Config::init_user_config();
+                println!("wrote config to {}", path.display());
+                Ok(())
+            }
+            ConfigCommand::Show => {
+                let project_dir = std::env::var("CLAUDE_PROJECT_DIR")
+                    .unwrap_or_else(|_| std::env::var("PWD").unwrap_or_else(|_| ".".to_string()));
+                let cfg = config::Config::load(&project_dir);
+                println!("{:#?}", cfg);
+                Ok(())
+            }
+            ConfigCommand::Path => {
+                println!("{}", config::Config::config_path());
                 Ok(())
             }
         },

--- a/tools/ways-cli/src/session.rs
+++ b/tools/ways-cli/src/session.rs
@@ -437,21 +437,10 @@ fn days_to_ymd(days: u64) -> (u64, u64, u64) {
 
 // ── Domain disable check ────────────────────────────────────────
 
-/// Check if a domain is disabled in ways.json.
+/// Check if a domain is disabled.
+/// config::global() — future migration: ctx.config.disabled_domains
 pub fn domain_disabled(domain: &str) -> bool {
-    let config = home_dir().join(".claude/ways.json");
-    let content = match std::fs::read_to_string(&config) {
-        Ok(c) => c,
-        Err(_) => return false,
-    };
-    let parsed: serde_json::Value = match serde_json::from_str(&content) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-    if let Some(disabled) = parsed.get("disabled").and_then(|v| v.as_array()) {
-        return disabled.iter().any(|v| v.as_str() == Some(domain));
-    }
-    false
+    crate::config::global().disabled_domains.iter().any(|d| d == domain)
 }
 
 

--- a/tools/ways-cli/tests/session_sim.rs
+++ b/tools/ways-cli/tests/session_sim.rs
@@ -40,8 +40,9 @@ fn fixture_ways_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/ways")
 }
 
-fn generate_corpus() -> PathBuf {
-    let corpus_dir = std::env::temp_dir().join("ways-sim-corpus");
+fn generate_corpus(name: &str) -> PathBuf {
+    // Per-test corpus dir avoids races when tests run in parallel
+    let corpus_dir = std::env::temp_dir().join(format!("ways-sim-corpus-{}-{}", name, std::process::id()));
     std::fs::create_dir_all(&corpus_dir).unwrap();
     let corpus_file = corpus_dir.join("ways-corpus.jsonl");
 
@@ -70,7 +71,7 @@ struct Session {
 impl Session {
     fn new(name: &str) -> Self {
         let id = format!("sim-{}-{}", name, std::process::id());
-        let corpus = generate_corpus();
+        let corpus = generate_corpus(name);
         // Clean any stale markers
         clean_markers(&id);
         Session { id, corpus }


### PR DESCRIPTION
## Summary

- **Config module** — `config::Config` with layered resolution: built-in defaults → `~/.claude/ways.json` (legacy) → `$XDG_CONFIG_HOME/ways/config.yaml` → `$PROJECT/.claude/ways.yaml`. Mirrors attend's config pattern (ADR-115).
- **`config::global()`** — `LazyLock`-based accessor. Each call site is annotated with `// config::global() — future migration: ctx.config.field` as grep targets for the daemon/RequestContext refactor.
- **5 direct ways.json reads replaced**: bm25_threshold default, default_scope, parent_threshold_multiplier, domain_disabled, configured engine, resolve_language, disabled domains.
- **`ways config init/show/path`** — subcommands matching attend's pattern.
- **Net -7 lines** — centralized config is more concise than scattered reads.

Tracking: #2

## Design direction

`config::global()` is option C from a design discussion about config threading:
- Config is process-wide and immutable → global static is appropriate
- Session/project state remains in function signatures → explicit
- Migration to daemon: grep for `config::global()`, replace with `ctx.config`, bundle params into `RequestContext`

## Test plan

- [ ] `make lint` passes
- [ ] `cargo test -p ways` — all 10 simulation tests pass
- [ ] `ways config path` shows user/legacy/project paths
- [ ] `ways config show` shows resolved config with language from ways.json
- [ ] `ways config init` creates XDG config file
- [ ] `ways status` still works (engine, disabled domains from config)
- [ ] Way matching behavior unchanged (thresholds, scopes from config)