### PR TITLE
feat: ADR-116 declarative permission requirements

### DIFF
--- a/docs/architecture/system/ADR-116-declarative-permission-requirements.md
+++ b/docs/architecture/system/ADR-116-declarative-permission-requirements.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-04-10
 deciders:
   - aaronsb

--- a/hooks/ways/core.md
+++ b/hooks/ways/core.md
@@ -1,5 +1,6 @@
 ---
 macro: prepend
+requires: ["Bash(awk:*)", "Bash(grep:*)", "Bash(sed:*)", "Bash(sort:*)", "Bash(tr:*)", "Bash(wc:*)"]
 ---
 # Core Ways of Working
 

--- a/hooks/ways/frontmatter-schema.yaml
+++ b/hooks/ways/frontmatter-schema.yaml
@@ -96,6 +96,12 @@ way:
       required: optional
       role: Run macro.sh alongside way content
 
+  permissions:
+    requires:
+      type: array
+      required: optional
+      role: Tool permissions this way needs (e.g. Bash(gh:*), Read). Audited against settings.json.
+
   extended:
     scan_exclude:
       type: regex

--- a/hooks/ways/meta/introspection/introspection.md
+++ b/hooks/ways/meta/introspection/introspection.md
@@ -6,6 +6,7 @@ pattern: pull.?request|create.*pr|pr.*create|write.*pr|open.*pr
 commands: gh\ pr\ create
 macro: prepend
 scope: agent
+requires: ["Bash(jq:*)", "Bash(ways:*)"]
 ---
 <!-- epistemic: heuristic -->
 # Introspection Way

--- a/hooks/ways/meta/knowledge/optimization/optimization.md
+++ b/hooks/ways/meta/knowledge/optimization/optimization.md
@@ -4,6 +4,7 @@ vocabulary: optimize vocabulary suggest gaps coverage unused threshold tune scor
 threshold: 2.0
 macro: prepend
 scope: agent
+requires: ["Read", "Bash(awk:*)", "Bash(find:*)", "Bash(grep:*)", "Bash(sed:*)", "Bash(sort:*)", "Bash(ways:*)"]
 ---
 <!-- epistemic: heuristic -->
 # Way Optimization

--- a/hooks/ways/meta/memory/memory.md
+++ b/hooks/ways/meta/memory/memory.md
@@ -6,6 +6,7 @@ threshold: 80
 pattern: remember|save.*(to|this|that).*memory|note.*(for|this).*(later|next)|don't forget|keep.*in.*mind
 macro: prepend
 scope: agent
+requires: ["Bash(jq:*)", "Bash(sed:*)", "Bash(ways:*)", "Bash(wc:*)"]
 ---
 <!-- epistemic: convention -->
 # Memory

--- a/hooks/ways/meta/todos/todos.md
+++ b/hooks/ways/meta/todos/todos.md
@@ -4,6 +4,7 @@ threshold: 75
 repeat: true
 macro: prepend
 scope: agent, subagent
+requires: ["Bash(jq:*)", "Bash(ways:*)"]
 ---
 <!-- epistemic: heuristic -->
 # Task List Checkpoint

--- a/hooks/ways/research/research.md
+++ b/hooks/ways/research/research.md
@@ -4,6 +4,7 @@ vocabulary: research investigate explore find out compare evaluate analyze synth
 threshold: 2.0
 macro: append
 scope: agent
+requires: ["Bash(grep:*)"]
 ---
 <!-- epistemic: heuristic -->
 # Research Way

--- a/hooks/ways/softwaredev/architecture/adr-context/adr-context.md
+++ b/hooks/ways/softwaredev/architecture/adr-context/adr-context.md
@@ -4,6 +4,7 @@ vocabulary: plan approach debate implement build work pick understand investigat
 threshold: 2.0
 scope: agent, subagent
 macro: prepend
+requires: ["Read", "Bash(find:*)", "Bash(wc:*)"]
 ---
 <!-- epistemic: convention -->
 # ADR Context — Read Before You Build

--- a/hooks/ways/softwaredev/architecture/adr/adr.md
+++ b/hooks/ways/softwaredev/architecture/adr/adr.md
@@ -6,6 +6,7 @@ pattern: (^| )adr( |$)|architect|decision|design.?pattern|technical.?choice|trad
 files: docs/architecture/.*\.md$
 macro: prepend
 scope: agent, subagent
+requires: ["Bash(chmod:*)", "Bash(cp:*)", "Bash(mkdir:*)", "Bash(touch:*)"]
 ---
 <!-- epistemic: convention -->
 # ADR Way

--- a/hooks/ways/softwaredev/code/quality/quality.md
+++ b/hooks/ways/softwaredev/code/quality/quality.md
@@ -7,6 +7,7 @@ redisclose: 15
 macro: append
 scan_exclude: \.md$|\.lock$|\.min\.(js|css)$|\.generated\.|\.bundle\.|vendor/|node_modules/|dist/|build/|__pycache__/
 scope: agent, subagent
+requires: ["Read", "Bash(awk:*)", "Bash(dirname:*)", "Bash(file:*)", "Bash(git:*)", "Bash(grep:*)", "Bash(head:*)", "Bash(sort:*)", "Bash(wc:*)"]
 ---
 <!-- epistemic: heuristic -->
 # Code Quality Way

--- a/hooks/ways/softwaredev/delivery/branching/branching.md
+++ b/hooks/ways/softwaredev/delivery/branching/branching.md
@@ -5,6 +5,7 @@ files: \.(md|rs|sh|py|js|ts|json|yaml|yml|toml|go|rb|java|c|cpp|h|hpp|css|html|s
 redisclose: 10
 macro: prepend
 scope: agent, subagent
+requires: ["Bash(cut:*)", "Bash(git:*)", "Bash(sed:*)"]
 ---
 <!-- epistemic: heuristic -->
 # Branching Context

--- a/hooks/ways/softwaredev/delivery/github/github.md
+++ b/hooks/ways/softwaredev/delivery/github/github.md
@@ -7,7 +7,7 @@ commands: ^gh\ |^gh$
 redisclose: 10
 macro: prepend
 scope: agent, subagent
-requires: ["Read", "Bash(cat:*)", "Bash(gh:*)", "Bash(git:*)", "Bash(grep:*)", "Bash(head:*)", "Bash(jq:*)", "Bash(sed:*)", "Bash(sort:*)", "Bash(tr:*)", "Bash(wc:*)"]
+requires: ["Read", "Bash(cat:*)", "Bash(gh:*)", "Bash(git:*)", "Bash(grep:*)", "Bash(head:*)", "Bash(jq:*)", "Bash(rm:*)", "Bash(sed:*)", "Bash(sort:*)", "Bash(tr:*)", "Bash(wc:*)"]
 ---
 <!-- epistemic: convention -->
 # GitHub Way

--- a/hooks/ways/softwaredev/delivery/github/github.md
+++ b/hooks/ways/softwaredev/delivery/github/github.md
@@ -7,6 +7,7 @@ commands: ^gh\ |^gh$
 redisclose: 10
 macro: prepend
 scope: agent, subagent
+requires: ["Read", "Bash(cat:*)", "Bash(gh:*)", "Bash(git:*)", "Bash(grep:*)", "Bash(head:*)", "Bash(jq:*)", "Bash(sed:*)", "Bash(sort:*)", "Bash(tr:*)", "Bash(wc:*)"]
 ---
 <!-- epistemic: convention -->
 # GitHub Way

--- a/hooks/ways/softwaredev/delivery/implement/implement.md
+++ b/hooks/ways/softwaredev/delivery/implement/implement.md
@@ -4,6 +4,7 @@ vocabulary: implement build begin start work execute plan breakdown parallelize 
 threshold: 2.0
 macro: append
 scope: agent
+requires: ["Read", "Bash(cat:*)", "Bash(find:*)", "Bash(wc:*)"]
 ---
 <!-- epistemic: convention -->
 # Implementation Way

--- a/hooks/ways/softwaredev/environment/attend/attend.md
+++ b/hooks/ways/softwaredev/environment/attend/attend.md
@@ -8,6 +8,7 @@ commands: attend
 redisclose: 15
 macro: append
 scope: agent, subagent
+requires: ["Bash(attend:*)", "Bash(grep:*)", "Bash(ps:*)", "Bash(sed:*)"]
 ---
 <!-- epistemic: tool-knowledge -->
 # Attend

--- a/hooks/ways/softwaredev/environment/makefile/makefile.md
+++ b/hooks/ways/softwaredev/environment/makefile/makefile.md
@@ -7,6 +7,7 @@ threshold: 1.5
 redisclose: 10
 scope: agent, subagent
 macro: append
+requires: ["Bash(awk:*)", "Bash(make:*)", "Bash(sort:*)", "Bash(tr:*)"]
 ---
 <!-- epistemic: convention -->
 # Makefile Way

--- a/hooks/ways/writing/writing.md
+++ b/hooks/ways/writing/writing.md
@@ -4,6 +4,7 @@ vocabulary: write draft compose author proposal report presentation deck slides 
 threshold: 2.0
 macro: append
 scope: agent
+requires: ["Bash(grep:*)"]
 ---
 <!-- epistemic: heuristic -->
 # Writing Way

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-fmt"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "figlet-rs",
  "libc",
@@ -83,7 +83,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "attend"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "agent-fmt",
 ]
