### PR TITLE
feat: ADR-118 focus groups — dynamic agent grouping

### DIFF
--- a/hooks/ways/softwaredev/environment/attend/attend.md
+++ b/hooks/ways/softwaredev/environment/attend/attend.md
@@ -1,6 +1,6 @@
 ---
 description: attend binary — active awareness sensor loop, peer session discovery, inter-session signaling for Claude Code
-vocabulary: attend attend-run attend-send attend-focus attend-peers attend-status sensor-loop awareness-layer focus-group signal-file disclosure-governor peer-session peer-discovery session-awareness environmental-sensing inter-session claude-session another-claude
+vocabulary: attend attend-run attend-send attend-focus attend-peers attend-status attend-scene sensor-loop awareness-layer focus-group signal-file disclosure-governor peer-session peer-discovery session-awareness environmental-sensing inter-session claude-session another-claude scene-private scene-open
 embed_threshold: 0.28
 threshold: 2.0
 pattern: attend|awareness.?layer|peer.?session|peer.?discover|signal.?file|focus.?group|sensor.?loop
@@ -28,24 +28,33 @@ Use `/attend` or launch manually via Monitor with `attend run`.
 ## Peer Messaging
 
 ```bash
-attend send your message here              # send to focus scope
-attend send --broadcast important news     # send to all sessions
-attend send --to /path/to/project message  # directed to one project
+attend send "your message here"            # send to project + focus groups
+attend send --focus deploy "message"       # send to a focus group
+attend send --broadcast "important news"   # send to all sessions
 ```
-
-Send scope mirrors receive scope — if you have a focus group, messages go to all group members.
 
 ## Focus Groups
 
+Named groups for shared signal routing. Dynamic — join and leave as needed.
+
 ```bash
-attend focus add ~/Projects/foo            # join a focus group
-attend focus list                          # show current group
+attend focus on deploy                     # focus on a named group
+attend focus on infra --pin                # focus + persist when empty
+attend focus off deploy                    # release focus
+attend focus list                          # show your groups
 attend focus clear                         # project-only mode
+```
+
+## Scenes
+
+```bash
+attend scene private                       # leave all groups
+attend scene open                          # join shared "open" group
 ```
 
 ## Discovery
 
 ```bash
-attend peers                               # list active Claude sessions
+attend peers                               # sessions with focus groups
 attend status                              # instances, signals, focus state
 ```

--- a/skills/attend/SKILL.md
+++ b/skills/attend/SKILL.md
@@ -43,31 +43,44 @@ All commands below are one-shot — run with Bash, not Monitor.
 
 ### Peer messaging
 
-Send defaults to your current scope (own project + focus group). Always wrap the message in double quotes to prevent shell metacharacter expansion (`?`, `*`, `!`).
+Send defaults to your current scope (own project + focus groups). Always wrap the message in double quotes to prevent shell metacharacter expansion (`?`, `*`, `!`).
 
 ```bash
 attend send "your message here"
+attend send --focus deploy "message to a focus group"
 attend send --broadcast "important announcement for all sessions"
 attend send --to /home/user/other-project "directed message"
 ```
 
 ### Focus groups
 
-A focus group is a set of peer project directories you listen to and send to. Send scope mirrors receive scope.
+Named groups that agents focus on for shared signal routing. Groups are dynamic — join and leave as needed.
 
 ```bash
-attend focus list                    # show current focus group
-attend focus add ~/Projects/foo      # add a peer project
-attend focus add ~/temp ~/bar        # add multiple at once
-attend focus remove ~/temp           # remove a peer
-attend focus clear                   # back to project-only mode
+attend focus list                    # show groups you're focused on
+attend focus on deploy               # focus on the "deploy" group
+attend focus on infra --pin          # focus + pin (persists when empty)
+attend focus off deploy              # release focus on a group
+attend focus clear                   # release all groups (project only)
+attend focus all                     # list all active groups with members
+attend focus dissolve deploy         # remove a group entirely
+```
+
+### Scenes
+
+Named presets that reconfigure focus group membership.
+
+```bash
+attend scene private                 # leave all groups (project only)
+attend scene open                    # join the shared "open" group
+attend scenes                        # list available scenes
 ```
 
 ### Discovery and status
 
 ```bash
-attend peers                         # list active Claude Code sessions
-attend status                        # running instances, pending signals, focus state
+attend peers                         # list active sessions with focus groups
+attend status                        # instances, signals, and focus state
 ```
 
 ### Stopping

--- a/tools/attend/src/groups.rs
+++ b/tools/attend/src/groups.rs
@@ -67,14 +67,21 @@ impl Groups {
         Ok(())
     }
 
-    /// Leave a named room.
+    /// Leave a named group.
     pub fn leave(&self, name: &str) -> Result<(), String> {
         let mut state = self.load_state();
         if let Some(entry) = state.get_mut(name) {
             entry.members.retain(|m| m != &self.session_id);
         }
+        // Clean up empty unpinned groups in one write
+        if state.get(name).is_some_and(|e| e.members.is_empty() && !e.pinned) {
+            let dir = self.group_dir(name);
+            if dir.is_dir() {
+                fs::remove_dir_all(&dir).ok();
+            }
+            state.remove(name);
+        }
         self.save_state(&state);
-        self.cleanup_if_empty(name, &state);
         Ok(())
     }
 
@@ -87,14 +94,21 @@ impl Groups {
         }
     }
 
-    /// Unpin a room.
+    /// Unpin a group.
     pub fn unpin(&self, name: &str) {
         let mut state = self.load_state();
         if let Some(entry) = state.get_mut(name) {
             entry.pinned = false;
-            self.save_state(&state);
         }
-        self.cleanup_if_empty(name, &state);
+        // Clean up if now empty and unpinned — one write
+        if state.get(name).is_some_and(|e| e.members.is_empty() && !e.pinned) {
+            let dir = self.group_dir(name);
+            if dir.is_dir() {
+                fs::remove_dir_all(&dir).ok();
+            }
+            state.remove(name);
+        }
+        self.save_state(&state);
     }
 
     /// Dissolve a room — remove it and notify members.
@@ -219,20 +233,6 @@ impl Groups {
         fs::write(&path, content).ok();
     }
 
-    fn cleanup_if_empty(&self, name: &str, state: &HashMap<String, GroupEntry>) {
-        if let Some(entry) = state.get(name) {
-            if entry.members.is_empty() && !entry.pinned {
-                let dir = self.group_dir(name);
-                if dir.is_dir() {
-                    fs::remove_dir_all(&dir).ok();
-                }
-                // Remove from state
-                let mut state = state.clone();
-                state.remove(name);
-                self.save_state(&state);
-            }
-        }
-    }
 }
 
 // ── Helpers ────────────────────────────────────────────────────

--- a/tools/attend/src/groups.rs
+++ b/tools/attend/src/groups.rs
@@ -1,34 +1,34 @@
-//! Room management for attend (ADR-118).
+//! Named group management for attend (ADR-118).
 //!
-//! Rooms are named signal namespaces that agents join and leave dynamically.
-//! Storage: `@room-name/` directories under the signals base, with membership
-//! tracked in `_rooms.yaml`.
+//! Groups are named signal namespaces that agents focus on and release.
+//! Storage: `@group-name/` directories under the signals base, with membership
+//! tracked in `_groups.yaml`.
 //!
-//! Every agent is always in its implicit project room (from cwd).
-//! Named rooms are explicit and opt-in via `attend room join <name>`.
+//! Every agent is always in its implicit project group (from cwd).
+//! Named groups are explicit and opt-in via `attend focus on <name>`.
 
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-/// Room membership entry.
+/// Group membership entry.
 #[derive(Debug, Clone)]
