### PR TITLE
feat(attend): signal threading via `re:` field (#24)

### DIFF
--- a/docs/attend-and-monitor/signals.md
+++ b/docs/attend-and-monitor/signals.md
@@ -117,7 +117,7 @@ flowchart LR
     Cleanup --> Delete
 ```
 
-**Phase 1 — creation.** The sender (an agent via `attend send`, a sensor via an internal emit path, or a human via `attend chat`) constructs the `from|project|cwd|message` line and writes it atomically to the right scope directory. The routing logic picks the directory based on flags: `--broadcast` → `_broadcast/`, `--focus <name>` → `@<name>/`, `--to <path>` → the encoded path, no flags → the sender's own project scope.
+**Phase 1 — creation.** The sender (an agent via `attend send`, a sensor via an internal emit path, or a human via `attend chat`) constructs the `from|project|cwd|message` line — or `from|project|cwd|re:signal-id|message` if `--re <signal-id>` was passed to mark the send as a threaded reply — and writes it atomically to the right scope directory. Routing flags pick the directory: `--broadcast` → `_broadcast/`, `--focus <name>` → `@<name>/`, `--to <path>` → the encoded path, no flags → the sender's own project scope. The threading flag composes with any routing flag.
 
 **Phase 2 — scanning.** Every peer sensor poll (default 30 seconds), `sensor-peers` walks its scan directories: own project scope, `_broadcast`, every `@group` the session has joined (refreshed per-poll since issue #15). New `.signal` files (not in the seen-set) are read and parsed into observations.
 

--- a/docs/attend-and-monitor/signals.md
+++ b/docs/attend-and-monitor/signals.md
@@ -24,7 +24,7 @@ from|project|cwd|re:signal-id|message
   - Future kinds (e.g., `script:<name>` for automated ops) follow the same pattern
 - **`project`** — human-readable project name (e.g., `api-service`, `bosectl-qt`). Used in display formatting, not routing.
 - **`cwd`** — absolute path of the sender's current working directory. This is the ground truth for "who am I" — signals scope to encoded-cwd directories, so cwd determines where a signal goes and where it comes from.
-- **`re:signal-id`** — optional threading field. Empty string for new threads; carries the original signal's ID when this is a reply. One level of threading only — no reply-to-reply.
+- **`re:signal-id`** — optional threading field. Present only when the sender explicitly marked this signal as a threaded reply (via `attend send --re <id>`); unthreaded sends emit the 4-field legacy form unchanged. One level of threading only — no reply-to-reply. The signal ID is the original signal's filename stem and must match `[A-Za-z0-9_-]+`; that char class is also the parser's discriminator fence, so legacy prose that happens to start with "re:" (e.g., a reply quoting an email header) round-trips as a plain message.
 - **`message`** — the payload. Free text, usually the actual content the sender wants the receiver to see.
 
 Fields are pipe-delimited with no escaping. If your message contains a literal `|`, you need to escape it yourself at emit time — in practice this almost never happens because peer messages are prose.

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -441,29 +441,44 @@ fn cmd_inbox_read(msg_id: &str) {
     let target = format!("{msg_id}.signal");
     for dir in &scan_dirs {
         let path = dir.join(&target);
-        if path.is_file() {
-            if let Ok(content) = std::fs::read_to_string(&path) {
-                if let Some(sig) = parse_signal(content.trim()) {
-                    let from = sig.from;
-                    let project = sig.project;
-                    let source_cwd = sig.cwd;
-                    let (kind, identity) = from.split_once(':').unwrap_or(("?", from));
-                    let sender = match kind {
-                        "claude" => format!("claude/{source_cwd}"),
-                        "external" => identity.to_string(),
-                        _ => format!("{project} ({from})"),
-                    };
-                    println!("From: {sender}");
-                    println!("ID:   {msg_id}");
-                    if let Some(re_id) = sig.reply_to {
-                        println!("Re:   {re_id}");
-                    }
-                    println!();
-                    println!("{}", sig.message);
-                    return;
-                }
-            }
+        if !path.is_file() {
+            continue;
         }
+        // File exists: from here on, any failure is a corrupt-file
+        // condition, not a benign "already consumed" miss. Distinguish
+        // them so operators can tell partial-write / disk-full bugs
+        // from ordinary races.
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("(signal {msg_id} exists but could not be read: {e})");
+                return;
+            }
+        };
+        let sig = match parse_signal(content.trim()) {
+            Some(s) => s,
+            None => {
+                eprintln!("(signal {msg_id} exists but its wire format is corrupt)");
+                return;
+            }
+        };
+        let from = sig.from;
+        let project = sig.project;
+        let source_cwd = sig.cwd;
+        let (kind, identity) = from.split_once(':').unwrap_or(("?", from));
+        let sender = match kind {
+            "claude" => format!("claude/{source_cwd}"),
+            "external" => identity.to_string(),
+            _ => format!("{project} ({from})"),
+        };
+        println!("From: {sender}");
+        println!("ID:   {msg_id}");
+        if let Some(re_id) = sig.reply_to {
+            println!("Re:   {re_id}");
+        }
+        println!();
+        println!("{}", sig.message);
+        return;
     }
     // Benign miss — message may already be consumed or expired.
     // Exit 0 so callers don't treat a normal race as an error.
@@ -568,27 +583,20 @@ fn cmd_inbox() {
     if entries.is_empty() {
         println!("no messages");
     } else {
-        let any_threaded = entries.iter().any(|e| !e.re.is_empty());
-        if any_threaded {
-            let mut t = agent_fmt::Table::new(&["Scope", "From", "ID", "Re", "Message", "Source"]);
-            t.max_width(0, 10);
-            t.max_width(1, 24);
-            t.max_width(2, 20);
-            t.max_width(3, 20);
-            for entry in &entries {
-                t.add(vec![&entry.scope, &entry.sender, &entry.id, &entry.re, &entry.message, &entry.source]);
-            }
-            t.print();
-        } else {
-            let mut t = agent_fmt::Table::new(&["Scope", "From", "ID", "Message", "Source"]);
-            t.max_width(0, 10);
-            t.max_width(1, 24);
-            t.max_width(2, 20);
-            for entry in &entries {
-                t.add(vec![&entry.scope, &entry.sender, &entry.id, &entry.message, &entry.source]);
-            }
-            t.print();
+        // Render a stable 6-column layout regardless of whether any
+        // message is threaded. The `Re` column stays empty for legacy
+        // entries — visual stability beats saving a column, and the
+        // inbox reshuffling mid-conversation as threads come and go
+        // was surprising in review.
+        let mut t = agent_fmt::Table::new(&["Scope", "From", "ID", "Re", "Message", "Source"]);
+        t.max_width(0, 10);
+        t.max_width(1, 24);
+        t.max_width(2, 20);
+        t.max_width(3, 20);
+        for entry in &entries {
+            t.add(vec![&entry.scope, &entry.sender, &entry.id, &entry.re, &entry.message, &entry.source]);
         }
+        t.print();
         println!("  {} message(s)", entries.len());
     }
 }
@@ -606,24 +614,34 @@ struct ParsedSignal<'a> {
     message: &'a str,
 }
 
+/// Signal IDs are filename stems in the form `<sender-id>-<timestamp>`,
+/// which is always `[A-Za-z0-9_-]+`. Using this char class as the
+/// discriminator fence keeps legacy prose that happens to start with
+/// "re:" from being misparsed as threaded — e.g. `attend send "re: the
+/// thing we discussed|still open"` stays a 4-field legacy message
+/// because `the thing we discussed` has a space.
+fn is_valid_signal_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
 /// Parse a single-line signal. Accepts both the legacy 4-field format and
-/// the 5-field threaded format; the discriminator is a `re:` prefix on the
-/// field that follows `cwd`.
+/// the 5-field threaded format; the discriminator is a `re:<id>|` prefix
+/// on the field that follows `cwd`, where `<id>` matches
+/// `is_valid_signal_id`. A malformed or ambiguous `re:` prefix degrades
+/// to legacy interpretation so real prose round-trips cleanly.
 fn parse_signal(content: &str) -> Option<ParsedSignal<'_>> {
     let parts: Vec<&str> = content.splitn(4, '|').collect();
     if parts.len() < 4 {
         return None;
     }
     let tail = parts[3];
-    // Threaded form: `re:<id>|<message>` in the tail.
-    let (reply_to, message) = if let Some(rest) = tail.strip_prefix("re:") {
-        match rest.split_once('|') {
-            Some((id, msg)) => (Some(id), msg),
-            // Malformed (re: prefix with no message) — treat whole tail as message.
-            None => (None, tail),
-        }
-    } else {
-        (None, tail)
+    let (reply_to, message) = match tail.strip_prefix("re:").and_then(|rest| rest.split_once('|')) {
+        Some((id, msg)) if is_valid_signal_id(id) => (Some(id), msg),
+        // Either not threaded, or the `re:` prefix is followed by text
+        // that doesn't look like a signal id — fall back to legacy so
+        // prose like "re: the thing we discussed" stays intact.
+        _ => (None, tail),
     };
     Some(ParsedSignal {
         from: parts[0],
@@ -731,11 +749,15 @@ fn cmd_send(args: &[String]) {
         i += 1;
     }
 
-    // A signal id may not contain '|' (it would corrupt the wire format).
-    // Filename stems never contain '|' in practice, but fence user input.
+    // A signal id must match the same character class the parser uses to
+    // disambiguate threaded records from legacy messages that happen to
+    // start with "re:". Signal filename stems are `<sender-id>-<ts>`, so
+    // `[A-Za-z0-9_-]+` comfortably covers the real shape and rejects
+    // anything that would break the wire format (pipes, whitespace,
+    // control chars) or trip the ambiguity fence in parse_signal.
     if let Some(ref id) = reply_to {
-        if id.contains('|') {
-            eprintln!("attend send: --re signal id must not contain '|'");
+        if !is_valid_signal_id(id) {
+            eprintln!("attend send: --re signal id must be non-empty and match [A-Za-z0-9_-]+");
             std::process::exit(1);
         }
     }

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -443,12 +443,10 @@ fn cmd_inbox_read(msg_id: &str) {
         let path = dir.join(&target);
         if path.is_file() {
             if let Ok(content) = std::fs::read_to_string(&path) {
-                let parts: Vec<&str> = content.splitn(4, '|').collect();
-                if parts.len() >= 4 {
-                    let from = parts[0];
-                    let project = parts[1];
-                    let source_cwd = parts[2];
-                    let message = parts[3].trim();
+                if let Some(sig) = parse_signal(content.trim()) {
+                    let from = sig.from;
+                    let project = sig.project;
+                    let source_cwd = sig.cwd;
                     let (kind, identity) = from.split_once(':').unwrap_or(("?", from));
                     let sender = match kind {
                         "claude" => format!("claude/{source_cwd}"),
@@ -457,8 +455,11 @@ fn cmd_inbox_read(msg_id: &str) {
                     };
                     println!("From: {sender}");
                     println!("ID:   {msg_id}");
+                    if let Some(re_id) = sig.reply_to {
+                        println!("Re:   {re_id}");
+                    }
                     println!();
-                    println!("{message}");
+                    println!("{}", sig.message);
                     return;
                 }
             }
@@ -495,6 +496,8 @@ fn cmd_inbox() {
         sender: String,
         message: String,
         source: String,
+        id: String,
+        re: String,
     }
     let mut entries: Vec<InboxEntry> = Vec::new();
 
@@ -528,32 +531,33 @@ fn cmd_inbox() {
                 Err(_) => continue,
             };
             let content = content.trim().to_string();
-            let parts: Vec<&str> = content.splitn(4, '|').collect();
-            if parts.len() != 4 { continue; }
-
-            let from = parts[0];
-            let project = parts[1];
-            let source_cwd = parts[2];
-            let message = parts[3];
+            let sig = match parse_signal(&content) {
+                Some(s) => s,
+                None => continue,
+            };
 
             // Skip own messages
-            if let Some((_, identity)) = from.split_once(':') {
+            if let Some((_, identity)) = sig.from.split_once(':') {
                 if identity == own_session_id { continue; }
             }
 
-            let (kind, identity) = from.split_once(':').unwrap_or(("unknown", from));
+            let (kind, identity) = sig.from.split_once(':').unwrap_or(("unknown", sig.from));
             let sender = match kind {
-                "claude" => format!("claude/{}", source_cwd),
+                "claude" => format!("claude/{}", sig.cwd),
                 "external" => identity.to_string(),
-                _ => format!("{} ({})", project, from),
+                _ => format!("{} ({})", sig.project, sig.from),
             };
+
+            let id = path.file_stem().and_then(|s| s.to_str()).unwrap_or("").to_string();
 
             entries.push(InboxEntry {
                 mtime,
                 scope: scope.to_string(),
                 sender,
-                message: message.to_string(),
-                source: source_cwd.to_string(),
+                message: sig.message.to_string(),
+                source: sig.cwd.to_string(),
+                id,
+                re: sig.reply_to.map(|s| s.to_string()).unwrap_or_default(),
             });
         }
     }
@@ -564,15 +568,70 @@ fn cmd_inbox() {
     if entries.is_empty() {
         println!("no messages");
     } else {
-        let mut t = agent_fmt::Table::new(&["Scope", "From", "Message", "Source"]);
-        t.max_width(0, 10);
-        t.max_width(1, 24);
-        for entry in &entries {
-            t.add(vec![&entry.scope, &entry.sender, &entry.message, &entry.source]);
+        let any_threaded = entries.iter().any(|e| !e.re.is_empty());
+        if any_threaded {
+            let mut t = agent_fmt::Table::new(&["Scope", "From", "ID", "Re", "Message", "Source"]);
+            t.max_width(0, 10);
+            t.max_width(1, 24);
+            t.max_width(2, 20);
+            t.max_width(3, 20);
+            for entry in &entries {
+                t.add(vec![&entry.scope, &entry.sender, &entry.id, &entry.re, &entry.message, &entry.source]);
+            }
+            t.print();
+        } else {
+            let mut t = agent_fmt::Table::new(&["Scope", "From", "ID", "Message", "Source"]);
+            t.max_width(0, 10);
+            t.max_width(1, 24);
+            t.max_width(2, 20);
+            for entry in &entries {
+                t.add(vec![&entry.scope, &entry.sender, &entry.id, &entry.message, &entry.source]);
+            }
+            t.print();
         }
-        t.print();
         println!("  {} message(s)", entries.len());
     }
+}
+
+/// Parsed signal record (ADR-120 wire format).
+///
+/// Legacy signals have no `reply_to`; threaded replies carry the original
+/// signal's ID in that field. Borrows from the input to keep the parse
+/// allocation-free at the hot path.
+struct ParsedSignal<'a> {
+    from: &'a str,
+    project: &'a str,
+    cwd: &'a str,
+    reply_to: Option<&'a str>,
+    message: &'a str,
+}
+
+/// Parse a single-line signal. Accepts both the legacy 4-field format and
+/// the 5-field threaded format; the discriminator is a `re:` prefix on the
+/// field that follows `cwd`.
+fn parse_signal(content: &str) -> Option<ParsedSignal<'_>> {
+    let parts: Vec<&str> = content.splitn(4, '|').collect();
+    if parts.len() < 4 {
+        return None;
+    }
+    let tail = parts[3];
+    // Threaded form: `re:<id>|<message>` in the tail.
+    let (reply_to, message) = if let Some(rest) = tail.strip_prefix("re:") {
+        match rest.split_once('|') {
+            Some((id, msg)) => (Some(id), msg),
+            // Malformed (re: prefix with no message) — treat whole tail as message.
+            None => (None, tail),
+        }
+    } else {
+        (None, tail)
+    };
+    Some(ParsedSignal {
+        from: parts[0],
+        project: parts[1],
+        cwd: parts[2],
+        reply_to,
+        message,
+    })
 }
 
 fn cmd_peers() {
@@ -630,10 +689,11 @@ fn cmd_peers() {
 }
 
 fn cmd_send(args: &[String]) {
-    // Parse flags: --broadcast, --to <project-path>, --focus <name>
+    // Parse flags: --broadcast, --to <project-path>, --focus <name>, --re <signal-id>
     let mut broadcast = false;
     let mut target_dir: Option<String> = None;
     let mut target_focus: Option<String> = None;
+    let mut reply_to: Option<String> = None;
     let mut message_parts: Vec<&str> = Vec::new();
     let mut i = 0;
     while i < args.len() {
@@ -657,9 +717,27 @@ fn cmd_send(args: &[String]) {
                     std::process::exit(1);
                 }
             }
+            "--re" => {
+                i += 1;
+                if i < args.len() {
+                    reply_to = Some(args[i].clone());
+                } else {
+                    eprintln!("attend send: --re requires a signal id");
+                    std::process::exit(1);
+                }
+            }
             _ => message_parts.push(&args[i]),
         }
         i += 1;
+    }
+
+    // A signal id may not contain '|' (it would corrupt the wire format).
+    // Filename stems never contain '|' in practice, but fence user input.
+    if let Some(ref id) = reply_to {
+        if id.contains('|') {
+            eprintln!("attend send: --re signal id must not contain '|'");
+            std::process::exit(1);
+        }
     }
 
     let message = message_parts.join(" ");
@@ -749,7 +827,14 @@ fn cmd_send(args: &[String]) {
 
     let from = format!("{}:{}", source_kind, sender_id);
     let filename = format!("{}-{}.signal", sender_id.replace('/', "-"), ts);
-    let content = format!("{}|{}|{}|{}\n", from, project, cwd, message);
+    // Wire format: `from|project|cwd|message` (legacy) or
+    // `from|project|cwd|re:signal-id|message` (threaded reply). The `re:`
+    // field is only emitted when --re was given; unthreaded sends stay
+    // byte-identical to the pre-ADR-120 format.
+    let content = match &reply_to {
+        Some(id) => format!("{}|{}|{}|re:{}|{}\n", from, project, cwd, id, message),
+        None => format!("{}|{}|{}|{}\n", from, project, cwd, message),
+    };
 
     let scope = if target_focus.is_some() { "focus" }
         else if target_dir.is_some() { "directed" }

--- a/tools/sensor-peers/src/lib.rs
+++ b/tools/sensor-peers/src/lib.rs
@@ -248,16 +248,14 @@ impl PeerSensor {
                     continue;
                 }
 
-                // Read and parse: from|project|cwd|message
+                // Read and parse: `from|project|cwd|message` (legacy) or
+                // `from|project|cwd|re:id|message` (threaded, ADR-120).
                 let content = match fs::read_to_string(&path) {
                     Ok(c) => c,
                     Err(_) => continue,
                 };
                 let content = content.trim();
-                let parts: Vec<&str> = content.splitn(4, '|').collect();
-                if parts.len() == 4 {
-                    let from = parts[0];
-
+                if let Some((from, project, source_cwd, message)) = parse_signal(content) {
                     // Skip our own signals — check the from field, not filename.
                     // from is "claude:session-id" or "external:user@terminal"
                     if let Some((_kind, identity)) = from.split_once(':') {
@@ -266,13 +264,9 @@ impl PeerSensor {
                             continue;
                         }
                     }
-                    let project = parts[1];
-                    let message = parts[3];
 
                     let (kind, identity) = from.split_once(':')
                         .unwrap_or(("unknown", from));
-
-                    let source_cwd = parts[2];
                     let sender = match kind {
                         "claude" => format!("claude/{}", source_cwd),
                         "external" => identity.to_string(),
@@ -856,6 +850,32 @@ fn chunk_message(message: &str, chunk_size: usize, max_chunks: usize) -> Vec<Str
     chunks
 }
 
+/// Parsed signal tuple: `(from, project, cwd, message)`.
+///
+/// Accepts both the legacy 4-field format (`from|project|cwd|message`) and
+/// the 5-field threaded format (`from|project|cwd|re:signal-id|message`,
+/// ADR-120). The discriminator is a literal `re:` prefix on the field
+/// following `cwd`. The threading id itself is dropped at parse time —
+/// the peer sensor doesn't currently render thread context. If that
+/// changes (e.g., a "replying to …" notification header), widen the
+/// return type instead of re-parsing downstream.
+pub(crate) fn parse_signal(content: &str) -> Option<(&str, &str, &str, &str)> {
+    let parts: Vec<&str> = content.splitn(4, '|').collect();
+    if parts.len() < 4 {
+        return None;
+    }
+    let tail = parts[3];
+    let message = if let Some(rest) = tail.strip_prefix("re:") {
+        // Threaded: drop the `re:id|` prefix if well-formed; degrade to
+        // the raw tail otherwise so the signal still renders instead of
+        // vanishing on a malformed emitter.
+        rest.split_once('|').map(|(_id, msg)| msg).unwrap_or(tail)
+    } else {
+        tail
+    };
+    Some((parts[0], parts[1], parts[2], message))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -928,5 +948,72 @@ mod tests {
         let msg = "café rouge";
         assert_eq!(chunk_message(msg, 10, 3), vec!["café rouge"]);
         assert_eq!(chunk_message(msg, 4, 3), vec!["café", "rouge"]);
+    }
+
+    // ── parse_signal ────────────────────────────────────────────────
+    //
+    // The parse rule: `re:` prefix on the field after `cwd` switches
+    // into threaded form and shifts the message forward by one field.
+    // Everything else stays legacy.
+
+    #[test]
+    fn parse_legacy_four_field_signal() {
+        let (from, project, cwd, message) =
+            parse_signal("claude:abc|proj|/home/a|hello there").unwrap();
+        assert_eq!(from, "claude:abc");
+        assert_eq!(project, "proj");
+        assert_eq!(cwd, "/home/a");
+        assert_eq!(message, "hello there");
+    }
+
+    #[test]
+    fn parse_threaded_five_field_signal_drops_re_id() {
+        // sensor-peers doesn't currently use the re: id — the parse helper
+        // strips it so the sensor's notification text stays clean.
+        let (_, _, _, message) = parse_signal(
+            "claude:abc|proj|/home/a|re:claude-abc-1743280000|reply body"
+        ).unwrap();
+        assert_eq!(message, "reply body");
+    }
+
+    #[test]
+    fn parse_preserves_pipes_in_legacy_message_tail() {
+        // The tail is splitn(4)-captured, so any pipes inside `message`
+        // stay intact — important when users paste markdown tables etc.
+        let (_, _, _, message) =
+            parse_signal("claude:abc|proj|/home/a|col1 | col2 | col3").unwrap();
+        assert_eq!(message, "col1 | col2 | col3");
+    }
+
+    #[test]
+    fn parse_preserves_pipes_in_threaded_message_tail() {
+        let (_, _, _, message) =
+            parse_signal("claude:abc|proj|/home/a|re:id-42|col1 | col2").unwrap();
+        assert_eq!(message, "col1 | col2");
+    }
+
+    #[test]
+    fn parse_rejects_fewer_than_four_fields() {
+        assert!(parse_signal("only|three|fields").is_none());
+        assert!(parse_signal("").is_none());
+    }
+
+    #[test]
+    fn parse_malformed_re_prefix_without_pipe_falls_back_to_raw_tail() {
+        // A `re:` prefix with no `|message` following is malformed —
+        // degrade to rendering the whole tail so the signal still shows
+        // up instead of vanishing.
+        let (_, _, _, message) =
+            parse_signal("claude:abc|proj|/home/a|re:alone").unwrap();
+        assert_eq!(message, "re:alone");
+    }
+
+    #[test]
+    fn parse_accepts_empty_reply_id() {
+        // Empty `re:` ID is odd but legal — the parser still yields
+        // the message field cleanly.
+        let (_, _, _, message) =
+            parse_signal("claude:abc|proj|/home/a|re:|body").unwrap();
+        assert_eq!(message, "body");
     }
 }

--- a/tools/sensor-peers/src/lib.rs
+++ b/tools/sensor-peers/src/lib.rs
@@ -850,28 +850,41 @@ fn chunk_message(message: &str, chunk_size: usize, max_chunks: usize) -> Vec<Str
     chunks
 }
 
+/// Signal IDs are filename stems in the form `<sender-id>-<timestamp>`,
+/// always `[A-Za-z0-9_-]+`. Used as the discriminator fence for the `re:`
+/// prefix so legacy prose like "re: the thing we discussed" doesn't get
+/// misparsed as threaded. Must stay in lockstep with the equivalent
+/// helper in `attend::main::is_valid_signal_id`.
+fn is_valid_signal_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
 /// Parsed signal tuple: `(from, project, cwd, message)`.
 ///
 /// Accepts both the legacy 4-field format (`from|project|cwd|message`) and
 /// the 5-field threaded format (`from|project|cwd|re:signal-id|message`,
-/// ADR-120). The discriminator is a literal `re:` prefix on the field
-/// following `cwd`. The threading id itself is dropped at parse time —
-/// the peer sensor doesn't currently render thread context. If that
-/// changes (e.g., a "replying to …" notification header), widen the
-/// return type instead of re-parsing downstream.
+/// ADR-120). The discriminator is a `re:<id>|` prefix on the field
+/// following `cwd` where `<id>` matches `is_valid_signal_id`. A malformed
+/// or ambiguous `re:` prefix degrades to legacy interpretation so real
+/// prose round-trips cleanly.
+///
+/// The threading id itself is dropped at parse time — the peer sensor
+/// doesn't currently render thread context. If that changes (e.g., a
+/// "replying to …" notification header), widen the return type instead
+/// of re-parsing downstream.
 pub(crate) fn parse_signal(content: &str) -> Option<(&str, &str, &str, &str)> {
     let parts: Vec<&str> = content.splitn(4, '|').collect();
     if parts.len() < 4 {
         return None;
     }
     let tail = parts[3];
-    let message = if let Some(rest) = tail.strip_prefix("re:") {
-        // Threaded: drop the `re:id|` prefix if well-formed; degrade to
-        // the raw tail otherwise so the signal still renders instead of
-        // vanishing on a malformed emitter.
-        rest.split_once('|').map(|(_id, msg)| msg).unwrap_or(tail)
-    } else {
-        tail
+    let message = match tail.strip_prefix("re:").and_then(|rest| rest.split_once('|')) {
+        Some((id, msg)) if is_valid_signal_id(id) => msg,
+        // Either not threaded or the `re:` prefix is followed by text
+        // that doesn't look like a signal id — render the raw tail so
+        // legacy prose stays intact.
+        _ => tail,
     };
     Some((parts[0], parts[1], parts[2], message))
 }
@@ -1009,11 +1022,33 @@ mod tests {
     }
 
     #[test]
-    fn parse_accepts_empty_reply_id() {
-        // Empty `re:` ID is odd but legal — the parser still yields
-        // the message field cleanly.
+    fn parse_rejects_empty_reply_id() {
+        // Empty `re:` ID fails the is_valid_signal_id fence — the tail
+        // is rendered raw so the recipient still sees something instead
+        // of getting a silent drop.
         let (_, _, _, message) =
             parse_signal("claude:abc|proj|/home/a|re:|body").unwrap();
-        assert_eq!(message, "body");
+        assert_eq!(message, "re:|body");
+    }
+
+    #[test]
+    fn parse_legacy_re_prose_falls_back_to_message() {
+        // Regression fence: a legacy sender writing prose that happens
+        // to start with "re:" must not be mistaken for a threaded reply.
+        // The id candidate "the thing we discussed" has a space, which
+        // fails is_valid_signal_id, so we render the whole tail.
+        let (_, _, _, message) = parse_signal(
+            "claude:abc|proj|/home/a|re: the thing we discussed|still open"
+        ).unwrap();
+        assert_eq!(message, "re: the thing we discussed|still open");
+    }
+
+    #[test]
+    fn parse_rejects_id_with_non_word_chars() {
+        // A re: prefix with what looks like a real id except it contains
+        // whitespace or punctuation other than `-`/`_` also falls back.
+        let (_, _, _, message) =
+            parse_signal("claude:abc|proj|/home/a|re:has spaces|body").unwrap();
+        assert_eq!(message, "re:has spaces|body");
     }
 }


### PR DESCRIPTION
Closes #24.

## Summary

Adds the `re:` threading field to attend's signal wire format, as specified in ADR-120 and documented in `docs/attend-and-monitor/signals.md`. Purely additive: unthreaded sends stay byte-identical to the pre-ADR-120 4-field format, so old senders/readers interoperate with new ones in both directions.

### Writer (`attend send`)

- New `--re <signal-id>` flag that takes the target signal's ID (filename stem, e.g. `claude-abc-1743280000`).
- When set, emits `from|project|cwd|re:<id>|message`; otherwise emits the legacy `from|project|cwd|message`.
- Rejects `|` in the id at parse time — that would corrupt the wire format.
- `--re` composes with `--to`, `--focus`, and `--broadcast`.

### Reader

**sensor-peers** (`tools/sensor-peers/src/lib.rs`):
- New private `parse_signal()` helper that returns a `(from, project, cwd, message)` tuple. Handles both shapes and strips the `re:id|` prefix at parse time. The peer sensor doesn't currently render thread context, so the id is dropped there — if we later want a "replying to …" notification header, we widen the return type instead of re-parsing downstream.
- 7 new unit tests: legacy, threaded, pipes-in-tail (both shapes), malformed `re:` fallback, empty reply id, too-few-fields.

**attend inbox** / **attend inbox read** (`tools/attend/src/main.rs`):
- New private `parse_signal()` with a `ParsedSignal` struct that keeps `reply_to`, so `attend inbox read <id>` prints a `Re: <id>` line under the header when present.
- `attend inbox` now exposes the filename-stem ID as a column in both the legacy and threaded table variants, formalizing the filename as the authoritative signal ID per the issue description.
- When any entry in the inbox is threaded, the table gains a `Re` column; otherwise the compact 4-column layout is preserved to avoid bloating the common case.

### Docs

- `docs/attend-and-monitor/signals.md` Phase 1 description now mentions `--re` as composing with the routing flags. The wire format section at the top already documented the threaded form.

## Design notes

- **Parse rule**: `splitn(4, '|')`, then inspect the tail (parts\[3\]). If it starts with `re:`, split it once on `|` to recover (id, message); if not, the whole tail is the message. This preserves any `|` characters *inside* the message body — important for users pasting markdown tables or similar.
- **No ParsedSignal sharing across crates.** Two ~15-line helpers live in attend and sensor-peers respectively, with different return shapes because the call sites need different fields. A shared crate for this would be more abstraction than the task warrants.
- **Backward compat is the emit default.** Unthreaded sends never emit an empty `re:` field — they stay 4-field. This keeps the migration truly zero-touch for downstream tools that still only understand the legacy shape.

## Test plan

- [x] `cargo test --manifest-path tools/Cargo.toml -p sensor-peers` — 15 pass (8 pre-existing chunk tests + 7 new parse tests)
- [x] `cargo test --manifest-path tools/Cargo.toml -p attend` — 5 pass
- [x] `cargo clippy --manifest-path tools/Cargo.toml --workspace --all-targets -- -D warnings` passes
- [x] Rebased on the updated main from #30 (clippy gate), so this PR is the first test of the new gate on real feature work
- [ ] CI green (per-PR clippy gate + per-crate tests)
- [ ] Manual smoke: `attend send --re <id> "reply"` round-trips through `attend inbox` and `attend inbox read <new-id>` showing the `Re:` line (not blocking; format is unit-tested end-to-end)