@@ -672,7 +672,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "ways"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "agent-fmt",
  "anyhow",

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -14,6 +14,7 @@ version = "0.4.0"
 dependencies = [
  "figlet-rs",
  "libc",
+ "serde_json",
 ]
 
 [[package]]

--- a/tools/agent-fmt/Cargo.toml
+++ b/tools/agent-fmt/Cargo.toml
@@ -8,3 +8,4 @@ license = "MIT"
 [dependencies]
 figlet-rs = "1.0.0"
 libc = "0.2.184"
+serde_json = "1"

--- a/tools/agent-fmt/src/lib.rs
+++ b/tools/agent-fmt/src/lib.rs
@@ -1,8 +1,10 @@
-//! Shared terminal formatting for agent-ways tools.
+//! Shared terminal formatting and utilities for agent-ways tools.
 //!
-//! Provides ANSI-aware table rendering, banner display, and help formatting.
+//! Provides ANSI-aware table rendering, banner display, help formatting,
+//! and permission matching (ADR-116).
 
 mod banner;
+pub mod permissions;
 mod table;
 
 pub use banner::{Banner, print_commands, GRADIENT_CORAL, GRADIENT_TEAL};

--- a/tools/agent-fmt/src/permissions.rs
+++ b/tools/agent-fmt/src/permissions.rs
@@ -138,68 +138,21 @@ pub fn load_settings_permissions(settings_path: &Path) -> Vec<Permission> {
         Err(_) => return Vec::new(),
     };
 
-    // Minimal JSON parsing — find "allow": [...] array
-    // Using serde_json would add a dependency to agent-fmt; parse manually instead.
-    let mut perms = Vec::new();
-    let mut in_allow = false;
+    let doc: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
 
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.contains("\"allow\"") && trimmed.contains('[') {
-            in_allow = true;
-            // Check if there are entries on the same line
-            if let Some(start) = trimmed.find('[') {
-                for entry in extract_string_entries(&trimmed[start..]) {
-                    if let Some(p) = Permission::parse(&entry) {
-                        perms.push(p);
-                    }
-                }
-            }
-            if trimmed.contains(']') {
-                in_allow = false;
-            }
-            continue;
-        }
-        if in_allow {
-            if trimmed.contains(']') {
-                // Might have entries before the ]
-                for entry in extract_string_entries(trimmed) {
-                    if let Some(p) = Permission::parse(&entry) {
-                        perms.push(p);
-                    }
-                }
-                in_allow = false;
-                continue;
-            }
-            for entry in extract_string_entries(trimmed) {
-                if let Some(p) = Permission::parse(&entry) {
-                    perms.push(p);
-                }
-            }
-        }
-    }
-    perms
-}
+    let allow = match doc.get("permissions").and_then(|p| p.get("allow")).and_then(|a| a.as_array()) {
+        Some(arr) => arr,
+        None => return Vec::new(),
+    };
 
-/// Extract quoted strings from a line (e.g., `"Bash(git:*)"` → `Bash(git:*)`).
-fn extract_string_entries(line: &str) -> Vec<String> {
-    let mut entries = Vec::new();
-    let mut chars = line.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '"' {
-            let mut s = String::new();
-            for c in chars.by_ref() {
-                if c == '"' {
-                    break;
-                }
-                s.push(c);
-            }
-            if !s.is_empty() && s != "allow" {
-                entries.push(s);
-            }
-        }
-    }
-    entries
+    allow
+        .iter()
+        .filter_map(|v| v.as_str())
+        .filter_map(Permission::parse)
+        .collect()
 }
 
 /// Audit result for a single requirement.
@@ -234,6 +187,78 @@ pub fn audit(
         }
     }
     results
+}
+
+/// Display audit results as an agent-fmt Table.
+///
+/// `title` is the heading (e.g., "Permissions Audit" or "Attend Permissions Audit").
+/// `source_header` is the first column label (e.g., "Way" or "Sensor").
+/// `has_tpm` triggers a deprecation notice for trusted-project-macros.
+pub fn display_audit(
+    title: &str,
+    source_header: &str,
+    results: &[AuditResult],
+    has_tpm: bool,
+) {
+    use crate::{Align, Table};
+
+    const RESET: &str = "\x1b[0m";
+    const BOLD: &str = "\x1b[1m";
+    const GREEN: &str = "\x1b[32m";
+    const RED: &str = "\x1b[31m";
+    const YELLOW: &str = "\x1b[33m";
+
+    println!();
+    println!("  {BOLD}{title}{RESET} (ADR-116)");
+    println!();
+
+    if results.is_empty() {
+        println!("  No {source_header}s declare requires: fields.");
+        println!();
+        return;
+    }
+
+    let mut table = Table::new(&[source_header, "Requires", "Status"]);
+    table.align(0, Align::Left);
+    table.align(1, Align::Left);
+    table.align(2, Align::Left);
+
+    let mut missing_count = 0u32;
+    let mut missing_perms: Vec<String> = Vec::new();
+
+    for r in results {
+        let status = if r.granted {
+            format!("{GREEN}granted{RESET}")
+        } else {
+            missing_count += 1;
+            if !missing_perms.contains(&r.requirement) {
+                missing_perms.push(r.requirement.clone());
+            }
+            format!("{RED}MISSING{RESET}")
+        };
+        table.add(vec![&r.source, &r.requirement, &status]);
+    }
+
+    table.print();
+    println!();
+
+    if missing_count > 0 {
+        println!("  {YELLOW}{missing_count} missing permission(s).{RESET} Add to settings.json:");
+        for p in &missing_perms {
+            println!("    \"{p}\"");
+        }
+    } else {
+        println!("  {GREEN}All permissions granted.{RESET}");
+    }
+
+    if has_tpm {
+        println!();
+        println!("  {YELLOW}Deprecation:{RESET} ~/.claude/trusted-project-macros found.");
+        println!("  This file is deprecated — use requires: fields in way frontmatter instead.");
+        println!("  See ADR-116 for migration guidance.");
+    }
+
+    println!();
 }
 
 #[cfg(test)]

