### PR TITLE
docs: attend-and-monitor — full documentation pass + example sensor + upstream rename

### DIFF
--- a/.claude-upstream
+++ b/.claude-upstream
@@ -1,1 +1,1 @@
-aaronsb/claude-code-config
+aaronsb/agent-ways

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,10 @@
 !docs/hooks-and-ways/*.md
 !docs/hooks-and-ways/**/
 !docs/hooks-and-ways/**/*.md
+!docs/attend-and-monitor/
+!docs/attend-and-monitor/*.md
+!docs/attend-and-monitor/**/
+!docs/attend-and-monitor/**/*.md
 !docs/images/
 !docs/images/*
 !docs/observations/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# claude-code-config
+# agent-ways
 # Top-level Makefile — build, install, and release.
 #
 # Quick start:   make setup
@@ -15,7 +15,7 @@ XDG_BIN = $(or $(XDG_BIN_HOME),$(HOME)/.local/bin)
 # --- Primary targets ---
 
 help:
-	@echo "claude-code-config"
+	@echo "agent-ways"
 	@echo ""
 	@echo "  make setup        Build ways CLI + attend + fetch embedding model + corpus"
 	@echo "  make install      Full first-time setup (hooks + tools + PATH)"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security issue, please report it by [opening a private security advisory](https://github.com/aaronsb/claude-code-config/security/advisories/new) rather than a public issue.
+If you discover a security issue, please report it by [opening a private security advisory](https://github.com/aaronsb/agent-ways/security/advisories/new) rather than a public issue.
 
 ## Scope
 

--- a/docs/attend-and-monitor/README.md
+++ b/docs/attend-and-monitor/README.md
@@ -1,0 +1,66 @@
+# Attend and Monitor
+
+This directory documents the active awareness layer — how `attend` and Claude Code's `Monitor` tool combine to surface environmental changes as async notifications into a running session.
+
+## The pair
+
+**Attend** is a sensor loop that watches the local environment (git state, peer sessions, context pressure, process activity, peer messages) and emits human-readable observations when something crosses a threshold. It runs as a single long-lived process inside the Claude Code session.
+
+**Monitor** is the Claude Code tool feature that launches a command and delivers each line of its stdout as an asynchronous notification into the conversation. The conversation receives the observations as they happen instead of blocking on a foreground tool call.
+
+Monitor is a general-purpose awareness channel, not an attend-specific thing. Its intended use is **any long-running process that produces unpredictable state updates** the agent needs to react to: a multi-minute build emitting compile errors, a watch-mode test runner flipping between green and red, a deploy pipeline reporting stage transitions, a custom event log tailing whatever the current task cares about. Anything that happens on its own timeline and matters mid-turn is a candidate.
+
+The common thread across those cases is **sporadic unpredictable state** — changes the agent didn't cause, arriving at unknown times, that still need to land in the conversation in time to affect the next decision. Every Monitor use case fits this shape; they just source their state from different things. A build watcher sources from one process's stdout. A test runner sources from filesystem watches plus child-process exit codes.
+
+**Attend is one more class of sporadic unpredictable state** — specifically, the one that comes from **complex interactions across peer agents plus ambient environmental awareness** (git, processes, context pressure, focus groups). The state isn't one process's output; it's an ecosystem's. Attend aggregates that ecosystem into a single stream of observations that Monitor can deliver.
+
+Attend without Monitor is a CLI that prints to a dead terminal. Monitor without attend is a generic stream relay — useful in its own right for build watchers and log tails, but without attend it has no opinion about *what* multi-agent ecosystem state should stream. Together they form the **awareness channel** — the mechanism by which the agent learns about reality changes it didn't cause.
+
+If you're coming from the hooks-and-ways world, the analogy is exact: `hooks` are Claude Code's harness mechanism for *synchronous* prompts against the model's decisions; `Monitor` is the harness mechanism for *asynchronous* observations about the world. `ways` are what runs synchronously through hooks; `attend` is what runs asynchronously through Monitor.
+
+## What lives in this directory
+
+| File | Purpose |
+|---|---|
+| [`README.md`](README.md) | Orientation — you are here |
+| [`loop.md`](loop.md) | The sensor loop — state diagrams, timing, signal flow |
+| [`sensors.md`](sensors.md) | What each built-in sensor observes and how it emits (planned) |
+| [`signals.md`](signals.md) | Signal file format, storage layout, lifecycle (planned) |
+| [`engagement.md`](engagement.md) | Action potential model in prose and diagrams (planned) |
+| [`salience.md`](salience.md) | Turn-based presentation decay — the ADR-121 mechanism (planned) |
+| [`focus-groups.md`](focus-groups.md) | Dynamic group membership and signal routing (planned) |
+| [`configuration.md`](configuration.md) | Config schema, overlay semantics, tuning workflow (planned) |
+
+Files marked **planned** are part of the ongoing documentation pass. Start with `loop.md` — everything else threads through it.
+
+## Reading order
+
+1. **[`loop.md`](loop.md)** — if you only read one file, read this. The sensor loop is the substrate that everything else rides on.
+2. **`sensors.md`** — once you understand the loop, individual sensors make sense as pluggable units inside it.
+3. **`engagement.md`** — the action potential model governs *when* sensors fire. Read this after sensors.
+4. **`signals.md`** — the wire format and storage layout for peer messages and notifications.
+5. **`focus-groups.md`** — how groups scope signal routing between agents.
+6. **`salience.md`** — presentation-layer aging; orthogonal to all the above.
+7. **`configuration.md`** — reference manual for the YAML surface.
+
+## Related docs
+
+- **ADR-113** (`docs/architecture/system/`) — the original decision to build attend as an active awareness module
+- **ADR-114** — attend as an insistent trigger type for ways
+- **ADR-115** — declarative config with project-scope overlay
+- **ADR-116** — permission requirements
+- **ADR-117** — sensor crate extraction
+- **ADR-118** — focus groups, dynamic agent grouping
+- **ADR-119** — action potential engagement model
+- **ADR-121** — salience decay for signal presentation (draft)
+- `docs/hooks-and-ways/` — sibling docs for the synchronous hook mechanism
+- `docs/design-notes/cognitive-loop-and-awareness-layer.md` — earlier design exploration that informed ADR-113
+
+## Where the code lives
+
+- `tools/attend/` — orchestrator, config, groups, state, CLI
+- `tools/sensor-trait/` — base `Sensor` trait, `SensorSlot`, engagement state
+- `tools/sensor-context/`, `sensor-git/`, `sensor-peers/`, `sensor-processes/` — the built-in sensors
+- `tools/agent-fmt/` — shared terminal formatting (banners, tables, commands)
+- `skills/attend/SKILL.md` — the invocation skill the agent reads when the user asks for awareness
+- `hooks/ways/softwaredev/environment/attend/` — the way that surfaces live attend state in the steering layer

--- a/docs/attend-and-monitor/README.md
+++ b/docs/attend-and-monitor/README.md
@@ -1,22 +1,54 @@
 # Attend and Monitor
 
-This directory documents the active awareness layer — how `attend` and Claude Code's `Monitor` tool combine to surface environmental changes as async notifications into a running session.
+This directory documents the active awareness layer — how `attend` rides on top of Claude Code's `Monitor` tool to surface environmental changes as async notifications into a running session, and how humans and other Claude agents can both participate in the same signal stream.
+
+## The thesis
+
+Monitor is Claude Code's general-purpose async delivery mechanism: launch a command, stream its stdout as notifications. Anthropic's assumption in designing it seems to be that Claude will wire up whatever ad-hoc command fits the moment — a `tail -f`, a `cargo watch`, a bespoke shell pipeline — and let Monitor relay whatever comes out. That's a powerful primitive but it puts the burden on every Claude session to reinvent the observation logic from scratch.
+
+**Attend is Monitor with intention.** It's a long-lived logic module that Claude doesn't have to tune case by case. It knows what kinds of changes matter, it governs their rate and salience through a formal engagement model (ADR-119), it routes messages between peer agents through focus groups (ADR-118), and it cleans up after itself (ADR-121 for presentation decay, plus the 30-day disk sweep). A Claude session drops into attend and gets a stable, opinionated awareness channel for free.
+
+Said another way: **Monitor is a delivery mechanism; attend is the editorial layer that decides what's worth delivering.** The combination turns "sporadic unpredictable state" into a structured stream of observations the agent can act on.
 
 ## The pair
 
-**Attend** is a sensor loop that watches the local environment (git state, peer sessions, context pressure, process activity, peer messages) and emits human-readable observations when something crosses a threshold. It runs as a single long-lived process inside the Claude Code session.
+**Attend** is a sensor loop. It watches the local environment (git state, peer sessions, context pressure, process activity, peer messages, and any external sensors a user wires in) and emits observations when something crosses a threshold. It runs as a single long-lived process inside the Claude Code session.
 
-**Monitor** is the Claude Code tool feature that launches a command and delivers each line of its stdout as an asynchronous notification into the conversation. The conversation receives the observations as they happen instead of blocking on a foreground tool call.
+**Monitor** is the Claude Code tool feature that launches a command and delivers each line of its stdout as an asynchronous notification into the conversation. It's general-purpose: build watchers, test runners, deploy pipelines, custom event logs all fit.
 
-Monitor is a general-purpose awareness channel, not an attend-specific thing. Its intended use is **any long-running process that produces unpredictable state updates** the agent needs to react to: a multi-minute build emitting compile errors, a watch-mode test runner flipping between green and red, a deploy pipeline reporting stage transitions, a custom event log tailing whatever the current task cares about. Anything that happens on its own timeline and matters mid-turn is a candidate.
+The common thread across every Monitor use case is **sporadic unpredictable state** — changes the agent didn't cause, arriving at unknown times, that still need to land in the conversation in time to affect the next decision. Attend is one class of sporadic state — the class that comes from *complex interactions across peer agents plus ambient environmental awareness*. A build watcher is another class. They share the mechanism; they differ in what they observe.
 
-The common thread across those cases is **sporadic unpredictable state** — changes the agent didn't cause, arriving at unknown times, that still need to land in the conversation in time to affect the next decision. Every Monitor use case fits this shape; they just source their state from different things. A build watcher sources from one process's stdout. A test runner sources from filesystem watches plus child-process exit codes.
+## Two consumers, one channel
 
-**Attend is one more class of sporadic unpredictable state** — specifically, the one that comes from **complex interactions across peer agents plus ambient environmental awareness** (git, processes, context pressure, focus groups). The state isn't one process's output; it's an ecosystem's. Attend aggregates that ecosystem into a single stream of observations that Monitor can deliver.
+Attend is not exclusively for AI agents. A human can launch it too, and both consumers share the same signal bus.
 
-Attend without Monitor is a CLI that prints to a dead terminal. Monitor without attend is a generic stream relay — useful in its own right for build watchers and log tails, but without attend it has no opinion about *what* multi-agent ecosystem state should stream. Together they form the **awareness channel** — the mechanism by which the agent learns about reality changes it didn't cause.
+**Agent mode — `attend run`:** An AI agent session invokes attend through Monitor. The sensor loop emits notifications into the conversation. The agent responds to what it sees, sends peer messages back through `attend send`, and participates in focus groups through `attend focus`. See [`loop.md`](loop.md) for the sensor loop substrate.
 
-If you're coming from the hooks-and-ways world, the analogy is exact: `hooks` are Claude Code's harness mechanism for *synchronous* prompts against the model's decisions; `Monitor` is the harness mechanism for *asynchronous* observations about the world. `ways` are what runs synchronously through hooks; `attend` is what runs asynchronously through Monitor.
+**Human mode — `attend chat`:** A human launches attend in an interactive TUI mode. The same signals the agent sees stream into a scrollable message view. The TUI is also a first-class conversation interface — the human addresses enrolled Claude agents (`@infra ship it`, `@api please rebase first`) through the same peer-messaging infrastructure, sees replies in real time, and steers a whole multi-agent session from one surface. See [`tui.md`](tui.md).
+
+The phrase that captures it: **humans wear the same clothes as an AI agent** as far as attend is concerned. Same signal protocol, same routing, same engagement model. The human just happens to have a keyboard and eyeballs instead of a context window.
+
+This dual-consumer property is deliberate. It means the signal protocol is dogfooded — the human feels the routing semantics directly, and any friction in how messages land is friction the agents also experience. It also means a solo developer watching one agent gets as much value as a coordinator orchestrating four.
+
+## Scale context
+
+The attend development effort so far has put significant weight on the multi-agent peer-messaging story: focus groups, action-potential engagement, per-peer magnitude boosts, cross-session signal routing. That's a real use case but it's not the common one. **Most uses of attend will be single-user: one human, one Claude agent, external state sources.**
+
+The common-case shape looks like this: you're writing code, Claude is helping, and you want the session to notice things that happen outside the conversation — a `make test` finished, an issue got assigned to you on GitHub, a long-running deploy finished. Attend's sensors feed those into the conversation without you having to interrupt and ask "what's the status?" The peer-messaging layer is still there if you ever run four agents at once, but you don't have to opt into it to get value.
+
+This is why **external sensors are a first-class design surface** — they're the bridge between attend's formal engagement model and whatever the user actually cares about watching. See the next section.
+
+## Sensor authorship is a design surface
+
+Attend is extensible through two sensor implementations, both first-class:
+
+**1. Compiled crate sensors.** A Rust crate implementing the `Sensor` trait from `sensor-trait`. Gets linked into the attend binary at build time, runs at full native speed, shares process memory with the loop. Used for the built-in sensors: `sensor-context`, `sensor-git`, `sensor-peers`, `sensor-processes`. The right choice when performance matters or when the sensor needs fine-grained control over its own state.
+
+**2. External script sensors.** A shell script (or any executable) declared in the attend config under a `+sensor-name:` block. Attend runs it as a subprocess on the configured interval, parses its stdout as events, and feeds those into the same engagement/threshold/disclosure machinery. No Rust required. No recompile. The right choice for integrations with CLI tools (`gh`, `kubectl`, custom ops scripts) or for per-project sensors that don't belong in the main codebase.
+
+**Both implementations share one constraint: the sensor author has to understand the loop's intention.** Events are not log lines — they're magnitude-weighted observations that feed an accumulator, decay over time, and fire disclosure only when they cross a refractory-aware threshold. A sensor that emits "something happened" on every tick will either flood the governor or get suppressed into silence by action potential. A well-designed sensor encodes *how much each kind of change matters* in the event magnitude, and lets the loop handle the rest.
+
+See [`authoring-sensors.md`](authoring-sensors.md) for the full author's guide, including a walkthrough of the canonical external sensor example: a `gh`-CLI bash wrapper that watches a GitHub Project board associated with the repo attend was invoked in, surfacing card movements as signals with magnitude tuned to whether the moved issue is assigned to the current git user.
 
 ## What lives in this directory
 
@@ -24,6 +56,8 @@ If you're coming from the hooks-and-ways world, the analogy is exact: `hooks` ar
 |---|---|
 | [`README.md`](README.md) | Orientation — you are here |
 | [`loop.md`](loop.md) | The sensor loop — state diagrams, timing, signal flow |
+| [`authoring-sensors.md`](authoring-sensors.md) | Writing crate and external sensors (planned) |
+| [`tui.md`](tui.md) | `attend chat` — human mode and conversation interface (planned) |
 | [`sensors.md`](sensors.md) | What each built-in sensor observes and how it emits (planned) |
 | [`signals.md`](signals.md) | Signal file format, storage layout, lifecycle (planned) |
 | [`engagement.md`](engagement.md) | Action potential model in prose and diagrams (planned) |
@@ -31,17 +65,19 @@ If you're coming from the hooks-and-ways world, the analogy is exact: `hooks` ar
 | [`focus-groups.md`](focus-groups.md) | Dynamic group membership and signal routing (planned) |
 | [`configuration.md`](configuration.md) | Config schema, overlay semantics, tuning workflow (planned) |
 
-Files marked **planned** are part of the ongoing documentation pass. Start with `loop.md` — everything else threads through it.
+Files marked **planned** are part of the ongoing documentation pass.
 
 ## Reading order
 
-1. **[`loop.md`](loop.md)** — if you only read one file, read this. The sensor loop is the substrate that everything else rides on.
-2. **`sensors.md`** — once you understand the loop, individual sensors make sense as pluggable units inside it.
-3. **`engagement.md`** — the action potential model governs *when* sensors fire. Read this after sensors.
-4. **`signals.md`** — the wire format and storage layout for peer messages and notifications.
-5. **`focus-groups.md`** — how groups scope signal routing between agents.
-6. **`salience.md`** — presentation-layer aging; orthogonal to all the above.
-7. **`configuration.md`** — reference manual for the YAML surface.
+1. **[`loop.md`](loop.md)** — if you only read one file, read this. The sensor loop is the substrate everything else rides on.
+2. **[`authoring-sensors.md`](authoring-sensors.md)** — if you're building a sensor (crate or external), read this next. It explains what you're designing for.
+3. **[`tui.md`](tui.md)** — if you're a human using attend directly, or coordinating multiple agents.
+4. **`sensors.md`** — reference for the built-in sensors' behavior.
+5. **`engagement.md`** — the action potential model governs when sensors fire.
+6. **`signals.md`** — the wire format and storage layout for peer messages and notifications.
+7. **`focus-groups.md`** — how groups scope signal routing between agents.
+8. **`salience.md`** — presentation-layer aging.
+9. **`configuration.md`** — reference manual for the YAML surface.
 
 ## Related docs
 
@@ -52,15 +88,16 @@ Files marked **planned** are part of the ongoing documentation pass. Start with 
 - **ADR-117** — sensor crate extraction
 - **ADR-118** — focus groups, dynamic agent grouping
 - **ADR-119** — action potential engagement model
+- **ADR-120** — interactive chat TUI, human in the signal loop
 - **ADR-121** — salience decay for signal presentation (draft)
 - `docs/hooks-and-ways/` — sibling docs for the synchronous hook mechanism
 - `docs/design-notes/cognitive-loop-and-awareness-layer.md` — earlier design exploration that informed ADR-113
 
 ## Where the code lives
 
-- `tools/attend/` — orchestrator, config, groups, state, CLI
+- `tools/attend/` — orchestrator, config, groups, state, CLI (`run`, `chat`, `send`, `inbox`, `focus`, `cleanup`, `tune`, `status`)
 - `tools/sensor-trait/` — base `Sensor` trait, `SensorSlot`, engagement state
-- `tools/sensor-context/`, `sensor-git/`, `sensor-peers/`, `sensor-processes/` — the built-in sensors
+- `tools/sensor-context/`, `sensor-git/`, `sensor-peers/`, `sensor-processes/` — the built-in crate sensors
 - `tools/agent-fmt/` — shared terminal formatting (banners, tables, commands)
 - `skills/attend/SKILL.md` — the invocation skill the agent reads when the user asks for awareness
 - `hooks/ways/softwaredev/environment/attend/` — the way that surfaces live attend state in the steering layer

--- a/docs/attend-and-monitor/authoring-sensors.md
+++ b/docs/attend-and-monitor/authoring-sensors.md
@@ -68,7 +68,7 @@ An external sensor is declared in attend config:
 ```yaml
 sensors:
   +github-project:
-    script: .claude/sensors/github-project.sh
+    script: $XDG_DATA_HOME/attend/sensors/github-project.sh
     interval: 120        # base interval in seconds
     min_interval: 30     # fastest interval
     threshold: 2.0       # emission threshold
@@ -77,7 +77,29 @@ sensors:
       - Bash(gh:*)       # permission audit (ADR-116)
 ```
 
-The `+` prefix declares a new sensor beyond the built-ins. The `script:` field is a path relative to the working directory (or an absolute path). The script is executed via `bash` with cwd set to the working directory attend was launched in.
+The `+` prefix declares a new sensor beyond the built-ins.
+
+**Where the script lives is up to you.** Attend deliberately imposes no single "sensors dir." A script path can be:
+
+- **User-global** under `$XDG_DATA_HOME/attend/sensors/` — the XDG-convention default, survives across projects, lives in your own trusted data home
+- **Project-scoped** at `<project>/.claude/sensors/*.sh` — only active when attend runs from that repo; useful for sensors tied to a specific codebase
+- **An absolute path** to anywhere on disk — a personal tools repo, a team-shared scripts directory, `~/bin`, `/usr/local/lib/my-sensors/`, wherever you keep trusted executables
+
+The config parser expands `$HOME`, `~`, `$XDG_CONFIG_HOME`, `$XDG_DATA_HOME`, `$XDG_STATE_HOME`, and `$XDG_CACHE_HOME` at load time, so `$XDG_DATA_HOME/attend/sensors/foo.sh` becomes an absolute path regardless of how attend is launched. This keeps configs portable across machines.
+
+The script is executed via `bash` with cwd set to the working directory attend was launched in. No arguments are passed.
+
+**Trust is the author's responsibility.** External sensors run arbitrary shell under your user — read every sensor before you enable it. Attend's design assumes sensors come from locations you already trust: your own data home, your own project dirs, your own tool repos. The parser will happily resolve any path, but if you point it at something you haven't audited, that's on you.
+
+**The shipped example.** Attend ships one reference external sensor at `tools/attend/examples/xdg-downloads.sh` in the agent-ways repo. The default user-scope config declares it as `+xdg-downloads:` with `enabled: false`. The intended workflow is:
+
+1. Open `$XDG_CONFIG_HOME/attend/config.yaml` and find the `+xdg-downloads:` block
+2. Follow the comment to copy the script from the agent-ways repo into `$XDG_DATA_HOME/attend/sensors/`
+3. Read the script — it's ~80 lines of bash, most of it comments explaining the pattern
+4. Flip `enabled: true`
+5. Restart attend
+
+After that, new files landing in your XDG Downloads directory trigger notifications via the magnitude hierarchy documented in the script header (1 file → 2.0, small batch → 2.5, burst → 3.0).
 
 **The subprocess contract:**
 

--- a/docs/attend-and-monitor/authoring-sensors.md
+++ b/docs/attend-and-monitor/authoring-sensors.md
@@ -1,0 +1,236 @@
+# Authoring sensors
+
+Sensor authorship is a first-class design surface in attend. A sensor is not a log tail — it's a module that translates raw environmental change into *magnitude-weighted observations* that feed attend's engagement model (ADR-119) and disclosure governor. A well-designed sensor encodes how much each kind of change matters in the magnitude, and lets the loop handle when to fire, how often, and whether to suppress.
+
+This page is for people building sensors, in either of attend's two implementations.
+
+## Two implementations
+
+| | Crate sensor | External script sensor |
+|---|---|---|
+| **Language** | Rust | Any executable (usually bash) |
+| **Linkage** | Compiled into the attend binary via a feature flag | Spawned as a subprocess on each poll |
+| **State** | Shared process memory; can hold arbitrary Rust state across polls | Stateless between polls (unless the script persists state externally) |
+| **Startup cost** | Free (already in memory) | Process spawn per poll — ~5–30 ms |
+| **Timeout** | None (sensor owns its poll duration) | 10 seconds, enforced by attend |
+| **Good for** | Built-in system sensors, high-frequency polling, complex state | Integrations with CLI tools, per-project sensors, quick experiments |
+| **Example** | `sensor-context`, `sensor-git`, `sensor-peers`, `sensor-processes` | `gh`-cli GitHub Project watcher, `kubectl` pod status, `docker events` tail |
+
+Both implementations land at the same place in the loop — attend calls `poll()` on a schedule, reads back a `Vec<(f64, String)>` of observations, and feeds them into the accumulator. The only difference is *how the code gets loaded and run*. Design-wise they're identical; pick the one that matches your integration and performance needs.
+
+## What sensor authors are designing around
+
+Before you write a single line of code, understand what your events will encounter once they leave your poll function. Every observation you emit goes through the same pipeline:
+
+1. **Accumulator.** Your `(magnitude, description)` pair is added to the sensor's `DeltaAccumulator`. Magnitudes accumulate across ticks until the sensor is drained or decays.
+2. **Emission threshold.** A per-sensor threshold — the accumulator has to exceed this before the sensor is a candidate to disclose. Low-magnitude events accumulate silently until several of them add up; a single high-magnitude event may cross threshold on its own.
+3. **Engagement / refractory (ADR-119).** After the sensor recently fired a disclosure, its effective threshold is temporarily elevated (relative refractory) or it's fully suppressed (absolute refractory, ~60s by default). During refractory, new events still accumulate but don't fire until the cooldown passes — unless their magnitude is high enough to break through the elevated threshold. This is how attend models "disengagement after a burst": low-magnitude follow-ups get swallowed, truly urgent events still get through.
+4. **Disclosure governor.** Even after the sensor is ready, a global governor rate-limits disclosures across the whole loop (default: 3 per 120s, with a 15s cooldown between them). If a burst of sensors all want to fire at once, some get held until the window rolls.
+5. **Monitor delivery.** Whatever survives all of the above gets printed as one stdout line per event and picked up by Monitor (or the `attend chat` TUI) as an async notification into the conversation.
+
+**The design implication**: *magnitude is the author's main lever*. Don't emit uniform-magnitude events; think carefully about which changes are loud and which are quiet. A sensor that emits magnitude 5.0 for every tick will flood the governor; one that emits 0.1 for everything will never fire. The right shape is usually a hierarchy: cheap background changes at 0.5–1.0, routine notable events at 2.0–3.0, things you want to break through refractory at 5.0+.
+
+## Crate sensors — the `Sensor` trait
+
+A crate sensor implements `sensor_trait::Sensor`:
+
+```rust
+pub trait Sensor: Send {
+    fn name(&self) -> &str;
+    fn poll(&mut self, focus: &Focus) -> Vec<(f64, String)>;
+    fn emission_threshold(&self) -> f64;
+    fn base_interval(&self) -> Duration;
+    fn min_interval(&self) -> Duration;
+    fn decay_threshold(&self) -> u32;
+
+    // Optional — for sensors that need state across process restarts
+    fn export_state(&self) -> Vec<(String, String)> { Vec::new() }
+    fn import_state(&mut self, _state: &[(String, String)]) {}
+}
+```
+
+The contract:
+
+- **`name()`** — stable identifier used in logs, config, and state keys.
+- **`poll(focus)`** — called whenever the sensor's turn comes up in the priority queue. Returns a list of `(magnitude, description)` pairs. Empty vec means "nothing changed this tick." The `Focus` argument carries the working directory, a human-readable description of current work, and any keywords attend knows about — use it to scope observations or skip irrelevant ones.
+- **`emission_threshold()`** — the accumulator floor this sensor must cross before it's a disclosure candidate. Typical values 1.5–2.5.
+- **`base_interval()`** — the slowest polling interval, used when the sensor has been quiet for a while. Typical 30–60 seconds.
+- **`min_interval()`** — the fastest polling interval, used when the sensor is actively observing change. Typical 5–20 seconds.
+- **`decay_threshold()`** — number of consecutive quiet polls before the interval grows back toward `base_interval`. Typical 3–5.
+- **`export_state` / `import_state`** — if your sensor needs to remember anything across an attend restart (e.g., "which signals have I already seen?"), implement these. Attend checkpoints every 30 seconds.
+
+To wire a new crate in, add it to `tools/attend/Cargo.toml` as an optional dep + feature, then register it in `tools/attend/src/sensors/mod.rs` with `register_builtin!`. See the existing sensors for reference.
+
+## External script sensors — the subprocess protocol
+
+An external sensor is declared in attend config:
+
+```yaml
+sensors:
+  +github-project:
+    script: .claude/sensors/github-project.sh
+    interval: 120        # base interval in seconds
+    min_interval: 30     # fastest interval
+    threshold: 2.0       # emission threshold
+    decay_threshold: 4   # quiet ticks before decay
+    requires:
+      - Bash(gh:*)       # permission audit (ADR-116)
+```
+
+The `+` prefix declares a new sensor beyond the built-ins. The `script:` field is a path relative to the working directory (or an absolute path). The script is executed via `bash` with cwd set to the working directory attend was launched in.
+
+**The subprocess contract:**
+
+- **Execution:** `bash <script>` each poll. No arguments passed in; the script can read env vars if it needs any (e.g., `$PWD`, `$HOME`).
+- **Timeout:** 10 seconds. Attend kills the process and discards its output if the script runs longer.
+- **Exit status:** Non-zero exit → attend silently discards any output. The sensor just reports "nothing observed this poll."
+- **Stdout format:** One event per line, as `magnitude|description`. Whitespace around the pipe is trimmed. Unparseable lines are silently dropped (they don't fail the poll; they just don't become events).
+- **Stderr:** Ignored by attend. Useful for debug logs that shouldn't leak into notifications.
+
+Minimal example:
+
+```bash
+#!/usr/bin/env bash
+# sensors/cargo-watch.sh — observe cargo build state
+
+if pgrep -x cargo >/dev/null; then
+  echo "1.0|cargo is running"
+fi
+
+if [[ -f target/debug/build-stamp ]]; then
+  age=$(( $(date +%s) - $(stat -c %Y target/debug/build-stamp) ))
+  if (( age < 60 )); then
+    echo "2.5|build completed $age seconds ago"
+  fi
+fi
+```
+
+Each time attend polls this sensor, it gets 0, 1, or 2 events depending on state. The magnitudes encode the relative importance: a running cargo process is mildly notable (1.0), a fresh build is more so (2.5).
+
+## Walkthrough: GitHub Project sensor
+
+This is the canonical external sensor — a clean illustration of how *event magnitude is the author's design lever*. It's a feasible, useful sensor that most people would actually benefit from (unlike the more esoteric peer-messaging machinery). We're documenting the shape; writing the full implementation is a separate task.
+
+### Motivation
+
+A common workflow: you're coding, Claude is helping, and you have a GitHub Project board where issues move between columns (backlog → in progress → review → done). When an issue moves, something changed about *what you should be working on*, but you wouldn't know unless you alt-tab to the browser. A sensor can watch the board and surface those moves as attend signals without interrupting the conversation.
+
+### Config
+
+```yaml
+sensors:
+  +github-project:
+    script: .claude/sensors/github-project.sh
+    interval: 300           # poll every 5 minutes by default
+    min_interval: 60        # speed up to 1 min when activity is detected
+    threshold: 2.5          # assigned-to-me moves cross this on a single event
+    decay_threshold: 3
+    requires:
+      - Bash(gh:*)
+```
+
+The sensor runs in the project's working directory. The script uses `gh` CLI and assumes the user has authenticated (`gh auth login`).
+
+### Script skeleton
+
+```bash
+#!/usr/bin/env bash
+# .claude/sensors/github-project.sh
+#
+# Watches the GitHub Project associated with this repo.
+# Emits magnitude-weighted events for card state changes.
+
+set -euo pipefail
+
+STATE_DIR="$HOME/.cache/attend/sensors/github-project"
+mkdir -p "$STATE_DIR"
+
+# Identify the repo and current git user
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) || exit 0
+ME=$(gh api user -q .login 2>/dev/null) || exit 0
+STATE_FILE="$STATE_DIR/$(echo "$REPO" | tr '/' '-').state"
+
+# Fetch the project board for this repo (first linked project, if any)
+BOARD_JSON=$(gh project item-list --owner "@me" --format json --limit 100 2>/dev/null) || exit 0
+
+# Extract (item_id, status, assignee) tuples
+CURRENT=$(echo "$BOARD_JSON" | jq -c '.items[] | {id, status: .status, assignee: (.assignees[0].login // "")}')
+
+# Compare against last snapshot
+if [[ -f "$STATE_FILE" ]]; then
+  PREV=$(cat "$STATE_FILE")
+  # For each item, check if status changed
+  echo "$CURRENT" | while read -r item; do
+    id=$(echo "$item" | jq -r .id)
+    cur_status=$(echo "$item" | jq -r .status)
+    cur_assignee=$(echo "$item" | jq -r .assignee)
+    prev_status=$(echo "$PREV" | jq -r "select(.id == \"$id\") | .status" 2>/dev/null || echo "")
+
+    if [[ -n "$prev_status" && "$cur_status" != "$prev_status" ]]; then
+      # State transition detected — encode magnitude based on assignment
+      if [[ "$cur_assignee" == "$ME" ]]; then
+        # Assigned to me — strong signal, single event should break through
+        echo "3.0|issue #$id moved: $prev_status → $cur_status (assigned to you)"
+      else
+        # Unassigned or someone else — weak signal, accumulates
+        echo "0.8|issue #$id moved: $prev_status → $cur_status"
+      fi
+    fi
+  done
+fi
+
+# Save current snapshot for next poll
+echo "$CURRENT" > "$STATE_FILE"
+```
+
+### Magnitude design — the nuance
+
+The interesting design decision is in the two `echo` lines at the end. Both are emitting an event for the same category of change (a card moved on the board), but with very different magnitudes:
+
+- **Assigned to me → 3.0.** Your emission threshold is 2.5. A single event with magnitude 3.0 clears the bar on its own, immediately. If you're the assignee and the card moved, you probably want to know right now.
+- **Not assigned to me → 0.8.** A single event sits below threshold and accumulates silently. One unassigned move is noise; attend won't bother you. But if the board has four unassigned moves in a polling window, they add up to 3.2 — now the threshold is crossed and attend discloses "several items moved on the board" collectively. That's the shape of useful awareness: individual moves are ignorable, aggregate activity is informative.
+
+This is the engagement model working as designed. The author didn't have to write any threshold logic, rate limiting, or refractory handling. They just encoded *how much each kind of change matters* into the magnitude, and attend handled the rest.
+
+**Further refinements the author could add** (all by adjusting magnitudes, not by touching attend):
+
+- A PR review requested on your own PR → 4.0 (break through refractory even during quiet focus)
+- A CI failure on your in-progress branch → 5.0 (never suppress)
+- A label change on any card → 0.3 (barely nudges accumulator; aggregate only)
+- A new card created in the backlog → 0.5 (background awareness)
+
+Each of these is a single-line change. The magnitude number is the entire design surface.
+
+### What attend does with the events
+
+Once the script's stdout reaches attend:
+
+1. Each valid `magnitude|description` line becomes one event.
+2. Events accumulate in the sensor's `DeltaAccumulator` between polls.
+3. When the accumulator exceeds the emission threshold (2.5 for this sensor), the sensor becomes a disclosure candidate.
+4. The disclosure governor decides whether to actually fire (respecting cooldown, rate window, and any active refractory from ADR-119).
+5. If fired, each event becomes one Monitor notification line delivered into the conversation (or rendered in `attend chat` if the consumer is a human).
+
+The sensor author never touches any of that machinery. They just write `gh`-CLI glue and pick magnitudes.
+
+## Design rules of thumb
+
+Written as heuristics, not commandments:
+
+1. **Design magnitudes as a hierarchy, not a scale.** Don't linearly interpolate magnitudes across your event types. Pick a few discrete tiers (background, notable, urgent, critical) and assign each event type to one.
+2. **Your background events should sum to something useful.** If your sensor only ever emits 0.5s, those 0.5s should aggregate to meaningful disclosure when enough of them happen. Check: does 3–5 background events add up to cross threshold?
+3. **Reserve the top tier for actual emergencies.** If your sensor can emit a 5.0 event, it should be the kind of thing that needs to break through an ongoing conversation about something else. Abuse of the top tier trains the user to ignore attend.
+4. **Prefer empty polls to noisy polls.** When nothing is happening, return an empty vec. The loop handles quiet — it slows the sensor's polling frequency, lets the engagement state relax, and stays out of the user's way. An always-chatty sensor is fighting the loop.
+5. **Make poll idempotent.** The script should produce the same output for the same state regardless of when it's called. Attend handles "what changed" via the accumulator; you just report the current situation. State tracking inside your script is fine (as in the GH example), but use it to detect transitions, not to throttle.
+6. **Fail silently and cheaply.** If your upstream is unavailable (network down, `gh` not authed, API rate-limited), exit 0 with no output. Don't emit error events — they pollute the notification stream. Use stderr if you need to log for debugging.
+7. **Respect the 10-second timeout.** External sensors have a hard wall. If your work might take longer, cache aggressively or split into a fast poll + an async background job that writes a state file the poll reads.
+
+## Related
+
+- [`loop.md`](loop.md) — the substrate your sensor plugs into
+- [`engagement.md`](engagement.md) *(planned)* — the action potential model in detail
+- [`sensors.md`](sensors.md) *(planned)* — reference for the built-in sensors
+- [`configuration.md`](configuration.md) *(planned)* — config schema for declaring sensors
+- **ADR-117** — sensor crate extraction and feature flags
+- **ADR-119** — action potential engagement model
+- **ADR-116** — permission requirements for sensors

--- a/docs/attend-and-monitor/configuration.md
+++ b/docs/attend-and-monitor/configuration.md
@@ -151,7 +151,7 @@ sensors:
 ```yaml
 sensors:
   +github-project:
-    script: .claude/sensors/github-project.sh
+    script: $XDG_DATA_HOME/attend/sensors/github-project.sh
     interval: 300
     min_interval: 60
     threshold: 2.5
@@ -160,7 +160,15 @@ sensors:
       - Bash(gh:*)
 ```
 
-The `+` prefix declares a new sensor beyond the built-ins. Script paths are relative to the working directory (or absolute).
+The `+` prefix declares a new sensor beyond the built-ins. Script paths are deliberately unconstrained — they can be:
+
+- **User-global**, under `$XDG_DATA_HOME/attend/sensors/` (the convention this config documents by default). Survives across projects; lives in your own trusted script dir.
+- **Project-scoped**, at `.claude/sensors/name.sh` in a specific repo. Only loads when attend runs from that project.
+- **Absolute paths** to anywhere on disk — your personal tools repo, a team-shared scripts dir, `~/bin`, wherever you keep trusted executables.
+
+Attend only cares that the path resolves and that the script respects the subprocess contract. The `$HOME`, `~`, and `$XDG_*` prefixes are expanded by the config parser, so `$XDG_DATA_HOME/...` in config becomes an absolute path at load time. This keeps configs portable across machines.
+
+**The shipped example.** Attend ships one external sensor at `tools/attend/examples/xdg-downloads.sh` in the agent-ways repo as a reference implementation. The default user-scope config declares it as `+xdg-downloads:` with `enabled: false`. To actually run it you copy the script to a trusted location you control (the comment in the default config walks through `$XDG_DATA_HOME/attend/sensors/` as the XDG-convention choice), review it, and flip `enabled: true`. The "copy to a trusted path, review, then enable" workflow is intentional — external sensors run arbitrary shell under your user, and you should always audit a sensor's code before letting it run.
 
 ### Per-sensor keys
 

--- a/docs/attend-and-monitor/configuration.md
+++ b/docs/attend-and-monitor/configuration.md
@@ -1,0 +1,258 @@
+# Configuration
+
+Attend reads a two-layer YAML configuration following the same overlay pattern as ways (ADR-115). User-scope config applies to every attend invocation; project-scope config layers on top to add or override specific settings for work in that project.
+
+This page is the reference for the full config surface: where files live, what every key does, and how the overlay works.
+
+## File locations
+
+```
+~/.config/attend/config.yaml                    # user scope — always loaded
+<cwd>/.claude/attend.yaml                       # project scope — layered on top
+```
+
+Both files are optional. Attend ships with sensible defaults in code, so running with no config at all works. User-scope is for your persistent defaults; project-scope is for per-repo overrides.
+
+The user-scope path respects `XDG_CONFIG_HOME` if set; otherwise it falls back to `$HOME/.config/`.
+
+## Bootstrapping
+
+```bash
+attend config init      # write a default config to ~/.config/attend/config.yaml
+attend config show      # print the merged config attend is currently using
+attend config path      # print the file paths attend loads from
+```
+
+`attend config init` creates the user-scope file with fully commented defaults — useful as a starting point to understand what's available.
+
+## Complete schema
+
+```yaml
+# Disclosure governor — global rate limiting across all sensors
+governor:
+  base_cooldown: 15          # seconds between any two disclosures
+  max_per_window: 3          # max disclosures in rate_window
+  rate_window: 120           # seconds of the rolling rate window
+
+# Action potential engagement model (ADR-119)
+# Run `attend tune` to auto-derive these from real session history
+engagement:
+  burst_window: 900          # seconds — window for counting recent disclosures
+  burst_threshold: 3         # disclosures within burst_window before refractory kicks in
+  step_multiplier: 1.25      # per-disclosure threshold elevation past burst_threshold
+  absolute_refractory: 60    # seconds of complete suppression after burst
+  decay_per_minute: 0.1      # rate at which elevated threshold returns to baseline
+  peer_activity_window: 900  # sliding window for per-peer engagement boost
+
+# Background cleanup of the signals base
+cleanup:
+  enabled: true              # master switch
+  interval: 600              # seconds between auto-sweeps (10 minutes)
+  retention: 2592000         # seconds — signal file age cutoff (30 days)
+
+# Per-sensor configuration — applies to built-ins and script sensors
+sensors:
+  context:
+    interval: 60             # base polling interval in seconds
+    min_interval: 20         # fastest polling interval
+    threshold: 1.5           # emission threshold (accumulator must exceed)
+    decay_threshold: 3       # quiet polls before interval decays back
+    requires:                # permission audit (ADR-116)
+      - Read
+  git:
+    interval: 30
+    min_interval: 10
+    threshold: 2.0
+    decay_threshold: 4
+    requires:
+      - Bash(git:*)
+  peers:
+    interval: 30
+    min_interval: 10
+    threshold: 2.0
+    decay_threshold: 5
+    requires:
+      - Read
+  processes:
+    interval: 30
+    min_interval: 5
+    threshold: 2.0
+    decay_threshold: 5
+    requires:
+      - Bash(ps:*)
+```
+
+## Section reference
+
+### `governor`
+
+Global rate limiting for disclosures. Even if every sensor is ready to fire, the governor caps how many actually reach the conversation.
+
+- **`base_cooldown`** (seconds, default 15): minimum time between any two consecutive disclosures. A burst of sensors all ready at the same time will have their disclosures serialized with at least this gap.
+- **`max_per_window`** (count, default 3): maximum disclosures allowed within the rolling `rate_window`. Additional ready sensors are held; their magnitudes stay in the accumulator.
+- **`rate_window`** (seconds, default 120): length of the rolling window for `max_per_window`.
+
+With defaults: at most 3 disclosures per 2 minutes, with at least 15 seconds between each.
+
+### `engagement`
+
+The action potential model parameters (ADR-119). Governs per-sensor refractory behavior. See [`engagement.md`](engagement.md) for the full model; the short version is:
+
+- **`burst_window`** (seconds, default 900): how far back the sensor looks when counting recent disclosures. Disclosures outside this window don't count toward burst detection.
+- **`burst_threshold`** (count, default 3): number of disclosures within `burst_window` before refractory starts elevating the threshold.
+- **`step_multiplier`** (float, default 1.25): threshold elevation per additional disclosure past `burst_threshold`. After 4 disclosures, threshold is multiplied by 1.25; after 5, by 1.5; etc.
+- **`absolute_refractory`** (seconds, default 60): complete suppression after a burst. No events fire during this window regardless of magnitude.
+- **`decay_per_minute`** (float, default 0.1): rate at which the elevated threshold returns to baseline. 0.1 means the multiplier decreases by 0.1 per minute of quiet.
+- **`peer_activity_window`** (seconds, default 900): sliding window used by `sensor-peers` for the per-peer engagement boost. Matches `burst_window` by default.
+
+**Auto-tuning.** Run `attend tune` to derive these from real session history. See [`engagement.md`](engagement.md) for how tuning works.
+
+### `cleanup`
+
+Background signal-file cleanup. Prevents the signals base from accumulating indefinitely. Scoped strictly to `~/.cache/attend/signals/`; never touches ways data or anything else.
+
+- **`enabled`** (bool, default true): master switch. If false, auto-cleanup is skipped and you must run `attend cleanup` manually to reclaim space.
+- **`interval`** (seconds, default 600): how often the auto-sweep runs inside `attend run`. At this interval the loop scans the signals base and removes stale files.
+- **`retention`** (seconds, default 2592000 = 30 days): age cutoff. Signal files older than this are removed.
+
+The sweep also removes empty encoded-cwd project subdirectories left as shells after their signals are cleaned up. Reserved names (`_broadcast`, `@groups`, anything starting with `_` or `@`) are never removed.
+
+`attend cleanup` can be run manually with overrides:
+
+```bash
+attend cleanup                        # use configured retention
+attend cleanup --older-than 5m        # custom age cutoff
+attend cleanup --dry-run              # list what would be removed
+attend cleanup --all                  # nuke everything (no age check)
+```
+
+### `sensors`
+
+Per-sensor configuration. Each built-in sensor can have its intervals, threshold, decay, and permissions overridden. User-authored sensors (script or crate) are declared in the same block with a `+` prefix.
+
+**Existing built-in override:**
+
+```yaml
+sensors:
+  git:
+    interval: 60         # poll less often in this project
+    threshold: 3.0       # raise the bar
+```
+
+**Disable a built-in:**
+
+```yaml
+sensors:
+  -processes:            # the '-' prefix disables
+```
+
+**Add a new script sensor:**
+
+```yaml
+sensors:
+  +github-project:
+    script: .claude/sensors/github-project.sh
+    interval: 300
+    min_interval: 60
+    threshold: 2.5
+    decay_threshold: 3
+    requires:
+      - Bash(gh:*)
+```
+
+The `+` prefix declares a new sensor beyond the built-ins. Script paths are relative to the working directory (or absolute).
+
+### Per-sensor keys
+
+All sensors (built-in or script) accept:
+
+- **`interval`** (seconds): base polling interval when quiet
+- **`min_interval`** (seconds): fastest polling interval during active change
+- **`threshold`** (float): emission threshold — accumulator must exceed this
+- **`decay_threshold`** (count): number of quiet polls before interval decays back to base
+- **`enabled`** (bool): set false to disable without removing the entry
+- **`script`** (path, script sensors only): path to the executable
+- **`requires`** (list): permission strings audited against `settings.json` (ADR-116)
+
+## Overlay semantics
+
+The overlay layers project-scope on top of user-scope. For each setting:
+
+- **Scalar values** (numbers, strings, bools): project-scope replaces user-scope entirely
+- **Sensor blocks**: merge on a per-key basis — a project can override just one sensor's interval without touching the others
+- **Sensor additions** (`+name:`): union — the project can add script sensors the user-scope doesn't know about
+- **Sensor disables** (`-name:`): marks the built-in disabled for this project only
+
+Example. User-scope:
+
+```yaml
+sensors:
+  git:
+    interval: 30
+    threshold: 2.0
+```
+
+Project-scope at `<repo>/.claude/attend.yaml`:
+
+```yaml
+sensors:
+  git:
+    interval: 60         # slow down git polling in this repo only
+  -processes:            # don't run the process sensor here
+  +build-watcher:
+    script: .claude/sensors/build-watcher.sh
+    interval: 20
+```
+
+Merged result in that project:
+
+- `git`: interval 60 (from project), threshold 2.0 (inherited from user)
+- `processes`: disabled
+- `context`, `peers`: unchanged defaults
+- `build-watcher`: active per project-scope declaration
+
+## Permissions (ADR-116)
+
+The `requires:` list on each sensor block declares the harness permissions that sensor needs. Running `attend permissions audit` walks your config and checks each declared requirement against `settings.json`:
+
+```bash
+$ attend permissions audit
+Attend Permissions Audit
+────────────────────────
+  context        Read               ✓ granted
+  git            Bash(git:*)        ✓ granted
+  peers          Read               ✓ granted
+  processes      Bash(ps:*)         ✓ granted
+  +build-watcher Bash(cargo:*)      ✗ MISSING
+```
+
+Use this to confirm your config will actually work before launching attend — a sensor that requires a permission you haven't granted will silently emit nothing.
+
+## Parser notes
+
+Attend's YAML parser is deliberately minimal — it's a hand-written subset that handles the specific shape described above, with no `serde` dependency. It supports:
+
+- Two-level section headers (`governor:`, `engagement:`, `sensors:`)
+- Four-space indent for sensor properties
+- Inline arrays for `requires:` (`requires: [Bash(gh:*), Read]`)
+- Comments (`#`) and blank lines
+- `+name:` and `-name:` sensor prefixes
+
+It does **not** support:
+
+- Anchors and references (`&`, `*`)
+- Multi-document files (`---`)
+- Block scalars (`|`, `>`)
+- Nested dicts beyond the documented depth
+
+If you need something the parser doesn't handle, either restructure or file an issue. The parser will grow as needed, not speculatively.
+
+## Related
+
+- **ADR-115** — declarative config with project-scope overlay (the pattern this implements)
+- **ADR-116** — permission requirements
+- **ADR-117** — sensor crate extraction (feature flags for compile-time sensor selection)
+- **ADR-119** — action potential engagement (the `engagement` block)
+- [`engagement.md`](engagement.md) — engagement model in depth
+- [`authoring-sensors.md`](authoring-sensors.md) — how to declare and write new sensors
+- [`sensors.md`](sensors.md) — the built-in sensors and their default values

--- a/docs/attend-and-monitor/engagement.md
+++ b/docs/attend-and-monitor/engagement.md
@@ -1,0 +1,155 @@
+# Engagement — the action potential model
+
+Attend's engagement model governs *when a sensor is allowed to fire a disclosure*. It's a per-sensor state machine inspired by the neuronal action potential: resting baseline, rapid rise on stimulus, refractory period after a burst, gradual return to rest. The biology gives us a predictable, well-studied shape for a phenomenon we actually care about — how productive engagement with a stimulus decays naturally over time.
+
+This page covers the model in prose and diagrams, explains what each parameter does, and walks through how it interacts with the disclosure governor. The authoritative source is **ADR-119**; this page is the implementer-and-author-friendly explainer.
+
+## The problem engagement solves
+
+Without engagement, attend's disclosure logic is a flat threshold. A sensor observes something, accumulates magnitude, crosses the emission threshold, fires. Rinse and repeat. This produces the "party problem": an agent responding to a lively conversation has no built-in signal that the return on engagement is declining. It will keep responding at the same threshold indefinitely until the human intervenes or the context window runs out.
+
+The action potential model adds **per-sensor memory of recent activity**. After a sensor has fired a burst of disclosures, its effective threshold *rises* for a while, then decays back to baseline. High-magnitude stimuli still break through. Low-magnitude follow-ups are silently suppressed. The sensor disengages from the fading topic on its own.
+
+Said another way: refractory isn't silence, it's *raised bar*. Nothing is censored; thresholds are just temporarily harder to cross.
+
+## The biological analogy
+
+```
+    Engagement
+    (magnitude)
+        ^
+   +30  |        * peak
+        |       / \
+        |      /   \
+        |     /     \
+    0   |    /       \
+        |   /         \
+  -55   |--*           \          ← threshold (normal)
+        | stimulus      \
+        |                \_____________ ← elevated threshold
+        |                               (relative refractory)
+  -70   |.................\___*___........ ← resting potential
+        |                 ^
+        |                 └── absolute refractory
+        +--------------------------------> time
+```
+
+- **Resting state**: sensor at baseline, polling on schedule, accumulating nothing. Threshold is whatever the author configured (default 1.5–2.5).
+- **Stimulus**: an observation arrives. Magnitude accumulates. Below threshold, it's quiet. At or above threshold, the sensor becomes a disclosure candidate.
+- **Depolarization / peak**: the sensor fires. Observations reach the agent.
+- **Absolute refractory**: for ~60 seconds after the burst, nothing from this sensor fires, regardless of magnitude. The agent is processing what it just received; another signal would interfere.
+- **Relative refractory**: for the next several minutes, the threshold is temporarily multiplied by an elevation factor. Routine events that would normally fire get silently accumulated. Only truly high-magnitude events break through.
+- **Decay**: the elevation factor drifts back toward 1.0 over time, at the configured rate (default 0.1 per minute). After enough quiet time, the sensor is fully at rest again.
+
+The biological action potential has an overshoot and hyperpolarization phase too, but attend's model is the simplified practical version: threshold rise + decay, no overshoot.
+
+## Burst detection
+
+A "burst" isn't a single firing — it's *N firings within a window*. Until the sensor fires enough times in a short enough period, no refractory kicks in. This preserves fast-reply behavior: two observations in quick succession both fire normally; the third (in the default config) triggers the elevated threshold.
+
+Default values:
+
+- `burst_window = 900s` (15 minutes)
+- `burst_threshold = 3` (firings)
+- `step_multiplier = 1.25` (per-firing threshold elevation past the burst threshold)
+
+With these numbers, the first three firings in a 15-minute window are all "free." The fourth starts elevating the threshold. The fifth elevates more. By the time you've fired five in a window, the effective threshold is meaningfully higher than the baseline.
+
+## Absolute vs relative refractory
+
+```mermaid
+stateDiagram-v2
+    [*] --> Rest
+    Rest --> Accumulating: poll returns event
+    Accumulating --> FireReady: magnitude ≥ threshold<br/>AND not in refractory
+    Accumulating --> Rest: quiet poll<br/>or decayed
+    FireReady --> Disclosed: governor permits
+    FireReady --> Accumulating: governor holding
+    Disclosed --> AbsoluteRefractory: record_disclosure()
+    AbsoluteRefractory --> RelativeRefractory: N seconds elapsed<br/>(default 60)
+    RelativeRefractory --> Rest: multiplier decayed to ~1.0
+    RelativeRefractory --> Disclosed: high-magnitude event breaks<br/>elevated threshold AND governor permits
+```
+
+**Absolute refractory** is a hard wall. For a configurable duration after any firing, the sensor cannot disclose at all — not even on a maximum-magnitude event. The default is 60 seconds, chosen to be roughly one Claude turn of complete silence. During this window, events still arrive and still accumulate, but none of them fire.
+
+**Relative refractory** is a moving threshold. After the absolute window passes, the sensor's effective threshold is `base_threshold × elevation_factor`. The elevation factor decays over time at `decay_per_minute` (default 0.1). Events that would normally fire at, say, magnitude 2.0 now need magnitude 2.5 or 3.0 to break through, depending on how recently the burst happened. A high-magnitude event (your PR-review-requested signal, say) can still break through; a chatty low-magnitude follow-up will sit in the accumulator silently.
+
+The result: natural disengagement on fading topics, preserved break-through for genuinely urgent new stimuli.
+
+## Per-peer boost (sensor-peers specific)
+
+One extension to the basic model lives inside `sensor-peers`: a **per-peer magnitude boost** that amplifies messages from agents the user has been actively conversing with. It's the engagement model applied at the level of individual conversation partners, not the sensor as a whole.
+
+The rules:
+
+- Track a sliding window (default 900 seconds = 15 minutes) of messages from each peer.
+- The first message from a peer in that window gets magnitude × 1.0 (normal).
+- The second message gets × 1.75 (participant emerging).
+- The third and subsequent get × 2.5 (established conversation partner — reliably breaks through elevated refractory).
+
+The effect: messages from a peer you've been going back and forth with climb above the refractory threshold, while broadcast noise from uninvolved peers stays at baseline and gets suppressed. **Auto-grouping emerges from the magnitude gradient** without any explicit group infrastructure — the conversation partners you care about naturally break through, and the unrelated chatter doesn't.
+
+This is what ADR-119 calls "routing simplification from action potential." There's no need to manually scope peer messaging to a focus group for most cases, because the engagement boost handles the scoping dynamically.
+
+## Tuning with `attend tune`
+
+The default engagement parameters are sized for a typical Claude session, but they're derivable from real data. `attend tune` surveys recent sessions under `~/.claude/projects/` (the 10 most-recent active projects, 5 most-recent sessions each by default), computes percentiles on turn cycle durations (assistant → user, user → user), and proposes engagement parameters grounded in actual usage:
+
+```
+$ attend tune
+[tune] surveying 18 sessions across 10 projects
+
+=== attend tune — session survey ===
+  projects surveyed:  10
+  sessions parsed:    18
+  turn samples:       544
+
+  assistant → user (think time):
+    median=24s  p75=62s  p90=164s
+  user → user (full cycle):
+    median=82s  p75=212s  p90=430s
+
+=== derived engagement config ===
+engagement:
+  burst_window: 1289          # 430s p90 × 3 burst threshold
+  burst_threshold: 3
+  step_multiplier: 1.25
+  absolute_refractory: 23     # median think time
+  decay_per_minute: 0.0291    # peak decays over 2× burst_window
+  peer_activity_window: 1289  # matches burst_window
+
+(pass --apply to write these values to your attend config)
+```
+
+The output is not applied automatically — it's a recommendation. Review, tweak, then `attend tune --apply` writes the values to your user-scope config. This is a one-time calibration; re-run whenever your session patterns change significantly.
+
+## Interaction with the disclosure governor
+
+Engagement is a **per-sensor** gate. The disclosure governor is a **global** gate. Both must permit a firing for it to happen.
+
+- **Sensor refractory says NO** → event accumulates silently. No disclosure fires.
+- **Sensor refractory says YES, governor cooldown active** → sensor is "ready" but held. The loop logs `N sensors ready but governor holding`. When the cooldown rolls, accumulated sensors fire together.
+- **Both say YES** → disclosure fires. Events are emitted as Monitor notifications, governor records the disclosure, engagement records the burst count.
+
+The governor protects against *global flood* — too many sensors all trying to fire at once. Engagement protects against *per-sensor spam* — one sensor firing too frequently on declining-value stimuli. They're complementary.
+
+## Design rules of thumb
+
+When should you tune these parameters vs leave defaults?
+
+- **Leave defaults unless you've run `attend tune`.** The defaults are reasonable for a typical dev workflow. Random tweaking is unlikely to improve things.
+- **Shorter `burst_window` if your sessions are short.** If you mostly have 5-minute interactions, a 15-minute burst window is too long — it'll never kick in. Drop to 5 minutes.
+- **Lower `burst_threshold` if you're getting spammed.** If a particular sensor is firing too often, lower the threshold to 2 so refractory kicks in faster.
+- **Higher `step_multiplier` if refractory isn't strong enough.** If elevated threshold still lets chatty events through, raise the multiplier from 1.25 to 1.5.
+- **Longer `absolute_refractory` if you need more silence.** 60 seconds is one Claude turn. If you want a full pause between bursts, raise it to 120–180.
+- **Faster `decay_per_minute` if you want quick return to normal.** The default (0.1) takes ~12 minutes to fully relax. If you want 3-minute recovery, raise to 0.33.
+
+All tuning is via attend config, using the ADR-115 overlay pattern — user scope, project scope, or both.
+
+## Related
+
+- **ADR-119** — the decision record for the action potential model
+- [`loop.md`](loop.md) — where engagement state sits in the loop iteration
+- [`authoring-sensors.md`](authoring-sensors.md) — how sensor authors design around engagement
+- [`configuration.md`](configuration.md) *(planned)* — full config schema for engagement parameters

--- a/docs/attend-and-monitor/focus-groups.md
+++ b/docs/attend-and-monitor/focus-groups.md
@@ -1,0 +1,140 @@
+# Focus groups — dynamic agent grouping
+
+Focus groups are attend's mechanism for **named signal scopes** that agents can join and leave dynamically. They solve the problem of "how do three agents talking about a deploy keep their signals scoped to each other without broadcasting to everyone else working on unrelated things."
+
+This page covers the group model, how membership works, the on-disk layout, and how groups interact with the action potential engagement model. The authoritative source is **ADR-118**.
+
+## The problem
+
+Attend's earliest design had two signal scopes: **project** (your own cwd, encoded as a directory name) and **broadcast** (everyone). This was sufficient for two-agent coordination — "agent A replies to agent B in A's project dir, B reads it via its scan of own-project" — but it fell over at three or more agents working on related-but-not-identical work.
+
+Concrete failure: agents on `api`, `infra`, and `docs` all working on a deploy together. If `api` sends a broadcast, it reaches `api`, `infra`, `docs`, and also every unrelated agent on the user's machine. If `api` sends to `infra` via `--to /home/aaron/.../infra`, that's directed and `docs` misses it. No way to say "reach the three agents working on this deploy, nobody else."
+
+The original workaround was static paths: add `--focus` flags pointing at specific directories. But paths are implementation details — agents kept misrouting because they reasoned about filesystem layout instead of about group intent. There was no way to dynamically add or remove agents from a scope without the sender knowing everyone's cwd.
+
+## The decision
+
+Focus groups are **named signal namespaces**. An agent joins a group by name (`attend focus on deploy`); attend creates an `@deploy` signal directory and records the session as a member. Other agents join the same group by name, and they all read each other's signals via the shared `@deploy` dir. Leaving (`attend focus off deploy`) removes the agent from the membership and — if the group is unpinned and empty — removes the group entirely.
+
+Groups compose naturally with the other two scopes:
+
+| Scope | Routing target | Reached by |
+|---|---|---|
+| Project | `-encoded-cwd/` | anyone in the same cwd |
+| Focus group | `@<name>/` | anyone who joined the named group |
+| Broadcast | `_broadcast/` | everyone with attend running |
+
+A single `attend send` can fan out to multiple scopes via flags; the default (ADR-119) is broadcast.
+
+## CLI surface
+
+```bash
+# Join and leave
+attend focus on deploy         # join the 'deploy' group, creating it if needed
+attend focus on infra --pin    # join and mark the group as persistent when empty
+attend focus off deploy        # leave the group; removes it if empty and unpinned
+attend focus clear             # leave all joined groups (project scope only)
+
+# Inspection
+attend focus list              # show groups this session is focused on
+attend focus all               # show all active groups with membership
+
+# Management
+attend focus pin <name>        # mark an existing group as persistent when empty
+attend focus unpin <name>      # unmark; group gets cleaned up if empty
+attend focus dissolve <name>   # remove the group entirely (ejects all members)
+```
+
+**Pinning** is for groups that should outlive any individual session's membership. An unpinned group is removed the moment its last member leaves; a pinned group persists even when empty so that new agents joining later can find it. Useful for long-lived coordination channels.
+
+**Dissolving** is the hard-delete for groups. All members are notified (via a final broadcast from the dissolver), the `@<name>/` directory is removed, and the state entry is cleared.
+
+## On-disk layout
+
+Groups live under the signals base (`~/.cache/attend/signals/`) alongside the other scope directories:
+
+```
+~/.cache/attend/signals/
+├── _broadcast/
+├── _groups.yaml            ← membership state
+├── @deploy/                ← focus group directory
+│   ├── claude-abc123-1743280000.signal
+│   └── claude-def456-1743280042.signal
+├── @infra/
+│   └── ...
+└── -home-aaron-Projects-foo/
+    └── ...
+```
+
+**Naming rules:**
+
+- Group names start with `@` on disk; the `@` is prepended automatically by attend (the user types `attend focus on deploy`, attend creates `@deploy/`)
+- Names cannot start with `_` or `@` (to avoid collision with reserved prefixes)
+- Names cannot contain `/` or whitespace
+- `broadcast` is reserved as a group name (would shadow `_broadcast`)
+
+**State file: `_groups.yaml`.** Membership is tracked in a YAML file at the root of the signals base. Each entry records the group's pin state and the session IDs currently in it:
+
+```yaml
+deploy:
+  pinned: false
+  members:
+    - abc123-...-session
+    - def456-...-session
+infra:
+  pinned: true
+  members:
+    - abc123-...-session
+```
+
+Writes are atomic (write-then-rename pattern, fixed in issue #16). Concurrent `attend focus` commands from multiple sessions don't corrupt the file.
+
+## The session-ID contract
+
+Each attend instance knows its own session ID (`own_session_id()` reads from `~/.claude/sessions/*.json`). When joining a group, attend writes that session ID into the `members:` list of the `_groups.yaml` entry. When leaving, it removes its session ID. Stale entries for exited sessions are cleaned up opportunistically by `cleanup_stale()` — though the session-alive check is currently a stub that always returns true, so in practice dead sessions can linger in the membership list until the group is dissolved or manually cleaned.
+
+This means group membership is **self-reported**. An agent adds itself to a group; no central authority verifies. The model assumes cooperative agents — which is the design assumption across all of attend, not specific to groups.
+
+## How the peer sensor scans focus groups
+
+`sensor-peers` scans three kinds of directories on every poll: own project scope, `_broadcast`, and every focus group the session has joined. As of the awareness-stabilization bundle (issue #15), the list of focus-group directories to scan is refreshed on every poll via a closure provider. Before this fix, attend captured the group list once at startup and never updated it; mid-session `attend focus on <name>` had no effect until the sensor loop restarted. Now the provider re-reads `_groups.yaml` on every scan, so joins and leaves take effect immediately.
+
+The provider mechanism is simple: when `sensor-peers` is registered during startup, it receives a closure that clones the `Groups` handle. On each scan, it calls the closure, which returns the current list of joined group directories. The closure closes over an owned clone of `Groups` so it doesn't hold a borrow into the main loop state.
+
+## Interaction with action potential (ADR-119)
+
+Focus groups and engagement compose cleanly. Groups scope **which signals reach the agent**; engagement governs **how the agent responds once they arrive**. They operate at different layers:
+
+- `attend focus on deploy` — agent now receives `@deploy` signals as well as project + broadcast
+- New signals accumulate normally against the (possibly refractory-elevated) threshold
+- If the agent just finished a burst of `@deploy` conversation, refractory is elevated, so only high-magnitude follow-ups break through
+- The agent naturally disengages from fading deploy chatter while still picking up urgent signals
+
+The per-peer engagement boost (see [`engagement.md`](engagement.md)) also applies across focus group boundaries. A peer you've been actively chatting with in `@deploy` gets their messages boosted globally, not just within that group. This is usually the right shape — "I've been talking to this agent a lot" is a conversation-level state, not a group-level state.
+
+## The routing simplification from ADR-119
+
+ADR-119 collapsed attend's peer-messaging routing down to a single default: **broadcast**. Before ADR-119, an agent had to reason about where to send messages — "should this go to a focus group? to a specific cwd? to broadcast?" — and routinely got it wrong. After ADR-119, the agent sends to broadcast and lets the engagement model sort out who pays attention.
+
+Focus groups still exist and are still useful, but their role has shifted. They're not the primary routing mechanism anymore; the action potential's per-peer boost handles most "which agents should engage with this" decisions automatically. Groups are now better understood as **explicit scoping for cases where the engagement model isn't enough**:
+
+- Multi-project coordination where you want signals visible to three specific agents and invisible to a fourth
+- Long-lived coordination channels that should persist across session restarts (via `--pin`)
+- Cases where you want to guarantee delivery regardless of engagement state
+
+For ad-hoc conversations, broadcast + engagement boost is sufficient and simpler. For structured scopes, use groups.
+
+## The TUI sidebar
+
+The `attend chat` TUI (ADR-120, documented in [`tui.md`](tui.md)) puts focus groups in the left sidebar as a clickable filter. Each joined group is listed with an unread indicator; clicking filters the message stream to only that group. The sidebar is how a human gets a visual handle on the otherwise-invisible scope topology.
+
+Importantly, clicking a group in the sidebar is a TUI-local filter — it doesn't change the session's actual group membership. To join or leave a group you still run `attend focus on` / `off` from a terminal (or, in future, via a TUI command). This separation means "looking at a group" and "being in a group" are distinct actions.
+
+## Related
+
+- **ADR-118** — the decision to build focus groups
+- **ADR-119** — action potential engagement; routing simplification
+- [`signals.md`](signals.md) — how `@<name>/` dirs fit into the overall signal layout
+- [`engagement.md`](engagement.md) — per-peer boost and refractory
+- [`tui.md`](tui.md) — the sidebar UI for groups
+- `tools/attend/src/groups.rs` — the implementation

--- a/docs/attend-and-monitor/loop.md
+++ b/docs/attend-and-monitor/loop.md
@@ -2,7 +2,9 @@
 
 Attend is a single long-lived process that runs a timer-driven sensor loop. It has no threads, no async runtime, no event subscriptions. Each iteration looks at a priority queue of upcoming sensor polls, sleeps until the next one is due, polls everything that's ready, decides whether to emit, and goes back to sleep.
 
-This page covers the rhythm of one iteration, the phases a sensor passes through inside that iteration, and how observations leave attend and reach the agent through Monitor. It's the substrate document — every other page in this directory refers back to something here.
+This page covers the rhythm of one iteration, the phases a sensor passes through inside that iteration, and how observations leave attend and reach whoever is listening. It's the substrate document — every other page in this directory refers back to something here.
+
+Two consumers ride on top of this loop: an AI agent session (via `attend run` delivering lines through Monitor) and a human operator (via `attend chat` rendering the same signals in an interactive TUI). The loop itself doesn't know or care which is connected — both drink from the same signal bus, and both are subject to the same engagement and governor rules. See [`tui.md`](tui.md) for the human mode.
 
 ## The rhythm
 
@@ -212,6 +214,8 @@ There's no graceful shutdown hook. The `attend run` process is meant to be start
 
 ## Where to go from here
 
+- **Writing new sensors**: [`authoring-sensors.md`](authoring-sensors.md) — how to implement a crate sensor or external script sensor that plays nicely with this loop.
+- **Human mode**: [`tui.md`](tui.md) — the `attend chat` interactive TUI, same signal bus as the agent side.
 - **Sensors individually**: `sensors.md` covers what each built-in observes and how it emits.
 - **Engagement curve**: `engagement.md` covers the action potential model — why sensors go quiet after bursts.
 - **Signal format**: `signals.md` covers the wire format, on-disk layout, and lifecycle.

--- a/docs/attend-and-monitor/loop.md
+++ b/docs/attend-and-monitor/loop.md
@@ -1,0 +1,219 @@
+# The attend loop
+
+Attend is a single long-lived process that runs a timer-driven sensor loop. It has no threads, no async runtime, no event subscriptions. Each iteration looks at a priority queue of upcoming sensor polls, sleeps until the next one is due, polls everything that's ready, decides whether to emit, and goes back to sleep.
+
+This page covers the rhythm of one iteration, the phases a sensor passes through inside that iteration, and how observations leave attend and reach the agent through Monitor. It's the substrate document — every other page in this directory refers back to something here.
+
+## The rhythm
+
+Attend's loop is **pull-based, not push-based**. Nothing wakes it up — it wakes itself up at timestamps it already knows about, does one unit of work, and goes back to sleep. The only external input is the filesystem: signal files other agents write, git state, process list, transcript changes. Sensors read these during their own scheduled polls.
+
+The implication for latency: attend's response time to an external change is bounded by the polling interval of the sensor that watches the relevant thing, not by the loop's "tick rate" (which doesn't really exist). A peer message arrives on disk immediately, but the peer sensor won't see it until its next poll — `min_interval` 10 seconds by default.
+
+The implication for cost: when nothing is happening, attend is asleep almost all the time. A quiet terminal with nothing changing is essentially free.
+
+## Startup
+
+Before the loop begins, `cmd_run_with_catchup` builds up the context it needs:
+
+1. **Focus** — resolve the working directory and human-readable description (`Focus::default_focus()`).
+2. **Config** — load `~/.config/attend/config.yaml`, then overlay `<cwd>/.claude/attend.yaml` on top (ADR-115 pattern).
+3. **Groups manager** — construct a `Groups` handle for the signals base and the current session ID. This is what ADR-118 focus groups ride on.
+4. **Sensor registration** — `sensors::register_sensors()` walks the config and feature flags, instantiating each enabled sensor with its configured intervals and thresholds. The peers sensor receives a closure provider for focus-group directories so it can refresh membership on every scan (ADR-118 / issue #15).
+5. **Engagement state** — apply ADR-119 action-potential parameters to every slot. Refractory behavior is per-sensor but the parameters are shared.
+6. **State restore** — if `~/.cache/attend/state/<session>.checkpoint` exists from a previous run, import the saved seen-signals and disclosed-thresholds so restart is continuous.
+7. **Banner** — print a startup line unless the fingerprint (version + commit + sensor list + focus) matches the last one written to `_last_banner`, in which case print `[attend] restarted (unchanged)` to keep noisy Monitors quiet.
+8. **Governor** — build a `DisclosureGovernor` with the configured cooldown, rate window, and max disclosures per window.
+9. **Priority queue** — push every sensor slot into a `BinaryHeap<ScheduledSensor>` keyed by `fire_at`.
+10. **Timers** — record startup `Instant`s for checkpoint, cleanup, and self-reload checks.
+
+Then the loop begins.
+
+## One iteration
+
+```mermaid
+flowchart TD
+    Start([loop iteration])
+    ReloadCheck{binary mtime<br/>changed?}
+    Exec[checkpoint state<br/>exec self]
+    PeekQueue{queue<br/>empty?}
+    Break([break])
+    Sleep[sleep until<br/>next fire_at]
+    Drain[drain all ready<br/>sensors from queue]
+    Poll[poll each sensor<br/>record events<br/>reschedule]
+    ReadyCheck{any sensor<br/>ready to disclose?}
+    GovernorCheck{governor<br/>can_disclose?}
+    Batch[format batch<br/>emit to stdout<br/>record disclosure<br/>record engagement]
+    Hold[log 'governor holding'<br/>leave magnitude accumulated]
+    CheckpointCheck{checkpoint<br/>due?}
+    Checkpoint[save state snapshot]
+    CleanupCheck{cleanup<br/>due?}
+    Cleanup[run_cleanup<br/>prune stale signals<br/>prune empty project dirs]
+    Continue([next iteration])
+
+    Start --> ReloadCheck
+    ReloadCheck -- yes --> Exec
+    ReloadCheck -- no --> PeekQueue
+    PeekQueue -- yes --> Break
+    PeekQueue -- no --> Sleep
+    Sleep --> Drain
+    Drain --> Poll
+    Poll --> ReadyCheck
+    ReadyCheck -- yes --> GovernorCheck
+    ReadyCheck -- no --> CheckpointCheck
+    GovernorCheck -- yes --> Batch
+    GovernorCheck -- no --> Hold
+    Batch --> CheckpointCheck
+    Hold --> CheckpointCheck
+    CheckpointCheck -- yes --> Checkpoint
+    CheckpointCheck -- no --> CleanupCheck
+    Checkpoint --> CleanupCheck
+    CleanupCheck -- yes --> Cleanup
+    CleanupCheck -- no --> Continue
+    Cleanup --> Continue
+```
+
+The reload branch is a hard exit — `execve(2)` replaces the current process image with a fresh copy of the binary. State is checkpointed first, and the new process restores from that checkpoint during startup, so observed signals, engagement history, and disclosed context thresholds survive the reload.
+
+The queue-empty branch is a defensive break. In practice it's unreachable because every poll reschedules the sensor, but a future sensor that explicitly retires could drop out of the queue.
+
+## The sensor queue
+
+`BinaryHeap<ScheduledSensor>` is a min-heap ordered by `fire_at` — the soonest-scheduled sensor is always at the top. The loop peeks it to find the next wakeup, sleeps precisely that long (no jitter, no coarse tick), then drains *every* sensor whose `fire_at` has passed.
+
+Draining is important: if two sensors both came due during the sleep, they both poll in this iteration. This keeps the loop from falling behind during bursts.
+
+After each poll, the sensor's `schedule_next()` computes its next `fire_at` based on whether it observed anything, the action-potential engagement state, and its `min_interval` floor. The updated entry gets pushed back into the heap.
+
+Scheduling dynamics:
+
+- **Quiet sensor**: interval grows toward `base_interval()`. Polls become less frequent.
+- **Active sensor**: interval shrinks toward `min_interval()`. Polls become more frequent.
+- **Refractory sensor**: interval still runs, but the effective threshold is elevated so polls that would normally cross threshold are suppressed. See `engagement.md` once it exists.
+
+## One sensor's lifecycle within an iteration
+
+Each drained sensor walks through a short state machine before control returns to the loop body:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Resting
+    Resting --> Polling: fire_at ≤ now
+    Polling --> Quiet: sensor reports no change
+    Polling --> Changed: sensor reports change
+
+    Quiet --> Rescheduled
+    Changed --> GovernorRecord: record_event()
+    GovernorRecord --> ReadyCheck: ready_to_disclose()?
+
+    ReadyCheck --> Ready: threshold crossed<br/>not in refractory
+    ReadyCheck --> Held: threshold crossed<br/>in absolute refractory
+    ReadyCheck --> Accumulating: below threshold
+
+    Ready --> Rescheduled: appended to<br/>ready_indices
+    Held --> Rescheduled: magnitude preserved<br/>for next poll
+    Accumulating --> Rescheduled: magnitude preserved<br/>for next poll
+
+    Rescheduled --> [*]: schedule_next()<br/>pushed back into heap
+```
+
+**Quiet** is the happy path when nothing changed. The sensor's interval grows, its accumulator stays at zero, the loop logs nothing, and it sleeps until next fire.
+
+**Changed but below threshold** means the sensor saw something but the magnitude isn't high enough to emit yet. The event is accumulated in the sensor's `DeltaAccumulator` and will be combined with future events if they arrive before the accumulator decays.
+
+**Changed, above threshold, but held in absolute refractory** means ADR-119's action potential is actively suppressing this sensor after a recent burst. The magnitude stays on the accumulator but the sensor is not added to `ready_indices`. The log line `held in absolute refractory` marks this case.
+
+**Ready** means the sensor crossed threshold and engagement state permits disclosure. The sensor index is appended to `ready_indices`, which the loop processes in a batch after draining.
+
+## Disclosure and the governor
+
+After all ready sensors are drained, the loop checks whether the `DisclosureGovernor` permits output. The governor enforces two limits:
+
+- **Base cooldown** — minimum seconds between disclosures (default 15s).
+- **Rate window** — max disclosures per rolling window (default 3 per 120s).
+
+If both pass, the loop builds a batch:
+
+1. For each ready sensor, compute a priority (`high` / `medium` / `low`) based on accumulated magnitude.
+2. Drain the sensor's events into a list of observations.
+3. Append `(sensor_name, priority, observations)` to the batch.
+4. Hand the batch to `emit::emit_batch()` which formats each event as a single Monitor-visible line.
+
+Each emitted event is a single `println!` to stdout. Monitor captures each line and delivers it to the conversation as an async notification. **One event = one notification line.** This is the reason peer messages have a practical ~400 character ceiling — longer payloads get truncated by Monitor's per-line buffer. See `skills/attend/SKILL.md` for the operator-facing note.
+
+After emission, the loop records a disclosure on the governor and records engagement for every sensor whose magnitude was actually actionable (≥ 3.0). Quiet filler events don't count toward engagement, so refractory only escalates when real bursts happen.
+
+If the governor rejects the batch, the magnitudes stay on the accumulators and the loop logs `N sensors ready but governor holding (X/Y in window)`. The next time the governor window rolls, those accumulated events will fire together.
+
+## Signal flow end-to-end
+
+```mermaid
+sequenceDiagram
+    participant World as External state<br/>(git, peers, processes)
+    participant Sensor
+    participant Slot as SensorSlot
+    participant Engagement as EngagementState
+    participant Governor as DisclosureGovernor
+    participant Emit as emit::emit_batch
+    participant Monitor as Claude Code Monitor
+    participant Agent as Conversation
+
+    World->>Sensor: filesystem / process state changes
+    Note right of Sensor: waits until next poll
+
+    Slot->>Sensor: poll(focus)
+    Sensor->>Slot: (changed, events)
+    Slot->>Slot: accumulate magnitude
+    Slot->>Governor: record_event() if changed
+    Slot->>Engagement: ready_to_disclose()?
+    Engagement-->>Slot: yes / held / absolute refractory
+
+    Slot->>Governor: can_disclose()?
+    Governor-->>Slot: yes / rate-limited
+
+    Slot->>Emit: batch of (name, priority, events)
+    Emit->>Monitor: println! — one line per event
+    Monitor->>Agent: async notification
+
+    Note over Governor,Engagement: Governor.record_disclosure()<br/>Engagement.record_disclosure() per sensor
+```
+
+This is the one-way data flow. Signals enter via sensors (reading the environment) and leave via stdout (intercepted by Monitor). Nothing in attend's runtime is event-driven — every transition is a poll that happened to find something new.
+
+## Timers running in parallel
+
+All of these tick inside the same single-threaded loop using `Instant::now()` comparisons against stored last-time values:
+
+| Timer | Interval | Purpose |
+|---|---|---|
+| Per-sensor poll | `slot.next_fire` (varies) | Primary loop rhythm — when to poll each sensor |
+| Self-reload check | 10s | Detect binary change, exec self |
+| Checkpoint | 30s | Save sensor state snapshot for restart continuity |
+| Cleanup sweep | `cleanup.interval` (default 600s) | Prune stale signal files + empty project dirs |
+| Sensor min_interval | per-sensor (default 10–20s) | Floor on polling frequency |
+| Sensor base_interval | per-sensor (default 30–60s) | Ceiling — rest-state polling frequency |
+| Governor cooldown | `governor.base_cooldown` (default 15s) | Minimum gap between disclosures |
+| Governor rate window | `governor.rate_window` (default 120s) | Rolling window for disclosure rate limit |
+| Action potential burst window | `engagement.burst_window` (default 900s) | Window for counting recent disclosures |
+| Absolute refractory | `engagement.absolute_refractory` (default 60s) | Full suppression after burst |
+| Relative refractory decay | `engagement.decay_per_minute` (default 0.1) | Rate at which elevated threshold returns to rest |
+
+The loop doesn't coordinate these explicitly — each is a separate "has enough time passed since the last time we did this?" check at the natural point in the iteration. The loop body walks through them in a fixed order so behavior is deterministic.
+
+## Loop termination
+
+Three ways the loop ends:
+
+1. **`execve` via self-reload.** The current process image is replaced and control never returns to the loop. State is checkpointed first so the replacement process restores cleanly.
+2. **Queue empty.** Defensive `break` — currently unreachable because every poll reschedules the sensor, but a future explicit-retire mechanism could drop out.
+3. **External signal (SIGTERM, etc).** Default handling — the process exits. The most recent checkpoint is the restore point; any accumulated-but-not-disclosed magnitude since then is lost. This is acceptable because accumulation is ephemeral by design.
+
+There's no graceful shutdown hook. The `attend run` process is meant to be started via Monitor, live as long as the session lives, and die when the session ends. The checkpoint timer is aggressive enough (30s) that losing <30s of accumulation is the worst case.
+
+## Where to go from here
+
+- **Sensors individually**: `sensors.md` covers what each built-in observes and how it emits.
+- **Engagement curve**: `engagement.md` covers the action potential model — why sensors go quiet after bursts.
+- **Signal format**: `signals.md` covers the wire format, on-disk layout, and lifecycle.
+- **Configuration**: `configuration.md` covers the YAML overlay and how to reshape any of the timers above.
+- **Salience decay**: `salience.md` covers ADR-121's presentation-layer aging — orthogonal to this loop, sitting in the emit path.

--- a/docs/attend-and-monitor/salience.md
+++ b/docs/attend-and-monitor/salience.md
@@ -1,0 +1,122 @@
+# Salience decay
+
+This page covers the **presentation-layer aging** mechanism: how a signal's visibility in the conversation fades over turns even while the signal file remains on disk. It's the turn-based cousin of the 30-day time-based disk cleanup described in [`signals.md`](signals.md).
+
+**Status**: designed in ADR-121 (draft), not yet implemented at the time of writing. This page describes the decision, not a current behavior — the mechanism will land as a follow-up.
+
+## The shape of the problem
+
+Disk retention (30 days) addresses bulk accumulation — signal files shouldn't live forever on disk. The action potential model (ADR-119, see [`engagement.md`](engagement.md)) addresses engagement — a sensor shouldn't keep firing on diminishing-value stimuli. But neither of those addresses the middle case: a signal that *was* disclosed, *is* still on disk, and *keeps getting re-presented* every time the peer sensor scans, long after it has stopped being load-bearing.
+
+In a 90-turn session, a signal that arrived at turn 3 is still being surfaced at turn 80 — even though by turn 80 that context has been overtaken by at least an order of magnitude of new events. The signal isn't stale in any disk-cleanup sense (it's hours old, not days), but it's stale in a *relevance* sense. The conversation has moved on.
+
+ADR-121's framing: **signals need presentation-layer aging, measured in turns, decaying smoothly.**
+
+## The decision
+
+Every signal carries a **salience** that starts at 1.0 when it arrives and decays exponentially with turns elapsed since arrival. Below a configurable floor (default 0.3), the signal stops appearing in notifications — but the file stays on disk until the 30-day cleanup removes it. Salience is reset to 1.0 whenever a signal is re-engaged (replied to, referenced, or otherwise touched).
+
+The parameter the user tunes is **half-life in turns**: the number of turns after which an un-engaged signal has dropped to 50% salience.
+
+```
+salience(t) = 0.5^((t - arrival_turn) / half_life)
+```
+
+Default half-life: **20 turns**. Default floor: **0.3**.
+
+### Why these numbers
+
+Half-life is grounded in survey data from real session transcripts. A sweep of 18 recent active sessions produced the distribution:
+
+```
+min=1  median=12  p75=45  p90=84  max=133  mean=32.6
+```
+
+With half-life 20 and floor 0.3, the behavior at each distribution point:
+
+| Session length | Salience of a first-turn signal at the end |
+|---|---|
+| median (12 turns) | 0.66 — still visible, nothing faded |
+| p75 (45 turns) | 0.21 — below floor, dropped from presentation |
+| p90 (84 turns) | 0.06 — effectively gone |
+
+**Read this as**: short sessions never see aging (nothing to prune), medium sessions see the oldest stuff drop out cleanly near the end, long sessions experience meaningful pruning. The curve is gentle enough that mid-session signals don't vanish too fast, and steep enough that long-tail signals actually go away.
+
+## Re-engagement resets
+
+A signal that's been replied to or referenced is a signal that's still relevant. The reset semantics:
+
+- When an agent or human replies to a signal (using the `re:` threading field from ADR-120), the original signal's `arrival_turn` is updated to the current turn. Its salience returns to 1.0.
+- When a message references a prior signal by content (best-effort matching, not implemented), the same reset happens.
+- When a signal is re-disclosed for any reason (e.g., an agent that joins mid-conversation sees backlog), the arrival_turn for *that agent's view* resets — because the signal just entered their attention.
+
+Re-engagement is the "conversation thread still alive" signal. As long as either side is responding, the thread stays hot. When neither side has touched it for ~20 turns, it fades.
+
+## Why turn-based, not time-based
+
+Short answer: **precision where it matters, convenience where it doesn't.**
+
+Disk retention operates at 30-day scale, where turn pacing variance averages out across thousands of turns. "30 days" is a round human number everyone intuits. Time is a fine proxy for bulk turns at that horizon.
+
+Attention window operates at 20-turn scale, where turn pacing variance is order-of-magnitude (a 10-minute think turn and a 15-second reply both count as "one turn"). Time-based aging at this grain would wobble with pacing — a conversation that happens to have long think turns would drop signals out of presentation based on wall clock, which has nothing to do with whether they're still relevant. Turn count tracks the actual thing we care about: how many rounds of decision-making have passed since this signal was useful.
+
+Both mechanisms exist for legitimate reasons. They use different units because different scales warrant different units. Future-us should not "fix" the apparent inconsistency — the split is deliberate and called out in ADR-121.
+
+## Where the turn counter comes from
+
+Attend can count turns from authoritative sources, no estimation needed:
+
+- **Primary source**: parse the active session's JSONL transcript at `~/.claude/projects/<encoded-cwd>/<session>.jsonl`. Count `"type":"user"` entries (excluding `tool_result`). Attend already reads these files in `attend tune`; the same parser can be used for the live turn counter.
+- **Secondary source**: the context sensor already tracks context percentage across polls. Turn count correlates with context growth; it's a less-precise but more-available signal.
+
+The primary source is exact. The secondary is a fallback if transcript reading fails for any reason. The implementation will try primary first.
+
+## What's different from engagement
+
+Salience decay and engagement (ADR-119) are two different mechanisms solving two different problems. They look similar on the surface — both involve curves, thresholds, decay — but they operate on opposite sides of the disclosure path:
+
+| | Engagement (ADR-119) | Salience (ADR-121) |
+|---|---|---|
+| **Question** | "Should this new event fire?" | "Should this already-fired signal still be visible?" |
+| **Direction** | Inward gate — stimulus → disclosure | Outward gate — disclosure → presentation |
+| **Unit** | Time (for refractory) | Turns |
+| **Scope** | Per sensor | Per signal |
+| **Effect** | Suppresses low-magnitude follow-ups after a burst | Ages out stale signals from active notification set |
+| **Resets on** | Decay over time | Re-engagement (reply, reference) |
+
+They compose. A signal that fires in a hot conversation passes both gates: engagement approves it (the sensor is in relative refractory but the magnitude is high enough to break through) and salience is at 1.0 (just arrived). Later, that same signal might still exist on disk while salience has fallen to 0.15 and the sensor is back at baseline engagement. If a follow-up event references it, salience resets to 1.0 and it becomes visible again.
+
+## Alternatives rejected in ADR-121
+
+Documented here for posterity. Full rationale is in the ADR itself.
+
+- **Hard cutoff at N turns.** Simpler than exponential, but produces a cliff — at turn 45, everything from before turn 0 vanishes abruptly. Exponential matches the "relevance declines gradually" intuition better.
+- **Linear decay over N turns.** Treats every turn's contribution to aging as equal. But the first few turns of irrelevance matter more than the last few — exponential's "halves repeatedly" shape is closer to how attention actually works.
+- **Time-based aging.** Wobbles with pacing, as described above.
+- **Per-category half-lives** (different decay rates for different signal types). Premature — start with one half-life globally, add per-category overrides if real use demands it.
+- **Subsume into engagement's refractory machinery.** Conflates the inward and outward gates, making both harder to reason about.
+
+## Implementation notes (when it lands)
+
+The mechanism needs three things:
+
+1. **Per-signal `arrival_turn` metadata.** Either in the signal file (a new field alongside `from|project|cwd|re:|message`) or in a side table. Side table is probably cleaner — it keeps the wire format stable for readers that don't care about salience.
+2. **A live turn counter.** Parse the active session's transcript; count user turns. Update on each peer sensor poll (cheap — the file is small and grows slowly).
+3. **A presentation gate in `sensor-peers`.** Before emitting a signal as an observation, compute its salience. If below the floor, suppress. If above, pass through.
+
+No changes to the engagement model, the disclosure governor, or the signal file format (assuming side-table storage for `arrival_turn`). The implementation is scoped to the peer sensor and a new small module for turn counting.
+
+Configuration additions when implemented:
+
+```yaml
+attention:
+  half_life_turns: 20      # default 20 — matches session distribution analysis
+  presentation_floor: 0.3  # below this, signal is no longer presented
+```
+
+## Related
+
+- **ADR-121** — the decision record (draft)
+- [`signals.md`](signals.md) — disk-side retention (the time-based cousin)
+- [`engagement.md`](engagement.md) — the inward-gate engagement model
+- [`loop.md`](loop.md) — where the presentation gate will sit in the loop

--- a/docs/attend-and-monitor/sensors.md
+++ b/docs/attend-and-monitor/sensors.md
@@ -1,0 +1,166 @@
+# Sensors — the built-in set
+
+Attend ships with four built-in sensors, each compiled in as a separate Rust crate and wired into the orchestrator via a feature flag. They form the baseline observation surface of "what's happening outside the conversation" — context state, git state, peer sessions, and process activity. Everything beyond these four is a user-authored sensor, either another crate or an external script (see [`authoring-sensors.md`](authoring-sensors.md)).
+
+This page covers what each built-in observes, what magnitudes it emits, and what kinds of events a reader will see in notifications.
+
+## Summary
+
+| Sensor | Observes | Base interval | Min interval | Threshold | Emits |
+|---|---|---|---|---|---|
+| **context** | Claude's own token usage | 60s | 20s | 1.5 | tier crossings, velocity spikes |
+| **git** | Working tree git state | 30s | 10s | 2.0 | branch changes, new commits, dirty file deltas |
+| **peers** | Other Claude sessions + signal files | 30s | 10s | 2.0 | peer status changes, peer messages |
+| **processes** | Build/dev-tool processes | 30s | 5s | 2.0 | process start/exit (cargo, npm, make, etc.) |
+
+All four use the adaptive interval scheme — they poll fast (`min_interval`) during active change and slow (`base_interval`) when quiet. All four participate in the action potential engagement model (ADR-119) with the shared global config.
+
+## `sensor-context` — interoceptive
+
+The canonical first sensor from ADR-113 — the one that prevents Claude from silently running off the context cliff. It's called "interoceptive" because it's the one sensor that watches *Claude itself* rather than the external world. The data source is `ways context --json`, which reads the running session's current token usage.
+
+### What it emits
+
+**Tier crossings.** Context percentage is bucketed into tiers; crossing into a new tier fires an observation. Each tier has an increasing magnitude:
+
+| Tier | % used | Magnitude | Label |
+|---|---|---|---|
+| low | 40% | 1.5 | approaching midpoint — plan wrap-up scope |
+| mid | 50% | 2.0 | midpoint — wrap-up window opening |
+| high | 65% | 3.0 | ways will fire todos checkpoint at 75% |
+| alert | 85% | 4.0 | ways fired memory save at 80% — verify it happened |
+| critical | 92% | 5.0 | compaction checkpoint at 95% — finish current task |
+
+Each tier is disclosed once per session — once you've crossed 65%, you won't see the 65% tier message again even if you bounce around that value. The emit includes the current percentage and a projection to 95% based on recent velocity.
+
+**Velocity spikes.** If context burn rate exceeds 2%/min and the percentage change is significant (>5%), a magnitude 2.0 observation fires separately: "context velocity spike: X% in last N min (V%/min)." This catches the case where you're burning through context unexpectedly fast — useful for detecting runaway tool loops or overly verbose file reads.
+
+**Affordance strings.** High-tier observations (alert and critical) append `Use \`ways show attend context-pressure --session $CLAUDE_SESSION_ID\` for reflection guidance` to the message. This points the agent at the context-pressure way for structured next-step decisions.
+
+### State the sensor carries
+
+- Last-disclosed tier per session (so tiers fire once, not repeatedly)
+- Prior snapshot (token count, percentage, wall-clock) for velocity computation
+
+### What it doesn't do
+
+Doesn't enforce anything. Doesn't compact for you. Doesn't save state. It only surfaces observations — the response is up to the agent and to the ways layer that fires at specific thresholds.
+
+## `sensor-git` — working tree state
+
+Watches git state in the current working directory. Reports application-level deltas (branch changed, N new commits, M new dirty files) rather than file-by-file churn. The underlying data comes from `git` shell-outs (with `GIT_OPTIONAL_LOCKS=0` to avoid races against foreground commits).
+
+### What it emits
+
+| Event | Magnitude | Example |
+|---|---|---|
+| branch changed | 3.0 | `branch changed: main → feat/new-thing` |
+| new commits on current branch | 2.0 | `new commits on feat/attend: HEAD abc123 → def456` |
+| new dirty files | 2.0 (burst scales) | `3 new dirty files: src/main.rs, src/config.rs, Cargo.toml` |
+| working tree clean | 1.0 | `working tree clean (changes committed or stashed)` |
+| new upstream commits | 2.0 | `4 new commits on upstream (now 4 behind)` |
+| unpushed local commits | 1.0 | `2 commits ahead of upstream (unpushed)` |
+
+Branch changes are the loudest event (3.0) because they're usually the signal of "I just switched contexts." New commits on the current branch (2.0) fire when something lands that you care about. Clean state (1.0) is soft — it aggregates with other background events rather than firing on its own.
+
+### State the sensor carries
+
+- Previous snapshot: branch name, HEAD SHA, dirty file set, ahead/behind counts
+
+### What it doesn't do
+
+Doesn't watch git hooks, doesn't parse commit messages, doesn't look at tags. It's strictly about working tree state and upstream divergence.
+
+## `sensor-peers` — other sessions and signal files
+
+Discovers other Claude Code sessions and reads peer signal files from `~/.cache/attend/signals/`. This is the sensor that makes multi-agent coordination possible — it reads messages sent via `attend send` from other sessions.
+
+### What it observes
+
+**Peer sessions.** Walks `~/.claude/sessions/*.json` to find other running Claude sessions. For each, tracks cwd, PID, project name, context percentage, model, and working/waiting status. Emits when peers appear, disappear, or change state.
+
+**Signal files.** Scans the sender's own project directory, `_broadcast`, and every focus group the session has joined. New `.signal` files (not in the seen-set) are parsed and emitted as peer message events.
+
+### What it emits
+
+| Event | Magnitude | Notes |
+|---|---|---|
+| peer session appeared | 2.0 | new Claude session detected |
+| peer session disappeared | 1.5 | session exited |
+| peer status change | 1.5 | working → waiting, etc. |
+| peer message | base × peer boost | see below |
+
+**Per-peer engagement boost.** Peer messages don't have a fixed magnitude — they're amplified based on how much back-and-forth the recipient has had with that specific peer:
+
+- First message from a peer in the activity window (default 15 min): × 1.0
+- Second message: × 1.75
+- Third and beyond: × 2.5
+
+This creates emergent auto-grouping: active conversation partners climb above the refractory threshold, while uninvolved broadcast noise stays at baseline and gets suppressed. See [`engagement.md`](engagement.md) for the full model.
+
+### State the sensor carries
+
+- Prior snapshot of all known peer sessions
+- Set of already-seen signal filenames (keyed by directory + filename)
+- Per-peer engagement history (sliding window of recent message timestamps)
+- Reply-hint-shown flag (once per session, not per message)
+- Own session ID (to skip self-signals)
+
+### Focus group provider
+
+As of the awareness-stabilization bundle (issue #15), the list of focus-group directories to scan is refreshed on every poll via a closure provider, not snapshotted at startup. This means mid-session `attend focus on <name>` takes effect immediately without restarting the sensor loop.
+
+## `sensor-processes` — build and dev tools
+
+Tracks specific dev-tool processes running under the user's session. Not a general process monitor — it's scoped to a whitelist of compilers, build tools, and package managers, because those are the processes whose lifecycle matters to a coding session.
+
+### Watched processes
+
+```
+cargo, rustc, make, cmake, ninja,
+gcc, g++, cc, c++, clang, clang++,
+go, npm, yarn, pnpm, tsc,
+mvn, gradle, pip, pip3
+```
+
+A future extension could make this list configurable; today it's hardcoded.
+
+### What it emits
+
+| Event | Magnitude | Example |
+|---|---|---|
+| process started | 2.0 | `cargo started` |
+| process exited | 2.0 | `cargo exited. Use \`ways show attend build-complete --session $CLAUDE_SESSION_ID\` for next steps` |
+
+Exit events include an affordance string pointing at the build-complete way. Start and exit are both 2.0 — neither is more important than the other.
+
+### State the sensor carries
+
+- Previous snapshot: map of app name → instance count
+
+### What it doesn't do
+
+Doesn't capture stdout/stderr from the watched processes. Doesn't track exit codes. Doesn't distinguish success from failure — "cargo exited" fires whether the build succeeded or errored. For exit-code awareness, pair this with an external script sensor that watches `$?` or parses a build output file.
+
+Also doesn't batch multiple events from the same build tool. If `cargo` starts, then `rustc` starts as a child, then `rustc` exits, then `cargo` exits, that's four events. Smoothing build lifecycles into "build started → build finished" aggregate events is a known todo (see issue #2 — "build event batching").
+
+## Picking the right sensor for a new observation
+
+If you want attend to notice *something new*, ask in order:
+
+1. **Does an existing built-in cover it?** If you want to know when git state changes, `sensor-git` already does. Don't duplicate.
+2. **Can it be done with an external script?** Anything you can observe with a shell command is a candidate for an external sensor. This is usually the right choice — no recompile, no Rust required, fast iteration. See [`authoring-sensors.md`](authoring-sensors.md).
+3. **Does it need native performance, shared state, or complex logic?** If yes, write a new crate sensor. Create a new `sensor-*` crate in `tools/`, implement `Sensor`, add it to `attend`'s Cargo.toml as an optional dep + feature, register it in `sensors/mod.rs`.
+
+Almost everything falls into category 2. Crate sensors are for the core observation surfaces that justify being in the binary — the current four. User-level observations (GitHub Project boards, Slack activity, custom event logs, etc.) are external sensors.
+
+## Related
+
+- [`authoring-sensors.md`](authoring-sensors.md) — how to write new sensors
+- [`engagement.md`](engagement.md) — the action potential model the sensors play into
+- [`signals.md`](signals.md) — the signal file format `sensor-peers` reads and writes
+- [`loop.md`](loop.md) — the sensor loop substrate
+- **ADR-113** — the original design of attend, including the first context sensor
+- **ADR-117** — sensor crate extraction and feature flags
+- **ADR-118** — focus groups (used by `sensor-peers`)
+- **ADR-119** — action potential engagement model

--- a/docs/attend-and-monitor/signals.md
+++ b/docs/attend-and-monitor/signals.md
@@ -1,0 +1,172 @@
+# Signals — wire format, storage, lifecycle
+
+Signals are attend's on-disk messaging primitive. Everything that flows between sessions — peer messages sent with `attend send`, notifications rendered into the conversation via Monitor, human-typed lines in `attend chat` — is mediated by signal files on the local filesystem. This page covers the wire format, how signals are organized on disk, and the full lifecycle from arrival to deletion.
+
+## The wire format
+
+Every signal is a single-line, pipe-delimited record in a `.signal` file:
+
+```
+from|project|cwd|message
+```
+
+With threading extensions (when the `re:` field is present, per ADR-120):
+
+```
+from|project|cwd|re:signal-id|message
+```
+
+**Field-by-field:**
+
+- **`from`** — identifier of the sender, in the form `<kind>:<identity>`. Kinds seen in practice:
+  - `claude:<session-id>` — a Claude Code session, identified by its 36-char session UUID
+  - `external:<user>@<terminal>` — a human sending via `attend chat` or `attend send` from a terminal
+  - Future kinds (e.g., `script:<name>` for automated ops) follow the same pattern
+- **`project`** — human-readable project name (e.g., `api-service`, `bosectl-qt`). Used in display formatting, not routing.
+- **`cwd`** — absolute path of the sender's current working directory. This is the ground truth for "who am I" — signals scope to encoded-cwd directories, so cwd determines where a signal goes and where it comes from.
+- **`re:signal-id`** — optional threading field. Empty string for new threads; carries the original signal's ID when this is a reply. One level of threading only — no reply-to-reply.
+- **`message`** — the payload. Free text, usually the actual content the sender wants the receiver to see.
+
+Fields are pipe-delimited with no escaping. If your message contains a literal `|`, you need to escape it yourself at emit time — in practice this almost never happens because peer messages are prose.
+
+**Encoding and length.** UTF-8. Monitor's per-line buffer is the practical length limit for messages — see [`skills/attend/SKILL.md`](../../skills/attend/SKILL.md) for the ~400 character ceiling note. Longer messages aren't truncated on disk, only in the Monitor notification line — recipients can always read the full file via `attend inbox <id>`.
+
+## Storage layout
+
+Signal files live under `~/.cache/attend/signals/` in a flat two-level hierarchy:
+
+```
+~/.cache/attend/signals/
+├── _broadcast/                               # broadcast scope
+│   ├── claude-abc123-1743280000.signal
+│   └── aaron-1743280042.signal
+├── _groups.yaml                              # focus group state (ADR-118)
+├── _last_banner                              # startup banner fingerprint dedup
+├── @deploy/                                  # named focus group
+│   └── claude-abc123-1743280100.signal
+├── @infra/                                   # another focus group
+│   └── aaron-1743280200.signal
+├── -home-aaron-Projects-api-service/         # encoded cwd (project scope)
+│   ├── claude-def456-1743280000.signal
+│   └── claude-abc123-1743280050.signal
+├── -home-aaron-Projects-infra/               # another project scope
+│   └── ...
+└── -home-aaron--claude/                      # the agent-ways project itself
+    └── ...
+```
+
+Three kinds of subdirectories:
+
+1. **`_broadcast/`** — the reserved broadcast dir. Every agent with attend running sees signals here regardless of their project or focus group membership.
+2. **`@<name>/`** — focus group directories (ADR-118). Only sessions that have joined that group (via `attend focus on <name>`) receive signals from here.
+3. **`-<encoded-cwd>/`** — project-scope directories. The cwd encoding replaces `/`, `_`, and `.` with `-` to produce a filesystem-safe name. A session working in `/home/aaron/Projects/api-service` writes to and reads from `-home-aaron-Projects-api-service/`.
+
+**Reserved names:**
+
+- Anything starting with `_` (e.g., `_broadcast`, `_groups.yaml`, `_last_banner`) is a system file or dir. Never touched by cleanup, never interpreted as a project dir.
+- Anything starting with `@` is a focus group dir. Managed by `attend focus` commands, self-cleaning on leave/dissolve.
+
+## Filename convention
+
+Signal filenames are `<sender-id>-<timestamp>.signal`:
+
+```
+claude-abc123-1743280000.signal
+aaron-1743280042.signal
+```
+
+- **`<sender-id>`** — for claude sessions, the session UUID (sometimes truncated); for humans, a simple username
+- **`<timestamp>`** — Unix seconds at emit time
+- **`.signal`** — the file extension. Cleanup and scan paths only touch `.signal` files; anything else in a signal directory is left alone.
+
+Filenames are sortable by timestamp when the sender ID is consistent — useful for chronological ordering within a single sender's history, though the TUI and `attend inbox` use the file's mtime for the authoritative order across senders.
+
+## Atomic writes
+
+Signals are written atomically via the classic write-then-rename pattern:
+
+1. Writer creates `<filename>.tmp` with the content
+2. Writer renames `<filename>.tmp` → `<filename>` (atomic on any POSIX filesystem)
+
+Readers that see `<filename>` are guaranteed to read complete, consistent content. Readers ignore `.tmp` files. This prevents a reader from catching a half-written signal mid-disk-flush.
+
+`_groups.yaml` uses the same pattern (this was the fix for issue #16 — before, it was written with a plain `fs::write` and concurrent writers could corrupt it). Any tool or sensor that writes to the signals base should follow this pattern.
+
+## The full lifecycle
+
+A signal's journey from creation to deletion:
+
+```mermaid
+flowchart LR
+    Create[attend send<br/>or sensor emit]
+    Write[write .tmp<br/>rename to .signal]
+    Scan[peer sensor scans<br/>reads new files]
+    Present[present to agent<br/>via Monitor]
+    Age[age with turns<br/>ADR-121 salience decay]
+    Below[below presentation floor<br/>no longer shown]
+    Cleanup[auto-cleanup sweep<br/>every 10 min]
+    Delete[file removed<br/>after 30 days]
+
+    Create --> Write
+    Write --> Scan
+    Scan --> Present
+    Present --> Age
+    Age --> Below
+    Age -->|re-engaged| Present
+    Below --> Cleanup
+    Cleanup --> Delete
+```
+
+**Phase 1 — creation.** The sender (an agent via `attend send`, a sensor via an internal emit path, or a human via `attend chat`) constructs the `from|project|cwd|message` line and writes it atomically to the right scope directory. The routing logic picks the directory based on flags: `--broadcast` → `_broadcast/`, `--focus <name>` → `@<name>/`, `--to <path>` → the encoded path, no flags → the sender's own project scope.
+
+**Phase 2 — scanning.** Every peer sensor poll (default 30 seconds), `sensor-peers` walks its scan directories: own project scope, `_broadcast`, every `@group` the session has joined (refreshed per-poll since issue #15). New `.signal` files (not in the seen-set) are read and parsed into observations.
+
+**Phase 3 — presentation.** Observations become events in the peer sensor's accumulator, feed into engagement/governor, and if they survive all the gates, emit as Monitor notification lines into the conversation. The agent sees them; the human (if running `attend chat`) sees them in the TUI.
+
+**Phase 4 — salience decay (ADR-121, drafted).** Once presented, a signal carries a salience that decays over turns. After its salience drops below the presentation floor, the signal stops appearing in notifications — but the file stays on disk. Re-engagement (a reply or reference) resets salience to 1.0 and the signal is visible again.
+
+**Phase 5 — auto-cleanup.** Every `cleanup.interval` seconds (default 10 minutes), the attend loop runs a sweep of the signals base. Any `.signal` file older than `cleanup.retention` (default 30 days) is removed. Empty project subdirs left behind after the file removal are also cleaned up.
+
+**Phase 6 — manual cleanup.** The operator can also run `attend cleanup` at any time to force an immediate sweep. Flags:
+
+- `--older-than <dur>` — override the retention cutoff (e.g., `5m`, `1h`, `1d`, `30d`)
+- `--dry-run` / `-n` — list what would be removed without deleting
+- `--all` — remove every signal regardless of age (nuclear option)
+
+## Two TTLs: disk vs attention
+
+Signals have **two different retention windows** that operate at different scales for different purposes:
+
+| | Disk retention | Attention window |
+|---|---|---|
+| **Unit** | Time (30 days) | Turns (half-life 20, per ADR-121) |
+| **Purpose** | Bulk storage hygiene | Presentation relevance |
+| **Controlled by** | `cleanup.retention` config | `attention.half_life` (planned) |
+| **Observable in** | Disk usage | Which signals Monitor notifies about |
+| **Resets on** | Nothing; strict cutoff | Re-engagement — reply or reference |
+
+The short answer on why two units: **precision where it matters, convenience where it doesn't.** Attention works in turns because turn pacing varies too much to use wall-clock time at fine grain. Disk retention works in time because at 30-day horizons the variance averages out and "30 days" is a human-readable unit everyone intuits.
+
+See [`salience.md`](salience.md) for the attention side and the ADR-121 decay curve math.
+
+## Reading signals in tooling
+
+The signal directory layout is stable and designed to be read by external tools. If you're building something that wants to observe what's flowing through the signal bus, the conventions are:
+
+- Only read `*.signal` files. Everything else is reserved or transient.
+- Parse the pipe-delimited format. The `re:` field is optional; handle its presence or absence.
+- Respect the mtime ordering — creation timestamps in filenames aren't always the same as the file's effective age after atomic rename.
+- Don't delete files you didn't write. Auto-cleanup handles retention.
+
+Reading from `_broadcast/` gives you cross-agent visibility. Reading from `@<name>/` gives you a focus-group tap. Reading from an encoded cwd gives you per-project history.
+
+## Related
+
+- **ADR-113** — the original attend design, including signal dir conventions
+- **ADR-118** — focus groups, `@<name>` directories
+- **ADR-120** — `attend chat`, the `re:` threading field
+- **ADR-121** — salience decay on the presentation side
+- [`loop.md`](loop.md) — where signals are scanned and emitted in the loop
+- [`tui.md`](tui.md) — how the TUI reads and writes signals
+- [`focus-groups.md`](focus-groups.md) *(planned)* — `@<name>` dir management in detail
+- [`salience.md`](salience.md) *(planned)* — presentation-layer aging

--- a/docs/attend-and-monitor/tui.md
+++ b/docs/attend-and-monitor/tui.md
@@ -1,0 +1,131 @@
+# `attend chat` — human mode
+
+This page describes the interactive TUI that places a human user inside the same signal protocol the AI agents use. It's written as if the feature exists today; the underlying design is captured in **ADR-120** (status: draft — implementation follows).
+
+The operating premise: *humans wear the same clothes as an AI agent* as far as attend is concerned. Same signal bus, same routing, same engagement rules. The only difference is that the human drives through a terminal UI instead of through a language-model context window.
+
+## Why it exists
+
+Attend's signal layer solves a coordination problem for multi-agent sessions. The human coordinator used to have no first-person view of that layer — they could fire `attend send --broadcast` blindly from a bare terminal, or snapshot `attend inbox`, or alt-tab between four Claude sessions one at a time. None of those let the human *participate* in the signal topology. Routing errors (agents sending `--to /home/aaron/.claude` when they meant `--broadcast`) were a symptom of an invisible abstraction. Coordination across more than two agents was essentially guesswork.
+
+`attend chat` solves this by giving the human a first-class seat at the signal bus. The same broadcast an agent sees, the human sees. The same `@focus-group` addressing an agent uses, the human uses. The human is not watching attend from outside — they *are* one of the endpoints.
+
+Two secondary consequences fall out of this:
+
+1. **The routing protocol gets dogfooded.** Any friction the human feels — wrong defaults, confusing scope, bad message framing — is friction the agents also feel. Design improvements surface faster when humans are first-person users.
+2. **Solo developers get value too.** The TUI is not only for four-agent orchestration. A single developer running one Claude session can launch `attend chat` and watch environmental signals (git state, GitHub Project moves, build finishes) in one pane while the agent works in another. It's a peripheral-vision surface that doesn't compete with the agent's terminal for attention.
+
+## Invocation
+
+```bash
+attend chat                           # open the TUI in the current project's focus
+attend chat --focus @infra            # open pre-scoped to a specific focus group
+attend chat --broadcast               # open with broadcast as the default filter
+```
+
+Like `attend run`, `attend chat` is a long-lived process. Unlike `attend run`, it expects to live in a foreground terminal where the human can see and type. You can run both at the same time — they share the same signals base on disk, so `attend chat` in one terminal and `attend run` in a Claude session is the intended multi-endpoint configuration.
+
+## Layout
+
+```
+┌─────────────┬──────────────────────────────────────┐
+│  Focus      │  Messages (chronological stream)      │
+│             │                                        │
+│ ● broadcast │  claude/api  @deploy                   │
+│   @deploy   │  Landed the auth refactor, ready for   │
+│   @infra    │  review.                               │
+│   project/… │                                        │
+│             │  claude/infra  @deploy                  │
+│─────────────│  Pulling in the new auth types now.     │
+│  Agents     │                                        │
+│             │  aaron  broadcast                       │
+│  api ↑2 73% │  @infra hold off until api merges.     │
+│  infra · 91%│                                        │
+│  docs · 45% │                                        │
+│  slack ↑1 88│                                        │
+│             ├──────────────────────────────────────┤
+│             │ > @deploy looks good, ship it_        │
+└─────────────┴──────────────────────────────────────┘
+```
+
+**Left sidebar, top — focus groups.** Every group the current session can see is listed. A filled dot (`●`) indicates unread activity in that group. Click or tab to filter the message stream to that group; the filter is local to the TUI and doesn't change the session's actual focus membership.
+
+**Left sidebar, bottom — agents.** Every peer Claude session attend has discovered is listed with ambient metadata: a status indicator (arrow = working, dot = idle), commits ahead/behind upstream, and current context percentage. This is the peer sensor's output rendered directly.
+
+**Main area — messages.** Chronological signal stream, scoped by whichever sidebar filter is active. Each message shows the sender (`claude/<session>` or `aaron`), the routing scope (`@focus-group`, `broadcast`, or project name), and the body. Messages fade after their salience drops below the presentation floor (ADR-121), matching the agent's view.
+
+**Input bar — compose.** Plain text input supports `@group` and `#issue` inline addressing. Enter sends.
+
+## Inline addressing
+
+The input bar parses two forms of inline reference:
+
+- **`@name ...`** — prefixing a message with `@<group-name>` routes the signal to that focus group's directory only. The human doesn't need to be a member of that group to send; attend writes the signal into the group's path and any agent (or human) subscribed to that group will see it.
+- **`#NNN`** — a repo-local issue reference. The TUI itself doesn't resolve `#172` against GitHub. It's a marker for the receiving agent — when an agent reads `@api look at #172`, it can interpret `#172` against its own repo via `gh issue view 172` in its own working directory. This keeps the TUI free of GitHub dependencies and lets each agent resolve references in its own context.
+
+**Default routing: broadcast.** Messages without an `@` prefix go to `_broadcast`, reaching every peer. This is the *inverse* of the agent default (agents default to project-scoped), because the human is operating as the coordination layer — most human messages should be visible to the whole team. Agents defaulting to project-scoped is right because most agent work is local to one project; humans defaulting to broadcast is right because most human work is cross-agent steering.
+
+## Signal protocol extensions
+
+The TUI extends the signal format with an optional threading field. The old format was:
+
+```
+from|project|cwd|message
+```
+
+With threading, the format becomes:
+
+```
+from|project|cwd|re:signal-id|message
+```
+
+The `re:` field is empty for new threads and carries the original signal's ID for replies. Replies are one level deep — no nested threads, no reply-to-reply recursion. The TUI draws a thin thread line between an original message and its direct replies; agents can use the field to maintain short-term conversational context when replying.
+
+Example sequence:
+
+```
+claude/api  broadcast
+Auth refactor ready for review. [id: abc123]
+
+aaron  @deploy
+@deploy  deploy to staging when you're ready. [re: abc123]
+
+claude/deploy  @deploy
+On it. [re: abc123]
+```
+
+The thread indicator tells the reader these three messages are part of one logical exchange even though they span different senders and groups.
+
+## What the TUI does NOT do
+
+By deliberate scope constraint:
+
+- **It does not replace Claude sessions.** Deep work — editing code, reading long outputs, multi-step tool use — happens in each agent's own terminal. The TUI is peripheral vision; the agent terminals are foveal vision. Switching between them is expected and correct.
+- **It does not fetch GitHub data.** `#issue` references are resolved by the receiving agent, not by the TUI. This keeps the TUI's dependencies minimal and avoids duplicating what the agents can already do.
+- **It does not manage agent lifecycle.** Starting, stopping, or restarting agents is outside scope. The TUI observes and participates in signals; session management is a separate concern (tmux, shell, whatever fits your workflow).
+- **It does not provide an editor.** No file browser, no buffer switching, no inline code edit. If you need to edit, switch to the agent's terminal or your own editor.
+
+## The conversation interface
+
+The TUI is the first-class conversation interface for enrolled Claude agents. "Enrolled" means any agent session that's running `attend run` in its own terminal — it automatically participates in the signal bus, so the TUI will see its messages and the agent will see yours. Enrollment is implicit: run attend, you're enrolled.
+
+The practical shape of a coordinated session:
+
+- 3–4 Konsole windows, each running a Claude Code session with `attend run` active
+- A fifth terminal running `attend chat`
+- Maybe a browser tab open to GitHub Projects for when you need to actually edit a card
+- Maybe a sixth terminal for git, `htop`, or whatever other reference state you need
+
+The human sits in `attend chat` to watch the whole signal layer. They steer with broadcast messages for "everyone hold off, api needs to land first" type directives and with `@group` messages for narrower scope. When deep work on one agent is needed, the human alt-tabs to that agent's terminal and types directly. When they're done, they come back to the chat surface.
+
+The chat TUI is where the human *orchestrates*. The agent terminals are where the human *contributes*. These are different activities and deserve different surfaces.
+
+## Related
+
+- **ADR-120** — the design decision for this feature (draft status)
+- **ADR-118** — focus groups; the TUI's sidebar depends directly on this model
+- **ADR-119** — action potential engagement; the TUI's message stream respects the same refractory and governor rules as the agent side
+- **ADR-121** — salience decay; the TUI fades old messages using the same turn-based curve
+- [`loop.md`](loop.md) — the sensor loop substrate that feeds the TUI
+- [`signals.md`](signals.md) *(planned)* — the wire format the TUI reads and writes
+- [`focus-groups.md`](focus-groups.md) *(planned)* — the group model the sidebar reflects

--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -1,11 +1,11 @@
 # Installation Guide
 
-This guide covers installing claude-code-config when the path isn't a straight line — existing files, custom config, previous installs, or forks you want to keep in sync.
+This guide covers installing agent-ways when the path isn't a straight line — existing files, custom config, previous installs, or forks you want to keep in sync.
 
 If you're starting fresh with no `~/.claude/` directory, you don't need this guide:
 
 ```bash
-git clone https://github.com/aaronsb/claude-code-config ~/.claude
+git clone https://github.com/aaronsb/agent-ways ~/.claude
 cd ~/.claude && make setup
 ```
 
@@ -44,7 +44,7 @@ cp -a ~/.claude/memory ~/claude-config-backup/ 2>/dev/null
 mv ~/.claude ~/.claude-pre-install
 
 # 3. Install
-git clone https://github.com/aaronsb/claude-code-config ~/.claude
+git clone https://github.com/aaronsb/agent-ways ~/.claude
 cd ~/.claude && make setup
 
 # 4. Restore your files
@@ -59,7 +59,7 @@ Your settings are `.gitignore`d in this repo, so they won't conflict with update
 
 ## Scenario 2: You have your own git tracking
 
-**Signs:** `~/.claude/.git/` exists, but it's your own repo — not a clone or fork of claude-code-config.
+**Signs:** `~/.claude/.git/` exists, but it's your own repo — not a clone or fork of agent-ways.
 
 This means you're already version-controlling your Claude config. Good instinct. The question is whether you want to adopt this framework or keep your own.
 
@@ -72,7 +72,7 @@ cp -a ~/.claude ~/.claude-my-version
 # Remove your .git and install ours
 rm -rf ~/.claude/.git
 rm -rf ~/.claude    # or mv to backup
-git clone https://github.com/aaronsb/claude-code-config ~/.claude
+git clone https://github.com/aaronsb/agent-ways ~/.claude
 cd ~/.claude && make setup
 
 # Cherry-pick your customizations back in
@@ -90,9 +90,9 @@ Read through this repo and copy the parts you want into your own config. The key
 
 This is more work but gives you full control.
 
-## Scenario 3: Previous claude-code-config install
+## Scenario 3: Previous agent-ways install
 
-**Signs:** `~/.claude/.git/` exists and origin points to `aaronsb/claude-code-config` or your fork of it.
+**Signs:** `~/.claude/.git/` exists and origin points to `aaronsb/agent-ways` or your fork of it.
 
 You're already installed. Just update:
 
@@ -110,11 +110,11 @@ The installer detects this automatically and runs the update path.
 ```bash
 # 1. Fork on GitHub first (use the web UI)
 # 2. Clone your fork
-git clone https://github.com/YOUR-USERNAME/claude-code-config ~/.claude
+git clone https://github.com/YOUR-USERNAME/agent-ways ~/.claude
 
 # 3. Set up upstream tracking
 cd ~/.claude
-git remote add upstream https://github.com/aaronsb/claude-code-config
+git remote add upstream https://github.com/aaronsb/agent-ways
 
 # 4. Set up semantic matching
 make setup

--- a/hooks/check-config-updates.sh
+++ b/hooks/check-config-updates.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Check if claude-code-config is up to date with upstream
+# Check if agent-ways is up to date with upstream
 # Handles four install scenarios: direct clone, fork, renamed clone, plugin
 #
 # Detection order:
 #   1. Is ~/.claude a git repo? If not, exit.
-#   2. Is origin aaronsb/claude-code-config? → direct clone
-#   3. Is origin a fork of aaronsb/claude-code-config? → fork
+#   2. Is origin aaronsb/agent-ways? → direct clone
+#   3. Is origin a fork of aaronsb/agent-ways? → fork
 #   4. Does .claude-upstream marker exist? → renamed clone (org internal copy)
 #   5. Is CLAUDE_PLUGIN_ROOT set? → plugin install
 #
@@ -13,7 +13,7 @@
 # Writes state to cache file; display is handled by `ways show core`.
 
 CLAUDE_DIR="${HOME}/.claude"
-UPSTREAM_REPO="aaronsb/claude-code-config"
+UPSTREAM_REPO="aaronsb/agent-ways"
 UPSTREAM_URL="https://github.com/${UPSTREAM_REPO}"
 UPSTREAM_MARKER="${CLAUDE_DIR}/.claude-upstream"
 CACHE_FILE="/tmp/.claude-config-update-state-$(id -u)"

--- a/hooks/ways/meta/project-health/project-health.md
+++ b/hooks/ways/meta/project-health/project-health.md
@@ -1,5 +1,5 @@
 ---
-description: Managing claude-code-config as a project — upstream tracking against Claude Code releases, ADR reconciliation, release discipline, maintaining relevance
+description: Managing agent-ways as a project — upstream tracking against Claude Code releases, ADR reconciliation, release discipline, maintaining relevance
 vocabulary: upstream changelog release version claude-code update adr status reconcile drift stale dormant shipped implemented current behind project pulse health review audit recently changed since last relevance feature gap opportunity
 threshold: 2.5
 scope: agent
@@ -11,7 +11,7 @@ when:
 
 ## This Project's Relationship to Claude Code
 
-claude-code-config is an opinionated framework built *on top of* Claude Code. It adds ways, skills, hooks, ADR tooling, governance, and structured thinking — none of which ship with Claude Code itself. But every capability we build depends on Claude Code's primitives (hooks, settings, skills, MCP, permissions).
+agent-ways is an opinionated framework built *on top of* Claude Code. It adds ways, skills, hooks, ADR tooling, governance, and structured thinking — none of which ship with Claude Code itself. But every capability we build depends on Claude Code's primitives (hooks, settings, skills, MCP, permissions).
 
 When Claude Code changes, we may need to adapt, adopt, or deliberately ignore.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Install claude-code-config into ~/.claude
+# Install agent-ways into ~/.claude
 #
 # This is a gateway, not a butler. It checks readiness, detects complexity,
 # and either proceeds with a clean install or tells you what to sort out first.
@@ -14,7 +14,7 @@
 
 set -euo pipefail
 
-UPSTREAM_REPO="aaronsb/claude-code-config"
+UPSTREAM_REPO="aaronsb/agent-ways"
 UPSTREAM_URL="https://github.com/${UPSTREAM_REPO}"
 DEST="${HOME}/.claude"
 
@@ -36,7 +36,7 @@ fi
 
 show_help() {
   cat <<HELP
-${BOLD}claude-code-config installer${RESET}
+${BOLD}agent-ways installer${RESET}
 
 ${CYAN}Usage:${RESET}
   scripts/install.sh                           Install from local clone
@@ -107,23 +107,23 @@ if [[ "$BOOTSTRAP" == "true" ]]; then
   check_prereqs
 
   echo ""
-  echo -e "${BOLD}claude-code-config bootstrap${RESET}"
+  echo -e "${BOLD}agent-ways bootstrap${RESET}"
   echo -e "Fetching latest from ${CYAN}${UPSTREAM_REPO}${RESET}..."
   echo ""
 
   BOOTSTRAP_DIR=$(mktemp -d)
   trap 'rm -rf "$BOOTSTRAP_DIR"' EXIT
 
-  if ! git clone --depth 1 "$UPSTREAM_URL" "$BOOTSTRAP_DIR/claude-code-config" 2>&1; then
+  if ! git clone --depth 1 "$UPSTREAM_URL" "$BOOTSTRAP_DIR/agent-ways" 2>&1; then
     echo -e "${RED}Failed to clone ${UPSTREAM_URL}${RESET}"
     exit 1
   fi
 
-  CLONE="$BOOTSTRAP_DIR/claude-code-config"
+  CLONE="$BOOTSTRAP_DIR/agent-ways"
 
   # Verify the clone
   if [[ ! -f "$CLONE/hooks/check-config-updates.sh" ]]; then
-    echo -e "${RED}Clone doesn't look like claude-code-config.${RESET}"
+    echo -e "${RED}Clone doesn't look like agent-ways.${RESET}"
     exit 1
   fi
 
@@ -148,7 +148,7 @@ fi
 SRC="$(cd "$(dirname "$0")/.." && pwd)"
 
 if [[ ! -f "$SRC/hooks/check-config-updates.sh" ]]; then
-  echo -e "${RED}Not running from a claude-code-config repo.${RESET}"
+  echo -e "${RED}Not running from an agent-ways repo.${RESET}"
   echo "Use --bootstrap to clone and install, or cd to the repo first."
   exit 1
 fi
@@ -156,7 +156,7 @@ fi
 check_prereqs
 
 echo ""
-echo -e "${BOLD}claude-code-config installer${RESET}"
+echo -e "${BOLD}agent-ways installer${RESET}"
 echo -e "Source: ${CYAN}${SRC}${RESET}"
 echo -e "Target: ${CYAN}${DEST}${RESET}"
 echo ""
@@ -212,7 +212,7 @@ if [[ -d "$DEST" ]]; then
 
   # --- Existing files: complexity detected ---
   if [[ "$CLOBBER" == "false" ]]; then
-    echo -e "${YELLOW}~/.claude/ already exists and isn't a claude-code-config install.${RESET}"
+    echo -e "${YELLOW}~/.claude/ already exists and isn't an agent-ways install.${RESET}"
     echo ""
 
     if [[ "$HAS_GIT" == "true" ]]; then

--- a/tools/attend/examples/xdg-downloads.sh
+++ b/tools/attend/examples/xdg-downloads.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# xdg-downloads.sh — example attend external sensor
+#
+# Observes new files landing in the user's XDG Downloads directory and
+# emits attend signals when something arrives. Demonstrates:
+#
+#   1. The external-sensor protocol: one line per event on stdout as
+#      `magnitude|description`, silent exit on quiet, 10s timeout.
+#   2. Reading XDG user-dirs to locate a well-known folder, with a
+#      sensible fallback if xdg-user-dirs isn't installed.
+#   3. Tracking state across polls via a marker file under XDG_STATE_HOME
+#      so attend restarts don't flood with old files.
+#   4. Designing a magnitude hierarchy: one file is notable, a batch
+#      of files is a clear burst worth surfacing more loudly.
+#
+# This is a pedagogical example. It runs on any typical Linux distro
+# with no dependencies beyond bash and coreutils. Disabled by default
+# in the attend config — flip `enabled: true` in the sensor block to
+# turn it on.
+#
+# Author's lever: magnitude. Everything else is attend's job.
+
+set -euo pipefail
+
+# --- Resolve the Downloads directory via xdg-user-dirs -----------------
+
+# xdg-user-dirs writes ~/.config/user-dirs.dirs with lines like:
+#   XDG_DOWNLOAD_DIR="$HOME/Downloads"
+# We parse it manually instead of sourcing to avoid executing
+# arbitrary shell from a config file.
+
+USER_DIRS="${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs"
+DOWNLOADS="$HOME/Downloads"
+
+if [[ -f "$USER_DIRS" ]]; then
+  xdg_value=$(grep -E "^XDG_DOWNLOAD_DIR=" "$USER_DIRS" 2>/dev/null | cut -d'=' -f2- | tr -d '"' || true)
+  xdg_value=${xdg_value/\$HOME/$HOME}
+  [[ -n "$xdg_value" && -d "$xdg_value" ]] && DOWNLOADS="$xdg_value"
+fi
+
+# No downloads dir → nothing to observe. Exit silently; attend treats
+# this as a quiet poll.
+[[ -d "$DOWNLOADS" ]] || exit 0
+
+# --- State marker ------------------------------------------------------
+
+# The marker file records the last time we scanned. find -newer <marker>
+# gives us files modified since then. We store it under XDG_STATE_HOME
+# per the base directory spec.
+
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/attend"
+mkdir -p "$STATE_DIR"
+MARKER="$STATE_DIR/xdg-downloads.marker"
+
+# First run: create the marker and emit nothing. Otherwise we would
+# immediately report every existing file as "new" on the first poll.
+if [[ ! -f "$MARKER" ]]; then
+  touch "$MARKER"
+  exit 0
+fi
+
+# --- Detect new files --------------------------------------------------
+
+# Top-level files only (no recursion into subdirectories). Keeps the
+# scan fast and avoids walking large archives users have extracted.
+new_files=$(find "$DOWNLOADS" -maxdepth 1 -type f -newer "$MARKER" 2>/dev/null || true)
+
+# Update the marker *after* the find so the next poll picks up from
+# here. Do this whether or not there were new files — the marker is
+# a rolling high-water mark.
+touch "$MARKER"
+
+# Quiet poll — return with no output. attend will see an empty
+# Vec<(f64, String)> and treat it as "nothing changed this tick."
+[[ -z "$new_files" ]] && exit 0
+
+# --- Emit observations with magnitude tiers ----------------------------
+
+count=$(echo "$new_files" | wc -l | tr -d ' ')
+
+# Magnitude hierarchy:
+#   1 file    → 2.0 (notable — a single arrival is worth surfacing)
+#   2-3 files → 2.5 (small batch — something's happening)
+#   4+ files  → 3.0 (clear burst — breaks through into notifications)
+#
+# These land above the default emission threshold of 2.0 for script
+# sensors, so a single file will fire on its own. If you want more
+# aggregation, lower the magnitudes here and raise `threshold` in
+# your attend config so multiple files accumulate before firing.
+
+if (( count == 1 )); then
+  name=$(basename "$(echo "$new_files" | head -1)")
+  echo "2.0|new file in Downloads: ${name}"
+elif (( count <= 3 )); then
+  echo "2.5|${count} new files in Downloads"
+else
+  echo "3.0|${count} new files in Downloads (burst)"
+fi

--- a/tools/attend/src/config.rs
+++ b/tools/attend/src/config.rs
@@ -256,6 +256,37 @@ sensors:
     min_interval: 5
     threshold: 2.0
 
+  # Example external sensor — disabled by default.
+  #
+  # To enable:
+  #   1. Copy the example script from the agent-ways repo to a path
+  #      where you keep trusted user scripts. XDG-convention default:
+  #        mkdir -p $XDG_DATA_HOME/attend/sensors
+  #        cp tools/attend/examples/xdg-downloads.sh \
+  #           $XDG_DATA_HOME/attend/sensors/
+  #      (Or put it anywhere you trust — ~/bin, .claude/sensors/ in a
+  #      project dir, a team-shared tools repo, wherever.)
+  #   2. Review the script. External sensors run arbitrary shell under
+  #      your user. You should read any sensor before enabling it.
+  #   3. Flip `enabled: true` below.
+  #
+  # Sensor sources are deliberately unconstrained — they can be
+  # user-global (like this example), project-scoped in .claude/sensors/,
+  # or absolute paths to anywhere on disk. attend only cares that the
+  # path resolves and the script respects the subprocess contract
+  # documented in docs/attend-and-monitor/authoring-sensors.md.
+  #
+  # This particular example watches XDG Downloads for new files and
+  # demonstrates the magnitude-as-design-lever pattern — a single new
+  # file fires at 2.0, a batch fires at 3.0.
+  +xdg-downloads:
+    script: $XDG_DATA_HOME/attend/sensors/xdg-downloads.sh
+    enabled: false
+    interval: 120
+    min_interval: 30
+    threshold: 2.0
+    decay_threshold: 3
+
 # Project-scope example (in .claude/attend.yaml):
 #
 # sensors:
@@ -436,7 +467,7 @@ fn apply_config(config: &mut Config, content: &str) {
                             }
                         }
                         "script" => {
-                            sensor.script = Some(value.to_string());
+                            sensor.script = Some(expand_path(value));
                         }
                         "enabled" => {
                             sensor.enabled = value == "true";
@@ -458,6 +489,25 @@ fn apply_config(config: &mut Config, content: &str) {
             }
         }
     }
+}
+
+/// Expand `$HOME`, `~`, `$XDG_CONFIG_HOME`, `$XDG_DATA_HOME`, and
+/// `$XDG_STATE_HOME` inside a config value. Keeps script paths portable
+/// across installs without depending on the caller's cwd.
+fn expand_path(value: &str) -> String {
+    let mut out = value.to_string();
+    if let Ok(home) = std::env::var("HOME") {
+        if out.starts_with("~/") {
+            out = format!("{home}{}", &out[1..]);
+        }
+        out = out.replace("$HOME", &home);
+    }
+    for var in &["XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME", "XDG_CACHE_HOME"] {
+        if let Ok(val) = std::env::var(var) {
+            out = out.replace(&format!("${var}"), &val);
+        }
+    }
+    out
 }
 
 /// Parse "key: value" from a trimmed line.

--- a/tools/way-embed/download-binary.sh
+++ b/tools/way-embed/download-binary.sh
@@ -16,7 +16,7 @@ OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 PLATFORM="${OS}-${ARCH}"
 
-GH_REPO="aaronsb/claude-code-config"
+GH_REPO="aaronsb/agent-ways"
 RELEASE_TAG="${WAY_EMBED_RELEASE:-latest}"
 BIN_NAME="way-embed-${PLATFORM}"
 XDG_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}"

--- a/tools/ways-cli/download-ways.sh
+++ b/tools/ways-cli/download-ways.sh
@@ -16,7 +16,7 @@ OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | sed 's/arm64/aarch64/')
 PLATFORM="${OS}-${ARCH}"
 
-GH_REPO="aaronsb/claude-code-config"
+GH_REPO="aaronsb/agent-ways"
 RELEASE_TAG="${WAYS_RELEASE:-latest}"
 BIN_NAME="ways-${PLATFORM}"
 

--- a/tools/ways-cli/src/cmd/show/metrics.rs
+++ b/tools/ways-cli/src/cmd/show/metrics.rs
@@ -157,7 +157,7 @@ pub(crate) fn update_status_text() -> String {
     let cached_type = get("type").unwrap_or_default();
     let behind: u32 = get("behind").and_then(|s| s.parse().ok()).unwrap_or(0);
     let has_upstream = get("has_upstream").unwrap_or_default() == "true";
-    let upstream_repo = "aaronsb/claude-code-config";
+    let upstream_repo = "aaronsb/agent-ways";
 
     if behind == 0 {
         return String::new();


### PR DESCRIPTION
## Summary

Full first-pass documentation of the attend active awareness layer, plus two side-bundles that fit the theme: an upstream rename cleanup and a reference external sensor that ships in-tree.

### The directory structure

New first-class docs directory `docs/attend-and-monitor/` mirroring the `docs/hooks-and-ways/` pattern:

| File | Purpose |
|---|---|
| README.md | Orientation — meta-framework thesis, dual-consumer framing, sensor authorship, GH sensor teaser |
| loop.md | The substrate document — mermaid state diagrams, timer table, termination modes |
| authoring-sensors.md | Two implementations (crate / script), GH Project sensor walkthrough, seven design rules |
| tui.md | `attend chat` written as-built per ADR-120 — layout, addressing, threading |
| engagement.md | ADR-119 in prose with diagrams, `attend tune` walkthrough |
| signals.md | Wire format, storage layout, atomic writes, two-TTL model |
| sensors.md | Reference for the four built-ins with magnitude tables |
| focus-groups.md | ADR-118 mechanics including the #15 fix |
| configuration.md | Full YAML schema reference with overlay semantics |
| salience.md | ADR-121 in reader-friendly form, grounded in session survey data |

### The meta-framework framing

The anchor thesis is that what got built isn't "a feature of attend," it's **a meta-framework for the Monitor tool**. Monitor is Anthropic's general async delivery mechanism; attend is the editorial layer that decides what's worth delivering. That framing reshapes the README and propagates through every other doc.

Two first-class consumers: `attend run` for AI agents (Monitor delivery), `attend chat` for humans (interactive TUI per ADR-120). Same signal bus, same engagement rules — humans "wear the same clothes" as agents.

Sensor authorship is elevated to a first-class design surface with its own doc. Two implementations (compiled crate, external script subprocess) share one constraint: the author has to understand the loop's intention, particularly that magnitude is the entire design surface.

### Side bundle #1: upstream rename cleanup (10 files)

The repo was renamed `aaronsb/claude-code-config` → `aaronsb/agent-ways`. Operational references to the old name were still in installer scripts, update checkers, download paths, and docs. Updated:

- `.claude-upstream`, `Makefile`, `SECURITY.md`
- `scripts/install.sh` (with "a"→"an" article fixes)
- `hooks/check-config-updates.sh`
- `docs/install-guide.md`
- `tools/way-embed/download-binary.sh`, `tools/ways-cli/download-ways.sh`
- `tools/ways-cli/src/cmd/show/metrics.rs`
- `hooks/ways/meta/project-health/project-health.md`

Historical references deliberately left intact: legacy ADRs, research reports, translation stubs. Those are period-correct snapshots.

### Side bundle #2: example external sensor (`tools/attend/examples/xdg-downloads.sh`)

The docs describe the external sensor protocol in detail but there was no shipped reference implementation. Adds one: ~80 lines of bash that watches `XDG_DOWNLOAD_DIR` for new files and emits magnitude-tiered observations (1 file → 2.0, small batch → 2.5, burst → 3.0).

Defaults to **disabled** in the shipped config with a multi-line comment walking through the copy-review-enable workflow. Script path defaults to `\$XDG_DATA_HOME/attend/sensors/xdg-downloads.sh` — user-trusted location, not framework-controlled `~/.claude/`, respecting the trust boundary. The config parser now expands `\$HOME`, `~`, and the four XDG_* base dir variables at load time via a small `expand_path()` helper.

### Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `docs/scripts/adr lint` passes
- [x] Merged origin/main cleanly (no conflicts)
- [ ] Post-merge, review docs on github with mermaid rendering
- [ ] Eventually: actually run `xdg-downloads.sh` end-to-end in a live session

No ADR changes in this PR — ADR-121 draft landed as part of the awareness-stabilization bundle (#20). This PR is docs + example sensor + rename cleanup only.