-pub struct RoomEntry {
+pub struct GroupEntry {
     /// Whether this room persists when empty.
     pub pinned: bool,
     /// Session IDs currently in this room.
     pub members: Vec<String>,
 }
 
-/// Room state manager.
-pub struct Rooms {
+/// Group state manager.
+pub struct Groups {
     base: PathBuf,
     session_id: String,
 }
 
 const ROOM_PREFIX: &str = "@";
 
-impl Rooms {
+impl Groups {
     pub fn new(signals_base: &Path, session_id: &str) -> Self {
         Self {
             base: signals_base.to_path_buf(),
@@ -37,23 +37,23 @@ impl Rooms {
     }
 
     /// Path to a named room's signal directory.
-    pub fn room_dir(&self, name: &str) -> PathBuf {
+    pub fn group_dir(&self, name: &str) -> PathBuf {
         self.base.join(format!("{ROOM_PREFIX}{name}"))
     }
 
     /// Path to the rooms state file.
     fn state_path(&self) -> PathBuf {
-        self.base.join("_rooms.yaml")
+        self.base.join("_groups.yaml")
     }
 
     /// Join a named room. Creates the room if it doesn't exist.
     pub fn join(&self, name: &str, pin: bool) -> Result<(), String> {
-        validate_room_name(name)?;
-        let dir = self.room_dir(name);
+        validate_group_name(name)?;
+        let dir = self.group_dir(name);
         fs::create_dir_all(&dir).map_err(|e| format!("creating room dir: {e}"))?;
 
         let mut state = self.load_state();
-        let entry = state.entry(name.to_string()).or_insert(RoomEntry {
+        let entry = state.entry(name.to_string()).or_insert(GroupEntry {
             pinned: false,
             members: Vec::new(),
         });
@@ -107,7 +107,7 @@ impl Rooms {
         self.save_state(&state);
 
         // Remove the signal directory
-        let dir = self.room_dir(name);
+        let dir = self.group_dir(name);
         if dir.is_dir() {
             fs::remove_dir_all(&dir).ok();
         }
@@ -115,7 +115,7 @@ impl Rooms {
     }
 
     /// List rooms this session has joined.
-    pub fn my_rooms(&self) -> Vec<(String, bool)> {
+    pub fn my_groups(&self) -> Vec<(String, bool)> {
         let state = self.load_state();
         state
             .iter()
@@ -125,7 +125,7 @@ impl Rooms {
     }
 
     /// List all active rooms with member counts and pin state.
-    pub fn all_rooms(&self) -> Vec<(String, usize, bool)> {
+    pub fn all_groups(&self) -> Vec<(String, usize, bool)> {
         let state = self.load_state();
         let mut rooms: Vec<(String, usize, bool)> = state
             .iter()
@@ -136,8 +136,8 @@ impl Rooms {
     }
 
     /// Get room names this session is in (for signal routing).
-    pub fn joined_room_names(&self) -> Vec<String> {
-        self.my_rooms().into_iter().map(|(name, _)| name).collect()
+    pub fn joined_group_names(&self) -> Vec<String> {
+        self.my_groups().into_iter().map(|(name, _)| name).collect()
     }
 
     /// Get signal directories for all rooms this session should receive from.
@@ -150,8 +150,8 @@ impl Rooms {
         dirs.push(self.base.join(encode_project(project_dir)));
 
         // Named rooms
-        for name in self.joined_room_names() {
-            dirs.push(self.room_dir(&name));
+        for name in self.joined_group_names() {
+            dirs.push(self.group_dir(&name));
         }
 
         // Broadcast (always)
@@ -185,7 +185,7 @@ impl Rooms {
             .collect();
 
         for name in &to_remove {
-            let dir = self.room_dir(name);
+            let dir = self.group_dir(name);
             if dir.is_dir() {
                 fs::remove_dir_all(&dir).ok();
             }
@@ -201,28 +201,28 @@ impl Rooms {
 
     // ── State persistence ──────────────────────────────────────
 
-    fn load_state(&self) -> HashMap<String, RoomEntry> {
+    fn load_state(&self) -> HashMap<String, GroupEntry> {
         let path = self.state_path();
         let content = match fs::read_to_string(&path) {
             Ok(c) => c,
             Err(_) => return HashMap::new(),
         };
-        parse_rooms_yaml(&content)
+        parse_groups_yaml(&content)
     }
 
-    fn save_state(&self, state: &HashMap<String, RoomEntry>) {
+    fn save_state(&self, state: &HashMap<String, GroupEntry>) {
         let path = self.state_path();
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).ok();
         }
-        let content = serialize_rooms_yaml(state);
+        let content = serialize_groups_yaml(state);
         fs::write(&path, content).ok();
     }
 
-    fn cleanup_if_empty(&self, name: &str, state: &HashMap<String, RoomEntry>) {
+    fn cleanup_if_empty(&self, name: &str, state: &HashMap<String, GroupEntry>) {
         if let Some(entry) = state.get(name) {
             if entry.members.is_empty() && !entry.pinned {
-                let dir = self.room_dir(name);
+                let dir = self.group_dir(name);
                 if dir.is_dir() {
                     fs::remove_dir_all(&dir).ok();
                 }
@@ -237,7 +237,7 @@ impl Rooms {
 
 // ── Helpers ────────────────────────────────────────────────────
 
-fn validate_room_name(name: &str) -> Result<(), String> {
+fn validate_group_name(name: &str) -> Result<(), String> {
     if name.is_empty() {
         return Err("room name cannot be empty".to_string());
     }
@@ -276,7 +276,7 @@ fn encode_project(path: &str) -> String {
 // ── Minimal YAML parser/serializer ─────────────────────────────
 // Keeps attend dependency-free on serde.
 
-fn parse_rooms_yaml(content: &str) -> HashMap<String, RoomEntry> {
+fn parse_groups_yaml(content: &str) -> HashMap<String, GroupEntry> {
     let mut rooms = HashMap::new();
     let mut current_room: Option<String> = None;
     let mut current_pinned = false;
@@ -296,7 +296,7 @@ fn parse_rooms_yaml(content: &str) -> HashMap<String, RoomEntry> {
             if let Some(ref name) = current_room {
                 rooms.insert(
                     name.clone(),
-                    RoomEntry {
+                    GroupEntry {
                         pinned: current_pinned,
                         members: current_members.clone(),
                     },
@@ -333,7 +333,7 @@ fn parse_rooms_yaml(content: &str) -> HashMap<String, RoomEntry> {
     if let Some(ref name) = current_room {
         rooms.insert(
             name.clone(),
-            RoomEntry {
+            GroupEntry {
                 pinned: current_pinned,
                 members: current_members,
             },
@@ -343,7 +343,7 @@ fn parse_rooms_yaml(content: &str) -> HashMap<String, RoomEntry> {
     rooms
 }
 
-fn serialize_rooms_yaml(state: &HashMap<String, RoomEntry>) -> String {
+fn serialize_groups_yaml(state: &HashMap<String, GroupEntry>) -> String {
     let mut out = String::new();
     let mut names: Vec<&String> = state.keys().collect();
     names.sort();
@@ -365,15 +365,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_validate_room_name() {
-        assert!(validate_room_name("deploy").is_ok());
-        assert!(validate_room_name("my-room").is_ok());
-        assert!(validate_room_name("").is_err());
-        assert!(validate_room_name("_internal").is_err());
-        assert!(validate_room_name("@bad").is_err());
-        assert!(validate_room_name("has/slash").is_err());
-        assert!(validate_room_name("has space").is_err());
-        assert!(validate_room_name("broadcast").is_err());
+    fn test_validate_group_name() {
+        assert!(validate_group_name("deploy").is_ok());
+        assert!(validate_group_name("my-room").is_ok());
+        assert!(validate_group_name("").is_err());
+        assert!(validate_group_name("_internal").is_err());
+        assert!(validate_group_name("@bad").is_err());
+        assert!(validate_group_name("has/slash").is_err());
+        assert!(validate_group_name("has space").is_err());
+        assert!(validate_group_name("broadcast").is_err());
     }
 
     #[test]
@@ -381,21 +381,21 @@ mod tests {
         let mut state = HashMap::new();
         state.insert(
             "deploy".to_string(),
-            RoomEntry {
+            GroupEntry {
                 pinned: true,
                 members: vec!["session-abc".to_string(), "session-xyz".to_string()],
             },
         );
         state.insert(
             "collab".to_string(),
-            RoomEntry {
+            GroupEntry {
                 pinned: false,
                 members: vec!["session-abc".to_string()],
             },
         );
 
-        let yaml = serialize_rooms_yaml(&state);
-        let parsed = parse_rooms_yaml(&yaml);
+        let yaml = serialize_groups_yaml(&state);
+        let parsed = parse_groups_yaml(&yaml);
 
         assert_eq!(parsed.len(), 2);
         assert!(parsed["deploy"].pinned);

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -1,5 +1,5 @@
 mod config;
-mod rooms;
+mod groups;
 mod scenes;
 mod state;
 mod emit;
@@ -111,23 +111,22 @@ fn cmd_run_with_catchup(catchup: bool) {
     // Load config: user scope → project scope overlay
     let cfg = config::Config::load(&focus.working_dir);
 
+    // Initialize rooms for signal routing (ADR-118)
+    let session_id = own_session_id().unwrap_or_else(|| format!("pid-{}", std::process::id()));
+    let group_mgr = groups::Groups::new(&signals_base(), &session_id);
+
     // Self-documenting startup
-    let focus_list = read_focus_list(&signals_base().join("focus"));
-    let focus_desc = if focus_list.is_empty() {
+    let my_groups = group_mgr.my_groups();
+    let focus_desc = if my_groups.is_empty() {
         "project only".to_string()
     } else {
-        let names: Vec<&str> = focus_list.iter()
-            .map(|p| p.rsplit('/').next().unwrap_or(p.as_str()))
-            .collect();
+        let names: Vec<&str> = my_groups.iter().map(|(n, _)| n.as_str()).collect();
         format!("project + {}", names.join(", "))
     };
 
     // Register sensors from config + feature flags
-    // Initialize rooms for signal routing (ADR-118)
-    let session_id = own_session_id().unwrap_or_else(|| format!("pid-{}", std::process::id()));
-    let room_mgr = rooms::Rooms::new(&signals_base(), &session_id);
 
-    let (mut slots, enabled_names) = sensors::register_sensors(&cfg, &focus, catchup, &room_mgr);
+    let (mut slots, enabled_names) = sensors::register_sensors(&cfg, &focus, catchup, &group_mgr);
 
     // State persistence
     let session_id = own_session_id();
@@ -349,18 +348,14 @@ fn cmd_inbox() {
 
     // Scan same dirs as the peer sensor: own project + broadcast + focus group
     let own_encoded = encode_project(&cwd);
+    let r = get_groups();
     let mut scan_dirs = vec![
         base.join(&own_encoded),
         base.join("_broadcast"),
     ];
-    let focus_file = base.join("focus");
-    if let Ok(content) = std::fs::read_to_string(&focus_file) {
-        for line in content.lines() {
-            let line = line.trim();
-            if !line.is_empty() {
-                scan_dirs.push(base.join(encode_project(line)));
-            }
-        }
+    // Add focus group dirs
+    for name in r.joined_group_names() {
+        scan_dirs.push(r.group_dir(&name));
     }
 
     // Collect all messages with mtime for chronological ordering
@@ -451,7 +446,7 @@ fn cmd_inbox() {
 }
 
 fn cmd_peers() {
-    let r = get_rooms();
+    let r = get_groups();
 
     #[cfg(feature = "sensor-peers")]
     let peers = {
@@ -461,22 +456,22 @@ fn cmd_peers() {
     #[cfg(not(feature = "sensor-peers"))]
     let peers: Vec<(String, String, String, f64)> = Vec::new();
 
-    let my_rooms = r.my_rooms();
+    let my_focus = r.my_groups();
 
-    let mut t = agent_fmt::Table::new(&["Room", "Agent", "Status", "Context"]);
+    let mut t = agent_fmt::Table::new(&["Focus", "Agent", "Status", "Context"]);
     t.max_width(1, 24);
 
-    // Show self in project room
+    // Show self in project group
     let cwd = std::env::current_dir()
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_default();
     let self_project = cwd.rsplit('/').next().unwrap_or("?");
     t.add(vec!["(project)", self_project, "working", ""]);
 
-    // Show named rooms we're in
-    for (room_name, pinned) in &my_rooms {
+    // Show named groups we're focused on
+    for (name, pinned) in &my_focus {
         let pin_marker = if *pinned { " (pinned)" } else { "" };
-        let label = format!("{room_name}{pin_marker}");
+        let label = format!("{name}{pin_marker}");
         t.add(vec![&label, "(you)", "", ""]);
     }
 
@@ -484,33 +479,31 @@ fn cmd_peers() {
     if !peers.is_empty() {
         t.add(vec!["", "", "", ""]);
         for (peer_cwd, project, status, ctx) in &peers {
-            // Determine room context: same project? in a shared room?
-            let room_label = if *peer_cwd == cwd {
+            let focus_label = if *peer_cwd == cwd {
                 "(project)".to_string()
             } else {
-                // Check if this peer's project name matches any room (heuristic)
                 String::new()
             };
-            t.add(vec![&room_label, project, status, &format!("{ctx:.0}%")]);
+            t.add(vec![&focus_label, project, status, &format!("{ctx:.0}%")]);
         }
     }
 
     t.print();
 
-    let room_count = my_rooms.len();
+    let focus_count = my_focus.len();
     let peer_count = peers.len();
     println!(
-        "  {} agent(s), {} room(s)",
+        "  {} agent(s), {} focus group(s)",
         peer_count + 1,
-        room_count + 1
+        focus_count + 1
     );
 }
 
 fn cmd_send(args: &[String]) {
-    // Parse flags: --broadcast, --to <project-path>, --room <name>
+    // Parse flags: --broadcast, --to <project-path>, --focus <name>
     let mut broadcast = false;
     let mut target_dir: Option<String> = None;
-    let mut target_room: Option<String> = None;
+    let mut target_focus: Option<String> = None;
     let mut message_parts: Vec<&str> = Vec::new();
     let mut i = 0;
     while i < args.len() {
@@ -525,12 +518,12 @@ fn cmd_send(args: &[String]) {
                     std::process::exit(1);
                 }
             }
-            "--room" => {
+            "--focus" => {
                 i += 1;
                 if i < args.len() {
-                    target_room = Some(args[i].clone());
+                    target_focus = Some(args[i].clone());
                 } else {
-                    eprintln!("attend send: --room requires a room name");
+                    eprintln!("attend send: --focus requires a focus group name");
                     std::process::exit(1);
                 }
             }
@@ -592,19 +585,6 @@ fn cmd_send(args: &[String]) {
                     eprintln!("\ndid you mean: {}?", suggestion);
                 }
             }
-            // Show focus group if configured
-            let focus_file = base.join("focus");
-            if let Ok(content) = std::fs::read_to_string(&focus_file) {
-                let groups: Vec<&str> = content.lines()
-                    .filter(|l| !l.trim().is_empty())
-                    .collect();
-                if !groups.is_empty() {
-                    eprintln!("\nfocus group (use `attend send` without --to to reach all):");
-                    for g in &groups {
-                        eprintln!("  {}", g);
-                    }
-                }
-            }
             std::process::exit(1);
         }
     }
@@ -613,11 +593,11 @@ fn cmd_send(args: &[String]) {
     // --broadcast: _broadcast only (reaches everyone)
     // --to <path>: specific project only
     // default: own project + focus group (mirrors what we read)
-    let r = get_rooms();
+    let r = get_groups();
     let dest_dirs: Vec<std::path::PathBuf> = if broadcast {
         vec![base.join("_broadcast")]
-    } else if let Some(ref room_name) = target_room {
-        vec![r.room_dir(room_name)]
+    } else if let Some(ref focus_name) = target_focus {
+        vec![r.group_dir(focus_name)]
     } else if let Some(ref path) = target_dir {
         let resolved = std::fs::canonicalize(path)
             .map(|p| p.to_string_lossy().to_string())
@@ -626,19 +606,9 @@ fn cmd_send(args: &[String]) {
     } else {
         // Default: send to own project + joined rooms + focus group peers
         let mut dirs = vec![base.join(encode_project(&cwd))];
-        // Named rooms
-        for name in r.joined_room_names() {
-            dirs.push(r.room_dir(&name));
-        }
-        // Legacy focus group (deprecated, still works)
-        let focus_file = base.join("focus");
-        if let Ok(content) = std::fs::read_to_string(&focus_file) {
-            for line in content.lines() {
-                let line = line.trim();
-                if !line.is_empty() {
-                    dirs.push(base.join(encode_project(line)));
-                }
-            }
+        // Focus groups (named signal namespaces)
+        for name in r.joined_group_names() {
+            dirs.push(r.group_dir(&name));
         }
         dirs
     };
@@ -655,9 +625,9 @@ fn cmd_send(args: &[String]) {
     let content = format!("{}|{}|{}|{}\n", from, project, cwd, message);
 
     let scope = if broadcast { "broadcast" }
-        else if target_room.is_some() { "room" }
+        else if target_focus.is_some() { "focus" }
         else if target_dir.is_some() { "directed" }
-        else if dest_dirs.len() > 1 { "rooms+focus" }
+        else if dest_dirs.len() > 1 { "focus" }
         else { "project" };
 
     for dest_dir in &dest_dirs {
@@ -718,17 +688,8 @@ fn cmd_status() {
     let own_count = count_signals(&own_dir);
     let broadcast_count = count_signals(&broadcast_dir);
 
-    let focus_file = base.join("focus");
-    let focus_peers: Vec<String> = if focus_file.exists() {
-        std::fs::read_to_string(&focus_file)
-            .unwrap_or_default()
-            .lines()
-            .filter(|l| !l.trim().is_empty())
-            .map(|l| l.to_string())
-            .collect()
-    } else {
-        Vec::new()
-    };
+    let r = get_groups();
+    let my_focus = r.my_groups();
 
     // Single table: Section | Detail | Info
     let mut t = agent_fmt::Table::new(&["", "Detail", "Info"]);
@@ -755,12 +716,14 @@ fn cmd_status() {
     t.add(vec!["", "", ""]);
 
     // ── Focus section
-    if focus_peers.is_empty() {
+    if my_focus.is_empty() {
         t.add(vec!["focus", "project only", ""]);
     } else {
-        for (i, peer) in focus_peers.iter().enumerate() {
+        for (i, (name, pinned)) in my_focus.iter().enumerate() {
             let label = if i == 0 { "focus" } else { "" };
-            t.add(vec![label, "peer", peer]);
+            let pin = if *pinned { " (pinned)" } else { "" };
+            let info = format!("{name}{pin}");
+            t.add(vec![label, &info, ""]);
         }
     }
 
@@ -950,7 +913,7 @@ fn cmd_scene(args: &[String]) {
         }
     };
 
-    let r = get_rooms();
+    let r = get_groups();
     match scenes::activate(name, &r) {
         Ok(result) => println!("[attend] scene '{name}': {result}"),
         Err(e) => {
@@ -965,33 +928,33 @@ fn cmd_scenes() {
     let mut names: Vec<&String> = all.keys().collect();
     names.sort();
 
-    let mut t = agent_fmt::Table::new(&["Scene", "Rooms"]);
+    let mut t = agent_fmt::Table::new(&["Scene", "Focus groups"]);
     for name in &names {
         let scene = &all[*name];
-        let rooms_str = if scene.rooms.is_empty() {
+        let groups_str = if scene.rooms.is_empty() {
             "(none — project only)".to_string()
         } else {
             scene.rooms.join(", ")
         };
-        t.add(vec![name.as_str(), &rooms_str]);
+        t.add(vec![name.as_str(), &groups_str]);
     }
     t.print();
 }
 
-fn get_rooms() -> rooms::Rooms {
+fn get_groups() -> groups::Groups {
     let session_id = own_session_id().unwrap_or_else(|| format!("pid-{}", std::process::id()));
-    rooms::Rooms::new(&signals_base(), &session_id)
+    groups::Groups::new(&signals_base(), &session_id)
 }
 
-fn cmd_room(args: &[String]) {
-    let r = get_rooms();
+fn cmd_focus_new(args: &[String]) {
+    let r = get_groups();
 
     match args.first().map(|s| s.as_str()) {
-        Some("join") => {
+        Some("on") => {
             let name = match args.get(1) {
                 Some(n) => n,
                 None => {
-                    eprintln!("usage: attend room join <name> [--pin]");
+                    eprintln!("usage: attend focus on <name> [--pin]");
                     std::process::exit(1);
                 }
             };
@@ -999,68 +962,92 @@ fn cmd_room(args: &[String]) {
             match r.join(name, pin) {
                 Ok(()) => {
                     let suffix = if pin { " (pinned)" } else { "" };
-                    println!("[attend] room: joined {name}{suffix}");
+                    println!("[attend] focus: attending to {name}{suffix}");
                 }
                 Err(e) => {
-                    eprintln!("[attend] room: {e}");
+                    eprintln!("[attend] focus: {e}");
                     std::process::exit(1);
                 }
             }
         }
-        Some("leave") => {
+        Some("off") => {
             let name = match args.get(1) {
                 Some(n) => n,
                 None => {
-                    eprintln!("usage: attend room leave <name>");
+                    eprintln!("usage: attend focus off <name>");
                     std::process::exit(1);
                 }
             };
             r.leave(name).ok();
-            println!("[attend] room: left {name}");
+            println!("[attend] focus: released {name}");
+        }
+        Some("clear") => {
+            for (name, _) in r.my_groups() {
+                r.leave(&name).ok();
+            }
+            println!("[attend] focus: cleared (project only)");
         }
         Some("pin") => {
             let name = match args.get(1) {
                 Some(n) => n,
                 None => {
-                    eprintln!("usage: attend room pin <name>");
+                    eprintln!("usage: attend focus pin <name>");
                     std::process::exit(1);
                 }
             };
             r.pin(name);
-            println!("[attend] room: pinned {name}");
+            println!("[attend] focus: pinned {name}");
         }
         Some("unpin") => {
             let name = match args.get(1) {
                 Some(n) => n,
                 None => {
-                    eprintln!("usage: attend room unpin <name>");
+                    eprintln!("usage: attend focus unpin <name>");
                     std::process::exit(1);
                 }
             };
             r.unpin(name);
-            println!("[attend] room: unpinned {name}");
+            println!("[attend] focus: unpinned {name}");
         }
         Some("dissolve") => {
             let name = match args.get(1) {
                 Some(n) => n,
                 None => {
-                    eprintln!("usage: attend room dissolve <name>");
+                    eprintln!("usage: attend focus dissolve <name>");
                     std::process::exit(1);
                 }
             };
             let members = r.dissolve(name);
             if members.is_empty() {
-                println!("[attend] room: dissolved {name} (was empty)");
+                println!("[attend] focus: dissolved {name} (was empty)");
             } else {
-                println!("[attend] room: dissolved {name} ({} members removed)", members.len());
+                println!("[attend] focus: dissolved {name} ({} members released)", members.len());
             }
         }
+        Some("all") => {
+            r.cleanup_stale();
+            let all = r.all_groups();
+            if all.is_empty() {
+                println!("no active focus groups");
+                return;
+            }
+            let mut t = agent_fmt::Table::new(&["Focus", "Members", "Pinned"]);
+            t.align(1, agent_fmt::Align::Right);
+            for (name, count, pinned) in &all {
+                t.add(vec![
+                    name.as_str(),
+                    &count.to_string(),
+                    if *pinned { "yes" } else { "no" },
+                ]);
+            }
+            t.print();
+        }
         Some("list") | None => {
-            let my = r.my_rooms();
+            let my = r.my_groups();
             if my.is_empty() {
-                println!("not in any named rooms (project room only)");
+                println!("focus: project only");
             } else {
-                let mut t = agent_fmt::Table::new(&["Room", "Pinned"]);
+                let mut t = agent_fmt::Table::new(&["Focus", "Pinned"]);
                 for (name, pinned) in &my {
                     t.add(vec![name.as_str(), if *pinned { "yes" } else { "no" }]);
                 }
@@ -1068,109 +1055,10 @@ fn cmd_room(args: &[String]) {
             }
         }
         Some(unknown) => {
-            eprintln!("attend room: unknown subcommand '{unknown}' — try join, leave, list, pin, unpin, dissolve");
+            eprintln!("attend focus: unknown subcommand '{unknown}' — try on, off, list, all, clear, pin, unpin, dissolve");
             std::process::exit(1);
         }
     }
-}
-
-fn cmd_rooms() {
-    let r = get_rooms();
-    r.cleanup_stale();
-    let all = r.all_rooms();
-
-    if all.is_empty() {
-        println!("no active rooms");
-        return;
-    }
-
-    let mut t = agent_fmt::Table::new(&["Room", "Members", "Pinned"]);
-    t.align(1, agent_fmt::Align::Right);
-    for (name, count, pinned) in &all {
-        t.add(vec![
-            name.as_str(),
-            &count.to_string(),
-            if *pinned { "yes" } else { "no" },
-        ]);
-    }
-    t.print();
-}
-
-fn cmd_focus(args: &[String]) {
-    let focus_file = signals_base().join("focus");
-
-    match args.first().map(|s| s.as_str()) {
-        Some("add") => {
-            // attend focus add /path/to/project [/path/to/other ...]
-            if args.len() < 2 {
-                eprintln!("usage: attend focus add <project-path> [...]");
-                std::process::exit(1);
-            }
-            let mut existing = read_focus_list(&focus_file);
-            for path in &args[1..] {
-                let resolved = std::fs::canonicalize(path)
-                    .map(|p| p.to_string_lossy().to_string())
-                    .unwrap_or_else(|_| path.clone());
-                if !existing.contains(&resolved) {
-                    existing.push(resolved.clone());
-                    eprintln!("[attend] focus: added {}", resolved);
-                }
-            }
-            write_focus_list(&focus_file, &existing);
-        }
-        Some("remove") | Some("rm") => {
-            if args.len() < 2 {
-                eprintln!("usage: attend focus remove <project-path> [...]");
-                std::process::exit(1);
-            }
-            let mut existing = read_focus_list(&focus_file);
-            for path in &args[1..] {
-                let resolved = std::fs::canonicalize(path)
-                    .map(|p| p.to_string_lossy().to_string())
-                    .unwrap_or_else(|_| path.clone());
-                existing.retain(|p| p != &resolved);
-                eprintln!("[attend] focus: removed {}", resolved);
-            }
-            write_focus_list(&focus_file, &existing);
-        }
-        Some("clear") => {
-            std::fs::remove_file(&focus_file).ok();
-            eprintln!("[attend] focus: cleared (project-only mode)");
-        }
-        Some("list") | None => {
-            let list = read_focus_list(&focus_file);
-            if list.is_empty() {
-                println!("focus: project only (no peers in focus group)");
-            } else {
-                println!("focus: {} peers", list.len());
-                for p in &list {
-                    let name = p.rsplit('/').next().unwrap_or(p);
-                    println!("  {} ({})", name, encode_project(p));
-                }
-            }
-        }
-        Some(unknown) => {
-            eprintln!("attend focus: unknown subcommand '{}' — try add, remove, clear, list", unknown);
-            std::process::exit(1);
-        }
-    }
-}
-
-fn read_focus_list(path: &std::path::Path) -> Vec<String> {
-    std::fs::read_to_string(path)
-        .unwrap_or_default()
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .map(|l| l.trim().to_string())
-        .collect()
-}
-
-fn write_focus_list(path: &std::path::Path, list: &[String]) {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).ok();
-    }
-    let content = list.join("\n") + "\n";
-    std::fs::write(path, content).ok();
 }
 
 // --- Permissions audit (ADR-116) ---
@@ -1225,20 +1113,14 @@ fn main() {
         Some("send") => {
             cmd_send(&args[1..]);
         }
-        Some("room") => {
-            cmd_room(&args[1..]);
-        }
-        Some("rooms") => {
-            cmd_rooms();
+        Some("focus") => {
+            cmd_focus_new(&args[1..]);
         }
         Some("scene") => {
             cmd_scene(&args[1..]);
         }
         Some("scenes") => {
             cmd_scenes();
-        }
-        Some("focus") => {
-            cmd_focus(&args[1..]);
         }
         Some("permissions") => {
             match args.get(1).map(|s| s.as_str()) {
@@ -1287,23 +1169,21 @@ fn main() {
                 .print();
             println!("usage: attend <command>\n");
             agent_fmt::print_commands("commands", &[
-                ("run",    "Start the sensor loop (use with Monitor for async delivery)"),
-                ("peers",  "List active Claude Code sessions"),
-                ("inbox",  "Read pending messages from peers"),
-                ("send",   "Send a signal to peer sessions"),
-                ("room",   "Join/leave named rooms (join, leave, list, pin, unpin, dissolve)"),
-                ("rooms",  "List all active rooms with members"),
-                ("scene",  "Activate a named scene (reconfigure room membership)"),
-                ("scenes", "List available scenes"),
-                ("focus",  "Manage focus group [deprecated — use room]"),
+                ("run",         "Start the sensor loop (use with Monitor for async delivery)"),
+                ("peers",       "List active Claude Code sessions and focus groups"),
+                ("inbox",       "Read pending messages from peers"),
+                ("send",        "Send a signal to peer sessions"),
+                ("focus",       "Manage attention groups (on, off, list, all, clear, pin, dissolve)"),
+                ("scene",       "Activate a named scene (reconfigure focus)"),
+                ("scenes",      "List available scenes"),
                 ("config",      "Manage configuration (init/show/path)"),
                 ("permissions", "Audit sensor permissions against settings.json"),
                 ("status",      "Show running instances, signals, and focus state"),
-                ("help",   "Show this help"),
+                ("help",        "Show this help"),
             ]);
             println!();
             agent_fmt::print_commands("send flags", &[
-                ("--room <name>", "Send to a named room"),
+                ("--focus <name>", "Send to a focus group"),
                 ("--broadcast",   "Send to all agents"),
                 ("--to <path>",   "Send to a specific project path (legacy)"),
             ]);

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -450,26 +450,59 @@ fn cmd_inbox() {
 }
 
 fn cmd_peers() {
+    let r = get_rooms();
+
     #[cfg(feature = "sensor-peers")]
     let peers = {
         let sensor = sensors::PeerSensor::new();
         sensor.list_peers()
     };
     #[cfg(not(feature = "sensor-peers"))]
-    let peers: Vec<(String, String, String, String)> = Vec::new();
+    let peers: Vec<(String, String, String, f64)> = Vec::new();
 
-    if peers.is_empty() {
-        println!("no active peer sessions");
-        return;
+    let my_rooms = r.my_rooms();
+
+    let mut t = agent_fmt::Table::new(&["Room", "Agent", "Status", "Context"]);
+    t.max_width(1, 24);
+
+    // Show self in project room
+    let cwd = std::env::current_dir()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let self_project = cwd.rsplit('/').next().unwrap_or("?");
+    t.add(vec!["(project)", self_project, "working", ""]);
+
+    // Show named rooms we're in
+    for (room_name, pinned) in &my_rooms {
+        let pin_marker = if *pinned { " (pinned)" } else { "" };
+        let label = format!("{room_name}{pin_marker}");
+        t.add(vec![&label, "(you)", "", ""]);
     }
 
-    let mut t = agent_fmt::Table::new(&["Project", "Path", "Status", "Context"]);
-    t.max_width(0, 20);
-    for (cwd, project, status, ctx) in &peers {
-        t.add(vec![project, cwd, status, &format!("{ctx:.0}%")]);
+    // Show peers
+    if !peers.is_empty() {
+        t.add(vec!["", "", "", ""]);
+        for (peer_cwd, project, status, ctx) in &peers {
+            // Determine room context: same project? in a shared room?
+            let room_label = if *peer_cwd == cwd {
+                "(project)".to_string()
+            } else {
+                // Check if this peer's project name matches any room (heuristic)
+                String::new()
+            };
+            t.add(vec![&room_label, project, status, &format!("{ctx:.0}%")]);
+        }
     }
+
     t.print();
-    println!("  {} peer(s)", peers.len());
+
+    let room_count = my_rooms.len();
+    let peer_count = peers.len();
+    println!(
+        "  {} agent(s), {} room(s)",
+        peer_count + 1,
+        room_count + 1
+    );
 }
 
 fn cmd_send(args: &[String]) {

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -122,7 +122,11 @@ fn cmd_run_with_catchup(catchup: bool) {
     };
 
     // Register sensors from config + feature flags
-    let (mut slots, enabled_names) = sensors::register_sensors(&cfg, &focus, catchup);
+    // Initialize rooms for signal routing (ADR-118)
+    let session_id = own_session_id().unwrap_or_else(|| format!("pid-{}", std::process::id()));
+    let room_mgr = rooms::Rooms::new(&signals_base(), &session_id);
+
+    let (mut slots, enabled_names) = sensors::register_sensors(&cfg, &focus, catchup, &room_mgr);
 
     // State persistence
     let session_id = own_session_id();
@@ -469,9 +473,10 @@ fn cmd_peers() {
 }
 
 fn cmd_send(args: &[String]) {
-    // Parse flags: --broadcast, --to <project-path>
+    // Parse flags: --broadcast, --to <project-path>, --room <name>
     let mut broadcast = false;
     let mut target_dir: Option<String> = None;
+    let mut target_room: Option<String> = None;
     let mut message_parts: Vec<&str> = Vec::new();
     let mut i = 0;
     while i < args.len() {
@@ -483,6 +488,15 @@ fn cmd_send(args: &[String]) {
                     target_dir = Some(args[i].clone());
                 } else {
                     eprintln!("attend send: --to requires a project path");
+                    std::process::exit(1);
+                }
+            }
+            "--room" => {
+                i += 1;
+                if i < args.len() {
+                    target_room = Some(args[i].clone());
+                } else {
+                    eprintln!("attend send: --room requires a room name");
                     std::process::exit(1);
                 }
             }
@@ -565,16 +579,24 @@ fn cmd_send(args: &[String]) {
     // --broadcast: _broadcast only (reaches everyone)
     // --to <path>: specific project only
     // default: own project + focus group (mirrors what we read)
+    let r = get_rooms();
     let dest_dirs: Vec<std::path::PathBuf> = if broadcast {
         vec![base.join("_broadcast")]
+    } else if let Some(ref room_name) = target_room {
+        vec![r.room_dir(room_name)]
     } else if let Some(ref path) = target_dir {
         let resolved = std::fs::canonicalize(path)
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_else(|_| path.clone());
         vec![base.join(encode_project(&resolved))]
     } else {
-        // Default: send to own project + all focus group peers
+        // Default: send to own project + joined rooms + focus group peers
         let mut dirs = vec![base.join(encode_project(&cwd))];
+        // Named rooms
+        for name in r.joined_room_names() {
+            dirs.push(r.room_dir(&name));
+        }
+        // Legacy focus group (deprecated, still works)
         let focus_file = base.join("focus");
         if let Ok(content) = std::fs::read_to_string(&focus_file) {
             for line in content.lines() {
@@ -599,8 +621,9 @@ fn cmd_send(args: &[String]) {
     let content = format!("{}|{}|{}|{}\n", from, project, cwd, message);
 
     let scope = if broadcast { "broadcast" }
+        else if target_room.is_some() { "room" }
         else if target_dir.is_some() { "directed" }
-        else if dest_dirs.len() > 1 { "focus group" }
+        else if dest_dirs.len() > 1 { "rooms+focus" }
         else { "project" };
 
     for dest_dir in &dest_dirs {
@@ -1200,8 +1223,9 @@ fn main() {
             ]);
             println!();
             agent_fmt::print_commands("send flags", &[
-                ("--broadcast", "Send to all projects, not just your own"),
-                ("--to <path>", "Send to a specific project's signals dir"),
+                ("--room <name>", "Send to a named room"),
+                ("--broadcast",   "Send to all agents"),
+                ("--to <path>",   "Send to a specific project path (legacy)"),
             ]);
         }
         Some(unknown) => {

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod rooms;
+mod scenes;
 mod state;
 mod emit;
 mod sensors;
@@ -939,6 +940,44 @@ fn own_session_id() -> Option<String> {
 
 // --- Entry point ---
 
+fn cmd_scene(args: &[String]) {
+    let name = match args.first() {
+        Some(n) => n,
+        None => {
+            eprintln!("usage: attend scene <name>");
+            eprintln!("  try: attend scenes (to list available)");
+            std::process::exit(1);
+        }
+    };
+
+    let r = get_rooms();
+    match scenes::activate(name, &r) {
+        Ok(result) => println!("[attend] scene '{name}': {result}"),
+        Err(e) => {
+            eprintln!("[attend] scene: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn cmd_scenes() {
+    let all = scenes::load_scenes();
+    let mut names: Vec<&String> = all.keys().collect();
+    names.sort();
+
+    let mut t = agent_fmt::Table::new(&["Scene", "Rooms"]);
+    for name in &names {
+        let scene = &all[*name];
+        let rooms_str = if scene.rooms.is_empty() {
+            "(none — project only)".to_string()
+        } else {
+            scene.rooms.join(", ")
+        };
+        t.add(vec![name.as_str(), &rooms_str]);
+    }
+    t.print();
+}
+
 fn get_rooms() -> rooms::Rooms {
     let session_id = own_session_id().unwrap_or_else(|| format!("pid-{}", std::process::id()));
     rooms::Rooms::new(&signals_base(), &session_id)
@@ -1192,6 +1231,12 @@ fn main() {
         Some("rooms") => {
             cmd_rooms();
         }
+        Some("scene") => {
+            cmd_scene(&args[1..]);
+        }
+        Some("scenes") => {
+            cmd_scenes();
+        }
         Some("focus") => {
             cmd_focus(&args[1..]);
         }
@@ -1248,6 +1293,8 @@ fn main() {
                 ("send",   "Send a signal to peer sessions"),
                 ("room",   "Join/leave named rooms (join, leave, list, pin, unpin, dissolve)"),
                 ("rooms",  "List all active rooms with members"),
+                ("scene",  "Activate a named scene (reconfigure room membership)"),
+                ("scenes", "List available scenes"),
                 ("focus",  "Manage focus group [deprecated — use room]"),
                 ("config",      "Manage configuration (init/show/path)"),
                 ("permissions", "Audit sensor permissions against settings.json"),

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -1,4 +1,5 @@
 mod config;
+mod rooms;
 mod state;
 mod emit;
 mod sensors;
@@ -882,6 +883,124 @@ fn own_session_id() -> Option<String> {
 
 // --- Entry point ---
 
+fn get_rooms() -> rooms::Rooms {
+    let session_id = own_session_id().unwrap_or_else(|| format!("pid-{}", std::process::id()));
+    rooms::Rooms::new(&signals_base(), &session_id)
+}
+
+fn cmd_room(args: &[String]) {
+    let r = get_rooms();
+
+    match args.first().map(|s| s.as_str()) {
+        Some("join") => {
+            let name = match args.get(1) {
+                Some(n) => n,
+                None => {
+                    eprintln!("usage: attend room join <name> [--pin]");
+                    std::process::exit(1);
+                }
+            };
+            let pin = args.iter().any(|a| a == "--pin");
+            match r.join(name, pin) {
+                Ok(()) => {
+                    let suffix = if pin { " (pinned)" } else { "" };
+                    println!("[attend] room: joined {name}{suffix}");
+                }
+                Err(e) => {
+                    eprintln!("[attend] room: {e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        Some("leave") => {
+            let name = match args.get(1) {
+                Some(n) => n,
+                None => {
+                    eprintln!("usage: attend room leave <name>");
+                    std::process::exit(1);
+                }
+            };
+            r.leave(name).ok();
+            println!("[attend] room: left {name}");
+        }
+        Some("pin") => {
+            let name = match args.get(1) {
+                Some(n) => n,
+                None => {
+                    eprintln!("usage: attend room pin <name>");
+                    std::process::exit(1);
+                }
+            };
+            r.pin(name);
+            println!("[attend] room: pinned {name}");
+        }
+        Some("unpin") => {
+            let name = match args.get(1) {
+                Some(n) => n,
+                None => {
+                    eprintln!("usage: attend room unpin <name>");
+                    std::process::exit(1);
+                }
+            };
+            r.unpin(name);
+            println!("[attend] room: unpinned {name}");
+        }
+        Some("dissolve") => {
+            let name = match args.get(1) {
+                Some(n) => n,
+                None => {
+                    eprintln!("usage: attend room dissolve <name>");
+                    std::process::exit(1);
+                }
+            };
+            let members = r.dissolve(name);
+            if members.is_empty() {
+                println!("[attend] room: dissolved {name} (was empty)");
+            } else {
+                println!("[attend] room: dissolved {name} ({} members removed)", members.len());
+            }
+        }
+        Some("list") | None => {
+            let my = r.my_rooms();
+            if my.is_empty() {
+                println!("not in any named rooms (project room only)");
+            } else {
+                let mut t = agent_fmt::Table::new(&["Room", "Pinned"]);
+                for (name, pinned) in &my {
+                    t.add(vec![name.as_str(), if *pinned { "yes" } else { "no" }]);
+                }
+                t.print();
+            }
+        }
+        Some(unknown) => {
+            eprintln!("attend room: unknown subcommand '{unknown}' — try join, leave, list, pin, unpin, dissolve");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn cmd_rooms() {
+    let r = get_rooms();
+    r.cleanup_stale();
+    let all = r.all_rooms();
+
+    if all.is_empty() {
+        println!("no active rooms");
+        return;
+    }
+
+    let mut t = agent_fmt::Table::new(&["Room", "Members", "Pinned"]);
+    t.align(1, agent_fmt::Align::Right);
+    for (name, count, pinned) in &all {
+        t.add(vec![
+            name.as_str(),
+            &count.to_string(),
+            if *pinned { "yes" } else { "no" },
+        ]);
+    }
+    t.print();
+}
+
 fn cmd_focus(args: &[String]) {
     let focus_file = signals_base().join("focus");
 
@@ -1011,6 +1130,12 @@ fn main() {
         Some("send") => {
             cmd_send(&args[1..]);
         }
+        Some("room") => {
+            cmd_room(&args[1..]);
+        }
+        Some("rooms") => {
+            cmd_rooms();
+        }
         Some("focus") => {
             cmd_focus(&args[1..]);
         }
@@ -1065,7 +1190,9 @@ fn main() {
                 ("peers",  "List active Claude Code sessions"),
                 ("inbox",  "Read pending messages from peers"),
                 ("send",   "Send a signal to peer sessions"),
-                ("focus",  "Manage focus group (add/remove/clear/list peer projects)"),
+                ("room",   "Join/leave named rooms (join, leave, list, pin, unpin, dissolve)"),
+                ("rooms",  "List all active rooms with members"),
+                ("focus",  "Manage focus group [deprecated — use room]"),
                 ("config",      "Manage configuration (init/show/path)"),
                 ("permissions", "Audit sensor permissions against settings.json"),
                 ("status",      "Show running instances, signals, and focus state"),

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -154,7 +154,7 @@ fn cmd_run_with_catchup(catchup: bool) {
     }
 
     let sensor_list = enabled_names.join(", ");
-    println!("[attend] v{} ({}) — sensors: {} | focus: {} | commands: attend send <msg>, attend inbox, attend peers, attend focus add <path>",
+    println!("[attend] v{} ({}) — sensors: {} | focus: {} | commands: attend send <msg>, attend inbox, attend peers, attend focus on <name>",
         env!("CARGO_PKG_VERSION"), env!("ATTEND_COMMIT"), sensor_list, focus_desc);
 
     let mut governor = DisclosureGovernor::new(

--- a/tools/attend/src/rooms.rs
+++ b/tools/attend/src/rooms.rs
@@ -1,0 +1,412 @@
+//! Room management for attend (ADR-118).
+//!
+//! Rooms are named signal namespaces that agents join and leave dynamically.
+//! Storage: `@room-name/` directories under the signals base, with membership
+//! tracked in `_rooms.yaml`.
+//!
+//! Every agent is always in its implicit project room (from cwd).
+//! Named rooms are explicit and opt-in via `attend room join <name>`.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Room membership entry.
+#[derive(Debug, Clone)]
+pub struct RoomEntry {
+    /// Whether this room persists when empty.
+    pub pinned: bool,
+    /// Session IDs currently in this room.
+    pub members: Vec<String>,
+}
+
+/// Room state manager.
+pub struct Rooms {
+    base: PathBuf,
+    session_id: String,
+}
+
+const ROOM_PREFIX: &str = "@";
+
+impl Rooms {
+    pub fn new(signals_base: &Path, session_id: &str) -> Self {
+        Self {
+            base: signals_base.to_path_buf(),
+            session_id: session_id.to_string(),
+        }
+    }
+
+    /// Path to a named room's signal directory.
+    pub fn room_dir(&self, name: &str) -> PathBuf {
+        self.base.join(format!("{ROOM_PREFIX}{name}"))
+    }
+
+    /// Path to the rooms state file.
+    fn state_path(&self) -> PathBuf {
+        self.base.join("_rooms.yaml")
+    }
+
+    /// Join a named room. Creates the room if it doesn't exist.
+    pub fn join(&self, name: &str, pin: bool) -> Result<(), String> {
+        validate_room_name(name)?;
+        let dir = self.room_dir(name);
+        fs::create_dir_all(&dir).map_err(|e| format!("creating room dir: {e}"))?;
+
+        let mut state = self.load_state();
+        let entry = state.entry(name.to_string()).or_insert(RoomEntry {
+            pinned: false,
+            members: Vec::new(),
+        });
+        if !entry.members.contains(&self.session_id) {
+            entry.members.push(self.session_id.clone());
+        }
+        if pin {
+            entry.pinned = true;
+        }
+        self.save_state(&state);
+        Ok(())
+    }
+
+    /// Leave a named room.
+    pub fn leave(&self, name: &str) -> Result<(), String> {
+        let mut state = self.load_state();
+        if let Some(entry) = state.get_mut(name) {
+            entry.members.retain(|m| m != &self.session_id);
+        }
+        self.save_state(&state);
+        self.cleanup_if_empty(name, &state);
+        Ok(())
+    }
+
+    /// Pin a room so it persists when empty.
+    pub fn pin(&self, name: &str) {
+        let mut state = self.load_state();
+        if let Some(entry) = state.get_mut(name) {
+            entry.pinned = true;
+            self.save_state(&state);
+        }
+    }
+
+    /// Unpin a room.
+    pub fn unpin(&self, name: &str) {
+        let mut state = self.load_state();
+        if let Some(entry) = state.get_mut(name) {
+            entry.pinned = false;
+            self.save_state(&state);
+        }
+        self.cleanup_if_empty(name, &state);
+    }
+
+    /// Dissolve a room — remove it and notify members.
+    pub fn dissolve(&self, name: &str) -> Vec<String> {
+        let mut state = self.load_state();
+        let members = state
+            .remove(name)
+            .map(|e| e.members)
+            .unwrap_or_default();
+        self.save_state(&state);
+
+        // Remove the signal directory
+        let dir = self.room_dir(name);
+        if dir.is_dir() {
+            fs::remove_dir_all(&dir).ok();
+        }
+        members
+    }
+
+    /// List rooms this session has joined.
+    pub fn my_rooms(&self) -> Vec<(String, bool)> {
+        let state = self.load_state();
+        state
+            .iter()
+            .filter(|(_, entry)| entry.members.contains(&self.session_id))
+            .map(|(name, entry)| (name.clone(), entry.pinned))
+            .collect()
+    }
+
+    /// List all active rooms with member counts and pin state.
+    pub fn all_rooms(&self) -> Vec<(String, usize, bool)> {
+        let state = self.load_state();
+        let mut rooms: Vec<(String, usize, bool)> = state
+            .iter()
+            .map(|(name, entry)| (name.clone(), entry.members.len(), entry.pinned))
+            .collect();
+        rooms.sort_by(|a, b| a.0.cmp(&b.0));
+        rooms
+    }
+
+    /// Get room names this session is in (for signal routing).
+    #[allow(dead_code)] // Used by signal routing (task 27)
+    pub fn joined_room_names(&self) -> Vec<String> {
+        self.my_rooms().into_iter().map(|(name, _)| name).collect()
+    }
+
+    /// Get signal directories for all rooms this session should receive from.
+    #[allow(dead_code)] // Used by signal routing (task 27)
+    /// Includes: project room, joined named rooms, broadcast.
+    pub fn receive_dirs(&self, project_dir: &str) -> Vec<PathBuf> {
+        let mut dirs = Vec::new();
+
+        // Project room (always)
+        dirs.push(self.base.join(encode_project(project_dir)));
+
+        // Named rooms
+        for name in self.joined_room_names() {
+            dirs.push(self.room_dir(&name));
+        }
+
+        // Broadcast (always)
+        dirs.push(self.base.join("_broadcast"));
+
+        dirs
+    }
+
+    /// Clean up stale members (sessions that no longer exist).
+    pub fn cleanup_stale(&self) {
+        let mut state = self.load_state();
+        let mut changed = false;
+
+        for entry in state.values_mut() {
+            let before = entry.members.len();
+            entry.members.retain(|sid| session_alive(sid));
+            if entry.members.len() != before {
+                changed = true;
+            }
+        }
+
+        if changed {
+            self.save_state(&state);
+        }
+
+        // Clean up empty unpinned rooms
+        let to_remove: Vec<String> = state
+            .iter()
+            .filter(|(_, e)| e.members.is_empty() && !e.pinned)
+            .map(|(name, _)| name.clone())
+            .collect();
+
+        for name in &to_remove {
+            let dir = self.room_dir(name);
+            if dir.is_dir() {
+                fs::remove_dir_all(&dir).ok();
+            }
+        }
+
+        if !to_remove.is_empty() {
+            for name in &to_remove {
+                state.remove(name);
+            }
+            self.save_state(&state);
+        }
+    }
+
+    // ── State persistence ──────────────────────────────────────
+
+    fn load_state(&self) -> HashMap<String, RoomEntry> {
+        let path = self.state_path();
+        let content = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => return HashMap::new(),
+        };
+        parse_rooms_yaml(&content)
+    }
+
+    fn save_state(&self, state: &HashMap<String, RoomEntry>) {
+        let path = self.state_path();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).ok();
+        }
+        let content = serialize_rooms_yaml(state);
+        fs::write(&path, content).ok();
+    }
+
+    fn cleanup_if_empty(&self, name: &str, state: &HashMap<String, RoomEntry>) {
+        if let Some(entry) = state.get(name) {
+            if entry.members.is_empty() && !entry.pinned {
+                let dir = self.room_dir(name);
+                if dir.is_dir() {
+                    fs::remove_dir_all(&dir).ok();
+                }
+                // Remove from state
+                let mut state = state.clone();
+                state.remove(name);
+                self.save_state(&state);
+            }
+        }
+    }
+}
+
+// ── Helpers ────────────────────────────────────────────────────
+
+fn validate_room_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("room name cannot be empty".to_string());
+    }
+    if name.starts_with('_') || name.starts_with('@') {
+        return Err("room name cannot start with _ or @".to_string());
+    }
+    if name.contains('/') || name.contains(' ') {
+        return Err("room name cannot contain / or spaces".to_string());
+    }
+    if name == "broadcast" {
+        return Err("'broadcast' is reserved".to_string());
+    }
+    Ok(())
+}
+
+/// Check if a Claude Code session is still alive by looking for its lock dir.
+fn session_alive(session_id: &str) -> bool {
+    // Claude sessions create dirs under ~/.claude/projects/
+    // A session is alive if its PID parent process exists
+    // For now, be conservative: assume alive (stale cleanup is best-effort)
+    let _ = session_id;
+    true // TODO: implement proper liveness check
+}
+
+/// Encode a project path: '/', '_', '.' → '-'
+#[allow(dead_code)] // Used by receive_dirs
+fn encode_project(path: &str) -> String {
+    path.chars()
+        .map(|c| match c {
+            '/' | '_' | '.' => '-',
+            _ => c,
+        })
+        .collect()
+}
+
+// ── Minimal YAML parser/serializer ─────────────────────────────
+// Keeps attend dependency-free on serde.
+
+fn parse_rooms_yaml(content: &str) -> HashMap<String, RoomEntry> {
+    let mut rooms = HashMap::new();
+    let mut current_room: Option<String> = None;
+    let mut current_pinned = false;
+    let mut current_members: Vec<String> = Vec::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let indent = line.len() - line.trim_start().len();
+
+        // Top-level: room name
+        if indent == 0 && trimmed.ends_with(':') {
+            // Save previous room
+            if let Some(ref name) = current_room {
+                rooms.insert(
+                    name.clone(),
+                    RoomEntry {
+                        pinned: current_pinned,
+                        members: current_members.clone(),
+                    },
+                );
+            }
+            current_room = Some(trimmed.trim_end_matches(':').to_string());
+            current_pinned = false;
+            current_members = Vec::new();
+            continue;
+        }
+
+        // Second-level: room properties
+        if indent == 2 {
+            if let Some((key, value)) = trimmed.split_once(':') {
+                let key = key.trim();
+                let value = value.trim();
+                match key {
+                    "pinned" => current_pinned = value == "true",
+                    "members" => {} // array header, items follow
+                    _ => {}
+                }
+            }
+        }
+
+        // Third-level: member list items
+        if indent == 4 {
+            if let Some(member) = trimmed.strip_prefix("- ") {
+                current_members.push(member.to_string());
+            }
+        }
+    }
+
+    // Save last room
+    if let Some(ref name) = current_room {
+        rooms.insert(
+            name.clone(),
+            RoomEntry {
+                pinned: current_pinned,
+                members: current_members,
+            },
+        );
+    }
+
+    rooms
+}
+
+fn serialize_rooms_yaml(state: &HashMap<String, RoomEntry>) -> String {
+    let mut out = String::new();
+    let mut names: Vec<&String> = state.keys().collect();
+    names.sort();
+
+    for name in names {
+        let entry = &state[name];
+        out.push_str(&format!("{name}:\n"));
+        out.push_str(&format!("  pinned: {}\n", entry.pinned));
+        out.push_str("  members:\n");
+        for member in &entry.members {
+            out.push_str(&format!("    - {member}\n"));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_room_name() {
+        assert!(validate_room_name("deploy").is_ok());
+        assert!(validate_room_name("my-room").is_ok());
+        assert!(validate_room_name("").is_err());
+        assert!(validate_room_name("_internal").is_err());
+        assert!(validate_room_name("@bad").is_err());
+        assert!(validate_room_name("has/slash").is_err());
+        assert!(validate_room_name("has space").is_err());
+        assert!(validate_room_name("broadcast").is_err());
+    }
+
+    #[test]
+    fn test_yaml_roundtrip() {
+        let mut state = HashMap::new();
+        state.insert(
+            "deploy".to_string(),
+            RoomEntry {
+                pinned: true,
+                members: vec!["session-abc".to_string(), "session-xyz".to_string()],
+            },
+        );
+        state.insert(
+            "collab".to_string(),
+            RoomEntry {
+                pinned: false,
+                members: vec!["session-abc".to_string()],
+            },
+        );
+
+        let yaml = serialize_rooms_yaml(&state);
+        let parsed = parse_rooms_yaml(&yaml);
+
+        assert_eq!(parsed.len(), 2);
+        assert!(parsed["deploy"].pinned);
+        assert_eq!(parsed["deploy"].members.len(), 2);
+        assert!(!parsed["collab"].pinned);
+        assert_eq!(parsed["collab"].members.len(), 1);
+    }
+
+    #[test]
+    fn test_encode_project() {
+        assert_eq!(encode_project("/home/aaron/.claude"), "-home-aaron--claude");
+    }
+}

--- a/tools/attend/src/rooms.rs
+++ b/tools/attend/src/rooms.rs
@@ -136,7 +136,6 @@ impl Rooms {
     }
 
     /// Get room names this session is in (for signal routing).
-    #[allow(dead_code)] // Used by signal routing (task 27)
     pub fn joined_room_names(&self) -> Vec<String> {
         self.my_rooms().into_iter().map(|(name, _)| name).collect()
     }

--- a/tools/attend/src/scenes.rs
+++ b/tools/attend/src/scenes.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
-use crate::rooms::Rooms;
+use crate::groups::Groups;
 
 /// A scene definition.
 #[derive(Debug, Clone)]
@@ -39,7 +39,7 @@ pub fn load_scenes() -> HashMap<String, Scene> {
 }
 
 /// Activate a scene — reconfigure room membership to match the preset.
-pub fn activate(scene_name: &str, rooms: &Rooms) -> Result<String, String> {
+pub fn activate(scene_name: &str, groups: &Groups) -> Result<String, String> {
     let scenes = load_scenes();
     let scene = scenes
         .get(scene_name)
@@ -47,13 +47,13 @@ pub fn activate(scene_name: &str, rooms: &Rooms) -> Result<String, String> {
             scenes.keys().map(|k| k.as_str()).collect::<Vec<_>>().join(", ")))?;
 
     // Leave all current named rooms
-    for (name, _) in rooms.my_rooms() {
-        rooms.leave(&name).ok();
+    for (name, _) in groups.my_groups() {
+        groups.leave(&name).ok();
     }
 
     // Join the scene's rooms
     for room_name in &scene.rooms {
-        rooms.join(room_name, false)?;
+        groups.join(room_name, false)?;
     }
 
     if scene.rooms.is_empty() {

--- a/tools/attend/src/scenes.rs
+++ b/tools/attend/src/scenes.rs
@@ -1,0 +1,175 @@
+//! Scene management for attend (ADR-118).
+//!
+//! A scene is a named preset that configures room membership.
+//! Scenes live in `~/.config/attend/scenes.yaml`.
+//!
+//! Built-in defaults:
+//!   private — leave all named rooms (project room only)
+//!   open    — join the well-known "open" room
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use crate::rooms::Rooms;
+
+/// A scene definition.
+#[derive(Debug, Clone)]
+pub struct Scene {
+    pub rooms: Vec<String>,
+}
+
+/// Load scenes from config file. Returns built-in defaults merged with user config.
+pub fn load_scenes() -> HashMap<String, Scene> {
+    let mut scenes = HashMap::new();
+
+    // Built-in defaults
+    scenes.insert("private".to_string(), Scene { rooms: Vec::new() });
+    scenes.insert("open".to_string(), Scene { rooms: vec!["open".to_string()] });
+
+    // User config overlay
+    let path = scenes_config_path();
+    if let Ok(content) = fs::read_to_string(&path) {
+        for (name, scene) in parse_scenes_yaml(&content) {
+            scenes.insert(name, scene);
+        }
+    }
+
+    scenes
+}
+
+/// Activate a scene — reconfigure room membership to match the preset.
+pub fn activate(scene_name: &str, rooms: &Rooms) -> Result<String, String> {
+    let scenes = load_scenes();
+    let scene = scenes
+        .get(scene_name)
+        .ok_or_else(|| format!("unknown scene '{scene_name}' — try: {}",
+            scenes.keys().map(|k| k.as_str()).collect::<Vec<_>>().join(", ")))?;
+
+    // Leave all current named rooms
+    for (name, _) in rooms.my_rooms() {
+        rooms.leave(&name).ok();
+    }
+
+    // Join the scene's rooms
+    for room_name in &scene.rooms {
+        rooms.join(room_name, false)?;
+    }
+
+    if scene.rooms.is_empty() {
+        Ok("project room only".to_string())
+    } else {
+        Ok(format!("joined: {}", scene.rooms.join(", ")))
+    }
+}
+
+fn scenes_config_path() -> PathBuf {
+    let config_dir = std::env::var("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+            PathBuf::from(home).join(".config")
+        });
+    config_dir.join("attend").join("scenes.yaml")
+}
+
+/// Parse scenes.yaml. Format:
+/// ```yaml
+/// private:
+///   rooms: []
+/// workroom:
+///   rooms: [deploy, infra]
+/// ```
+fn parse_scenes_yaml(content: &str) -> HashMap<String, Scene> {
+    let mut scenes = HashMap::new();
+    let mut current_name: Option<String> = None;
+    let mut current_rooms: Vec<String> = Vec::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let indent = line.len() - line.trim_start().len();
+
+        // Top-level: scene name
+        if indent == 0 && trimmed.ends_with(':') {
+            if let Some(ref name) = current_name {
+                scenes.insert(name.clone(), Scene { rooms: current_rooms.clone() });
+            }
+            current_name = Some(trimmed.trim_end_matches(':').to_string());
+            current_rooms = Vec::new();
+            continue;
+        }
+
+        // Second-level: rooms key with inline array or list items
+        if indent == 2 {
+            if let Some((key, value)) = trimmed.split_once(':') {
+                let key = key.trim();
+                let value = value.trim();
+                if key == "rooms" {
+                    // Inline array: rooms: [deploy, infra]
+                    if value.starts_with('[') && value.ends_with(']') {
+                        let inner = &value[1..value.len() - 1];
+                        current_rooms = inner
+                            .split(',')
+                            .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
+                            .filter(|s| !s.is_empty())
+                            .collect();
+                    } else if value == "[]" {
+                        current_rooms = Vec::new();
+                    }
+                    // else: list items follow at indent 4
+                }
+            }
+        }
+
+        // Third-level: list items
+        if indent == 4 {
+            if let Some(room) = trimmed.strip_prefix("- ") {
+                current_rooms.push(room.trim_matches('"').trim_matches('\'').to_string());
+            }
+        }
+    }
+
+    // Save last scene
+    if let Some(ref name) = current_name {
+        scenes.insert(name.clone(), Scene { rooms: current_rooms });
+    }
+
+    scenes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_scenes() {
+        let yaml = r#"
+private:
+  rooms: []
+workroom:
+  rooms: [deploy, infra]
+custom:
+  rooms:
+    - alpha
+    - beta
+"#;
+        let scenes = parse_scenes_yaml(yaml);
+        assert_eq!(scenes.len(), 3);
+        assert!(scenes["private"].rooms.is_empty());
+        assert_eq!(scenes["workroom"].rooms, vec!["deploy", "infra"]);
+        assert_eq!(scenes["custom"].rooms, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn test_builtins() {
+        let scenes = load_scenes();
+        assert!(scenes.contains_key("private"));
+        assert!(scenes.contains_key("open"));
+        assert!(scenes["private"].rooms.is_empty());
+        assert_eq!(scenes["open"].rooms, vec!["open"]);
+    }
+}

--- a/tools/attend/src/sensors/mod.rs
+++ b/tools/attend/src/sensors/mod.rs
@@ -28,6 +28,7 @@ pub use script::ScriptSensor;
 // ── Sensor registration ─────────────────────────────────────────
 
 use crate::config::Config;
+use crate::rooms::Rooms;
 #[allow(unused_imports)]
 use std::time::Duration;
 
@@ -45,6 +46,7 @@ pub fn register_sensors(
     cfg: &Config,
     focus: &Focus,
     catchup: bool,
+    rooms: &Rooms,
 ) -> (Vec<SensorSlot>, Vec<String>) {
     let mut slots: Vec<SensorSlot> = Vec::new();
     let mut enabled_names: Vec<String> = Vec::new();
@@ -82,6 +84,13 @@ pub fn register_sensors(
     {
         if cfg.sensors.get("peers").map(|s| s.enabled).unwrap_or(true) {
             let mut peer_sensor = PeerSensor::new();
+            // Pass room directories for signal scanning (ADR-118)
+            let room_dirs: Vec<std::path::PathBuf> = rooms
+                .joined_room_names()
+                .into_iter()
+                .map(|name| rooms.room_dir(&name))
+                .collect();
+            peer_sensor.set_extra_scan_dirs(room_dirs);
             if !catchup {
                 peer_sensor.mark_existing_as_seen(focus);
             }

--- a/tools/attend/src/sensors/mod.rs
+++ b/tools/attend/src/sensors/mod.rs
@@ -28,7 +28,7 @@ pub use script::ScriptSensor;
 // ── Sensor registration ─────────────────────────────────────────
 
 use crate::config::Config;
-use crate::rooms::Rooms;
+use crate::groups::Groups;
 #[allow(unused_imports)]
 use std::time::Duration;
 
@@ -46,7 +46,7 @@ pub fn register_sensors(
     cfg: &Config,
     focus: &Focus,
     catchup: bool,
-    rooms: &Rooms,
+    groups: &Groups,
 ) -> (Vec<SensorSlot>, Vec<String>) {
     let mut slots: Vec<SensorSlot> = Vec::new();
     let mut enabled_names: Vec<String> = Vec::new();
@@ -85,12 +85,12 @@ pub fn register_sensors(
         if cfg.sensors.get("peers").map(|s| s.enabled).unwrap_or(true) {
             let mut peer_sensor = PeerSensor::new();
             // Pass room directories for signal scanning (ADR-118)
-            let room_dirs: Vec<std::path::PathBuf> = rooms
-                .joined_room_names()
+            let group_dirs: Vec<std::path::PathBuf> = groups
+                .joined_group_names()
                 .into_iter()
-                .map(|name| rooms.room_dir(&name))
+                .map(|name| groups.group_dir(&name))
                 .collect();
-            peer_sensor.set_extra_scan_dirs(room_dirs);
+            peer_sensor.set_extra_scan_dirs(group_dirs);
             if !catchup {
                 peer_sensor.mark_existing_as_seen(focus);
             }

--- a/tools/sensor-peers/src/lib.rs
+++ b/tools/sensor-peers/src/lib.rs
@@ -30,6 +30,9 @@ pub struct PeerSensor {
     own_session_id: Option<String>,
     /// First poll establishes baseline
     baseline_established: bool,
+    /// Additional signal directories to scan (e.g., room dirs from ADR-118).
+    /// Set by the orchestrator via `set_extra_scan_dirs()`.
+    extra_scan_dirs: Vec<PathBuf>,
 }
 
 #[allow(dead_code)]
@@ -83,7 +86,14 @@ impl PeerSensor {
             reply_hint_shown: false,
             own_session_id,
             baseline_established: false,
+            extra_scan_dirs: Vec::new(),
         }
+    }
+
+    /// Set additional signal directories to scan (e.g., room dirs).
+    /// Called by the orchestrator after room membership is known.
+    pub fn set_extra_scan_dirs(&mut self, dirs: Vec<PathBuf>) {
+        self.extra_scan_dirs = dirs;
     }
 
     /// Return a list of active peer sessions as (cwd, project_name, status, context_percent).
@@ -114,6 +124,8 @@ impl PeerSensor {
                 }
             }
         }
+        // Room directories (ADR-118)
+        scan_dirs.extend(self.extra_scan_dirs.iter().cloned());
 
         for dir in &scan_dirs {
             let entries = match fs::read_dir(dir) {
@@ -138,19 +150,19 @@ impl PeerSensor {
     }
 
     /// Read signal files from peers. Scans own project dir, broadcast dir,
-    /// and any dirs in the focus list. Returns observations for new signals.
+    /// focus list, and joined rooms. Returns observations for new signals.
     fn read_signals(&mut self, focus: &Focus) -> Vec<(f64, String)> {
         let mut observations = Vec::new();
         let base = signals_base();
 
-        // Directories to scan: own project + broadcast + focus group
+        // Directories to scan: own project + broadcast + focus group + rooms
         let own_encoded = encode_cwd(&focus.working_dir);
         let mut scan_dirs = vec![
             base.join(&own_encoded),
             base.join("_broadcast"),
         ];
 
-        // Add focus group dirs
+        // Add focus group dirs (deprecated, still works)
         let focus_file = base.join("focus");
         if let Ok(content) = fs::read_to_string(&focus_file) {
             for line in content.lines() {
@@ -160,6 +172,8 @@ impl PeerSensor {
                 }
             }
         }
+        // Room directories (ADR-118)
+        scan_dirs.extend(self.extra_scan_dirs.iter().cloned());
 
         let own_session_id = self.own_session_id.as_deref().unwrap_or("---none---");
 

--- a/tools/sensor-peers/src/lib.rs
+++ b/tools/sensor-peers/src/lib.rs
@@ -115,16 +115,7 @@ impl PeerSensor {
             base.join(&own_encoded),
             base.join("_broadcast"),
         ];
-        let focus_file = base.join("focus");
-        if let Ok(content) = fs::read_to_string(&focus_file) {
-            for line in content.lines() {
-                let line = line.trim();
-                if !line.is_empty() {
-                    scan_dirs.push(base.join(encode_cwd(line)));
-                }
-            }
-        }
-        // Room directories (ADR-118)
+        // Focus group directories (ADR-118 — named signal namespaces)
         scan_dirs.extend(self.extra_scan_dirs.iter().cloned());
 
         for dir in &scan_dirs {
@@ -162,17 +153,7 @@ impl PeerSensor {
             base.join("_broadcast"),
         ];
 
-        // Add focus group dirs (deprecated, still works)
-        let focus_file = base.join("focus");
-        if let Ok(content) = fs::read_to_string(&focus_file) {
-            for line in content.lines() {
-                let line = line.trim();
-                if !line.is_empty() {
-                    scan_dirs.push(base.join(encode_cwd(line)));
-                }
-            }
-        }
-        // Room directories (ADR-118)
+        // Focus group directories (ADR-118 — named signal namespaces)
         scan_dirs.extend(self.extra_scan_dirs.iter().cloned());
 
         let own_session_id = self.own_session_id.as_deref().unwrap_or("---none---");


### PR DESCRIPTION
## Summary

Implements ADR-118: named focus groups replacing the old static focus file.

- `attend focus on/off/list/all/clear/pin/dissolve` — manage named groups
- `attend send --focus <name>` — send signals to a focus group
- `attend scene private/open` — named presets for focus configuration
- Peer sensor scans joined group directories for signals
- Unified `attend peers` view with focus group context
- Old focus file plumbing removed entirely
- Internal naming: groups.rs (not rooms — agents don't have rooms)

5 commits, 5 unit tests, clean lint + build.

## Test plan

- [ ] `attend focus on deploy && attend focus list` shows group
- [ ] `attend send --focus deploy "msg"` lands signal in @deploy/
- [ ] `attend scene private` clears all groups
- [ ] `attend scene open` joins "open" group  
- [ ] `attend peers` shows focus groups alongside agents
- [ ] `attend status` shows focus section
- [ ] `make lint` passes
- [ ] `cargo test -p attend` passes (5 tests)