--- a/tools/agent-fmt/src/permissions.rs
+++ b/tools/agent-fmt/src/permissions.rs
@@ -1,0 +1,324 @@
+//! Permission matching engine for ADR-116.
+//!
+//! Parses permission strings (Tool, Tool(scope), *) and checks whether
+//! a grant satisfies a requirement via containment hierarchy.
+//!
+//! Rules:
+//! - `*` covers everything
+//! - `Bash(*)` covers any `Bash(cmd:*)`
+//! - `Read` (unscoped) covers `Read(/any/path)`
+//! - `Bash(git:*)` covers `Bash(git:status)` but NOT `Bash(*)`
+
+use std::fmt;
+use std::path::Path;
+
+/// A parsed permission.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Permission {
+    /// Wildcard — covers everything.
+    Wildcard,
+    /// Unscoped tool access (e.g., `Read`, `Edit`).
+    Tool(String),
+    /// Scoped tool access (e.g., `Bash(git:*)`, `Read(/home/**)`).
+    Scoped(String, String),
+}
+
+impl Permission {
+    /// Parse a permission string into a Permission.
+    ///
+    /// Examples: `"*"`, `"Read"`, `"Bash(git:*)"`, `"Write(/home/**)"`.
+    pub fn parse(s: &str) -> Option<Permission> {
+        let s = s.trim();
+        if s == "*" {
+            return Some(Permission::Wildcard);
+        }
+        if let Some(paren_start) = s.find('(') {
+            if !s.ends_with(')') {
+                return None;
+            }
+            let tool = s[..paren_start].to_string();
+            let scope = s[paren_start + 1..s.len() - 1].to_string();
+            if tool.is_empty() || scope.is_empty() {
+                return None;
+            }
+            Some(Permission::Scoped(tool, scope))
+        } else if !s.is_empty() && s.chars().next().unwrap().is_ascii_uppercase() {
+            Some(Permission::Tool(s.to_string()))
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Display for Permission {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Permission::Wildcard => write!(f, "*"),
+            Permission::Tool(t) => write!(f, "{t}"),
+            Permission::Scoped(t, s) => write!(f, "{t}({s})"),
+        }
+    }
+}
+
+/// Check if a grant satisfies a requirement.
+///
+/// A grant satisfies a requirement if the grant is at least as broad:
+/// - `*` satisfies any requirement
+/// - `Bash(*)` satisfies `Bash(git:*)` but not vice versa
+/// - `Read` (unscoped) satisfies `Read(/path)` but not vice versa
+/// - `Bash(git:*)` satisfies `Bash(git:status)` (prefix match on command scope)
+pub fn grant_satisfies(grant: &Permission, requirement: &Permission) -> bool {
+    match (grant, requirement) {
+        // Wildcard grant covers everything
+        (Permission::Wildcard, _) => true,
+        // Nothing else covers a wildcard requirement
+        (_, Permission::Wildcard) => false,
+
+        // Unscoped grant covers unscoped or any scoped requirement of the same tool
+        (Permission::Tool(gt), Permission::Tool(rt)) => gt == rt,
+        (Permission::Tool(gt), Permission::Scoped(rt, _)) => gt == rt,
+
+        // Scoped grant does not cover unscoped requirement
+        (Permission::Scoped(_, _), Permission::Tool(_)) => false,
+
+        // Scoped grant covers scoped requirement if tools match and scope contains
+        (Permission::Scoped(gt, gs), Permission::Scoped(rt, rs)) => {
+            gt == rt && scope_contains(gs, rs)
+        }
+    }
+}
+
+/// Check if a grant scope contains a requirement scope.
+///
+/// For Bash commands: `*` contains anything, `git:*` contains `git:status`.
+/// For paths: glob-style containment — `/home/**` contains `/home/user/file`.
+fn scope_contains(grant_scope: &str, req_scope: &str) -> bool {
+    // Wildcard scope covers everything
+    if grant_scope == "*" {
+        return true;
+    }
+    // Exact match
+    if grant_scope == req_scope {
+        return true;
+    }
+    // Command prefix: grant "git:*" matches requirement "git:status"
+    if let Some(prefix) = grant_scope.strip_suffix(":*") {
+        if let Some(req_prefix) = req_scope.strip_suffix(":*") {
+            // git:* covers git:* (already caught by exact match above, but be safe)
+            return req_prefix == prefix || req_prefix.starts_with(&format!("{prefix}:"));
+        }
+        // grant "git:*" covers requirement "git:status"
+        return req_scope.starts_with(&format!("{prefix}:"));
+    }
+    // Path glob: grant "/home/**" matches requirement "/home/user/file"
+    if grant_scope.contains("**") {
+        let prefix = grant_scope.trim_end_matches("**");
+        return req_scope.starts_with(prefix);
+    }
+    // Tilde expansion: "~/.claude/**" matches "/home/user/.claude/foo"
+    if grant_scope.starts_with("~/") {
+        if let Some(home) = home_dir() {
+            let expanded = format!("{}{}", home.display(), &grant_scope[1..]);
+            return scope_contains(&expanded, req_scope);
+        }
+    }
+    false
+}
+
+fn home_dir() -> Option<std::path::PathBuf> {
+    std::env::var("HOME").ok().map(std::path::PathBuf::from)
+}
+
+/// Load permissions from settings.json.
+///
+/// Reads `~/.claude/settings.json` and parses `permissions.allow` array.
+pub fn load_settings_permissions(settings_path: &Path) -> Vec<Permission> {
+    let content = match std::fs::read_to_string(settings_path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+
+    // Minimal JSON parsing — find "allow": [...] array
+    // Using serde_json would add a dependency to agent-fmt; parse manually instead.
+    let mut perms = Vec::new();
+    let mut in_allow = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.contains("\"allow\"") && trimmed.contains('[') {
+            in_allow = true;
+            // Check if there are entries on the same line
+            if let Some(start) = trimmed.find('[') {
+                for entry in extract_string_entries(&trimmed[start..]) {
+                    if let Some(p) = Permission::parse(&entry) {
+                        perms.push(p);
+                    }
+                }
+            }
+            if trimmed.contains(']') {
+                in_allow = false;
+            }
+            continue;
+        }
+        if in_allow {
+            if trimmed.contains(']') {
+                // Might have entries before the ]
+                for entry in extract_string_entries(trimmed) {
+                    if let Some(p) = Permission::parse(&entry) {
+                        perms.push(p);
+                    }
+                }
+                in_allow = false;
+                continue;
+            }
+            for entry in extract_string_entries(trimmed) {
+                if let Some(p) = Permission::parse(&entry) {
+                    perms.push(p);
+                }
+            }
+        }
+    }
+    perms
+}
+
+/// Extract quoted strings from a line (e.g., `"Bash(git:*)"` → `Bash(git:*)`).
+fn extract_string_entries(line: &str) -> Vec<String> {
+    let mut entries = Vec::new();
+    let mut chars = line.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '"' {
+            let mut s = String::new();
+            for c in chars.by_ref() {
+                if c == '"' {
+                    break;
+                }
+                s.push(c);
+            }
+            if !s.is_empty() && s != "allow" {
+                entries.push(s);
+            }
+        }
+    }
+    entries
+}
+
+/// Audit result for a single requirement.
+#[derive(Debug)]
+pub struct AuditResult {
+    /// Source of the requirement (way ID or sensor name).
+    pub source: String,
+    /// The permission string required.
+    pub requirement: String,
+    /// Whether it's satisfied by a grant in settings.json.
+    pub granted: bool,
+}
+
+/// Audit a set of (source, requirements) against granted permissions.
+pub fn audit(
+    requirements: &[(String, Vec<String>)],
+    grants: &[Permission],
+) -> Vec<AuditResult> {
+    let mut results = Vec::new();
+    for (source, reqs) in requirements {
+        for req_str in reqs {
+            let granted = if let Some(req) = Permission::parse(req_str) {
+                grants.iter().any(|g| grant_satisfies(g, &req))
+            } else {
+                false // malformed requirement
+            };
+            results.push(AuditResult {
+                source: source.clone(),
+                requirement: req_str.clone(),
+                granted,
+            });
+        }
+    }
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_wildcard() {
+        assert_eq!(Permission::parse("*"), Some(Permission::Wildcard));
+    }
+
+    #[test]
+    fn test_parse_tool() {
+        assert_eq!(Permission::parse("Read"), Some(Permission::Tool("Read".to_string())));
+    }
+
+    #[test]
+    fn test_parse_scoped() {
+        assert_eq!(
+            Permission::parse("Bash(git:*)"),
+            Some(Permission::Scoped("Bash".to_string(), "git:*".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_wildcard_covers_all() {
+        let grant = Permission::Wildcard;
+        let req = Permission::parse("Bash(git:*)").unwrap();
+        assert!(grant_satisfies(&grant, &req));
+    }
+
+    #[test]
+    fn test_unscoped_covers_scoped() {
+        let grant = Permission::Tool("Read".to_string());
+        let req = Permission::Scoped("Read".to_string(), "/home/user".to_string());
+        assert!(grant_satisfies(&grant, &req));
+    }
+
+    #[test]
+    fn test_scoped_does_not_cover_unscoped() {
+        let grant = Permission::Scoped("Read".to_string(), "/home/**".to_string());
+        let req = Permission::Tool("Read".to_string());
+        assert!(!grant_satisfies(&grant, &req));
+    }
+
+    #[test]
+    fn test_bash_wildcard_scope() {
+        let grant = Permission::Scoped("Bash".to_string(), "*".to_string());
+        let req = Permission::Scoped("Bash".to_string(), "git:*".to_string());
+        assert!(grant_satisfies(&grant, &req));
+    }
+
+    #[test]
+    fn test_bash_prefix_scope() {
+        let grant = Permission::Scoped("Bash".to_string(), "git:*".to_string());
+        let req = Permission::Scoped("Bash".to_string(), "git:status".to_string());
+        assert!(grant_satisfies(&grant, &req));
+    }
+
+    #[test]
+    fn test_bash_no_cross_tool() {
+        let grant = Permission::Scoped("Bash".to_string(), "git:*".to_string());
+        let req = Permission::Scoped("Bash".to_string(), "gh:*".to_string());
+        assert!(!grant_satisfies(&grant, &req));
+    }
+
+    #[test]
+    fn test_path_glob_containment() {
+        let grant = Permission::Scoped("Write".to_string(), "/home/aaron/.claude/**".to_string());
+        let req = Permission::Scoped("Write".to_string(), "/home/aaron/.claude/foo".to_string());
+        assert!(grant_satisfies(&grant, &req));
+    }
+
+    #[test]
+    fn test_audit_finds_missing() {
+        let grants = vec![
+            Permission::parse("Bash(git:*)").unwrap(),
+            Permission::parse("Read").unwrap(),
+        ];
+        let reqs = vec![
+            ("github".to_string(), vec!["Bash(git:*)".to_string(), "Bash(gh:*)".to_string()]),
+        ];
+        let results = audit(&reqs, &grants);
+        assert_eq!(results.len(), 2);
+        assert!(results[0].granted);  // git:* — granted
+        assert!(!results[1].granted); // gh:* — missing
+    }
+}

--- a/tools/attend/src/config.rs
+++ b/tools/attend/src/config.rs
@@ -38,6 +38,8 @@ pub struct SensorConfig {
     pub decay_threshold: u32,
     /// For script sensors: path to the script (relative to project root)
     pub script: Option<String>,
+    /// Permission requirements (ADR-116) — tool permissions this sensor needs.
+    pub requires: Vec<String>,
 }
 
 impl Default for GovernorConfig {
@@ -60,6 +62,7 @@ impl Default for Config {
             threshold: 1.5,
             decay_threshold: 3,
             script: None,
+            requires: vec!["Read".to_string()],
         });
         sensors.insert("git".to_string(), SensorConfig {
             enabled: true,
@@ -68,6 +71,7 @@ impl Default for Config {
             threshold: 2.0,
             decay_threshold: 4,
             script: None,
+            requires: vec!["Bash(git:*)".to_string()],
         });
         sensors.insert("peers".to_string(), SensorConfig {
             enabled: true,
@@ -76,6 +80,7 @@ impl Default for Config {
             threshold: 2.0,
             decay_threshold: 5,
             script: None,
+            requires: vec!["Read".to_string()],
         });
         sensors.insert("processes".to_string(), SensorConfig {
             enabled: true,
@@ -84,6 +89,7 @@ impl Default for Config {
             threshold: 2.0,
             decay_threshold: 5,
             script: None,
+            requires: vec!["Bash(ps:*)".to_string()],
         });
         Self {
             governor: GovernorConfig::default(),
@@ -245,6 +251,7 @@ fn apply_config(config: &mut Config, content: &str) {
                         threshold: 2.0,
                         decay_threshold: 4,
                         script: None,
+                        requires: Vec::new(),
                     });
                     current_sensor = name;
                 } else {
@@ -285,6 +292,17 @@ fn apply_config(config: &mut Config, content: &str) {
                         }
                         "enabled" => {
                             sensor.enabled = value == "true";
+                        }
+                        "requires" => {
+                            // Inline array: requires: [Bash(gh:*), Read]
+                            if value.starts_with('[') && value.ends_with(']') {
+                                let inner = &value[1..value.len() - 1];
+                                sensor.requires = inner
+                                    .split(',')
+                                    .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
+                                    .filter(|s| !s.is_empty())
+                                    .collect();
+                            }
                         }
                         _ => {}
                     }

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -941,6 +941,86 @@ fn write_focus_list(path: &std::path::Path, list: &[String]) {
     std::fs::write(path, content).ok();
 }
 
+// --- Permissions audit (ADR-116) ---
+
+fn cmd_permissions_audit() {
+    use agent_fmt::permissions;
+
+    let focus = Focus::default_focus();
+    let cfg = config::Config::load(&focus.working_dir);
+
+    // Load settings.json grants
+    let home = std::env::var("HOME").unwrap_or_default();
+    let settings_path = std::path::PathBuf::from(&home).join(".claude/settings.json");
+    let grants = permissions::load_settings_permissions(&settings_path);
+
+    if grants.is_empty() {
+        eprintln!("Warning: no permissions found in {}", settings_path.display());
+    }
+
+    // Collect (sensor_name, requires) pairs from config
+    let mut requirements: Vec<(String, Vec<String>)> = Vec::new();
+    let mut names: Vec<&String> = cfg.sensors.keys().collect();
+    names.sort();
+    for name in names {
+        let sensor = &cfg.sensors[name];
+        if !sensor.requires.is_empty() {
+            let prefix = if sensor.script.is_some() { "+" } else { "" };
+            requirements.push((
+                format!("{prefix}{name}"),
+                sensor.requires.clone(),
+            ));
+        }
+    }
+
+    let results = permissions::audit(&requirements, &grants);
+
+    // Display
+    println!();
+    println!("  \x1b[1mAttend Permissions Audit\x1b[0m (ADR-116)");
+    println!();
+
+    if results.is_empty() {
+        println!("  No sensors declare requires: fields.");
+        println!();
+        return;
+    }
+
+    let mut table = agent_fmt::Table::new(&["Sensor", "Requires", "Status"]);
+    table.align(0, agent_fmt::Align::Left);
+    table.align(1, agent_fmt::Align::Left);
+    table.align(2, agent_fmt::Align::Left);
+
+    let mut missing_count = 0u32;
+    let mut missing_perms: Vec<String> = Vec::new();
+
+    for r in &results {
+        let status = if r.granted {
+            "\x1b[32mgranted\x1b[0m".to_string()
+        } else {
+            missing_count += 1;
+            if !missing_perms.contains(&r.requirement) {
+                missing_perms.push(r.requirement.clone());
+            }
+            "\x1b[31mMISSING\x1b[0m".to_string()
+        };
+        table.add(vec![&r.source, &r.requirement, &status]);
+    }
+
+    table.print();
+    println!();
+
+    if missing_count > 0 {
+        println!("  \x1b[33m{missing_count} missing permission(s).\x1b[0m Add to settings.json:");
+        for p in &missing_perms {
+            println!("    \"{p}\"");
+        }
+    } else {
+        println!("  \x1b[32mAll permissions granted.\x1b[0m");
+    }
+    println!();
+}
+
 // --- Entry point ---
 
 fn main() {
@@ -959,6 +1039,15 @@ fn main() {
         }
         Some("focus") => {
             cmd_focus(&args[1..]);
+        }
+        Some("permissions") => {
+            match args.get(1).map(|s| s.as_str()) {
+                Some("audit") | None => cmd_permissions_audit(),
+                Some(sub) => {
+                    eprintln!("attend permissions: unknown subcommand '{}' — try audit", sub);
+                    std::process::exit(1);
+                }
+            }
         }
         Some("config") => {
             match args.get(1).map(|s| s.as_str()) {
@@ -1003,8 +1092,9 @@ fn main() {
                 ("inbox",  "Read pending messages from peers"),
                 ("send",   "Send a signal to peer sessions"),
                 ("focus",  "Manage focus group (add/remove/clear/list peer projects)"),
-                ("config", "Manage configuration (init/show/path)"),
-                ("status", "Show running instances, signals, and focus state"),
+                ("config",      "Manage configuration (init/show/path)"),
+                ("permissions", "Audit sensor permissions against settings.json"),
+                ("status",      "Show running instances, signals, and focus state"),
                 ("help",   "Show this help"),
             ]);
             println!();

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -974,51 +974,7 @@ fn cmd_permissions_audit() {
     }
 
     let results = permissions::audit(&requirements, &grants);
-
-    // Display
-    println!();
-    println!("  \x1b[1mAttend Permissions Audit\x1b[0m (ADR-116)");
-    println!();
-
-    if results.is_empty() {
-        println!("  No sensors declare requires: fields.");
-        println!();
-        return;
-    }
-
-    let mut table = agent_fmt::Table::new(&["Sensor", "Requires", "Status"]);
-    table.align(0, agent_fmt::Align::Left);
-    table.align(1, agent_fmt::Align::Left);
-    table.align(2, agent_fmt::Align::Left);
-
-    let mut missing_count = 0u32;
-    let mut missing_perms: Vec<String> = Vec::new();
-
-    for r in &results {
-        let status = if r.granted {
-            "\x1b[32mgranted\x1b[0m".to_string()
-        } else {
-            missing_count += 1;
-            if !missing_perms.contains(&r.requirement) {
-                missing_perms.push(r.requirement.clone());
-            }
-            "\x1b[31mMISSING\x1b[0m".to_string()
-        };
-        table.add(vec![&r.source, &r.requirement, &status]);
-    }
-
-    table.print();
-    println!();
-
-    if missing_count > 0 {
-        println!("  \x1b[33m{missing_count} missing permission(s).\x1b[0m Add to settings.json:");
-        for p in &missing_perms {
-            println!("    \"{p}\"");
-        }
-    } else {
-        println!("  \x1b[32mAll permissions granted.\x1b[0m");
-    }
-    println!();
+    permissions::display_audit("Attend Permissions Audit", "Sensor", &results, false);
 }
 
 // --- Entry point ---

--- a/tools/ways-cli/src/cmd/lint.rs
+++ b/tools/ways-cli/src/cmd/lint.rs
@@ -341,6 +341,42 @@ fn lint_file(
         }
     }
 
+    // requires: field validation (ADR-116)
+    let has_macro = has_field(&fm_str, "macro");
+    let has_requires = has_field(&fm_str, "requires");
+    if has_macro && !has_requires {
+        if fix {
+            // Scan adjacent macro.sh for external commands → generate requires:
+            let macro_path = path.parent().map(|p| p.join("macro.sh"));
+            if let Some(ref mp) = macro_path {
+                if mp.is_file() {
+                    let reqs = scan_macro_requires(mp);
+                    if !reqs.is_empty() {
+                        let requires_yaml = format_requires_yaml(&reqs);
+                        content = insert_requires_field(&content, &requires_yaml);
+                        modified = true;
+                        *fixes += 1;
+                        eprintln!("  FIXED: {rel} — added requires: [{}]", reqs.join(", "));
+                    }
+                }
+            }
+        } else {
+            eprintln!("  WARNING: {rel} — macro: without requires: (run --fix to auto-populate)");
+            *warnings += 1;
+        }
+    }
+    if has_requires {
+        // Validate requires: values are well-formed permission strings
+        if let Some(reqs) = extract_requires_list(&fm_str) {
+            for req in &reqs {
+                if !is_valid_permission(req) {
+                    eprintln!("  ERROR: {rel} — invalid requires value '{req}' (expected: Tool, Tool(scope), or *)");
+                    *errors += 1;
+                }
+            }
+        }
+    }
+
     // Trigger enum
     if let Some(val) = get_field_value(&fm_str, "trigger") {
         if !schema.valid_triggers.iter().any(|v| v == &val) {
@@ -631,6 +667,243 @@ fn extract_string_list(doc: &serde_yaml::Value, keys: &[&str]) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+// ── ADR-116: requires field helpers ─────────────────────────────
+
+/// Known external commands that map to Bash(cmd:*) permissions.
+/// Shell builtins and control flow keywords are excluded.
+const EXTERNAL_COMMANDS: &[&str] = &[
+    "attend", "awk", "basename", "cargo", "cat", "chmod", "cp", "curl", "cut",
+    "date", "df", "diff", "dirname", "du", "file", "find", "gh", "git", "grep",
+    "head", "id", "jq", "ln", "ls", "make", "mkdir", "mv", "node", "npm",
+    "pnpm", "ps", "python3", "realpath", "rg", "rm", "sed", "sha256sum",
+    "sort", "stat", "tail", "tee", "touch", "tr", "tree", "uname", "uniq",
+    "ways", "wc", "which", "xargs", "yarn",
+];
+
+/// Scan a macro.sh file and extract external commands → permission strings.
+fn scan_macro_requires(path: &Path) -> Vec<String> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut found: Vec<&str> = Vec::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        // Skip comments and empty lines
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        // Look for external commands: word boundaries in the line
+        for cmd in EXTERNAL_COMMANDS {
+            if line_uses_command(trimmed, cmd) && !found.contains(cmd) {
+                found.push(cmd);
+            }
+        }
+    }
+
+    found.sort();
+
+    // Also check if the script reads files (common: cat, source, .)
+    let mut perms: Vec<String> = Vec::new();
+
+    // Check if script needs Read access (reads files outside macro dir)
+    let needs_read = found.iter().any(|c| matches!(*c, "cat" | "head" | "tail" | "ls" | "file" | "stat" | "find" | "tree"));
+    if needs_read {
+        perms.push("Read".to_string());
+    }
+
+    for cmd in &found {
+        perms.push(format!("Bash({cmd}:*)"));
+    }
+
+    perms
+}
+
+/// Check if a shell line uses a specific command (not just as a substring).
+fn line_uses_command(line: &str, cmd: &str) -> bool {
+    // Match command at line start, after pipe, after $(), after backtick,
+    // after &&, after ||, after ;, or after assignment
+    for token in shell_tokens(line) {
+        if token == cmd {
+            return true;
+        }
+    }
+    false
+}
+
+/// Simple shell tokenizer — extracts tokens in "command position".
+/// Command position: first word of line, after |, &&, ||, ;, or inside $().
+/// Also handles VAR=$(cmd ...) and trap 'cmd ...' patterns.
+fn shell_tokens(line: &str) -> Vec<&str> {
+    let mut tokens = Vec::new();
+    let mut expect_cmd = true; // first word is a command
+
+    for word in line.split_whitespace() {
+        // Handle VAR=$(cmd — split on $( inside the word
+        let subshell_word = if let Some(pos) = word.find("$(") {
+            let after = &word[pos + 2..];
+            if !after.is_empty() {
+                Some(after)
+            } else {
+                None // trailing $( — next word is the command
+            }
+        } else {
+            None
+        };
+
+        // If we extracted a command from inside $(), process it
+        if let Some(sw) = subshell_word {
+            let clean = sw
+                .trim_start_matches('\'')
+                .trim_start_matches('"')
+                .trim_end_matches(|c: char| !c.is_alphanumeric() && c != '_' && c != '-');
+            if !clean.is_empty() && !clean.starts_with('-') {
+                tokens.push(clean);
+            }
+        }
+
+        // Detect if this word itself starts a subshell/substitution
+        let starts_subshell = word.starts_with("$(")
+            || word.starts_with('`')
+            || word.starts_with('(');
+
+        let is_cmd = expect_cmd || starts_subshell;
+
+        // Strip leading shell syntax to get to the actual command
+        let w = word
+            .trim_start_matches("$(")
+            .trim_start_matches('`')
+            .trim_start_matches('(')
+            .trim_start_matches('\'')
+            .trim_start_matches('"');
+
+        if is_cmd && !w.is_empty() && !w.starts_with('-') && !w.contains('=') {
+            let clean = w.trim_end_matches(|c: char| !c.is_alphanumeric() && c != '_' && c != '-');
+            if !clean.is_empty() && !tokens.contains(&clean) {
+                tokens.push(clean);
+            }
+            expect_cmd = false;
+        }
+
+        // trap 'cmd ...' — the first word inside the quotes is a command
+        if expect_cmd && w == "trap" {
+            // Next whitespace-separated token will be the quoted command
+            expect_cmd = false; // trap itself consumed
+            // We'll catch the command via the quote-stripping on the next token
+            // when it's not in command position, but we need a special case
+        }
+
+        // These signal the next word is a command
+        if word.ends_with('|') || word == "&&" || word == "||" || word.ends_with(';')
+            || word == "|" || word.ends_with("$(") || word.ends_with('`')
+        {
+            expect_cmd = true;
+        }
+    }
+    tokens
+}
+
+/// Format requires list as YAML inline array for frontmatter.
+fn format_requires_yaml(reqs: &[String]) -> String {
+    let items: Vec<String> = reqs.iter().map(|r| format!("\"{}\"", r)).collect();
+    format!("requires: [{}]", items.join(", "))
+}
+
+/// Insert a requires: field into frontmatter, before the closing ---.
+fn insert_requires_field(content: &str, requires_line: &str) -> String {
+    let mut lines: Vec<&str> = content.lines().collect();
+    // Find the closing --- of frontmatter
+    let mut close_idx = None;
+    let mut in_fm = false;
+    for (i, line) in lines.iter().enumerate() {
+        if i == 0 && *line == "---" {
+            in_fm = true;
+            continue;
+        }
+        if in_fm && *line == "---" {
+            close_idx = Some(i);
+            break;
+        }
+    }
+
+    if let Some(idx) = close_idx {
+        lines.insert(idx, requires_line);
+    }
+
+    let mut result = lines.join("\n");
+    if content.ends_with('\n') {
+        result.push('\n');
+    }
+    result
+}
+
+/// Parse requires: field from frontmatter as a list of strings.
+/// Handles both inline array [a, b] and YAML list (- a) formats.
+fn extract_requires_list(fm: &str) -> Option<Vec<String>> {
+    let prefix = "requires:";
+    for (i, line) in fm.lines().enumerate() {
+        if !line.starts_with(prefix) {
+            continue;
+        }
+        let rest = line[prefix.len()..].trim();
+
+        // Inline array: requires: ["Bash(gh:*)", "Read"]
+        if rest.starts_with('[') && rest.ends_with(']') {
+            let inner = &rest[1..rest.len() - 1];
+            let items: Vec<String> = inner
+                .split(',')
+                .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+            return Some(items);
+        }
+
+        // YAML list: requires:\n  - Bash(gh:*)
+        if rest.is_empty() {
+            let mut items = Vec::new();
+            for subsequent in fm.lines().skip(i + 1) {
+                let trimmed = subsequent.trim();
+                if let Some(val) = trimmed.strip_prefix("- ") {
+                    items.push(val.trim_matches('"').trim_matches('\'').to_string());
+                } else {
+                    break;
+                }
+            }
+            return Some(items);
+        }
+
+        return None;
+    }
+    None
+}
+
+/// Validate that a permission string is well-formed.
+fn is_valid_permission(perm: &str) -> bool {
+    // Wildcard
+    if perm == "*" {
+        return true;
+    }
+    // Simple tool name: Read, Write, Edit, Bash
+    if matches!(perm, "Read" | "Write" | "Edit" | "Bash") {
+        return true;
+    }
+    // Tool(scope): Read(/path/**), Bash(git:*), Bash(*)
+    if let Some(paren_start) = perm.find('(') {
+        if !perm.ends_with(')') {
+            return false;
+        }
+        let tool = &perm[..paren_start];
+        if !matches!(tool, "Read" | "Write" | "Edit" | "Bash") {
+            return false;
+        }
+        let scope = &perm[paren_start + 1..perm.len() - 1];
+        !scope.is_empty()
+    } else {
+        false
+    }
 }
 
 use crate::util::{detect_project_dir, home_dir};

--- a/tools/ways-cli/src/cmd/lint.rs
+++ b/tools/ways-cli/src/cmd/lint.rs
@@ -690,12 +690,41 @@ fn scan_macro_requires(path: &Path) -> Vec<String> {
     };
 
     let mut found: Vec<&str> = Vec::new();
+    let mut heredoc_delim: Option<String> = None;
+
     for line in content.lines() {
         let trimmed = line.trim();
+
+        // Skip here-doc bodies — content between <<DELIM and DELIM
+        if let Some(ref delim) = heredoc_delim {
+            if trimmed == delim.as_str() {
+                heredoc_delim = None;
+            }
+            continue;
+        }
+        // Detect here-doc start: cat <<EOF, cat <<'EOF', cat <<"EOF"
+        if let Some(pos) = trimmed.find("<<") {
+            let after = trimmed[pos + 2..].trim_start_matches(&['-', '~'][..]);
+            let delim = after
+                .trim_start_matches('\'').trim_start_matches('"')
+                .split(|c: char| c.is_whitespace() || c == '\'' || c == '"')
+                .next()
+                .unwrap_or("");
+            if !delim.is_empty() {
+                heredoc_delim = Some(delim.to_string());
+            }
+        }
+
         // Skip comments and empty lines
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
         }
+
+        // Extract commands from trap 'cmd args' — the quoted command string
+        if trimmed.starts_with("trap ") {
+            scan_trap_command(trimmed, EXTERNAL_COMMANDS, &mut found);
+        }
+
         // Look for external commands: word boundaries in the line
         for cmd in EXTERNAL_COMMANDS {
             if line_uses_command(trimmed, cmd) && !found.contains(cmd) {
@@ -788,14 +817,6 @@ fn shell_tokens(line: &str) -> Vec<&str> {
             expect_cmd = false;
         }
 
-        // trap 'cmd ...' — the first word inside the quotes is a command
-        if expect_cmd && w == "trap" {
-            // Next whitespace-separated token will be the quoted command
-            expect_cmd = false; // trap itself consumed
-            // We'll catch the command via the quote-stripping on the next token
-            // when it's not in command position, but we need a special case
-        }
-
         // These signal the next word is a command
         if word.ends_with('|') || word == "&&" || word == "||" || word.ends_with(';')
             || word == "|" || word.ends_with("$(") || word.ends_with('`')
@@ -804,6 +825,32 @@ fn shell_tokens(line: &str) -> Vec<&str> {
         }
     }
     tokens
+}
+
+/// Extract commands from trap 'cmd args' SIGNAL patterns.
+/// The command string is inside single or double quotes as the second argument.
+fn scan_trap_command<'a>(line: &'a str, external_commands: &[&'a str], found: &mut Vec<&'a str>) {
+    // Find the quoted command string: trap 'rm -rf ...' EXIT
+    let after_trap = line.strip_prefix("trap ").unwrap_or("").trim();
+    let (quote_char, start) = if after_trap.starts_with('\'') {
+        ('\'', 1)
+    } else if after_trap.starts_with('"') {
+        ('"', 1)
+    } else {
+        return; // no quoted command
+    };
+
+    if let Some(end) = after_trap[start..].find(quote_char) {
+        let cmd_str = &after_trap[start..start + end];
+        // Extract the first word as the command
+        if let Some(first_word) = cmd_str.split_whitespace().next() {
+            for cmd in external_commands {
+                if first_word == *cmd && !found.contains(cmd) {
+                    found.push(cmd);
+                }
+            }
+        }
+    }
 }
 
 /// Format requires list as YAML inline array for frontmatter.
@@ -842,67 +889,26 @@ fn insert_requires_field(content: &str, requires_line: &str) -> String {
 
 /// Parse requires: field from frontmatter as a list of strings.
 /// Handles both inline array [a, b] and YAML list (- a) formats.
+/// Delegate to shared implementation in permissions module.
 fn extract_requires_list(fm: &str) -> Option<Vec<String>> {
-    let prefix = "requires:";
-    for (i, line) in fm.lines().enumerate() {
-        if !line.starts_with(prefix) {
-            continue;
-        }
-        let rest = line[prefix.len()..].trim();
-
-        // Inline array: requires: ["Bash(gh:*)", "Read"]
-        if rest.starts_with('[') && rest.ends_with(']') {
-            let inner = &rest[1..rest.len() - 1];
-            let items: Vec<String> = inner
-                .split(',')
-                .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
-            return Some(items);
-        }
-
-        // YAML list: requires:\n  - Bash(gh:*)
-        if rest.is_empty() {
-            let mut items = Vec::new();
-            for subsequent in fm.lines().skip(i + 1) {
-                let trimmed = subsequent.trim();
-                if let Some(val) = trimmed.strip_prefix("- ") {
-                    items.push(val.trim_matches('"').trim_matches('\'').to_string());
-                } else {
-                    break;
-                }
-            }
-            return Some(items);
-        }
-
-        return None;
-    }
-    None
+    super::permissions::extract_requires(fm)
 }
 
 /// Validate that a permission string is well-formed.
+///
+/// Intentionally stricter than `Permission::parse` — restricts tool names to
+/// the four Claude Code tools (Read, Write, Edit, Bash) rather than accepting
+/// any uppercase identifier. This catches typos like "Rad(foo)" that parse()
+/// would accept as structurally valid but aren't real Claude Code permissions.
 fn is_valid_permission(perm: &str) -> bool {
-    // Wildcard
-    if perm == "*" {
-        return true;
-    }
-    // Simple tool name: Read, Write, Edit, Bash
-    if matches!(perm, "Read" | "Write" | "Edit" | "Bash") {
-        return true;
-    }
-    // Tool(scope): Read(/path/**), Bash(git:*), Bash(*)
-    if let Some(paren_start) = perm.find('(') {
-        if !perm.ends_with(')') {
-            return false;
+    use agent_fmt::permissions::Permission;
+
+    match Permission::parse(perm) {
+        None => false,
+        Some(Permission::Wildcard) => true,
+        Some(Permission::Tool(ref t)) | Some(Permission::Scoped(ref t, _)) => {
+            matches!(t.as_str(), "Read" | "Write" | "Edit" | "Bash")
         }
-        let tool = &perm[..paren_start];
-        if !matches!(tool, "Read" | "Write" | "Edit" | "Bash") {
-            return false;
-        }
-        let scope = &perm[paren_start + 1..perm.len() - 1];
-        !scope.is_empty()
-    } else {
-        false
     }
 }
 

--- a/tools/ways-cli/src/cmd/mod.rs
+++ b/tools/ways-cli/src/cmd/mod.rs
@@ -9,6 +9,7 @@ pub mod language;
 pub mod lint;
 pub mod list;
 pub mod match_bm25;
+pub mod permissions;
 pub mod provenance;
 pub mod render;
 pub mod reset;

--- a/tools/ways-cli/src/cmd/permissions.rs
+++ b/tools/ways-cli/src/cmd/permissions.rs
@@ -1,0 +1,212 @@
+//! Permission audit — diff requires: fields against settings.json grants (ADR-116).
+
+use agent_fmt::permissions::{self, AuditResult};
+use agent_fmt::{Align, Table};
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+use crate::util::home_dir;
+
+/// Run `ways permissions audit`.
+pub fn audit(global: bool) -> Result<()> {
+    let ways_dir = home_dir().join(".claude/hooks/ways");
+    let settings_path = home_dir().join(".claude/settings.json");
+
+    // Determine scan dirs (same logic as lint)
+    let mut scan_dirs = vec![ways_dir.clone()];
+    if !global {
+        let project_dir = std::env::var("CLAUDE_PROJECT_DIR")
+            .ok()
+            .or_else(crate::util::detect_project_dir);
+        if let Some(ref pd) = project_dir {
+            let project_ways = PathBuf::from(pd).join(".claude/ways");
+            if project_ways.is_dir() {
+                scan_dirs.push(project_ways);
+            }
+        }
+    }
+
+    // Collect (way_id, requires) pairs
+    let mut requirements: Vec<(String, Vec<String>)> = Vec::new();
+    for scan_dir in &scan_dirs {
+        collect_way_requirements(scan_dir, &ways_dir, &mut requirements)?;
+    }
+
+    // Load settings.json grants
+    let grants = permissions::load_settings_permissions(&settings_path);
+
+    if grants.is_empty() {
+        eprintln!("Warning: no permissions found in {}", settings_path.display());
+    }
+
+    // Run audit
+    let results = permissions::audit(&requirements, &grants);
+
+    // Check for trusted-project-macros deprecation
+    let tpm_path = home_dir().join(".claude/trusted-project-macros");
+    let has_tpm = tpm_path.is_file();
+
+    // Display results
+    display_audit(&results, has_tpm);
+
+    Ok(())
+}
+
+/// Scan way files and collect (way_id, requires_list) pairs.
+fn collect_way_requirements(
+    dir: &Path,
+    ways_dir: &Path,
+    out: &mut Vec<(String, Vec<String>)>,
+) -> Result<()> {
+    for entry in WalkDir::new(dir)
+        .follow_links(true)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+        // Skip check files
+        if path.file_name().and_then(|n| n.to_str()).is_some_and(|n| n.contains(".check.")) {
+            continue;
+        }
+
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let fm = match extract_frontmatter(&content) {
+            Some(f) => f,
+            None => continue,
+        };
+
+        if let Some(reqs) = extract_requires(&fm) {
+            if !reqs.is_empty() {
+                let way_id = path
+                    .strip_prefix(ways_dir)
+                    .unwrap_or(path)
+                    .with_extension("")
+                    .display()
+                    .to_string();
+                out.push((way_id, reqs));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Extract YAML frontmatter from a way file.
+fn extract_frontmatter(content: &str) -> Option<String> {
+    let mut lines = content.lines();
+    if lines.next()? != "---" {
+        return None;
+    }
+    let mut fm_lines = Vec::new();
+    for line in lines {
+        if line == "---" {
+            return Some(fm_lines.join("\n"));
+        }
+        fm_lines.push(line);
+    }
+    None
+}
+
+/// Parse requires: field from frontmatter.
+fn extract_requires(fm: &str) -> Option<Vec<String>> {
+    let prefix = "requires:";
+    for (i, line) in fm.lines().enumerate() {
+        if !line.starts_with(prefix) {
+            continue;
+        }
+        let rest = line[prefix.len()..].trim();
+
+        // Inline array: requires: ["Bash(gh:*)", "Read"]
+        if rest.starts_with('[') && rest.ends_with(']') {
+            let inner = &rest[1..rest.len() - 1];
+            let items: Vec<String> = inner
+                .split(',')
+                .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+            return Some(items);
+        }
+
+        // YAML list
+        if rest.is_empty() {
+            let mut items = Vec::new();
+            for subsequent in fm.lines().skip(i + 1) {
+                let trimmed = subsequent.trim();
+                if let Some(val) = trimmed.strip_prefix("- ") {
+                    items.push(val.trim_matches('"').trim_matches('\'').to_string());
+                } else {
+                    break;
+                }
+            }
+            return Some(items);
+        }
+
+        return None;
+    }
+    None
+}
+
+/// Display audit results as an agent-fmt Table.
+fn display_audit(results: &[AuditResult], has_tpm: bool) {
+    println!();
+    println!("  \x1b[1mPermissions Audit\x1b[0m (ADR-116)");
+    println!();
+
+    if results.is_empty() {
+        println!("  No ways declare requires: fields.");
+        println!("  Run `ways lint --fix --global` to auto-populate from macro.sh files.");
+        println!();
+        return;
+    }
+
+    let mut table = Table::new(&["Way", "Requires", "Status"]);
+    table.align(0, Align::Left);
+    table.align(1, Align::Left);
+    table.align(2, Align::Left);
+
+    let mut missing_count = 0u32;
+    let mut missing_perms: Vec<String> = Vec::new();
+
+    for r in results {
+        let status = if r.granted {
+            "\x1b[32mgranted\x1b[0m".to_string()
+        } else {
+            missing_count += 1;
+            if !missing_perms.contains(&r.requirement) {
+                missing_perms.push(r.requirement.clone());
+            }
+            "\x1b[31mMISSING\x1b[0m".to_string()
+        };
+        table.add(vec![&r.source, &r.requirement, &status]);
+    }
+
+    table.print();
+    println!();
+
+    if missing_count > 0 {
+        println!(
+            "  \x1b[33m{missing_count} missing permission(s).\x1b[0m Add to settings.json:"
+        );
+        for p in &missing_perms {
+            println!("    \"{p}\"");
+        }
+    } else {
+        println!("  \x1b[32mAll permissions granted.\x1b[0m");
+    }
+
+    if has_tpm {
+        println!();
+        println!("  \x1b[33mDeprecation:\x1b[0m ~/.claude/trusted-project-macros found.");
+        println!("  This file is deprecated — use requires: fields in way frontmatter instead.");
+        println!("  See ADR-116 for migration guidance.");
+    }
+
+    println!();
+}

--- a/tools/ways-cli/src/cmd/permissions.rs
+++ b/tools/ways-cli/src/cmd/permissions.rs
@@ -1,7 +1,6 @@
 //! Permission audit — diff requires: fields against settings.json grants (ADR-116).
 
-use agent_fmt::permissions::{self, AuditResult};
-use agent_fmt::{Align, Table};
+use agent_fmt::permissions;
 use anyhow::Result;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
@@ -48,7 +47,7 @@ pub fn audit(global: bool) -> Result<()> {
     let has_tpm = tpm_path.is_file();
 
     // Display results
-    display_audit(&results, has_tpm);
+    permissions::display_audit("Permissions Audit", "Way", &results, has_tpm);
 
     Ok(())
 }
@@ -115,7 +114,8 @@ fn extract_frontmatter(content: &str) -> Option<String> {
 }
 
 /// Parse requires: field from frontmatter.
-fn extract_requires(fm: &str) -> Option<Vec<String>> {
+/// Also used by lint.rs for validation and --fix.
+pub fn extract_requires(fm: &str) -> Option<Vec<String>> {
     let prefix = "requires:";
     for (i, line) in fm.lines().enumerate() {
         if !line.starts_with(prefix) {
@@ -153,60 +153,3 @@ fn extract_requires(fm: &str) -> Option<Vec<String>> {
     None
 }
 
-/// Display audit results as an agent-fmt Table.
-fn display_audit(results: &[AuditResult], has_tpm: bool) {
-    println!();
-    println!("  \x1b[1mPermissions Audit\x1b[0m (ADR-116)");
-    println!();
-
-    if results.is_empty() {
-        println!("  No ways declare requires: fields.");
-        println!("  Run `ways lint --fix --global` to auto-populate from macro.sh files.");
-        println!();
-        return;
-    }
-
-    let mut table = Table::new(&["Way", "Requires", "Status"]);
-    table.align(0, Align::Left);
-    table.align(1, Align::Left);
-    table.align(2, Align::Left);
-
-    let mut missing_count = 0u32;
-    let mut missing_perms: Vec<String> = Vec::new();
-
-    for r in results {
-        let status = if r.granted {
-            "\x1b[32mgranted\x1b[0m".to_string()
-        } else {
-            missing_count += 1;
-            if !missing_perms.contains(&r.requirement) {
-                missing_perms.push(r.requirement.clone());
-            }
-            "\x1b[31mMISSING\x1b[0m".to_string()
-        };
-        table.add(vec![&r.source, &r.requirement, &status]);
-    }
-
-    table.print();
-    println!();
-
-    if missing_count > 0 {
-        println!(
-            "  \x1b[33m{missing_count} missing permission(s).\x1b[0m Add to settings.json:"
-        );
-        for p in &missing_perms {
-            println!("    \"{p}\"");
-        }
-    } else {
-        println!("  \x1b[32mAll permissions granted.\x1b[0m");
-    }
-
-    if has_tpm {
-        println!();
-        println!("  \x1b[33mDeprecation:\x1b[0m ~/.claude/trusted-project-macros found.");
-        println!("  This file is deprecated — use requires: fields in way frontmatter instead.");
-        println!("  See ADR-116 for migration guidance.");
-    }
-
-    println!();
-}

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -263,6 +263,14 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Permission audit — diff requires: fields against settings.json grants (ADR-116)
+    Permissions {
+        #[command(subcommand)]
+        action: PermissionsCommand,
+        /// Scan global ways (ignore project-local)
+        #[arg(long, global = true)]
+        global: bool,
+    },
     /// Governance provenance queries — report, trace, control, policy, gaps, stale, active, matrix, lint
     Governance {
         #[command(subcommand)]
@@ -397,6 +405,12 @@ enum ConfigCommand {
     Show,
     /// Show config file paths
     Path,
+}
+
+#[derive(Subcommand)]
+enum PermissionsCommand {
+    /// Audit requires: fields against settings.json grants
+    Audit,
 }
 
 #[derive(Subcommand)]
@@ -546,6 +560,11 @@ fn main() -> Result<()> {
         }
         Commands::Reset { session, all, confirm } => {
             cmd::reset::run(session.as_deref(), all, confirm)
+        }
+        Commands::Permissions { action, global } => {
+            match action {
+                PermissionsCommand::Audit => cmd::permissions::audit(global),
+            }
         }
         Commands::Governance { mode, json, global } => {
             let gov_mode = match mode {


### PR DESCRIPTION
## Summary

- Add `requires:` field to way frontmatter and attend sensor config declaring tool permissions needed
- Shared containment-aware permission matching engine in `agent-fmt::permissions` (11 unit tests)
- `ways permissions audit` and `attend permissions audit` commands diff declared requirements against `settings.json` grants
- `ways lint` warns on `macro:` without `requires:`; `--fix` auto-populates by scanning macro.sh for external commands
- All 15 macro-bearing ways populated with `requires:` fields via lint --fix
- Built-in attend sensor defaults: context→Read, git→Bash(git:\*), peers→Read, processes→Bash(ps:\*)
- Deprecation notice for `trusted-project-macros` in audit output
- ADR-116 promoted from Draft to Accepted

First real audit found `Bash(jq:*)` missing from settings.json (4 ways need it).

## Test plan

- [ ] `make lint` passes (clippy -D warnings, zero tolerance)
- [ ] `cargo test -p ways` passes (10 scenarios)
- [ ] `cargo test -p agent-fmt` passes (11 permission matching tests)
- [ ] `ways lint --global` shows 0 errors, 1 warning (migration.md — no adjacent macro.sh)
- [ ] `ways permissions audit --global` outputs table with granted/MISSING status
- [ ] `attend permissions audit` outputs table with 4 built-in sensor permissions
- [ ] Revert a way's requires field, run `ways lint --fix --global`, verify it's re-populated correctly