### PR TITLE
attend awareness stabilization — cleanup, group lifecycle, git lock mitigation

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -38,9 +38,10 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-115](./system/ADR-115-declarative-config-with-project-scope-overlay.md) | Declarative Configuration with Project-Scope Overlay | Draft |
 | [ADR-116](./system/ADR-116-declarative-permission-requirements.md) | Declarative Permission Requirements | Accepted |
 | [ADR-117](./system/ADR-117-sensor-crate-extraction-and-feature-flags.md) | Sensor Crate Extraction and Feature Flags | Accepted |
-| [ADR-118](./system/ADR-118-focus-groups-dynamic-agent-grouping.md) | Focus Groups — Dynamic Agent Grouping | Draft |
+| [ADR-118](./system/ADR-118-focus-groups-dynamic-agent-grouping.md) | Focus Groups — Dynamic Agent Grouping | Accepted |
 | [ADR-119](./system/ADR-119-action-potential-engagement-model.md) | Action Potential Engagement Model | Accepted |
 | [ADR-120](./system/ADR-120-interactive-chat-tui-human-in-the-signal-loop.md) | Interactive Chat TUI — Human in the Signal Loop | Draft |
+| [ADR-121](./system/ADR-121-salience-decay-for-signal-presentation-turn-based-exponential.md) | Salience decay for signal presentation — turn-based exponential | Draft |
 
 ## Documentation
 _Documentation structure, tooling, coherence_

--- a/docs/architecture/system/ADR-118-focus-groups-dynamic-agent-grouping.md
+++ b/docs/architecture/system/ADR-118-focus-groups-dynamic-agent-grouping.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-04-10
 deciders:
   - aaronsb

