### PR TITLE
Show version and commit hash in tool banners

### DIFF
--- a/tools/agent-fmt/src/banner.rs
+++ b/tools/agent-fmt/src/banner.rs
@@ -42,6 +42,7 @@ pub struct Banner<'a> {
     text: &'a str,
     title: &'a str,
     subtitle: Option<&'a str>,
+    version: Option<&'a str>,
     gradient: &'a [&'a str],
 }
 
@@ -51,6 +52,7 @@ impl<'a> Banner<'a> {
             text,
             title: "A G E N T",
             subtitle: None,
+            version: None,
             gradient: &GRADIENT_CORAL,
         }
     }
@@ -62,6 +64,11 @@ impl<'a> Banner<'a> {
 
     pub fn subtitle(mut self, s: &'a str) -> Self {
         self.subtitle = Some(s);
+        self
+    }
+
+    pub fn version(mut self, v: &'a str) -> Self {
+        self.version = Some(v);
         self
     }
 
@@ -98,6 +105,9 @@ impl<'a> Banner<'a> {
 
         if let Some(sub) = self.subtitle {
             println!("  {DIM}{sub}{RESET}");
+        }
+        if let Some(ver) = self.version {
+            println!("  {DIM}{ver}{RESET}");
         }
         println!();
     }

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -990,8 +990,10 @@ fn main() {
             println!("attend {} ({})", env!("CARGO_PKG_VERSION"), env!("ATTEND_COMMIT"));
         }
         Some("help") | Some("--help") | Some("-h") | None => {
+            let version = format!("v{} ({})", env!("CARGO_PKG_VERSION"), env!("ATTEND_COMMIT"));
             agent_fmt::Banner::new("ATTEND")
                 .subtitle("active awareness for Claude Code sessions")
+                .version(&version)
                 .gradient(&agent_fmt::GRADIENT_TEAL)
                 .print();
             println!("usage: attend <command>\n");

--- a/tools/ways-cli/build.rs
+++ b/tools/ways-cli/build.rs
@@ -1,4 +1,19 @@
+use std::process::Command;
+
 fn main() {
-    // Phase 2 will add cc::Build here to compile csrc/ C/C++ sources.
-    // For now, pure Rust — no native compilation needed.
+    // Bake git commit hash into the binary
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok();
+
+    let commit = output
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=WAYS_COMMIT={}", commit);
+
+    // Rerun if git HEAD changes
+    println!("cargo:rerun-if-changed=.git/HEAD");
 }

--- a/tools/ways-cli/src/cmd/banner.rs
+++ b/tools/ways-cli/src/cmd/banner.rs
@@ -1,8 +1,10 @@
 use anyhow::Result;
 
 pub fn run() -> Result<()> {
+    let version = format!("v{} ({})", env!("CARGO_PKG_VERSION"), env!("WAYS_COMMIT"));
     agent_fmt::Banner::new("WAYS")
         .subtitle("cognitive steering for AI agents")
+        .version(&version)
         .gradient(&agent_fmt::GRADIENT_CORAL)
         .print();
     Ok(())


### PR DESCRIPTION
## Summary

Both `ways` and `attend` now display version and commit hash when invoked with no arguments:

```
  cognitive steering for AI agents
  v0.3.1 (94ed366)
```

- `Banner::version()` builder method added to agent-fmt
- ways-cli `build.rs` now bakes `WAYS_COMMIT` (attend already had `ATTEND_COMMIT`)
- Dim styled, consistent with subtitle

## Test plan

- [ ] `ways` (no args) shows version line under subtitle
- [ ] `attend` (no args) shows version line under subtitle
- [ ] `make lint` passes