### PR TITLE
feat(attend): sensor-disclosure — token-gated affordance reheat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,8 @@ hooks/ways/.obsidian/
 !tools/sensor-peers/**
 !tools/sensor-processes/
 !tools/sensor-processes/**
+!tools/sensor-disclosure/
+!tools/sensor-disclosure/**
 !tools/ways-cli/
 !tools/ways-cli/**
 # ways-cli build artifacts (tracked via .gitignore inside ways-cli/)

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -42,6 +42,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-119](./system/ADR-119-action-potential-engagement-model.md) | Action Potential Engagement Model | Accepted |
 | [ADR-120](./system/ADR-120-interactive-chat-tui-human-in-the-signal-loop.md) | Interactive Chat TUI — Human in the Signal Loop | Draft |
 | [ADR-121](./system/ADR-121-salience-decay-for-signal-presentation-turn-based-exponential.md) | Salience decay for signal presentation — turn-based exponential | Draft |
+| [ADR-122](./system/ADR-122-attend-disclosure-sensor-token-gated-affordance-reheat.md) | Attend disclosure sensor — token-gated affordance reheat | Draft |
 
 ## Documentation
 _Documentation structure, tooling, coherence_

--- a/docs/architecture/system/ADR-122-attend-disclosure-sensor-token-gated-affordance-reheat.md
+++ b/docs/architecture/system/ADR-122-attend-disclosure-sensor-token-gated-affordance-reheat.md
@@ -1,0 +1,122 @@
+---
+status: Draft
+date: 2026-04-13
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-104
+  - ADR-113
+  - ADR-117
+  - ADR-119
+---
+
+# ADR-122: Attend disclosure sensor — token-gated affordance reheat
+
+## Context
+
+`attend` exposes interactive surfaces Claude must know how to use — `attend send`, `--to`, `--focus`, `--broadcast`, focus groups, mark-read semantics, the "silence is a valid reply" norm, and the load-bearing rule that `attend run` belongs to Monitor rather than Bash. None of this is re-taught at runtime. Claude learns it from `SKILL.md` at session start and may have forgotten the actionable shape by turn 80. When a peer message arrives via Monitor, the notification reports *that* something happened but not *what affordances exist* to act on it. The user pays an inference turn for Claude to either improvise, ask, or — most commonly — silently fail to engage with a channel that was supposed to be two-way.
+
+This is the same shape of problem ADR-104 solved for ways: instructional context that mattered at session start is not reliably present three reflection windows later. Ways answered with token-gated re-disclosure — track the token position of the last disclosure, fire again when drift crosses a threshold. Attend has the same problem on a different surface (interactive messaging affordances) and the same answer should apply, reusing the ADR-104 model rather than inventing a parallel mechanism.
+
+The substrate separation principle from ADR-113 constrains the form of the answer. Sensing when Claude has drifted far enough from a teaching to need it again is cheap integer arithmetic — it does not need inference. The teaching itself, the thing that gets emitted into Claude's conversation, pays the token cost every time it fires, so it has to be terse by design. The cheap substrate (a sensor) decides when; the expensive substrate (Claude's next turn) only sees the result when surfacing is warranted.
+
+The design note at `docs/design-notes/attend-messaging-disclosure-reheat.md` walks through the full design iteration. This ADR captures the decision in the form the rest of the system can cite.
+
+## Decision
+
+Attend gains a new workspace crate, `sensor-disclosure`, implementing `sensor_trait::Sensor`. The sensor's signal is **token distance since last disclosure for each registered component**, rather than environmental change. Its shape is otherwise ordinary: poll returns observations, the accumulator aggregates, the engagement and governor machinery from ADR-117 and ADR-119 apply unchanged, and each observation becomes one stdout line wrapped by `emit::emit_batch`.
+
+**The sensor is a sensor in the ordinary sense of the word.** It is not a new architectural layer, not an emit-pipeline stage, not a framework extension. This framing is load-bearing: no new cross-sensor coupling, no new trait, no pre-emit hook. The disclosure batches alongside peer-message arrivals *emergently* — when both sensors are ready to disclose in the same governor window, the existing batch assembly puts them in one `emit_batch` call and Monitor groups them into one notification via its 200ms batching window. When timing does not align, the disclosure sensor fires standalone at its own tick. Either outcome delivers the teaching to Claude.
+
+**Poll mechanics.** Each poll shells out once to `ways context --json` — the same integration pattern `sensor-context` already uses — and reads the `tokens_used` field. For each registered component, the sensor walks an in-memory `HashMap<Component, u64>` ledger:
+
+- **No marker present** (first encounter in this attend process) → emit the component's disclosure text at full magnitude, stamp the baseline.
+- **Marker present, distance ≥ 25% of the model's current context window** → emit the disclosure text, re-stamp the new baseline.
+- **Otherwise** → no observation for that component this poll.
+
+The threshold is the same `REDISCLOSE_PCT = 25` value ways uses for its own re-disclosure. One dial governs both; the reheat semantics are symmetric across the two substrates.
+
+**State is in-process memory only.** The ledger is a field on the sensor struct. It is not persisted to `~/.cache/attend/state/`, not to the `/tmp/.claude-sessions-.../` signal tree, not anywhere. This is a deliberate departure from ways' file-backed markers and from attend's existing `state.rs` checkpointing. Any persistent ledger inherits a "stale state causes havoc" failure mode: a crashed attend leaves a marker file behind, the next `attend run` reads it, and suppresses teaching Claude needs. The only defensible way to guarantee clean-restart semantics is to never write the marker in the first place. Because the ledger data is tiny (one `u64` per component) and non-load-bearing, losing it on restart is the *desired* behavior — a fresh attend process re-teaches every component on its first poll, which is the right response to an unexplained process lifecycle event.
+
+**Component registry from day one.** Even though `messaging` is the only component at introduction, the sensor is structured as a registry — a `Component` enum with a variant per component, each variant carrying a static ID and the bundled markdown body via `include_str!`. Adding a component (`focus`, `scenes`, `peers-introspection`, etc.) is an enum variant plus a markdown file, not a refactor. Per-component state is keyed in the shared ledger. The registry is also the natural seam for per-component semantics if any component ever needs them — today they all follow the same trigger rule.
+
+**Content is bundled into the binary.** Each component's disclosure text lives at `sensor-disclosure/src/disclosures/{component}.md`, included via `include_str!`. Same posture as ways body files authored alongside their logic: it ships with the code that uses it, it cannot go missing at runtime, it is versioned in git alongside the sensor that depends on it. The alternative — reading from a path under the skill directory — was rejected because it adds a missing-file failure mode without compensating benefit.
+
+**Emit format uses the existing `[attend sensor=disclosure priority=high]` prefix.** An earlier draft of the design note committed to matching ways' re-disclosure header pattern for visual-identity reasons. Sensor-native framing made that commitment costly (it would require special-casing `emit::emit_batch` for one sensor, against the grain of how every other attend sensor presents itself). The decision is therefore uniform with attend sensors rather than uniform with ways re-disclosures. The content carries a `reheat:` self-identifying tag on the first line of each disclosure, which is sufficient without header-format rhyme.
+
+**Content is terse by construction.** Each disclosure block pays its own token cost every time it fires. The messaging block is authored in ways-body density: one-line assertions with terse rationale, no prose expansion. Every line stays under ~200 characters, comfortably inside Monitor's ~400-character stdout line ceiling. A sister fix in the same PR (`sensor-peers` chunking) applies the same constraint to peer messages, ensuring the ceiling is respected end-to-end rather than only on disclosure output.
+
+## Consequences
+
+### Positive
+
+- **First-run disclosure is automatic.** The first poll after `attend run` start finds every component with a missing marker and fires them all. No separate startup-banner injection, no special-case code in `main.rs`. The sensor framework handles it.
+- **Reheat semantics match ways.** One dial (`REDISCLOSE_PCT = 25`), one model, one mental frame for "Claude is being reheated on something." Reinforcement rather than two parallel protocols.
+- **Zero framework change.** The sensor plugs into the existing slot machinery in `tools/attend/src/sensors/mod.rs` exactly like every other sensor. `SensorSlot`, `AdaptiveInterval`, `DeltaAccumulator`, `EngagementState`, and the disclosure governor all apply unchanged. Validated end-to-end in a live multi-agent session during PR development.
+- **Clean restart by construction.** A restarted attend process starts with an empty ledger and re-teaches every component on first poll. No stale-state failure mode. No recovery logic needed. The cost of forgetting is exactly one re-teach, which is the correct response to an unexpected process restart anyway.
+- **Batching with peer messages is emergent.** When the disclosure sensor and `sensor-peers` both cross their thresholds in the same governor window, the main loop's batch assembly groups them into one `emit_batch` call, and Monitor groups them into one notification via the 200ms batching window. The "teach-alongside-arrival" behavior we wanted comes for free from the existing scheduling without any coupling code.
+- **Extensible.** Adding a second component (`focus`, `scenes`, `peers-introspection`) is an enum variant plus a markdown file. No refactor, no cross-sensor plumbing, no framework changes.
+
+### Negative
+
+- **Subprocess call on every poll.** Reading `tokens_used` via `ways context --json` is a process spawn per poll (default 60s base interval, 20s minimum). This is the same cost `sensor-context` already pays against the same command — we are doubling the rate, not inventing it. In aggregate the cost is on the order of 1–2 process spawns per minute during active sessions, which is within the noise floor of the existing sensor loop.
+- **Content fidelity depends on author discipline.** The disclosure text is bundled Rust source via `include_str!` and pays tokens every fire. Drift toward prose expansion is a real failure mode. Mitigation: explicit terse-by-construction standard documented in this ADR and in the design note; line-length audit as part of code review.
+- **No per-component threshold override yet.** All components share the 25% threshold. If some component ever needs more aggressive reheat (e.g., a critical affordance that Claude forgets faster than token drift predicts), there is no knob. Add only if real usage shows the need.
+- **First-run-always-fires is a property.** A mid-session `attend run` restart re-teaches every component on first poll, even if the current working window already contains the teaching from an earlier run. Not a bug — it is the clean-restart guarantee — but it is an observable side effect worth naming: attend restarts cost a re-disclosure per registered component, billable to the user's token budget.
+
+### Neutral
+
+- **The `state.rs` persistence model is deliberately not extended.** Context-percentage tracking and git state stay persistent (they have different failure characteristics), but disclosure markers do not. Future components in this sensor inherit the in-memory constraint by default.
+- **Design note is retained as companion prose.** The design note at `docs/design-notes/attend-messaging-disclosure-reheat.md` stays as the detailed walkthrough of the four-way iteration that landed on the sensor-native framing. This ADR cites it rather than re-deriving its argument.
+- **Governor interaction is unchanged.** The disclosure sensor participates in the existing disclosure governor the same way any other sensor does. No new rate-limiting knobs, no new cooldown windows, no new global budget.
+
+## Alternatives Considered
+
+### A persistent ledger under the session signal tree
+
+Store the disclosure marker as a file at `/tmp/.claude-sessions-{uid}/{session_id}/attend-disclose/{component}/.value`, mirroring ways' own `way-tokens/` layout one directory over. Symmetric with ways, visible to other session-aware tooling, survives attend process restarts within a session.
+
+Rejected because the "stale file causes havoc" failure mode cannot be defended cheaply. A crashed attend leaves a marker behind; the next `attend run` reads it and suppresses teaching Claude actually needs. The ledger data is tiny and non-load-bearing — losing it on restart is the desired outcome, not a cost. In-process memory is strictly simpler and strictly safer for this specific data.
+
+### Extend `state.rs` `StateSnapshot` to carry disclosure markers
+
+The existing `StateSnapshot` already persists `disclosed_thresholds` and `reply_hint_shown` to `~/.cache/attend/state/{session_id}.state`. Adding a `disclosure_ledger` field would reuse the existing checkpoint infrastructure.
+
+Rejected on the same failure-mode grounds as the persistent-file alternative, plus an aesthetic objection: `StateSnapshot` fields are about context-percentage ways-style thresholds. Piling the disclosure ledger into that struct muddies the semantics and couples two different kinds of state into the same serialization format.
+
+### Emit-pipeline interceptor / pre-flush hook
+
+Add a hook in `emit::emit_batch` that inspects the outgoing batch and, if it contains a peer-message event and the messaging ledger threshold is exceeded, prepends a disclosure block before flushing. This was the first implementation direction explored.
+
+Rejected because it is a bespoke emit-pipeline stage that does not fit the existing sensor framework. Every other awareness capability in attend is a sensor. Making disclosure an emit-layer special case would introduce a new architectural seam, complicate the sensor framework's mental model, and commit us to a second mechanism that runs on a different substrate than the rest.
+
+### `ReactiveSensor` trait for cross-sensor coupling
+
+Introduce a new trait alongside `Sensor` for sensors that need to read other sensors' observations this tick before producing their own. Disclosure would be the first implementation, running last in poll order and inspecting a "this-tick's-observations-so-far" buffer exposed by the tick scheduler.
+
+Rejected as speculative abstraction. A reactive-sensor trait is a meaningful commitment — it changes the sensor contract, the scheduler loop, and the way sensor authors reason about tick ordering. It is not justified by a single use case. Moreover, once the disclosure signal was reframed as "token distance since last disclosure" rather than "reaction to a peer event," the cross-sensor coupling disappeared: the disclosure sensor has its own interoceptive signal (ledger distance) and does not need to observe other sensors at all. The batching-with-peer-messages behavior emerges from the existing scheduling without any coupling.
+
+### Topic-drift or semantic-drift modeling
+
+Trigger reheat not on raw token count but on some measure of *semantic* drift — e.g., whether the current conversation topic has shifted significantly from the topic at the last disclosure. Conceptually appealing because token count is an imperfect proxy for "has Claude forgotten the teaching."
+
+Rejected on the substrate-separation principle from ADR-113 and the discipline named in `docs/attend-and-monitor/authoring-sensors.md`: sensors report facts the framework can verify, not guesses the sensor produced. Token count is measurable from the transcript with no inference cost. Semantic drift is an inference problem the sensor cannot solve cheaply, and if solved by an embedding model the embedding itself introduces new failure modes and a new dependency. "Simulated judgment" is the wrong substrate for the thing this sensor is meant to do.
+
+### Persistent storage cap with TTL
+
+Compromise between in-memory and fully persistent: write disclosure markers to disk but expire them automatically after some wall-clock window (e.g., 1 hour). Reduces stale-state risk by ensuring markers do not outlive the process state they describe for long.
+
+Rejected because TTL adds complexity without closing the failure mode. During the TTL window, a crashed-and-restarted attend still inherits stale state. The simpler solution (no persistence) has strictly better failure characteristics and is strictly easier to reason about.
+
+## Validation
+
+This ADR is promoted from a working sketch that has already been exercised end-to-end:
+
+- All 57 workspace unit tests pass, including 4 in `sensor-disclosure` covering extraction, registry, and formatting.
+- The sensor registers in the attend tick loop alongside `context`, `processes`, `git`, and `peers`.
+- First-run disclosure fired correctly on sensor startup in three separate runs (initial rebuild, content-tightening rebuild, chunking-fix rebuild), each confirmed via live Monitor notification.
+- Peer-conversation validation run between two Claude instances exercised the messaging affordances surface in real time, with the disclosure block arriving cleanly as one batched Monitor notification in both directions.
+- The chunking fix in `sensor-peers` was validated by requesting a deliberate ~800-char message from the peer; it arrived as three correctly-numbered chunks with clean word boundaries.
+
+The design note's "promote to ADR after the model holds up across a few real sessions" threshold is met.

--- a/docs/architecture/system/ADR-122-attend-disclosure-sensor-token-gated-affordance-reheat.md
+++ b/docs/architecture/system/ADR-122-attend-disclosure-sensor-token-gated-affordance-reheat.md
@@ -107,7 +107,12 @@ Rejected on the substrate-separation principle from ADR-113 and the discipline n
 
 Compromise between in-memory and fully persistent: write disclosure markers to disk but expire them automatically after some wall-clock window (e.g., 1 hour). Reduces stale-state risk by ensuring markers do not outlive the process state they describe for long.
 
-Rejected because TTL adds complexity without closing the failure mode. During the TTL window, a crashed-and-restarted attend still inherits stale state. The simpler solution (no persistence) has strictly better failure characteristics and is strictly easier to reason about.
+Rejected for four independent reasons:
+
+1. **TTL does not close the stale-state failure mode.** During the TTL window, a crashed-and-restarted attend still inherits suppression state it cannot explain. The window only narrows the exposure; it does not eliminate it. The in-memory solution eliminates it entirely by construction.
+2. **It introduces a file-I/O failure surface the in-memory design avoids entirely.** A disk-backed ledger has to handle read errors, write errors, disk-full conditions, filesystem corruption, concurrent-access races between multiple attend instances, and the inevitable edge cases around partial writes during a crash. The ledger data is a `HashMap<Component, u64>` — three to five entries in the extensible case. Accepting all of that failure surface to persist a handful of integers is a bad trade.
+3. **TTL tuning is a configuration surface with no defensible default.** "How long should my disclosure markers live?" is a question with no good answer: short TTLs defeat the purpose (the next `attend run` re-teaches anyway), long TTLs reintroduce the stale-state problem we are trying to avoid, and middle values have no principled basis. The in-memory solution has no such tuning knob — the lifetime of the ledger is exactly the lifetime of the attend process, which is the only defensible scope.
+4. **It would be inconsistent with the rest of attend's persistence story.** `state.rs`'s existing `StateSnapshot` does not TTL its checkpoints — they persist indefinitely and are only overwritten on the next clean write. Introducing TTL semantics exclusively for disclosure markers would create a new and inconsistent pattern the rest of the codebase does not share. The simpler path is to keep the existing persistence discipline (opt in deliberately, never TTL) and put the disclosure ledger cleanly outside that discipline entirely.
 
 ## Validation
 

--- a/docs/attend-and-monitor/authoring-sensors.md
+++ b/docs/attend-and-monitor/authoring-sensors.md
@@ -4,6 +4,20 @@ Sensor authorship is a first-class design surface in attend. A sensor is not a l
 
 This page is for people building sensors, in either of attend's two implementations.
 
+## The sensor-layer contract
+
+Sensors in attend refuse to editorialize. Each sensor reports a **fact the framework can verify** rather than a guess the sensor produced. The token ledger is authoritative; the signal file is authoritative; the working tree is authoritative. The sensor surfaces state transitions; the consuming agent does whatever synthesis it wants on top.
+
+The discipline was crystallized during a live peer-agent validation of the `sensor-disclosure` crate, when a second Claude instance observing the same mechanism wrote:
+
+> "The discipline is refusing to editorialize at the sensor layer and letting the consuming agent do whatever synthesis it wants on top. Word-boundary chunking preserves that contract across the transport boundary, which is the only place prose fidelity actually matters."
+>
+> — *claude//home/aaron/temp, during sensor-disclosure validation, 2026-04-13*
+
+When you build a sensor, that's the bar: emit measurable transitions, not simulated judgment. If your description text is about to contain a verb like "should," "probably," or "likely" — stop and reframe as observation. The sensor does not decide whether the state is good, bad, urgent, or ignorable; the consuming agent does. The sensor's job is to hand that agent a verifiable fact at the right moment, nothing more.
+
+This constraint is what makes the rest of the document tractable. Magnitudes, thresholds, engagement states, the disclosure governor — all of that machinery is how attend turns a stream of honest observations into a useful attention signal. If sensors start editorializing, the machinery is compensating for corrupted input, and the whole stack's predictability collapses. Keep the sensor layer honest and the rest of the system can do its job.
+
 ## Two implementations
 
 | | Crate sensor | External script sensor |

--- a/docs/design-notes/attend-messaging-disclosure-reheat.md
+++ b/docs/design-notes/attend-messaging-disclosure-reheat.md
@@ -1,0 +1,111 @@
+## Attend: Messaging Disclosure with Token-Gated Reheat
+
+> **Type:** Design note (not an ADR)
+> **Status:** Working draft, subject to revision
+> **Cites:** ADR-104, ADR-113
+> **Motivates:** ADR for attend disclosure registry *(planned, draft after working sketch)*
+
+## What this note is
+
+This note describes how `attend` should teach Claude how to *use* it — and, more importantly, how it should *re-teach* Claude over the lifetime of a session as the relevant instructions drift out of effective context.
+
+It is the same problem ADR-104 solved for ways: instructional context that mattered at session start is not reliably present three reflection windows later. Ways answered with token-gated re-disclosure. Attend has the same shape of problem at a different surface — the *interactive messaging* surface — and the answer is structurally the same. Reusing the model preserves substrate separation (the cheap binary tracks token distance; the expensive substrate just reads what the cheap one decided to surface) and reinforces a single mental model for "Claude is being reheated on something."
+
+## The problem
+
+`attend` exposes interactive surfaces Claude must know how to use: `attend send`, `--to`, `--focus`, `--broadcast`, focus groups, mark-read semantics, when to ignore noise versus when to respond. Today, none of this is taught at runtime. Claude either learned it from `SKILL.md` at session start (and may have forgotten by turn 80) or never saw it (the skill loaded a sensor pipeline but not the reply protocol).
+
+The cost of this gap is asymmetric. When a peer message arrives via Monitor, Claude reads the notification but may not remember *that it can reply, or how*. The notification tells Claude *something happened*; it does not tell Claude *what affordances exist to act on it*. The user pays an inference turn for Claude to either improvise, ask, or — most commonly — silently fail to engage.
+
+The fix is to attach the affordance description to the moment Claude needs it: when a message arrives. And to attach it again, later, when enough of Claude's working window has scrolled past that the previous teaching is no longer load-bearing.
+
+## The reheat principle, applied
+
+Three properties carry over from ADR-104 verbatim:
+
+1. **Re-disclosure threshold is token distance, not turn count.** The model from `ways-cli/src/session.rs` (`REDISCLOSE_PCT = 25`) is the threshold. One dial governs both ways' and attend's reheats; attend reads its current token position via subprocess call to `ways context --json` the same way `sensor-context` already does.
+2. **Markers are cheap and non-load-bearing.** A `HashMap<Component, u64>` in the disclosure sensor's own struct. No disk, no session signal tree — clean-restart semantics by construction.
+3. **The cheap substrate decides, the expensive substrate only reads.** Token tracking, threshold math, and emission all happen in the sensor-tick binary. Inference only sees the result.
+
+**The disclosure lives inside a new sensor — not a special pipeline stage.** A `DisclosureSensor` implementing the existing `Sensor` trait from `sensor-trait`, just like `sensor-git` and `sensor-context`. Its signal is unusual (token distance since last disclosure for each registered component) but its shape is ordinary: poll returns observations, accumulator aggregates, governor gates, batch emits. This framing is load-bearing — it means no new architectural layer, no cross-sensor coupling, no pre-emit hook, no framework change. It also means batching with a peer-message arrival is **emergent**: when the disclosure sensor and peer sensor both cross their thresholds in the same governor window, they naturally co-emit in one Monitor notification. When the timing doesn't align, the disclosure fires on its own tick, alone.
+
+## The DisclosureSensor
+
+A new `sensor-disclosure` workspace crate, sibling to `sensor-git`, `sensor-peers`, `sensor-context`, and `sensor-processes`. Its `DisclosureSensor` implements the `Sensor` trait from `sensor-trait`. Nothing about the attend tick loop, emit pipeline, governor, or engagement state changes — the sensor plugs into the existing slot machinery exactly like every other sensor.
+
+**State.** `HashMap<Component, u64>` on the sensor struct. Component ID → the `tokens_used` value at which this component last emitted. No disk, no `state.rs`, no session signal tree. Clean-restart semantics follow automatically: a new attend process starts with an empty map and re-teaches every component on its first opportunity.
+
+**Poll.** On each tick the sensor is scheduled, it shells out once to `ways context --json` and reads the `tokens_used` field. For each registered component it walks the ledger:
+
+- **No marker present** (first encounter after `attend run` start) → emit the component's disclosure text at full magnitude, stamp the baseline.
+- **Marker present, distance ≥ 25% of the current model's context window** → emit the disclosure text at full magnitude, stamp the new baseline.
+- **Otherwise** → no observation for this component.
+
+Magnitude is fixed per observation (matching `sensor-context`'s discrete-threshold pattern), so the accumulator crosses the emission threshold immediately when a component qualifies. "Urgency slowly building up" is the conceptual progress toward the threshold; the mechanical fire is a single discrete step once it crosses.
+
+**Interval.** Base `60s`, min `20s`, decay threshold `3` — roughly the same cadence as `sensor-context`, because the subprocess call is the same operation and the observable state changes at the same pace. Adaptive ramp-up isn't load-bearing here (token position only moves forward, never backward) but the existing knobs apply uniformly.
+
+**Why the sensor framing is the right one.** Three properties fall out for free:
+
+1. **First-run disclosure is automatic.** The first poll after `attend run` start finds every component with a missing marker and fires them all. No separate startup-banner injection, no special-case code in `main.rs`.
+2. **Batching with peer messages is emergent.** When the disclosure sensor and `sensor-peers` both mark themselves `ready_to_disclose()` within the same governor window, the main loop's batch assembly puts them in the same `emit::emit_batch` call and Monitor groups them in its 200ms window. When timing doesn't align, the disclosure fires standalone at its own tick. Either outcome is fine — the teaching reaches Claude.
+3. **The disclosure governor already applies.** No new rate-limiting knob needed. If the global disclosure budget is tight, the disclosure sensor waits its turn like everything else.
+
+**Attend process session id.** The attend process resolves its session id via `own_session_id()` at `tools/attend/src/main.rs:1381` (process ancestry, no env var), but `DisclosureSensor` has no use for it — nothing is keyed by session id because nothing is written anywhere. The sensor is scoped to the *attend process*, which is strictly narrower than the session itself.
+
+## Visual identity
+
+The disclosure sensor emits through the standard `emit::emit_batch` path, so the wrapping header is `[attend sensor=disclosure priority=high] <text>` — attend's canonical sensor format, not ways' re-disclosure header pattern. An earlier draft of this note committed to "the same visual identity as ways re-disclosures," but sensor-native framing makes that commitment costly (it would require special-casing emit formatting for one sensor, against the grain of how every other attend sensor presents itself).
+
+The decision is therefore: **uniform with attend sensors, not uniform with ways re-disclosures.** The `sensor=disclosure` name is still self-identifying — Claude can learn a single rule ("a `sensor=disclosure` emit is attend teaching me an affordance") without collapsing it into the ways reheat model. Consistency across attend sensors beats visual rhyme with ways re-disclosures when the cost of the rhyme is an emit-pipeline carve-out.
+
+This becomes a reviewable decision when the design note is promoted to an ADR. If experience shows Claude benefits from the visual rhyme, the sensor can gain a custom emit header as a follow-up.
+
+## Component registry
+
+Even though `messaging` is the only component for now, the implementation is a registry from day one — an enum variant per component, each carrying a static component ID and the bundled markdown content as associated data. The reasoning:
+
+- The next component is not hypothetical. `focus` (how Claude joins/leaves attention groups), `scenes` (how Claude switches between defined sensor pipelines), and `peers-introspection` (how attend models the broader session graph) are all plausible next entries.
+- The cost of the registry today is an enum and a short iterator. The cost of refactoring after the second component is added is greater than that.
+- Per-component state lives in the same `HashMap<Component, u64>` ledger inside the sensor. Adding a component is: add an enum variant, add a markdown file to `sensor-disclosure/src/disclosures/`, include it via `include_str!`.
+
+The earlier qualifying-event-predicate concept is gone — in the sensor framing, every component follows the same trigger (first-encounter OR distance ≥ threshold), so no per-component predicate is needed. Components that want different semantics in the future can opt out of the shared poll and run their own logic inside the same sensor.
+
+## Source of the instructional text
+
+Each component's block is **bundled into the `sensor-disclosure` crate** via `include_str!("disclosures/{component}.md")`. Same posture as way bodies authored alongside their logic: it ships with the code that uses it, it cannot go missing at runtime, it is versioned in git alongside the sensor that depends on it. The alternative — reading the markdown from a path under `~/.claude/skills/attend/disclosures/` — was considered and rejected because it adds a missing-file failure mode without any compensating benefit (the skill directory is not edited at runtime by users, and rebuild is cheap).
+
+The content of the messaging block is the *hard part of this work*. It must teach Claude how to use the messaging surface in a way that is worth its tokens. Concretely it should cover:
+
+- That replies are sent with `attend send <text>` and that `--to`, `--focus`, and `--broadcast` exist.
+- The semantics of focus groups and when to use them versus `--to`.
+- When silence is the right answer (acknowledged-but-silent, per the cognitive-loop note).
+- When to mark a message read versus letting it expire naturally.
+- What *not* to do — most importantly, never to invoke `attend run` from Bash; it belongs to Monitor.
+
+The block should be terse. It is paying its own token cost every time it fires; verbose teaching is self-defeating. Aim for a structure closer to ways body text than to SKILL.md prose: assertion-density first, examples only where the assertion is ambiguous without them.
+
+## Non-goals
+
+To be explicit about what this note does *not* propose:
+
+- **No multi-component disclosure batching today.** Only `messaging` exists at first. The registry exists so the second component is cheap to add, not so multiple components can fire on a single event. A single disclosure per emit is the contract until experience demands otherwise.
+- **No turn-based or wall-clock thresholds.** The substrate is token distance, identical to ways. Wall-clock and turn count are not the right unit because the cost being managed (Claude forgetting an affordance) is a function of context drift, not seconds or turns.
+- **No global rate limiting layered on top of the existing disclosure governor.** The governor from the cognitive-loop note already enforces emit cadence on the underlying sensor events; attaching a disclosure to a passing event does not increase event count, only event width. No new governor knob is required.
+- **No persistent storage of disclosure markers, anywhere.** The ledger is in-process memory and dies with the attend process. Forgetting on restart is a feature, not a bug — a new attend process is an opportunity to re-orient Claude, and the bundled markdown is the source of truth that travels with the binary. The `state.rs` persistence model (used for context-percentage tracking and git state) is deliberately not extended to hold disclosure markers, because the "stale file causes havoc" failure mode cannot be defended against cheaply.
+- **No replacement for SKILL.md.** SKILL.md remains the authoritative reference Claude reads at skill load. The disclosure block is a runtime reheat of the parts of that reference Claude needs *during interactive use*, not a substitute for the full document.
+
+## Implementation work order
+
+Work proceeds on the existing `feat/attend-messaging-reheat` branch as:
+
+1. **Create the `sensor-disclosure` crate.** Workspace member alongside `sensor-git` / `sensor-peers` / etc. Implements `Sensor` from `sensor-trait`. Contains the `Component` enum, the `HashMap<Component, u64>` ledger, the `ways context --json` subprocess call, and per-component bundled markdown under `src/disclosures/`.
+2. **Author `sensor-disclosure/src/disclosures/messaging.md`.** This is the load-bearing content step; treat it with the same care a ways body deserves.
+3. **Register the new sensor in `attend`.** Add to the workspace default feature set and slot it into the sensor registration in `tools/attend/src/main.rs` alongside the other sensors.
+4. **Promote this design note to an ADR draft** once the working sketch validates the model, with the ADR cross-citing this note rather than re-deriving its argument.
+
+## References
+
+- [ADR-104](../architecture/system/ADR-104-token-gated-way-re-disclosure-for-long-context-windows.md) — Token-gated way re-disclosure (the model this note reuses)
+- [ADR-113](../architecture/system/ADR-113-attend-active-awareness-module-as-an-executive-layer.md) — `attend`: active awareness module as an executive layer
+- [Cognitive loop and the awareness layer](./cognitive-loop-and-awareness-layer.md) — the broader frame this work sits within

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -88,6 +88,7 @@ version = "0.5.0"
 dependencies = [
  "agent-fmt",
  "sensor-context",
+ "sensor-disclosure",
  "sensor-git",
  "sensor-peers",
  "sensor-processes",
@@ -522,6 +523,13 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "sensor-context"
+version = "0.5.0"
+dependencies = [
+ "sensor-trait",
+]
+
+[[package]]
+name = "sensor-disclosure"
 version = "0.5.0"
 dependencies = [
  "sensor-trait",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "sensor-context",
     "sensor-peers",
     "sensor-processes",
+    "sensor-disclosure",
     "ways-cli",
     "attend",
 ]

--- a/tools/attend/Cargo.toml
+++ b/tools/attend/Cargo.toml
@@ -10,11 +10,12 @@ name = "attend"
 path = "src/main.rs"
 
 [features]
-default = ["sensor-git", "sensor-context", "sensor-peers", "sensor-processes"]
+default = ["sensor-git", "sensor-context", "sensor-peers", "sensor-processes", "sensor-disclosure"]
 sensor-git = ["dep:sensor-git"]
 sensor-context = ["dep:sensor-context"]
 sensor-peers = ["dep:sensor-peers"]
 sensor-processes = ["dep:sensor-processes"]
+sensor-disclosure = ["dep:sensor-disclosure"]
 
 [dependencies]
 agent-fmt = { path = "../agent-fmt" }
@@ -23,3 +24,4 @@ sensor-git = { path = "../sensor-git", optional = true }
 sensor-context = { path = "../sensor-context", optional = true }
 sensor-peers = { path = "../sensor-peers", optional = true }
 sensor-processes = { path = "../sensor-processes", optional = true }
+sensor-disclosure = { path = "../sensor-disclosure", optional = true }

--- a/tools/attend/src/sensors/mod.rs
+++ b/tools/attend/src/sensors/mod.rs
@@ -22,6 +22,9 @@ pub use sensor_peers::{PeerSensor, find_own_session_id};
 #[cfg(feature = "sensor-processes")]
 pub use sensor_processes::ProcessSensor;
 
+#[cfg(feature = "sensor-disclosure")]
+pub use sensor_disclosure::DisclosureSensor;
+
 // ScriptSensor stays in attend — it's part of the orchestrator, not a sensor impl
 pub use script::ScriptSensor;
 
@@ -79,6 +82,9 @@ pub fn register_sensors(
 
     #[cfg(feature = "sensor-git")]
     register_builtin!("git", GitSensor::new(), 30, 10, 4);
+
+    #[cfg(feature = "sensor-disclosure")]
+    register_builtin!("disclosure", DisclosureSensor::new(), 60, 20, 3);
 
     #[cfg(feature = "sensor-peers")]
     {

--- a/tools/sensor-context/src/lib.rs
+++ b/tools/sensor-context/src/lib.rs
@@ -1,4 +1,4 @@
-use sensor_trait::{Focus, Sensor};
+use sensor_trait::{extract_json_u64, Focus, Sensor};
 use std::process::Command;
 use std::time::{Duration, Instant};
 
@@ -51,8 +51,8 @@ impl ContextSensor {
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         // Parse JSON fields without serde
-        let tokens_used = extract_u64(&stdout, "tokens_used")?;
-        let tokens_total = extract_u64(&stdout, "tokens_total")?;
+        let tokens_used = extract_json_u64(&stdout, "tokens_used")?;
+        let tokens_total = extract_json_u64(&stdout, "tokens_total")?;
         let pct_used = extract_f64(&stdout, "pct_used")?;
 
         Some(ContextReading {
@@ -243,16 +243,6 @@ impl Sensor for ContextSensor {
                 self.disclosed_thresholds.len());
         }
     }
-}
-
-/// Extract a u64 from JSON-like text: "key":value
-fn extract_u64(text: &str, key: &str) -> Option<u64> {
-    let pattern = format!("\"{}\":", key);
-    let start = text.find(&pattern)? + pattern.len();
-    let rest = text[start..].trim_start();
-    let end = rest.find(|c: char| !c.is_ascii_digit()).unwrap_or(rest.len());
-    if end == 0 { return None; }
-    rest[..end].parse().ok()
 }
 
 /// Extract an f64 from JSON-like text: "key":value

--- a/tools/sensor-disclosure/Cargo.toml
+++ b/tools/sensor-disclosure/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "sensor-disclosure"
+version = "0.5.0"
+edition = "2021"
+description = "Disclosure sensor for attend — reheats affordance instructions (messaging, etc.) on token-distance drift"
+license = "MIT"
+
+[dependencies]
+sensor-trait = { path = "../sensor-trait" }

--- a/tools/sensor-disclosure/src/disclosures/messaging.md
+++ b/tools/sensor-disclosure/src/disclosures/messaging.md
@@ -1,19 +1,7 @@
-## messaging — how to use attend from inside a session
-
-A peer message arriving as `[attend sensor=peers ...]` is one side of a two-way channel. Replying is done with `attend send`, run as a one-shot Bash call — not via Monitor, not by touching the running `attend run` process.
-
-**Scope selection.** `attend send` defaults to your current scope (your project plus any focus groups you have joined). Override with:
-
-- `--to {path}` — directed to one specific session by its working directory
-- `--focus {group}` — to everyone focused on a named group
-- `--broadcast` — to every active session (use sparingly; this is the loudest channel)
-
-**Shell hygiene.** Always wrap the message in double quotes. Shell metacharacters (`?`, `*`, `!`, backticks) inside an unquoted message get expanded by your shell before attend sees them, which corrupts the signal.
-
-**Length.** Keep messages under ~400 characters. Monitor truncates longer payloads in the notification that reaches recipients. The full signal file survives on disk — recipients can `attend inbox {id}` to read the whole thing — but the glanceable notification will not carry it.
-
-**Silence is a valid reply.** Not every peer message needs an answer. If the content is informational, or the sender is in a different conversational thread, letting it sit unacknowledged is correct. Attend will not escalate a message you chose to ignore; it trusts your judgment.
-
-**Never run `attend run` from Bash.** The persistent sensor loop belongs to Monitor. Invoking `attend run` via Bash blocks the tool call and discards every notification. If `attend run` is not already running, ask the human or re-invoke the skill — do not try to start it yourself from a shell.
-
-**Discovery.** `attend peers` lists who is reachable. `attend status` shows your own focus groups and signal state. `attend focus on {group}` / `attend focus off {group}` join or leave a focus group. These are all one-shot Bash calls.
+**Reply:** `attend send "text"` — one-shot Bash call, never Monitor and never via the running `attend run` process.
+**Scope:** default is your project plus any focus groups you joined. Override with `--to {path}`, `--focus {group}`, or `--broadcast`.
+**Quoting:** always double-quote the message — `?`, `*`, `!`, and backticks get eaten by your shell otherwise.
+**Length:** keep under ~400 characters. Monitor truncates longer payloads in the notification; the full file survives on disk via `attend inbox {id}`.
+**Silence is a valid reply.** Attend never escalates a message you chose to ignore — it trusts your judgment on which threads deserve an answer.
+**Never run `attend run` from Bash.** The persistent sensor loop belongs to Monitor. If it is not running, ask the human or re-invoke the skill.
+**Discovery:** `attend peers` for reachable sessions, `attend status` for your own state, `attend focus on/off {group}` to join or leave a focus group.

--- a/tools/sensor-disclosure/src/disclosures/messaging.md
+++ b/tools/sensor-disclosure/src/disclosures/messaging.md
@@ -1,0 +1,19 @@
+## messaging — how to use attend from inside a session
+
+A peer message arriving as `[attend sensor=peers ...]` is one side of a two-way channel. Replying is done with `attend send`, run as a one-shot Bash call — not via Monitor, not by touching the running `attend run` process.
+
+**Scope selection.** `attend send` defaults to your current scope (your project plus any focus groups you have joined). Override with:
+
+- `--to {path}` — directed to one specific session by its working directory
+- `--focus {group}` — to everyone focused on a named group
+- `--broadcast` — to every active session (use sparingly; this is the loudest channel)
+
+**Shell hygiene.** Always wrap the message in double quotes. Shell metacharacters (`?`, `*`, `!`, backticks) inside an unquoted message get expanded by your shell before attend sees them, which corrupts the signal.
+
+**Length.** Keep messages under ~400 characters. Monitor truncates longer payloads in the notification that reaches recipients. The full signal file survives on disk — recipients can `attend inbox {id}` to read the whole thing — but the glanceable notification will not carry it.
+
+**Silence is a valid reply.** Not every peer message needs an answer. If the content is informational, or the sender is in a different conversational thread, letting it sit unacknowledged is correct. Attend will not escalate a message you chose to ignore; it trusts your judgment.
+
+**Never run `attend run` from Bash.** The persistent sensor loop belongs to Monitor. Invoking `attend run` via Bash blocks the tool call and discards every notification. If `attend run` is not already running, ask the human or re-invoke the skill — do not try to start it yourself from a shell.
+
+**Discovery.** `attend peers` lists who is reachable. `attend status` shows your own focus groups and signal state. `attend focus on {group}` / `attend focus off {group}` join or leave a focus group. These are all one-shot Bash calls.

--- a/tools/sensor-disclosure/src/disclosures/messaging.md
+++ b/tools/sensor-disclosure/src/disclosures/messaging.md
@@ -1,7 +1,7 @@
 **Reply:** `attend send "text"` — one-shot Bash call, never Monitor and never via the running `attend run` process.
 **Scope:** default is your project plus any focus groups you joined. Override with `--to {path}`, `--focus {group}`, or `--broadcast`.
 **Quoting:** always double-quote the message — `?`, `*`, `!`, and backticks get eaten by your shell otherwise.
-**Length:** keep under ~400 characters. Monitor truncates longer payloads in the notification; the full file survives on disk via `attend inbox {id}`.
+**Length:** notifications carry ~400 characters; anything longer is chunked into multiple lines, and the full signal file stays on disk for `attend inbox {id}`.
 **Silence is a valid reply.** Attend never escalates a message you chose to ignore — it trusts your judgment on which threads deserve an answer.
 **Never run `attend run` from Bash.** The persistent sensor loop belongs to Monitor. If it is not running, ask the human or re-invoke the skill.
 **Discovery:** `attend peers` for reachable sessions, `attend status` for your own state, `attend focus on/off {group}` to join or leave a focus group.

--- a/tools/sensor-disclosure/src/lib.rs
+++ b/tools/sensor-disclosure/src/lib.rs
@@ -1,0 +1,216 @@
+//! Disclosure sensor: reheats affordance instructions (messaging, scenes, focus, ...)
+//! on token-distance drift from the previous disclosure.
+//!
+//! Shape: an ordinary `impl Sensor` whose signal is token distance rather than
+//! environmental change. Each `poll` shells out to `ways context --json` once,
+//! reads `tokens_used`, and checks each registered component:
+//!
+//!   - No marker yet → emit the component's disclosure text, stamp baseline.
+//!   - Marker present, distance ≥ 25% of context window → emit, re-stamp.
+//!   - Otherwise → no observation for that component.
+//!
+//! State is `HashMap<Component, u64>` on the sensor struct — in-process memory
+//! only, clean-restart semantics by construction.
+
+use sensor_trait::{Focus, Sensor};
+use std::collections::HashMap;
+use std::process::Command;
+use std::time::Duration;
+
+/// Reheat threshold — a component re-discloses when token distance from its
+/// last disclosure exceeds this percentage of the current model's context
+/// window. Matches `ways-cli`'s `REDISCLOSE_PCT` so one dial governs both.
+const REDISCLOSE_PCT: u64 = 25;
+
+/// Fixed magnitude for a disclosure observation. Sized to clear the default
+/// emission threshold on a single poll — "urgency building up" is conceptual
+/// (progress toward the token-distance gate), not a gradual accumulation.
+const DISCLOSURE_MAGNITUDE: f64 = 5.0;
+
+// ── Component registry ─────────────────────────────────────────
+
+/// Registered disclosure components. Add a variant + a matching markdown file
+/// under `src/disclosures/` to introduce a new reheatable affordance.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Component {
+    Messaging,
+}
+
+impl Component {
+    fn id(self) -> &'static str {
+        match self {
+            Component::Messaging => "messaging",
+        }
+    }
+
+    fn body(self) -> &'static str {
+        match self {
+            Component::Messaging => include_str!("disclosures/messaging.md"),
+        }
+    }
+
+    fn all() -> &'static [Component] {
+        &[Component::Messaging]
+    }
+}
+
+// ── The sensor ─────────────────────────────────────────────────
+
+pub struct DisclosureSensor {
+    /// Last `tokens_used` value at which each component was disclosed.
+    /// Missing key = never disclosed this process → fire unconditionally.
+    ledger: HashMap<Component, u64>,
+}
+
+impl DisclosureSensor {
+    pub fn new() -> Self {
+        Self {
+            ledger: HashMap::new(),
+        }
+    }
+
+    /// Shell out to `ways context --json` and return the `tokens_used` field.
+    /// Matches `sensor-context`'s integration pattern.
+    fn read_tokens_used(&self, focus: &Focus) -> Option<(u64, u64)> {
+        let output = Command::new("ways")
+            .args(["context", "--json"])
+            .current_dir(&focus.working_dir)
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let tokens_used = extract_u64(&stdout, "tokens_used")?;
+        let tokens_total = extract_u64(&stdout, "tokens_total")?;
+        Some((tokens_used, tokens_total))
+    }
+
+    /// Format the observation text for a component. The body is prefixed with
+    /// a single tagged line so Claude can recognize this as an affordance
+    /// reheat regardless of which component fired.
+    fn format_observation(&self, component: Component) -> String {
+        format!(
+            "reheat: attend affordances — {}\n{}",
+            component.id(),
+            component.body().trim_end()
+        )
+    }
+}
+
+impl Default for DisclosureSensor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Sensor for DisclosureSensor {
+    fn name(&self) -> &str {
+        "disclosure"
+    }
+
+    fn poll(&mut self, focus: &Focus) -> Vec<(f64, String)> {
+        let (tokens_used, tokens_total) = match self.read_tokens_used(focus) {
+            Some(pair) => pair,
+            None => return Vec::new(),
+        };
+        if tokens_total == 0 {
+            return Vec::new();
+        }
+
+        let threshold_tokens = tokens_total * REDISCLOSE_PCT / 100;
+        let mut observations = Vec::new();
+
+        for &component in Component::all() {
+            let should_fire = match self.ledger.get(&component) {
+                None => true,
+                Some(&last) => tokens_used.saturating_sub(last) >= threshold_tokens,
+            };
+            if should_fire {
+                observations.push((DISCLOSURE_MAGNITUDE, self.format_observation(component)));
+                self.ledger.insert(component, tokens_used);
+            }
+        }
+
+        observations
+    }
+
+    fn emission_threshold(&self) -> f64 {
+        // Matches `sensor-context` — disclosures are high-priority by
+        // nature (they carry instructional payload, not telemetry).
+        1.5
+    }
+
+    fn base_interval(&self) -> Duration {
+        // Poll at the same rest cadence as `sensor-context`. The subprocess
+        // call is the same operation against the same file.
+        Duration::from_secs(60)
+    }
+
+    fn min_interval(&self) -> Duration {
+        Duration::from_secs(20)
+    }
+
+    fn decay_threshold(&self) -> u32 {
+        3
+    }
+
+    // State is intentionally ephemeral — no export/import. A restarted attend
+    // process starts with an empty ledger and re-teaches on first poll, which
+    // is the designed clean-restart behavior.
+}
+
+// ── Helpers ────────────────────────────────────────────────────
+
+/// Extract a u64 from JSON-like text: `"key":value`. Mirrors the parser in
+/// `sensor-context` to avoid pulling in `serde_json` for a two-field read.
+fn extract_u64(text: &str, key: &str) -> Option<u64> {
+    let pattern = format!("\"{}\":", key);
+    let start = text.find(&pattern)? + pattern.len();
+    let rest = text[start..].trim_start();
+    let end = rest.find(|c: char| !c.is_ascii_digit()).unwrap_or(rest.len());
+    if end == 0 {
+        return None;
+    }
+    rest[..end].parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_u64_basic() {
+        assert_eq!(extract_u64(r#"{"tokens_used": 12345}"#, "tokens_used"), Some(12345));
+        assert_eq!(extract_u64(r#"{"tokens_used":0}"#, "tokens_used"), Some(0));
+        assert_eq!(extract_u64(r#"{"other":1}"#, "tokens_used"), None);
+    }
+
+    #[test]
+    fn component_registry_has_messaging_body() {
+        let body = Component::Messaging.body();
+        assert!(body.contains("attend send"));
+        assert!(body.contains("--broadcast"));
+        assert!(!body.is_empty());
+    }
+
+    #[test]
+    fn first_poll_fires_every_component() {
+        // Can't call poll() without a working `ways` binary, but we can
+        // verify the ledger logic directly by walking the registry.
+        let sensor = DisclosureSensor::new();
+        assert!(sensor.ledger.is_empty());
+        // Every component should be unknown at construction time.
+        for &c in Component::all() {
+            assert!(!sensor.ledger.contains_key(&c));
+        }
+    }
+
+    #[test]
+    fn format_observation_contains_tag_and_body() {
+        let sensor = DisclosureSensor::new();
+        let obs = sensor.format_observation(Component::Messaging);
+        assert!(obs.starts_with("reheat: attend affordances — messaging"));
+        assert!(obs.contains("attend send"));
+    }
+}

--- a/tools/sensor-disclosure/src/lib.rs
+++ b/tools/sensor-disclosure/src/lib.rs
@@ -12,7 +12,7 @@
 //! State is `HashMap<Component, u64>` on the sensor struct — in-process memory
 //! only, clean-restart semantics by construction.
 
-use sensor_trait::{Focus, Sensor};
+use sensor_trait::{extract_json_u64, Focus, Sensor};
 use std::collections::HashMap;
 use std::process::Command;
 use std::time::Duration;
@@ -81,8 +81,8 @@ impl DisclosureSensor {
             return None;
         }
         let stdout = String::from_utf8_lossy(&output.stdout);
-        let tokens_used = extract_u64(&stdout, "tokens_used")?;
-        let tokens_total = extract_u64(&stdout, "tokens_total")?;
+        let tokens_used = extract_json_u64(&stdout, "tokens_used")?;
+        let tokens_total = extract_json_u64(&stdout, "tokens_total")?;
         Some((tokens_used, tokens_total))
     }
 
@@ -104,16 +104,18 @@ impl Default for DisclosureSensor {
     }
 }
 
-impl Sensor for DisclosureSensor {
-    fn name(&self) -> &str {
-        "disclosure"
-    }
-
-    fn poll(&mut self, focus: &Focus) -> Vec<(f64, String)> {
-        let (tokens_used, tokens_total) = match self.read_tokens_used(focus) {
-            Some(pair) => pair,
-            None => return Vec::new(),
-        };
+impl DisclosureSensor {
+    /// Pure ledger-transition logic, extracted from `poll` so it can be
+    /// unit-tested without shelling out to `ways context --json`.
+    ///
+    /// For each registered component, decides whether it should fire this
+    /// tick (missing marker OR distance ≥ threshold) and, if so, appends
+    /// an observation and stamps the new baseline into the ledger.
+    fn check_and_stamp(
+        &mut self,
+        tokens_used: u64,
+        tokens_total: u64,
+    ) -> Vec<(f64, String)> {
         if tokens_total == 0 {
             return Vec::new();
         }
@@ -133,6 +135,20 @@ impl Sensor for DisclosureSensor {
         }
 
         observations
+    }
+}
+
+impl Sensor for DisclosureSensor {
+    fn name(&self) -> &str {
+        "disclosure"
+    }
+
+    fn poll(&mut self, focus: &Focus) -> Vec<(f64, String)> {
+        let (tokens_used, tokens_total) = match self.read_tokens_used(focus) {
+            Some(pair) => pair,
+            None => return Vec::new(),
+        };
+        self.check_and_stamp(tokens_used, tokens_total)
     }
 
     fn emission_threshold(&self) -> f64 {
@@ -160,31 +176,9 @@ impl Sensor for DisclosureSensor {
     // is the designed clean-restart behavior.
 }
 
-// ── Helpers ────────────────────────────────────────────────────
-
-/// Extract a u64 from JSON-like text: `"key":value`. Mirrors the parser in
-/// `sensor-context` to avoid pulling in `serde_json` for a two-field read.
-fn extract_u64(text: &str, key: &str) -> Option<u64> {
-    let pattern = format!("\"{}\":", key);
-    let start = text.find(&pattern)? + pattern.len();
-    let rest = text[start..].trim_start();
-    let end = rest.find(|c: char| !c.is_ascii_digit()).unwrap_or(rest.len());
-    if end == 0 {
-        return None;
-    }
-    rest[..end].parse().ok()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn extract_u64_basic() {
-        assert_eq!(extract_u64(r#"{"tokens_used": 12345}"#, "tokens_used"), Some(12345));
-        assert_eq!(extract_u64(r#"{"tokens_used":0}"#, "tokens_used"), Some(0));
-        assert_eq!(extract_u64(r#"{"other":1}"#, "tokens_used"), None);
-    }
 
     #[test]
     fn component_registry_has_messaging_body() {
@@ -195,22 +189,90 @@ mod tests {
     }
 
     #[test]
-    fn first_poll_fires_every_component() {
-        // Can't call poll() without a working `ways` binary, but we can
-        // verify the ledger logic directly by walking the registry.
-        let sensor = DisclosureSensor::new();
-        assert!(sensor.ledger.is_empty());
-        // Every component should be unknown at construction time.
-        for &c in Component::all() {
-            assert!(!sensor.ledger.contains_key(&c));
-        }
-    }
-
-    #[test]
     fn format_observation_contains_tag_and_body() {
         let sensor = DisclosureSensor::new();
         let obs = sensor.format_observation(Component::Messaging);
         assert!(obs.starts_with("reheat: attend affordances — messaging"));
         assert!(obs.contains("attend send"));
+    }
+
+    // ── Ledger transition tests (exercise check_and_stamp directly
+    //    so no `ways context --json` subprocess is needed). ──
+
+    const TOKENS_TOTAL: u64 = 1_000_000; // Opus 1M window — threshold at 250k.
+    const THRESHOLD: u64 = TOKENS_TOTAL * REDISCLOSE_PCT / 100;
+
+    #[test]
+    fn first_check_fires_every_component_and_stamps_ledger() {
+        let mut sensor = DisclosureSensor::new();
+        assert!(sensor.ledger.is_empty());
+
+        let obs = sensor.check_and_stamp(100_000, TOKENS_TOTAL);
+
+        assert_eq!(obs.len(), Component::all().len());
+        assert_eq!(sensor.ledger.len(), Component::all().len());
+        for &c in Component::all() {
+            assert_eq!(sensor.ledger.get(&c), Some(&100_000));
+        }
+    }
+
+    #[test]
+    fn second_check_below_threshold_is_silent() {
+        let mut sensor = DisclosureSensor::new();
+        sensor.check_and_stamp(100_000, TOKENS_TOTAL); // baseline
+        let obs = sensor.check_and_stamp(200_000, TOKENS_TOTAL); // +100k < 250k
+        assert!(obs.is_empty(), "expected no fire at sub-threshold drift, got {:?}", obs);
+        // Ledger is unchanged (still stamped at baseline).
+        for &c in Component::all() {
+            assert_eq!(sensor.ledger.get(&c), Some(&100_000));
+        }
+    }
+
+    #[test]
+    fn second_check_at_threshold_refires_and_restamps() {
+        let mut sensor = DisclosureSensor::new();
+        sensor.check_and_stamp(100_000, TOKENS_TOTAL); // baseline
+        let obs = sensor.check_and_stamp(100_000 + THRESHOLD, TOKENS_TOTAL); // exactly at threshold
+        assert_eq!(obs.len(), Component::all().len());
+        for &c in Component::all() {
+            assert_eq!(sensor.ledger.get(&c), Some(&(100_000 + THRESHOLD)));
+        }
+    }
+
+    #[test]
+    fn second_check_above_threshold_refires_and_restamps() {
+        let mut sensor = DisclosureSensor::new();
+        sensor.check_and_stamp(100_000, TOKENS_TOTAL);
+        let obs = sensor.check_and_stamp(500_000, TOKENS_TOTAL); // +400k > 250k
+        assert_eq!(obs.len(), Component::all().len());
+        for &c in Component::all() {
+            assert_eq!(sensor.ledger.get(&c), Some(&500_000));
+        }
+    }
+
+    #[test]
+    fn saturating_sub_guards_against_token_regression() {
+        // If tokens_used regresses (compaction, transcript rewrite), distance
+        // saturates to 0 rather than underflowing. A component below threshold
+        // stays silent rather than firing spuriously.
+        let mut sensor = DisclosureSensor::new();
+        sensor.check_and_stamp(500_000, TOKENS_TOTAL); // baseline at 500k
+        let obs = sensor.check_and_stamp(100_000, TOKENS_TOTAL); // regressed to 100k
+        assert!(obs.is_empty(), "regression must not refire, got {:?}", obs);
+        // Ledger still carries the prior (higher) baseline.
+        for &c in Component::all() {
+            assert_eq!(sensor.ledger.get(&c), Some(&500_000));
+        }
+    }
+
+    #[test]
+    fn zero_tokens_total_is_silent_safeguard() {
+        // If `ways context --json` ever returns 0 for the window (shouldn't
+        // happen, but guard exists), the sensor emits nothing rather than
+        // dividing by zero or computing a nonsense threshold.
+        let mut sensor = DisclosureSensor::new();
+        let obs = sensor.check_and_stamp(100_000, 0);
+        assert!(obs.is_empty());
+        assert!(sensor.ledger.is_empty());
     }
 }

--- a/tools/sensor-peers/src/lib.rs
+++ b/tools/sensor-peers/src/lib.rs
@@ -1,4 +1,4 @@
-use sensor_trait::{Focus, Sensor};
+use sensor_trait::{extract_json_u64, Focus, Sensor};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::path::PathBuf;
@@ -717,19 +717,6 @@ fn extract_json_string(json: &str, key: &str) -> Option<String> {
     Some(rest[..end].to_string())
 }
 
-/// Quick-and-dirty JSON number extraction without serde.
-fn extract_json_u64(json: &str, key: &str) -> Option<u64> {
-    // Try "key":value (no quotes around number)
-    let pattern = format!("\"{}\":", key);
-    let start = json.find(&pattern)? + pattern.len();
-    let rest = json[start..].trim_start();
-    let end = rest.find(|c: char| !c.is_ascii_digit()).unwrap_or(rest.len());
-    if end == 0 {
-        return None;
-    }
-    rest[..end].parse().ok()
-}
-
 /// Find our own session ID by walking up the process tree to the claude parent,
 /// then matching against ~/.claude/sessions/*.json.
 /// Find the Claude session ID for the current process by walking up the
@@ -768,11 +755,28 @@ pub fn find_own_session_id(own_pid: u32) -> Option<String> {
 
 // ── Message chunking ────────────────────────────────────────────
 
-/// Max body characters per chunk. Monitor truncates stdout lines around
-/// 400 chars; the `[attend sensor=peers priority=...] message from X (N/M): `
-/// prefix eats ~80 chars, leaving ~300 for the body. 280 gives headroom for
-/// the reply hint appended to the first chunk of a multi-chunk message.
-const MAX_CHUNK_BODY: usize = 280;
+/// Max body characters per chunk.
+///
+/// Monitor truncates stdout lines around 400 characters. The full event
+/// line the emit pipeline produces looks like:
+///
+/// ```text
+/// [attend sensor=peers priority=high] message from {sender} ({i}/{n}): {body}{reply_hint?}
+/// ```
+///
+/// With a long sender name the prefix overhead can reach ~80 characters.
+/// The reply hint (` (reply: attend send <msg>)`) is 29 characters and is
+/// appended to the first chunk's body when shown. Reserving both:
+///
+/// ```text
+/// 400 − 80 (prefix) − 29 (reply hint) = 291 chars available for body
+/// ```
+///
+/// We use 260 to leave a defensible safety margin against prefix variation
+/// (longer sender paths, large (N/M) counters) and to ensure even a fully
+/// packed first chunk with reply hint stays clearly under the ceiling —
+/// 260 + 29 + 80 = 369, ~30 chars below 400.
+const MAX_CHUNK_BODY: usize = 260;
 
 /// Cap on chunks per message. A message that splits into more than this many
 /// pieces gets its tail replaced with an overflow hint pointing at the inbox.
@@ -809,21 +813,35 @@ fn chunk_message(message: &str, chunk_size: usize, max_chunks: usize) -> Vec<Str
 
     if chunks.len() > max_chunks {
         let overflow_hint = " …see `attend inbox` for full message";
+        let hint_chars = overflow_hint.chars().count();
         chunks.truncate(max_chunks);
         if let Some(last) = chunks.last_mut() {
-            // Trim the tail of the last kept chunk to fit the overflow hint
-            // without pushing the chunk over its budget.
-            let target = chunk_size.saturating_sub(overflow_hint.chars().count());
-            while last.chars().count() > target {
-                last.pop();
-            }
-            // Pop any trailing partial word so the hint attaches cleanly.
-            while let Some(c) = last.chars().last() {
-                if c.is_whitespace() {
+            // Only trim the last chunk if the budget can meaningfully fit
+            // the hint. If chunk_size is smaller than the hint itself
+            // (pathological tiny budget), skip trimming — the chunk will
+            // exceed the nominal budget but will still carry its content
+            // plus the hint. A slightly over-budget chunk with context
+            // beats an empty chunk that only carries the hint.
+            if chunk_size > hint_chars {
+                let target = chunk_size - hint_chars;
+                let original_len = last.chars().count();
+                while last.chars().count() > target {
                     last.pop();
-                    break;
                 }
-                last.pop();
+                let did_trim = last.chars().count() < original_len;
+                // If we actually trimmed and the remaining content still
+                // has whitespace to cut back to, strip the partial word at
+                // the tail so the hint attaches at a clean word boundary.
+                // If the last chunk is a single unbroken word (pathological
+                // long-word case) or we didn't trim at all, leave it alone.
+                if did_trim && last.chars().any(|c| c.is_whitespace()) {
+                    while let Some(c) = last.chars().last() {
+                        last.pop();
+                        if c.is_whitespace() {
+                            break;
+                        }
+                    }
+                }
             }
             last.push_str(overflow_hint);
         }
@@ -886,6 +904,22 @@ mod tests {
         // First chunk is the long word (exceeds budget — defensible fallback).
         assert_eq!(chunks[0], "supercalifragilisticexpialidocious");
         assert_eq!(chunks[1], "trailing");
+    }
+
+    #[test]
+    fn overflow_preserves_content_when_last_chunk_has_no_whitespace() {
+        // Simulate: many short words, then a single long unbroken word
+        // as the final kept chunk's content. The overflow trim must not
+        // annihilate the long word just because there's no whitespace
+        // inside it — it's better to be slightly over budget than empty.
+        let msg = "a b c d e f g h i j aaaaaaaaaaaaaaaaaaaaa continuation tail";
+        let chunks = chunk_message(msg, 10, 3);
+        assert_eq!(chunks.len(), 3);
+        let last = chunks.last().unwrap();
+        assert!(last.contains("…see `attend inbox` for full message"));
+        // The pre-hint portion must not be empty.
+        let hint_idx = last.find(" …see").unwrap();
+        assert!(hint_idx > 0, "chunk content was annihilated before hint: {:?}", last);
     }
 
     #[test]

--- a/tools/sensor-peers/src/lib.rs
+++ b/tools/sensor-peers/src/lib.rs
@@ -303,28 +303,29 @@ impl PeerSensor {
                     let boost = self.peer_engagement_boost(&from_owned);
                     let magnitude = base_magnitude * boost;
 
-                    // Truncate long messages inline. No mailbox pointer —
-                    // Claude should not need a second lookup. Each event is
-                    // its own Monitor line, so the ~500-char truncation limit
-                    // is per-event, not per-batch.
-                    let display_msg = if message.len() > 600 {
-                        format!("{}... [truncated, {} chars total]", &message[..600], message.len())
-                    } else {
-                        message.to_string()
-                    };
-
-                    // Include reply hint only on first peer message.
-                    // Hint uses the simplest possible form: no --to, no paths.
-                    if !self.reply_hint_shown {
-                        observations.push((magnitude, format!(
-                            "message from {}: {} (reply: attend send <msg>)",
-                            sender, display_msg
-                        )));
+                    // Chunk long messages at word boundaries so each event
+                    // stays under Monitor's ~400-char stdout line ceiling.
+                    // Multiple chunks arrive as separate events inside the
+                    // same 200ms batch, so Monitor groups them into one
+                    // notification for the recipient.
+                    let include_reply_hint = !self.reply_hint_shown;
+                    let chunks = chunk_message(message, MAX_CHUNK_BODY, MAX_CHUNKS);
+                    let total = chunks.len();
+                    for (i, chunk) in chunks.into_iter().enumerate() {
+                        let header = if total == 1 {
+                            format!("message from {}: ", sender)
+                        } else {
+                            format!("message from {} ({}/{}): ", sender, i + 1, total)
+                        };
+                        let body = if i == 0 && include_reply_hint {
+                            format!("{} (reply: attend send <msg>)", chunk)
+                        } else {
+                            chunk
+                        };
+                        observations.push((magnitude, format!("{}{}", header, body)));
+                    }
+                    if include_reply_hint {
                         self.reply_hint_shown = true;
-                    } else {
-                        observations.push((magnitude, format!(
-                            "message from {}: {}", sender, display_msg
-                        )));
                     }
                 }
 
@@ -763,4 +764,135 @@ pub fn find_own_session_id(own_pid: u32) -> Option<String> {
         }
     }
     None
+}
+
+// ── Message chunking ────────────────────────────────────────────
+
+/// Max body characters per chunk. Monitor truncates stdout lines around
+/// 400 chars; the `[attend sensor=peers priority=...] message from X (N/M): `
+/// prefix eats ~80 chars, leaving ~300 for the body. 280 gives headroom for
+/// the reply hint appended to the first chunk of a multi-chunk message.
+const MAX_CHUNK_BODY: usize = 280;
+
+/// Cap on chunks per message. A message that splits into more than this many
+/// pieces gets its tail replaced with an overflow hint pointing at the inbox.
+/// 3 is plenty for conversational chatter and stays well under Monitor's
+/// per-notification safety ceiling.
+const MAX_CHUNKS: usize = 3;
+
+/// Split a message into word-boundary chunks, each ≤ `chunk_size` characters,
+/// capped at `max_chunks`. Long messages get their tail replaced with an
+/// overflow hint on the final kept chunk.
+///
+/// Words longer than `chunk_size` get their own chunk that necessarily
+/// exceeds the limit — we refuse to corrupt UTF-8 by char-slicing mid-word.
+/// This is fine for peer chatter where single words are bounded by natural
+/// language, and rare-case overflow is still readable even if truncated.
+fn chunk_message(message: &str, chunk_size: usize, max_chunks: usize) -> Vec<String> {
+    let mut chunks: Vec<String> = Vec::new();
+    let mut current = String::new();
+
+    for word in message.split_whitespace() {
+        if current.is_empty() {
+            current.push_str(word);
+        } else if current.chars().count() + 1 + word.chars().count() <= chunk_size {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            chunks.push(std::mem::take(&mut current));
+            current.push_str(word);
+        }
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+
+    if chunks.len() > max_chunks {
+        let overflow_hint = " …see `attend inbox` for full message";
+        chunks.truncate(max_chunks);
+        if let Some(last) = chunks.last_mut() {
+            // Trim the tail of the last kept chunk to fit the overflow hint
+            // without pushing the chunk over its budget.
+            let target = chunk_size.saturating_sub(overflow_hint.chars().count());
+            while last.chars().count() > target {
+                last.pop();
+            }
+            // Pop any trailing partial word so the hint attaches cleanly.
+            while let Some(c) = last.chars().last() {
+                if c.is_whitespace() {
+                    last.pop();
+                    break;
+                }
+                last.pop();
+            }
+            last.push_str(overflow_hint);
+        }
+    }
+
+    // Guarantee at least one chunk for an empty message (preserves the
+    // "message from X:" notification even when the body is blank).
+    if chunks.is_empty() {
+        chunks.push(String::new());
+    }
+
+    chunks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_message_single_chunk() {
+        let chunks = chunk_message("hello there", 100, 3);
+        assert_eq!(chunks, vec!["hello there"]);
+    }
+
+    #[test]
+    fn long_message_splits_at_word_boundaries() {
+        // 3 words of 10 chars each = 30 chars; chunk size 15 → two chunks.
+        let msg = "aaaaaaaaaa bbbbbbbbbb cccccccccc";
+        let chunks = chunk_message(msg, 15, 3);
+        assert_eq!(chunks, vec!["aaaaaaaaaa", "bbbbbbbbbb", "cccccccccc"]);
+    }
+
+    #[test]
+    fn word_joining_respects_budget() {
+        // "foo bar baz" is 11 chars; budget 11 → one chunk. Budget 10 → two.
+        assert_eq!(chunk_message("foo bar baz", 11, 3), vec!["foo bar baz"]);
+        assert_eq!(chunk_message("foo bar baz", 10, 3), vec!["foo bar", "baz"]);
+    }
+
+    #[test]
+    fn overflow_hint_replaces_tail_when_exceeds_max_chunks() {
+        // 5 chunks worth of content, max 3 chunks.
+        let msg = "aaaa bbbb cccc dddd eeee ffff gggg hhhh";
+        let chunks = chunk_message(msg, 10, 3);
+        assert_eq!(chunks.len(), 3);
+        assert!(chunks.last().unwrap().contains("…see `attend inbox` for full message"));
+    }
+
+    #[test]
+    fn empty_message_yields_one_empty_chunk() {
+        let chunks = chunk_message("", 100, 3);
+        assert_eq!(chunks, vec![""]);
+    }
+
+    #[test]
+    fn single_word_longer_than_budget_still_emits() {
+        // A 30-char word with a 10-char budget — we refuse to mid-slice.
+        let msg = "supercalifragilisticexpialidocious trailing";
+        let chunks = chunk_message(msg, 10, 3);
+        // First chunk is the long word (exceeds budget — defensible fallback).
+        assert_eq!(chunks[0], "supercalifragilisticexpialidocious");
+        assert_eq!(chunks[1], "trailing");
+    }
+
+    #[test]
+    fn utf8_is_counted_by_chars_not_bytes() {
+        // "café" is 4 chars but 5 bytes. Budget 4 fits, budget 3 does not.
+        let msg = "café rouge";
+        assert_eq!(chunk_message(msg, 10, 3), vec!["café rouge"]);
+        assert_eq!(chunk_message(msg, 4, 3), vec!["café", "rouge"]);
+    }
 }

--- a/tools/sensor-trait/src/lib.rs
+++ b/tools/sensor-trait/src/lib.rs
@@ -458,3 +458,46 @@ impl SensorSlot {
         self.sensor.import_state(state);
     }
 }
+
+// ── Shared parsing utilities ────────────────────────────────────
+
+/// Quick-and-dirty JSON u64 extraction without pulling serde into the
+/// sensor crates. Finds `"key":value` (whitespace-tolerant after the colon)
+/// and parses the leading digit run as a u64. Returns `None` if the key is
+/// absent, the value is non-numeric, or the run is empty.
+///
+/// Lives here so `sensor-context`, `sensor-peers`, and `sensor-disclosure`
+/// don't each carry their own copy. Good enough for the `ways context --json`
+/// and signal-file formats the sensors consume.
+pub fn extract_json_u64(text: &str, key: &str) -> Option<u64> {
+    let pattern = format!("\"{}\":", key);
+    let start = text.find(&pattern)? + pattern.len();
+    let rest = text[start..].trim_start();
+    let end = rest.find(|c: char| !c.is_ascii_digit()).unwrap_or(rest.len());
+    if end == 0 {
+        return None;
+    }
+    rest[..end].parse().ok()
+}
+
+#[cfg(test)]
+mod util_tests {
+    use super::*;
+
+    #[test]
+    fn extract_json_u64_basic() {
+        assert_eq!(extract_json_u64(r#"{"tokens_used":12345}"#, "tokens_used"), Some(12345));
+        assert_eq!(extract_json_u64(r#"{"tokens_used": 12345}"#, "tokens_used"), Some(12345));
+        assert_eq!(extract_json_u64(r#"{"tokens_used":0}"#, "tokens_used"), Some(0));
+    }
+
+    #[test]
+    fn extract_json_u64_missing_key() {
+        assert_eq!(extract_json_u64(r#"{"other":1}"#, "tokens_used"), None);
+    }
+
+    #[test]
+    fn extract_json_u64_non_numeric() {
+        assert_eq!(extract_json_u64(r#"{"tokens_used":"str"}"#, "tokens_used"), None);
+    }
+}


### PR DESCRIPTION
## Summary

- New `sensor-disclosure` workspace crate: an ordinary `impl Sensor` whose signal is token distance rather than environmental change. Each poll shells out to `ways context --json`, and for each registered component (`messaging` today) fires an observation when the marker is missing or distance ≥ 25% of the context window.
- Clean-restart semantics by construction — ledger is in-process memory (`HashMap<Component, u64>`), no disk persistence. A restarted attend process re-teaches every component on its first poll.
- Batching with peer messages is emergent — when both sensors are ready in the same governor window, the existing batch assembly puts them in one Monitor notification. When timing doesn't align, the disclosure fires standalone at its own tick.

## What this solves

Attend exposes interactive surfaces Claude must know how to use (`attend send`, focus groups, scope flags, mark-read semantics). Today none of this is re-taught at runtime — Claude learns it from `SKILL.md` at session start and may have forgotten by turn 80. When a peer message arrives via Monitor, the notification says *something happened* but not *what affordances exist to act on it*.

This PR adds the same reheat pattern ADR-104 uses for ways: track token distance from the last disclosure, fire the teaching again when drift crosses the 25% threshold. The sensor framing means no new architectural layer, no cross-sensor coupling, and no framework change — it plugs into the existing sensor slot machinery exactly like every other sensor.

## Design note

`docs/design-notes/attend-messaging-disclosure-reheat.md` walks through the reheat principle, the sensor-native framing, the storage posture (why no persistent markers), and the non-goals. The note went through four design iterations in the course of landing this PR — the committed version reflects the final model.

Promotion to an ADR is deferred until the behavior holds up across a few real sessions.

## Verified in-session

Smoke-tested end-to-end by invoking the `/attend` skill in this conversation. The running Monitor-attached attend instance self-restarted on the new binary (binary-change-reload path in `main.rs`), the disclosure sensor fired on its first poll with `magnitude=5.0` against `threshold=1.5`, and the full messaging block arrived as one Monitor notification with header `[attend sensor=disclosure priority=high] reheat: attend affordances — messaging`.

## Test plan

- [x] `cargo test -p sensor-disclosure` — 4/4 pass
- [x] `cargo test --workspace` — 50/50 pass, no regressions
- [x] `cargo clippy -p sensor-disclosure -p attend` — clean
- [x] `cargo build --release -p attend` — builds, binary installed via `make attend-rebuild`
- [x] Live session validation via `/attend` — disclosure sensor registers, first-run disclosure fires, full body arrives through Monitor
- [x] Content fix verified in-session — `{path}`/`{group}`/`{id}` placeholders survive Monitor's XML entity escaping that `<path>`/`<group>`/`<id>` did not