--- a/docs/architecture/system/ADR-121-salience-decay-for-signal-presentation-turn-based-exponential.md
+++ b/docs/architecture/system/ADR-121-salience-decay-for-signal-presentation-turn-based-exponential.md
@@ -1,0 +1,78 @@
+---
+status: Draft
+date: 2026-04-12
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-113
+  - ADR-114
+  - ADR-119
+---
+
+# ADR-121: Salience decay for signal presentation — turn-based exponential
+
+## Context
+
+ADR-119 (action potential engagement model) governs *when new stimuli break through* to fire a disclosure. Disk retention (default 30 days, per the cleanup work on `fix/attend-awareness-stabilization`) governs *how long signal files live on disk*. Neither mechanism addresses the middle case: a signal that has already been disclosed, is still on disk, and is still within the "present to the agent" set at every turn regardless of whether it's still load-bearing.
+
+In a long session, this manifests as presentation bloat — signals from the first few turns keep appearing in notifications 40, 60, 80 turns later, long after their context has been overtaken. A survey of 18 recent active sessions shows the distribution is long-tailed: median 12 turns, p75 45, p90 84, max 133. Short sessions never see the problem; long sessions see it badly.
+
+Time-based aging is tempting but wrong at this scale. Turn pacing varies by an order of magnitude — a 10-minute think turn and a 15-second reply both count as "one turn" and should age the same. A time-based window would wobble with pacing; a turn-based window tracks the actual thing we care about: how many rounds of decision-making have passed since this signal was useful.
+
+Disk retention (30 days) is intentionally time-based because at that horizon time is a fine proxy for "bulk turns" — variance averages out across thousands of turns. Presentation aging operates at a much finer grain where the turn/time distinction matters, so the two mechanisms use different units.
+
+## Decision
+
+Signals carry a **salience** that starts at 1.0 when they arrive and decays exponentially with turns elapsed since arrival. Below a configurable floor, a signal stops appearing in notifications — but the file stays on disk until the 30-day cleanup removes it. Salience is reset to 1.0 whenever a signal is re-engaged (replied to, referenced).
+
+The decay is parameterized by a **half-life in turns** — the number of turns after which an un-engaged signal has dropped to 50% salience. Default: 20 turns. Presentation floor: 0.3.
+
+Re-engagement semantics preserve the "keep the active thread alive" behavior: an ongoing peer conversation keeps its signals hot as long as either side is replying.
+
+Salience decay is a presentation-layer mechanism. It does not delete, mutate, or hide signals at the storage layer. It only gates what the peer sensor emits into notifications.
+
+## Consequences
+
+### Positive
+
+- **Graceful fade, not a cliff.** Exponential decay means no hard "at turn 45 everything drops" behavior. The curve tracks declining relevance smoothly.
+- **Short sessions unaffected.** With half-life 20 and median session 12 turns, the typical session sees no aging — first-turn signals are still ~66% salient at session end.
+- **Long sessions see natural pruning.** In a p75 (45-turn) session, signals from the opening are below the 0.3 floor by the end; in a p90 (84-turn) session they're gone well before the end.
+- **Symmetric with ADR-119.** Action potential handles engagement (when to fire); salience decay handles presentation (when to fade). Together they form an inward-outward pair.
+- **Turn-based matches mental model.** Users think in conversational turns, not wall clock. The unit matches the intuition.
+
+### Negative
+
+- **Mechanism complexity.** Every signal now needs an `arrival_turn` field and the peer sensor gains a per-signal salience computation on every scan. Modest, but not free.
+- **Turn counter dependency.** Requires a reliable source of "current turn" — tying attend's presentation to the session transcript couples it to Claude Code's JSONL format. If the format changes, attend breaks. ADR-119's tune command already has this coupling; extending it is not a net-new risk.
+- **Re-engagement detection is heuristic.** "Did this signal get re-engaged?" requires matching replies or references against earlier signals. Imperfect matching will leak some aging through; accepting that as cost.
+- **Threshold tuning.** The half-life and presentation floor are empirically chosen. The 20-turn default is grounded in real session data, but the right values on someone else's usage may differ. Config overrides handle this, but there's no automatic tuning yet.
+
+### Neutral
+
+- **Orthogonal to disk retention.** The 30-day disk cleanup is unchanged. Salience decay sits entirely above it, in the presentation path.
+- **Replaces nothing.** ADR-119's engagement model is untouched. This layers on top.
+- **Configurable.** All parameters live in attend config following the ADR-115 overlay pattern.
+
+## Alternatives Considered
+
+### Hard cutoff at N turns
+
+Reject signals older than turn `current - N`. Simpler to implement (no per-signal salience), but produces a cliff — at turn 45, everything from before turn 0 vanishes abruptly. The user's framing ("could be exponential") explicitly argued against this. Exponential matches the intuition that relevance declines gradually, not abruptly.
+
+### Time-based aging (minutes or hours)
+
+Use `u2u_median` (~82s) as one-turn-equivalent and compute salience from wall clock. Cheaper because no turn counter needed. Rejected because turn pacing varies too much at this granularity — a single deep think turn can inflate apparent "age" and drop fresh signals below the floor incorrectly. At 30-day horizons time is fine (disk retention), but not at minutes-to-hours.
+
+### Linear decay over N turns
+
+`salience = max(0, 1 - (turns_since / N))`. Even simpler than exponential. Rejected because linear decay implies "every turn contributes equally to aging," which misrepresents the real curve: the first few turns of irrelevance matter more than the last few. Exponential naturally models "relevance halves repeatedly," which is closer to how attention actually works.
+
+### Per-category half-lives
+
+Different signal types (peer message vs. build event vs. git change) could age at different rates. Tempting but premature — start with one half-life across all signal types, add per-category overrides only if real use demands it. ADR-119 set the precedent of global defaults with per-sensor overrides available; follow the same pattern.
+
+### Subsume into ADR-119's refractory machinery
+
+Action potential already tracks engagement dynamics. Why not extend the refractory curve to cover presentation aging too? Rejected because the two mechanisms answer different questions. Refractory asks "should this new stimulus fire?" — an inward gate. Salience asks "should this already-fired signal still be shown?" — an outward gate. Conflating them would force a single curve to serve two opposite purposes and make both harder to reason about.

--- a/hooks/ways/require-ways.sh
+++ b/hooks/ways/require-ways.sh
@@ -11,3 +11,10 @@ WAYS_BIN="${HOME}/.claude/bin/ways"
 if [[ ! -x "$WAYS_BIN" ]]; then
   exit 0
 fi
+
+# Avoid racing with foreground git commits. `git status` / `describe --dirty`
+# and similar read-ish operations normally take .git/index.lock to refresh the
+# stat cache; GIT_OPTIONAL_LOCKS=0 tells git to skip that lock. Hooks run
+# opportunistically alongside user git activity, so optional locks are always
+# safe here — we never rely on the cache being rewritten.
+export GIT_OPTIONAL_LOCKS=0

--- a/skills/attend/SKILL.md
+++ b/skills/attend/SKILL.md
@@ -52,6 +52,8 @@ attend send --broadcast "important announcement for all sessions"
 attend send --to /home/user/other-project "directed message"
 ```
 
+Keep messages under ~400 characters. Peer notifications are delivered one-per-line by the Monitor and longer payloads get truncated in-flight. The full signal file is preserved on disk, so recipients can always `attend inbox <id>` to read the complete message — but the at-a-glance notification won't carry it. Concise is the design, not a workaround.
+
 ### Focus groups
 
 Named groups that agents focus on for shared signal routing. Groups are dynamic — join and leave as needed.

--- a/tools/attend/src/config.rs
+++ b/tools/attend/src/config.rs
@@ -18,7 +18,35 @@ use std::time::Duration;
 pub struct Config {
     pub governor: GovernorConfig,
     pub engagement: EngagementConfig,
+    pub cleanup: CleanupConfig,
     pub sensors: HashMap<String, SensorConfig>,
+}
+
+/// Background signal-file cleanup. Runs inside `attend run` so the signals
+/// base doesn't accumulate indefinitely. Defaults keep peer discussion
+/// readable for ~30 days, which is long enough to pick up a conversation
+/// the next day or the next week and short enough that nothing lives forever.
+#[derive(Debug, Clone)]
+pub struct CleanupConfig {
+    /// Master switch. Disable to skip auto-cleanup entirely.
+    pub enabled: bool,
+    /// How often the sensor loop runs a cleanup sweep.
+    pub interval: Duration,
+    /// Signal files older than this are removed by auto-cleanup.
+    pub retention: Duration,
+}
+
+impl Default for CleanupConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            // Every 10 minutes — directory scan is O(files) and cheap.
+            interval: Duration::from_secs(600),
+            // 30 days — conservative enough that peer discussion threads
+            // stay readable across multi-day gaps.
+            retention: Duration::from_secs(30 * 86400),
+        }
+    }
 }
 
 /// Disclosure governor parameters.
@@ -139,6 +167,7 @@ impl Default for Config {
         Self {
             governor: GovernorConfig::default(),
             engagement: EngagementConfig::default(),
+            cleanup: CleanupConfig::default(),
             sensors,
         }
     }
@@ -200,6 +229,14 @@ engagement:
   absolute_refractory: 60    # seconds of complete suppression after burst
   decay_per_minute: 0.1      # relative refractory decay rate
   peer_activity_window: 900  # per-peer engagement window
+
+# Background signal-file cleanup. Runs inside `attend run` so the signals
+# base doesn't accumulate indefinitely. `attend cleanup` is the manual
+# escape hatch with --older-than / --all / --dry-run.
+cleanup:
+  enabled: true
+  interval: 600              # seconds — how often the sweep runs (10 min)
+  retention: 2592000         # seconds — age cutoff (30 days)
 
 sensors:
   context:
@@ -282,6 +319,25 @@ fn apply_config(config: &mut Config, content: &str) {
                         "rate_window" => {
                             if let Ok(v) = value.parse::<u64>() {
                                 config.governor.rate_window = Duration::from_secs(v);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            } else if current_section == "cleanup" {
+                if let Some((key, value)) = parse_kv(trimmed) {
+                    match key {
+                        "enabled" => {
+                            config.cleanup.enabled = value == "true";
+                        }
+                        "interval" => {
+                            if let Ok(v) = value.parse::<u64>() {
+                                config.cleanup.interval = Duration::from_secs(v);
+                            }
+                        }
+                        "retention" => {
+                            if let Ok(v) = value.parse::<u64>() {
+                                config.cleanup.retention = Duration::from_secs(v);
                             }
                         }
                         _ => {}

--- a/tools/attend/src/groups.rs
+++ b/tools/attend/src/groups.rs
@@ -230,7 +230,10 @@ impl Groups {
             fs::create_dir_all(parent).ok();
         }
         let content = serialize_groups_yaml(state);
-        fs::write(&path, content).ok();
+        let tmp = path.with_extension("yaml.tmp");
+        if fs::write(&tmp, &content).is_ok() {
+            fs::rename(&tmp, &path).ok();
+        }
     }
 
 }

--- a/tools/attend/src/groups.rs
+++ b/tools/attend/src/groups.rs
@@ -21,6 +21,7 @@ pub struct GroupEntry {
 }
 
 /// Group state manager.
+#[derive(Clone)]
 pub struct Groups {
     base: PathBuf,
     session_id: String,

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -893,8 +893,8 @@ fn cmd_tune(apply: bool) {
     let step_multiplier = 1.25_f64;
     let peak_multiplier = 1.0 + (1.0 * step_multiplier); // peak at exactly burst_threshold
 
-    let burst_window_s = ((u2u_p90 * burst_threshold).max(300.0).min(3600.0)) as u64;
-    let abs_refractory_s = (a2u_median.max(15.0).min(300.0)) as u64;
+    let burst_window_s = (u2u_p90 * burst_threshold).clamp(300.0, 3600.0) as u64;
+    let abs_refractory_s = a2u_median.clamp(15.0, 300.0) as u64;
     let burst_window_min = burst_window_s as f64 / 60.0;
     let decay_per_minute = (peak_multiplier - 1.0) / (2.0 * burst_window_min);
 

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -7,6 +7,7 @@ mod sensors;
 
 use sensors::Focus;
 use std::collections::BinaryHeap;
+use std::path::Path;
 use std::time::{Duration, Instant};
 
 // --- Disclosure governor ---
@@ -198,6 +199,15 @@ fn cmd_run_with_catchup(catchup: bool) {
     let mut last_checkpoint = Instant::now();
     let checkpoint_interval = Duration::from_secs(30);
 
+    // Auto-cleanup timer — prune stale signal files and empty project dirs.
+    // Default 30-day retention + 10-minute sweep interval (see CleanupConfig).
+    // Fire a first sweep on startup so long-running instances don't wait
+    // a full interval before the first prune.
+    let mut last_cleanup: Option<Instant> = None;
+    let cleanup_enabled = cfg.cleanup.enabled;
+    let cleanup_interval = cfg.cleanup.interval;
+    let cleanup_retention = cfg.cleanup.retention;
+
     emit::log(&format!("tick loop running — {} sensors registered", slots.len()));
     for slot in &slots {
         emit::log(&format!(
@@ -362,6 +372,28 @@ fn cmd_run_with_catchup(catchup: bool) {
             let snapshot = collect_snapshot(&slots);
             state_store.checkpoint(&snapshot);
             last_checkpoint = Instant::now();
+        }
+
+        // Periodic cleanup sweep — remove stale signal files and empty
+        // project subdirs from the signals base. Scoped strictly to
+        // attend's own data (~/.cache/attend/signals/); never touches
+        // ways data or anything else.
+        if cleanup_enabled {
+            let due = match last_cleanup {
+                None => true,
+                Some(t) => t.elapsed() >= cleanup_interval,
+            };
+            if due {
+                let base = signals_base();
+                let stats = run_cleanup(&base, cleanup_retention, false, false);
+                if stats.removed > 0 || stats.dirs_removed > 0 {
+                    emit::log(&format!(
+                        "cleanup: removed {} signal(s) ({} bytes), {} empty project dir(s)",
+                        stats.removed, stats.bytes, stats.dirs_removed,
+                    ));
+                }
+                last_cleanup = Some(Instant::now());
+            }
         }
     }
 }
@@ -1549,6 +1581,204 @@ fn cmd_permissions_audit() {
     permissions::display_audit("Attend Permissions Audit", "Sensor", &results, false);
 }
 
+/// Parse a duration like "30s", "5m", "1h". Bare digits are treated as seconds.
+fn parse_duration_arg(s: &str) -> Option<Duration> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    let (num, unit) = match s.chars().last()? {
+        c if c.is_ascii_digit() => (s, "s"),
+        _ => s.split_at(s.len() - 1),
+    };
+    let n: u64 = num.parse().ok()?;
+    let mult: u64 = match unit {
+        "s" => 1,
+        "m" => 60,
+        "h" => 3600,
+        "d" => 86400,
+        _ => return None,
+    };
+    Some(Duration::from_secs(n * mult))
+}
+
+/// Statistics from a cleanup sweep.
+#[derive(Default, Debug)]
+struct CleanupStats {
+    examined: u64,
+    removed: u64,
+    bytes: u64,
+    dirs_removed: u64,
+}
+
+/// Core cleanup routine, shared by `attend cleanup` and the in-loop auto-sweep.
+///
+/// Two passes over the signals base:
+///   1. Remove stale `*.signal` files older than `older_than` (or all if `nuke_all`).
+///   2. Remove now-empty encoded-cwd project subdirs — the shells left behind
+///      after projects go dormant. Never removes `_broadcast`, `@groups`, or
+///      any dir containing non-signal files (e.g., `_groups.yaml`).
+///
+/// On `dry_run`, emits a line per candidate to stdout instead of deleting.
+fn run_cleanup(base: &Path, older_than: Duration, dry_run: bool, nuke_all: bool) -> CleanupStats {
+    let mut stats = CleanupStats::default();
+    if !base.is_dir() {
+        return stats;
+    }
+
+    let now = std::time::SystemTime::now();
+    let entries = match std::fs::read_dir(base) {
+        Ok(e) => e,
+        Err(_) => return stats,
+    };
+
+    // Pass 1: prune stale signal files.
+    for sub in entries.flatten() {
+        let subpath = sub.path();
+        if !subpath.is_dir() {
+            continue;
+        }
+        let files = match std::fs::read_dir(&subpath) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for f in files.flatten() {
+            let path = f.path();
+            let name = match path.file_name().and_then(|s| s.to_str()) {
+                Some(n) => n,
+                None => continue,
+            };
+            if !name.ends_with(".signal") {
+                continue;
+            }
+            stats.examined += 1;
+
+            let meta = match f.metadata() {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            let age = meta
+                .modified()
+                .ok()
+                .and_then(|mt| now.duration_since(mt).ok())
+                .unwrap_or(Duration::ZERO);
+
+            if !nuke_all && age < older_than {
+                continue;
+            }
+
+            let size = meta.len();
+            if dry_run {
+                println!("would remove {} ({}s old, {} bytes)", path.display(), age.as_secs(), size);
+            } else if std::fs::remove_file(&path).is_ok() {
+                stats.removed += 1;
+                stats.bytes += size;
+            }
+        }
+    }
+
+    // Pass 2: remove empty encoded-cwd project subdirs left as shells.
+    // A project subdir is a non-reserved name (not _broadcast, not @group,
+    // not _anything) that now contains nothing. Focus-group dirs self-clean
+    // on leave/dissolve already; we don't touch those here.
+    if let Ok(entries) = std::fs::read_dir(base) {
+        for sub in entries.flatten() {
+            let subpath = sub.path();
+            if !subpath.is_dir() {
+                continue;
+            }
+            let name = match subpath.file_name().and_then(|s| s.to_str()) {
+                Some(n) => n,
+                None => continue,
+            };
+            // Reserved names we never touch.
+            if name.starts_with('_') || name.starts_with('@') {
+                continue;
+            }
+            // Dir is a candidate only if fully empty now.
+            let empty = std::fs::read_dir(&subpath)
+                .map(|mut it| it.next().is_none())
+                .unwrap_or(false);
+            if !empty {
+                continue;
+            }
+            if dry_run {
+                println!("would remove empty project dir {}", subpath.display());
+            } else if std::fs::remove_dir(&subpath).is_ok() {
+                stats.dirs_removed += 1;
+            }
+        }
+    }
+
+    stats
+}
+
+fn cmd_cleanup(args: &[String]) {
+    // Default to the config's retention so the manual command's semantics
+    // match the auto-sweep by default. Overrides with --older-than.
+    let focus = Focus::default_focus();
+    let cfg = config::Config::load(&focus.working_dir);
+    let mut older_than = cfg.cleanup.retention;
+    let mut dry_run = false;
+    let mut nuke_all = false;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--dry-run" | "-n" => dry_run = true,
+            "--all" => nuke_all = true,
+            "--older-than" => {
+                if let Some(v) = args.get(i + 1) {
+                    match parse_duration_arg(v) {
+                        Some(d) => older_than = d,
+                        None => {
+                            eprintln!("attend cleanup: invalid duration '{}' — try 5m, 1h, 30s", v);
+                            std::process::exit(2);
+                        }
+                    }
+                    i += 1;
+                } else {
+                    eprintln!("attend cleanup: --older-than requires a value");
+                    std::process::exit(2);
+                }
+            }
+            "--help" | "-h" => {
+                println!("attend cleanup — remove stale signal files from ~/.cache/attend/signals/\n");
+                println!("usage: attend cleanup [--older-than <dur>] [--dry-run] [--all]\n");
+                println!("  --older-than <dur>  age cutoff (default: cleanup.retention from config)");
+                println!("                       duration format: 30s, 5m, 1h, 2d");
+                println!("  --dry-run, -n       list what would be removed without deleting");
+                println!("  --all               remove every signal file regardless of age");
+                println!();
+                println!("Auto-cleanup also runs inside `attend run` every cleanup.interval seconds.");
+                return;
+            }
+            other => {
+                eprintln!("attend cleanup: unknown flag '{other}' — try --help");
+                std::process::exit(2);
+            }
+        }
+        i += 1;
+    }
+
+    let base = signals_base();
+    if !base.is_dir() {
+        println!("no signals base at {} — nothing to clean", base.display());
+        return;
+    }
+
+    let stats = run_cleanup(&base, older_than, dry_run, nuke_all);
+
+    if dry_run {
+        println!("\ndry run: examined {} signal file(s)", stats.examined);
+    } else {
+        println!(
+            "cleaned up {} signal file(s), freed {} bytes (examined {}); removed {} empty project dir(s)",
+            stats.removed, stats.bytes, stats.examined, stats.dirs_removed,
+        );
+    }
+}
+
 // --- Entry point ---
 
 fn main() {
@@ -1592,6 +1822,9 @@ fn main() {
                     std::process::exit(1);
                 }
             }
+        }
+        Some("cleanup") => {
+            cmd_cleanup(&args[1..]);
         }
         Some("config") => {
             match args.get(1).map(|s| s.as_str()) {
@@ -1641,6 +1874,7 @@ fn main() {
                 ("config",      "Manage configuration (init/show/path)"),
                 ("tune",        "Survey session history and derive engagement config (--apply to write)"),
                 ("permissions", "Audit sensor permissions against settings.json"),
+                ("cleanup",     "Remove stale signal files from the signals base (default: 5m)"),
                 ("status",      "Show running instances, signals, and focus state"),
                 ("help",        "Show this help"),
             ]);

--- a/tools/attend/src/sensors/mod.rs
+++ b/tools/attend/src/sensors/mod.rs
@@ -84,13 +84,17 @@ pub fn register_sensors(
     {
         if cfg.sensors.get("peers").map(|s| s.enabled).unwrap_or(true) {
             let mut peer_sensor = PeerSensor::new();
-            // Pass focus group directories for signal scanning (ADR-118)
-            let group_dirs: Vec<std::path::PathBuf> = groups
-                .joined_group_names()
-                .into_iter()
-                .map(|name| groups.group_dir(&name))
-                .collect();
-            peer_sensor.set_extra_scan_dirs(group_dirs);
+            // Register a provider that re-reads group membership on every
+            // poll, so mid-session focus-group join/leave is reflected
+            // without restarting the sensor loop (ADR-118 + issue #15).
+            let groups_for_scan = groups.clone();
+            peer_sensor.set_extra_scan_dirs_provider(std::sync::Arc::new(move || {
+                groups_for_scan
+                    .joined_group_names()
+                    .into_iter()
+                    .map(|name| groups_for_scan.group_dir(&name))
+                    .collect()
+            }));
             // Align per-peer engagement window with global engagement config.
             peer_sensor.set_peer_activity_window(cfg.engagement.peer_activity_window);
             if !catchup {

--- a/tools/sensor-git/src/lib.rs
+++ b/tools/sensor-git/src/lib.rs
@@ -207,6 +207,7 @@ impl Sensor for GitSensor {
 /// Run a git command and return trimmed stdout, or None on failure.
 fn git_cmd(dir: &str, args: &[&str]) -> Option<String> {
     let output = Command::new("git")
+        .env("GIT_OPTIONAL_LOCKS", "0")
         .arg("-C")
         .arg(dir)
         .args(args)

--- a/tools/sensor-peers/src/lib.rs
+++ b/tools/sensor-peers/src/lib.rs
@@ -3,7 +3,13 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+/// Callback that returns the current set of extra signal directories
+/// (typically focus-group dirs). Called on every scan so mid-session
+/// group join/leave is reflected without restarting the sensor loop.
+pub type ExtraScanDirsFn = Arc<dyn Fn() -> Vec<PathBuf> + Send + Sync>;
 
 /// Discovers peer Claude Code sessions by reading ~/.claude/sessions/*.json
 /// and their transcript files. Same discovery pattern as abtop.
@@ -30,9 +36,12 @@ pub struct PeerSensor {
     own_session_id: Option<String>,
     /// First poll establishes baseline
     baseline_established: bool,
-    /// Additional signal directories to scan (e.g., room dirs from ADR-118).
-    /// Set by the orchestrator via `set_extra_scan_dirs()`.
-    extra_scan_dirs: Vec<PathBuf>,
+    /// Provider that returns additional signal directories to scan on each
+    /// poll (e.g., focus-group dirs from ADR-118). A closure lets the sensor
+    /// pick up focus-group joins and leaves that happen after startup
+    /// without the orchestrator having to push updates. Set via
+    /// `set_extra_scan_dirs_provider()`.
+    extra_scan_dirs_fn: Option<ExtraScanDirsFn>,
     /// Per-peer message timestamps for engagement-based magnitude boosting.
     /// Keyed by "from" field (e.g., "claude:<session_id>").
     /// When the same peer sends multiple messages in a window, their
@@ -95,7 +104,7 @@ impl PeerSensor {
             reply_hint_shown: false,
             own_session_id,
             baseline_established: false,
-            extra_scan_dirs: Vec::new(),
+            extra_scan_dirs_fn: None,
             peer_activity: HashMap::new(),
             peer_activity_window: Duration::from_secs(900),
         }
@@ -118,9 +127,9 @@ impl PeerSensor {
     /// 3 messages between agents takes 5-10 minutes of wall clock.
     ///
     /// - 1st message in window: 1.0x (entry level, fires at rest)
-    /// - 2nd message:           1.75x (participant emerging)
-    /// - 3rd+ message:          2.5x (established conversation partner —
-    ///                          reliably breaks through refractory)
+    /// - 2nd message: 1.75x (participant emerging)
+    /// - 3rd+ message: 2.5x (established conversation partner — reliably
+    ///   breaks through refractory)
     fn peer_engagement_boost(&mut self, from: &str) -> f64 {
         let now = Instant::now();
         let window = self.peer_activity_window;
@@ -141,10 +150,19 @@ impl PeerSensor {
         }
     }
 
-    /// Set additional signal directories to scan (e.g., room dirs).
-    /// Called by the orchestrator after room membership is known.
-    pub fn set_extra_scan_dirs(&mut self, dirs: Vec<PathBuf>) {
-        self.extra_scan_dirs = dirs;
+    /// Register a provider for additional signal directories. The closure
+    /// is invoked on every scan, so mid-session focus-group join/leave
+    /// propagates without restarting the sensor loop.
+    pub fn set_extra_scan_dirs_provider(&mut self, f: ExtraScanDirsFn) {
+        self.extra_scan_dirs_fn = Some(f);
+    }
+
+    /// Current snapshot of extra scan dirs. Empty if no provider is set.
+    fn current_extra_scan_dirs(&self) -> Vec<PathBuf> {
+        match &self.extra_scan_dirs_fn {
+            Some(f) => f(),
+            None => Vec::new(),
+        }
     }
 
     /// Return a list of active peer sessions as (cwd, project_name, status, context_percent).
@@ -167,7 +185,7 @@ impl PeerSensor {
             base.join("_broadcast"),
         ];
         // Focus group directories (ADR-118 — named signal namespaces)
-        scan_dirs.extend(self.extra_scan_dirs.iter().cloned());
+        scan_dirs.extend(self.current_extra_scan_dirs());
 
         for dir in &scan_dirs {
             let entries = match fs::read_dir(dir) {
@@ -205,7 +223,7 @@ impl PeerSensor {
         ];
 
         // Focus group directories (ADR-118 — named signal namespaces)
-        scan_dirs.extend(self.extra_scan_dirs.iter().cloned());
+        scan_dirs.extend(self.current_extra_scan_dirs());
 
         let own_session_id: String = self.own_session_id
             .clone()

--- a/tools/ways-cli/src/cmd/show/metrics.rs
+++ b/tools/ways-cli/src/cmd/show/metrics.rs
@@ -78,6 +78,7 @@ pub(crate) fn count_siblings(way_id: &str, project_dir: &str, session_id: &str) 
 /// Get a human-readable version string from git describe.
 pub(crate) fn git_version(repo: &Path) -> String {
     let output = Command::new("git")
+        .env("GIT_OPTIONAL_LOCKS", "0")
         .args(["-C", &repo.display().to_string(), "describe", "--tags", "--match", "v*", "--always", "--dirty"])
         .output();
 
@@ -190,6 +191,7 @@ pub(crate) fn update_status_text() -> String {
 /// Return dirty file status from git.
 pub(crate) fn dirty_status_text(claude_dir: &Path) -> String {
     let output = Command::new("git")
+        .env("GIT_OPTIONAL_LOCKS", "0")
         .args(["-C", &claude_dir.display().to_string(), "status", "--short"])
         .output();
 


### PR DESCRIPTION
## Summary

Stabilization bundle for the attend awareness layer — fixes real bugs surfaced during the ADR-113/114/118/119 shipping, adds auto-cleanup so the signals base doesn't accumulate indefinitely, and drafts ADR-121 for the next design step (turn-based salience decay).

Everything is scoped strictly to attend's own concerns. Ways data is untouched; the split control-surface principle holds.

## Commits (in landing order)

1. **docs(adr-118)** — mark Accepted after PR #14 landed the code (status drift)
2. **docs(attend)** — note ~400 char peer message limit in `skills/attend/SKILL.md` (closes #17)
3. **fix(attend)** — atomic writes for `_groups.yaml` via write-then-rename (closes #16)
4. **fix(git-races)** — `GIT_OPTIONAL_LOCKS=0` in hooks and read-only git call sites (opens #19 to track root cause)
5. **fix(attend)** — refresh focus group dirs on every sensor poll via a closure-based provider (closes #15)
6. **feat(attend)** — `attend cleanup` subcommand + auto-sweep inside `attend run` with 30-day default retention, plus empty project dir pruning (addresses op items from #2)
7. **docs(adr-121)** — salience decay draft, turn-based exponential

## Key behaviors

### Focus group liveness (#15)
The peer sensor used to snapshot focus-group directories once at `register_sensors()` and never update them. Mid-session join/leave had no effect until the sensor loop restarted. Replaced the one-shot `set_extra_scan_dirs(Vec<PathBuf>)` with a closure-based provider that re-reads group membership from `Groups` on every scan. `Groups` now derives `Clone` so the closure can own its copy.

### Cleanup (#2 op items)
- `attend cleanup` — manual operator command with `--older-than`, `--dry-run`, `--all`
- Auto-sweep inside `attend run` — runs every 10 minutes by default, prunes signal files older than 30 days, then removes now-empty encoded-cwd project subdirs
- Reserved names (`_broadcast`, `@groups`, anything starting with `_` or `@`) are never touched
- Scoped exclusively to `~/.cache/attend/signals/` — no reach into ways data

Surprise finding: sensor-peers never actually cleaned up signal files (the claim in #2 was aspirational). My dev machine had 110 stale signal files dating back ~52 hours across project scopes, `_broadcast`, and peer dirs. The new cleanup immediately reclaims all of it on a schedule.

Config surface (defaults-on):
```yaml
cleanup:
  enabled: true
  interval: 600      # 10 minute sweep
  retention: 2592000 # 30 day age cutoff
```

### Atomic `_groups.yaml` writes (#16)
Applied the write-then-rename pattern from `state.rs::checkpoint()`. Closes a race window where concurrent attend instances could corrupt the state file.

### Git lock mitigation (#19)
Hook execution was intermittently colliding with foreground `git commit` at `.git/index.lock`. `GIT_OPTIONAL_LOCKS=0` exported from `hooks/ways/require-ways.sh` (covers every sourced hook) and `.env()`-set on the 3 runtime git call sites in ways-cli and sensor-git. Read-ish operations skip the index lock; the occasional stale stat cache is fine for every caller here. Root cause is still unknown — #19 tracks the investigation.

### ADR-121 draft
Salience decay for signal presentation. Orthogonal to disk retention — signals fade out of notifications via turn-based exponential decay while their files remain on disk until the 30-day cleanup. Half-life 20 turns by default, grounded in survey data from 18 recent active sessions. Decision-rights only; implementation is a follow-up.

## Drive-by cleanups

Two pre-existing clippy lints surfaced when running `cargo clippy --workspace -- -D warnings` on the new code:
- `sensor-peers`: doc-list overindent in `peer_engagement_boost`
- `attend/main`: `.max().min()` → `.clamp()` in action-potential parameter derivation

Folded into the commit that introduced them for this branch; a separate PR will add the clippy CI gate that should have caught them upstream.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `attend cleanup --dry-run` smoke-tested against real signals base (found 110 stale files + 1 empty project shell)
- [x] `attend cleanup --older-than 30d --dry-run` verified new default behavior
- [x] `attend tune` still works after peer sensor refactor
- [x] `make attend-rebuild` clean
- [x] `docs/scripts/adr lint` passes on ADR-121
- [ ] Live multi-agent session test of focus-group mid-session join/leave — recommend running after merge to confirm no regression in the refresh path
- [ ] Observe auto-sweep in a long-running `attend run` session — recommend keeping an eye on the `[attend] cleanup: removed N signal(s)…` log lines

## Closes

- #15 — focus group dirs not updated mid-session
- #16 — _groups.yaml atomic writes
- #17 — peer message truncation at ~500 chars (closed via doc note earlier)

## Related

- #2 — attend remaining work (op items addressed, tracker re-audited)
- #19 — git lock race root cause (mitigation shipped here, investigation follow-up)