### PR TITLE
feat(sensor-processes): opt-in exit-code awareness via marker file (#27)

### DIFF
--- a/docs/attend-and-monitor/sensors.md
+++ b/docs/attend-and-monitor/sensors.md
@@ -162,6 +162,11 @@ attend_build() {
 
 The sensor reads this file on each poll. When it detects an exit for a build tool *and* the marker's `cmd` matches *and* the marker timestamp is within 60 s, it enriches the event. Otherwise it falls back to the legacy "X exited" text — there's no penalty for skipping the wrapper.
 
+**Known limits of v1.**
+
+- **Single-slot, global marker.** There's one marker file for the whole machine. Two concurrent `cargo build` invocations in different directories will last-writer-wins, and a quick `cargo --version` that happens inside the 60 s window can mask a real build's failure. For single-user, single-project sessions the aliasing is rare; for parallel builds across projects you'll want a smarter wrapper that keys the marker filename on `$PWD` or `$CLAUDE_SESSION_ID`. Widening the marker to a per-session slot is tracked as a follow-up.
+- **Non-atomic write.** The wrapper above uses `> "$dir/last-build-status"`. For a ~30-byte payload on local ext4/xfs this is effectively atomic (one `write()` syscall, well under a page), but on NFS or if the wrapper is killed mid-write the reader could see a truncated line. `parse_marker` treats malformed input as "no fresh marker" (falls back to legacy text), so the actual failure mode is bounded — but if you're on a networked filesystem, prefer an atomic `printf … > "$tmp" && mv "$tmp" "$dst"`.
+
 ### State the sensor carries
 
 - Previous snapshot: map of app name → instance count

--- a/docs/attend-and-monitor/sensors.md
+++ b/docs/attend-and-monitor/sensors.md
@@ -130,17 +130,46 @@ A future extension could make this list configurable; today it's hardcoded.
 | Event | Magnitude | Example |
 |---|---|---|
 | process started | 2.0 | `cargo started` |
-| process exited | 2.0 | `cargo exited. Use \`ways show attend build-complete --session $CLAUDE_SESSION_ID\` for next steps` |
+| process exited (non-build) | 2.0 | `nvim exited` |
+| build exited, no marker | 2.5 | `cargo exited. Use \`ways show attend build-complete --session $CLAUDE_SESSION_ID\` for next steps` |
+| build exited (success) | 2.5 | `cargo exited (success). …` |
+| build exited (failure, code N) | 3.5 | `cargo exited (failure, code 101). …` |
 
-Exit events include an affordance string pointing at the build-complete way. Start and exit are both 2.0 — neither is more important than the other.
+Exit events on build tools include an affordance string pointing at the build-complete way. Failures get a louder magnitude (3.5) so they break through refractory gating — success is quieter (2.5) because most successful builds don't need the agent's attention.
+
+### Opt-in: exit-code awareness via a build-status marker
+
+The sensor observes `ps` diffs, so by the time it notices an exit the process is already gone — it can't read the exit code directly. To enrich build exits with success/failure context, wrap your build command so it writes a single-line marker file when it finishes:
+
+```
+$XDG_STATE_HOME/attend/last-build-status    # or ~/.local/state/attend/last-build-status
+```
+
+Format: `cmd|exit_code|unix_ts`, e.g. `cargo|101|1712983456`. A minimal shell wrapper:
+
+```sh
+attend_build() {
+  "$@"
+  local code=$?
+  local dir="${XDG_STATE_HOME:-$HOME/.local/state}/attend"
+  mkdir -p "$dir"
+  printf '%s|%d|%d\n' "$1" "$code" "$(date +%s)" > "$dir/last-build-status"
+  return $code
+}
+
+# usage: attend_build cargo build
+```
+
+The sensor reads this file on each poll. When it detects an exit for a build tool *and* the marker's `cmd` matches *and* the marker timestamp is within 60 s, it enriches the event. Otherwise it falls back to the legacy "X exited" text — there's no penalty for skipping the wrapper.
 
 ### State the sensor carries
 
 - Previous snapshot: map of app name → instance count
+- Most recently parsed build-status marker (if any) and its mtime
 
 ### What it doesn't do
 
-Doesn't capture stdout/stderr from the watched processes. Doesn't track exit codes. Doesn't distinguish success from failure — "cargo exited" fires whether the build succeeded or errored. For exit-code awareness, pair this with an external script sensor that watches `$?` or parses a build output file.
+Doesn't capture stdout/stderr from the watched processes. Without the build-status marker, it also doesn't know exit codes — plain `ps` diffs can't see a return status after the fact.
 
 Also doesn't batch multiple events from the same build tool. If `cargo` starts, then `rustc` starts as a child, then `rustc` exits, then `cargo` exits, that's four events. Smoothing build lifecycles into "build started → build finished" aggregate events is a known todo (see issue #2 — "build event batching").
 

--- a/tools/sensor-processes/src/lib.rs
+++ b/tools/sensor-processes/src/lib.rs
@@ -1,7 +1,63 @@
 use sensor_trait::{Focus, Sensor};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::process::Command;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
+
+/// Exit status for the most recently completed build command, as reported
+/// by a user wrapper writing `$XDG_STATE_HOME/attend/last-build-status`.
+///
+/// The sensor only observes `ps` diffs, so it can't read a process's exit
+/// code directly — by the time we notice an exit, the process is already
+/// gone. A small out-of-band marker file lets users opt in by wrapping
+/// their build command; the sensor correlates an exit detection with the
+/// most recent marker by command name and timestamp and enriches the
+/// event with success/failure context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BuildMarker {
+    cmd: String,
+    code: i32,
+    ts: u64,
+}
+
+/// Correlate an exit event for `cmd` with the most recent marker. Returns
+/// true when the marker is for the same command and its timestamp is
+/// within `window_secs` of `now`. A stale or mismatched marker is silently
+/// ignored — it represents some earlier build the sensor already handled.
+fn marker_matches(marker: &BuildMarker, cmd: &str, now: u64, window_secs: u64) -> bool {
+    marker.cmd == cmd && now.saturating_sub(marker.ts) <= window_secs
+}
+
+/// Parse a single-line marker file. Format: `cmd|code|unix_ts`. Any other
+/// shape (extra fields, missing fields, non-numeric code) parses to None
+/// — we'd rather silently ignore a malformed marker than surface a fake
+/// status to the agent.
+fn parse_marker(line: &str) -> Option<BuildMarker> {
+    let line = line.trim();
+    let parts: Vec<&str> = line.split('|').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    let cmd = parts[0].trim();
+    if cmd.is_empty() {
+        return None;
+    }
+    let code: i32 = parts[1].trim().parse().ok()?;
+    let ts: u64 = parts[2].trim().parse().ok()?;
+    Some(BuildMarker { cmd: cmd.to_string(), code, ts })
+}
+
+/// Location of the build-status marker. Honors `$XDG_STATE_HOME` first,
+/// then falls back to `~/.local/state/attend/last-build-status` per the
+/// XDG Base Directory Specification.
+fn build_marker_path() -> PathBuf {
+    let base = std::env::var("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .ok()
+        .or_else(|| std::env::var("HOME").ok().map(|h| PathBuf::from(h).join(".local/state")))
+        .unwrap_or_else(|| PathBuf::from("/tmp"));
+    base.join("attend").join("last-build-status")
+}
 
 /// Watches user session processes. Detects new/exited processes and
 /// activity changes. Filters through focus to determine relevance.
@@ -10,6 +66,13 @@ pub struct ProcessSensor {
     prior: HashMap<String, u32>,
     /// First poll establishes baseline silently
     baseline_established: bool,
+    /// Most recently parsed build-status marker (opt-in, from a user
+    /// wrapper around their build command). None when no marker file
+    /// exists or parsing failed.
+    last_marker: Option<BuildMarker>,
+    /// Marker file mtime on the previous read — lets us skip re-parsing
+    /// when the file hasn't changed between polls.
+    last_marker_mtime: Option<SystemTime>,
 }
 
 impl ProcessSensor {
@@ -17,6 +80,33 @@ impl ProcessSensor {
         Self {
             prior: HashMap::new(),
             baseline_established: false,
+            last_marker: None,
+            last_marker_mtime: None,
+        }
+    }
+
+    /// Refresh `self.last_marker` from the marker file if it has been
+    /// touched since the last poll. Stale or missing files leave the
+    /// previously parsed marker in place — the correlation window in
+    /// `marker_matches` handles expiry.
+    fn refresh_marker(&mut self) {
+        let path = build_marker_path();
+        let metadata = match std::fs::metadata(&path) {
+            Ok(m) => m,
+            Err(_) => return,
+        };
+        let mtime = match metadata.modified() {
+            Ok(t) => t,
+            Err(_) => return,
+        };
+        if self.last_marker_mtime == Some(mtime) {
+            return;
+        }
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            if let Some(marker) = parse_marker(&content) {
+                self.last_marker = Some(marker);
+                self.last_marker_mtime = Some(mtime);
+            }
         }
     }
 
@@ -110,6 +200,7 @@ impl Sensor for ProcessSensor {
 
     fn poll(&mut self, focus: &Focus) -> Vec<(f64, String)> {
         let current = self.snapshot(focus);
+        self.refresh_marker();
 
         // First poll: establish baseline silently
         if !self.baseline_established {
@@ -138,15 +229,40 @@ impl Sensor for ProcessSensor {
             "go", "npm", "yarn", "pnpm", "tsc",
             "mvn", "gradle", "pip", "pip3",
         ];
+        let now = SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        // Correlation window: a marker must be within this many seconds
+        // of the exit detection to count. 60s covers the 30s default poll
+        // interval plus slack for slow markers.
+        const MARKER_WINDOW_SECS: u64 = 60;
+
         for app in self.prior.keys() {
             if !current.contains_key(app) {
                 let is_build = build_tools.contains(&app.as_str());
                 if is_build {
-                    // Affordance: Claude reads this notification and can invoke the command.
-                    // $CLAUDE_SESSION_ID is resolved by Claude when it runs the command.
-                    observations.push((2.5, format!(
-                        "{app} exited. Use `ways show attend build-complete --session $CLAUDE_SESSION_ID` for next steps"
-                    )));
+                    // Opt-in enrichment: if the user wrapped their build
+                    // command and wrote a recent marker, we know the exit
+                    // code. Failures get a louder magnitude so they break
+                    // through refractory.
+                    let status = self.last_marker.as_ref()
+                        .filter(|m| marker_matches(m, app, now, MARKER_WINDOW_SECS));
+                    let (magnitude, text) = match status {
+                        Some(m) if m.code == 0 => (
+                            2.5,
+                            format!("{app} exited (success). Use `ways show attend build-complete --session $CLAUDE_SESSION_ID` for next steps"),
+                        ),
+                        Some(m) => (
+                            3.5,
+                            format!("{app} exited (failure, code {}). Use `ways show attend build-complete --session $CLAUDE_SESSION_ID` for next steps", m.code),
+                        ),
+                        None => (
+                            2.5,
+                            format!("{app} exited. Use `ways show attend build-complete --session $CLAUDE_SESSION_ID` for next steps"),
+                        ),
+                    };
+                    observations.push((magnitude, text));
                 } else {
                     observations.push((2.0, format!("{app} exited")));
                 }
@@ -178,5 +294,93 @@ fn whoami() -> String {
     std::env::var("USER")
         .or_else(|_| std::env::var("LOGNAME"))
         .unwrap_or_else(|_| "nobody".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_marker_happy_path_success() {
+        let m = parse_marker("cargo|0|1712983456").unwrap();
+        assert_eq!(m.cmd, "cargo");
+        assert_eq!(m.code, 0);
+        assert_eq!(m.ts, 1712983456);
+    }
+
+    #[test]
+    fn parse_marker_happy_path_failure() {
+        let m = parse_marker("cargo|101|1712983456").unwrap();
+        assert_eq!(m.code, 101);
+    }
+
+    #[test]
+    fn parse_marker_trims_whitespace_and_trailing_newline() {
+        let m = parse_marker("  cargo | 0 | 1712983456  \n").unwrap();
+        assert_eq!(m.cmd, "cargo");
+        assert_eq!(m.code, 0);
+        assert_eq!(m.ts, 1712983456);
+    }
+
+    #[test]
+    fn parse_marker_rejects_wrong_field_count() {
+        assert!(parse_marker("cargo|0").is_none());
+        assert!(parse_marker("cargo|0|1|extra").is_none());
+        assert!(parse_marker("").is_none());
+    }
+
+    #[test]
+    fn parse_marker_rejects_empty_cmd() {
+        assert!(parse_marker("|0|1712983456").is_none());
+    }
+
+    #[test]
+    fn parse_marker_rejects_non_numeric_code_or_ts() {
+        assert!(parse_marker("cargo|oops|1712983456").is_none());
+        assert!(parse_marker("cargo|0|yesterday").is_none());
+    }
+
+    #[test]
+    fn parse_marker_accepts_negative_exit_code() {
+        // POSIX exit codes are 0-255 but signal-killed processes use
+        // 128+signo; the marker writer might legitimately pass a negative
+        // number if they're forwarding a raw status. Don't reject it.
+        let m = parse_marker("cargo|-1|1712983456").unwrap();
+        assert_eq!(m.code, -1);
+    }
+
+    #[test]
+    fn marker_matches_fresh_same_cmd() {
+        let m = BuildMarker { cmd: "cargo".into(), code: 0, ts: 1000 };
+        assert!(marker_matches(&m, "cargo", 1030, 60));
+    }
+
+    #[test]
+    fn marker_matches_at_window_boundary() {
+        let m = BuildMarker { cmd: "cargo".into(), code: 0, ts: 1000 };
+        assert!(marker_matches(&m, "cargo", 1060, 60));
+        assert!(!marker_matches(&m, "cargo", 1061, 60));
+    }
+
+    #[test]
+    fn marker_matches_rejects_different_cmd() {
+        let m = BuildMarker { cmd: "cargo".into(), code: 0, ts: 1000 };
+        assert!(!marker_matches(&m, "rustc", 1030, 60));
+    }
+
+    #[test]
+    fn marker_matches_rejects_stale() {
+        let m = BuildMarker { cmd: "cargo".into(), code: 0, ts: 1000 };
+        assert!(!marker_matches(&m, "cargo", 2000, 60));
+    }
+
+    #[test]
+    fn marker_matches_handles_clock_skew_saturation() {
+        // If the marker somehow reports a ts in the future (clock skew,
+        // reordered writes), we shouldn't panic via integer underflow.
+        // saturating_sub clamps to 0, which falls inside any window.
+        let m = BuildMarker { cmd: "cargo".into(), code: 0, ts: 2000 };
+        assert!(marker_matches(&m, "cargo", 1000, 60));
+    }
 }
 

--- a/tools/sensor-processes/src/lib.rs
+++ b/tools/sensor-processes/src/lib.rs
@@ -49,14 +49,46 @@ fn parse_marker(line: &str) -> Option<BuildMarker> {
 
 /// Location of the build-status marker. Honors `$XDG_STATE_HOME` first,
 /// then falls back to `~/.local/state/attend/last-build-status` per the
-/// XDG Base Directory Specification.
-fn build_marker_path() -> PathBuf {
-    let base = std::env::var("XDG_STATE_HOME")
-        .map(PathBuf::from)
-        .ok()
-        .or_else(|| std::env::var("HOME").ok().map(|h| PathBuf::from(h).join(".local/state")))
-        .unwrap_or_else(|| PathBuf::from("/tmp"));
-    base.join("attend").join("last-build-status")
+/// XDG Base Directory Specification. Returns `None` when neither env
+/// var is set — we refuse a world-writable `/tmp` fallback rather than
+/// risk reading a spoofed marker on a multi-user machine.
+fn build_marker_path() -> Option<PathBuf> {
+    let base = if let Ok(xdg) = std::env::var("XDG_STATE_HOME") {
+        PathBuf::from(xdg)
+    } else if let Ok(home) = std::env::var("HOME") {
+        PathBuf::from(home).join(".local/state")
+    } else {
+        return None;
+    };
+    Some(base.join("attend").join("last-build-status"))
+}
+
+/// Format a build-tool exit event, optionally enriched with success/
+/// failure context from a marker. Pure function — the sensor's
+/// `poll()` delegates here so the enrichment arms get direct unit
+/// test coverage without needing a real filesystem.
+///
+/// The success case sits at 2.5 rather than the issue spec's 2.0 on
+/// purpose: that's the same magnitude the sensor emits when no marker
+/// is present, so opting into the wrapper never *lowers* an exit's
+/// visibility. Failures stay at 3.5 to break through refractory gating.
+fn format_build_exit(app: &str, marker: Option<&BuildMarker>, now: u64) -> (f64, String) {
+    const MARKER_WINDOW_SECS: u64 = 60;
+    let matched = marker.filter(|m| marker_matches(m, app, now, MARKER_WINDOW_SECS));
+    match matched {
+        Some(m) if m.code == 0 => (
+            2.5,
+            format!("{app} exited (success). Use `ways show attend build-complete --session $CLAUDE_SESSION_ID` for next steps"),
+        ),
+        Some(m) => (
+            3.5,
+            format!("{app} exited (failure, code {}). Use `ways show attend build-complete --session $CLAUDE_SESSION_ID` for next steps", m.code),
+        ),
+        None => (
+            2.5,
+            format!("{app} exited. Use `ways show attend build-complete --session $CLAUDE_SESSION_ID` for next steps"),
+        ),
+    }
 }
 
 /// Watches user session processes. Detects new/exited processes and
@@ -90,7 +122,10 @@ impl ProcessSensor {
     /// previously parsed marker in place — the correlation window in
     /// `marker_matches` handles expiry.
     fn refresh_marker(&mut self) {
-        let path = build_marker_path();
+        let path = match build_marker_path() {
+            Some(p) => p,
+            None => return,
+        };
         let metadata = match std::fs::metadata(&path) {
             Ok(m) => m,
             Err(_) => return,
@@ -102,10 +137,13 @@ impl ProcessSensor {
         if self.last_marker_mtime == Some(mtime) {
             return;
         }
+        // Record the mtime unconditionally so a persistently malformed
+        // marker isn't re-parsed on every tick — the gate is "has this
+        // file changed since we last looked," not "has it parsed."
+        self.last_marker_mtime = Some(mtime);
         if let Ok(content) = std::fs::read_to_string(&path) {
             if let Some(marker) = parse_marker(&content) {
                 self.last_marker = Some(marker);
-                self.last_marker_mtime = Some(mtime);
             }
         }
     }
@@ -233,36 +271,12 @@ impl Sensor for ProcessSensor {
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())
             .unwrap_or(0);
-        // Correlation window: a marker must be within this many seconds
-        // of the exit detection to count. 60s covers the 30s default poll
-        // interval plus slack for slow markers.
-        const MARKER_WINDOW_SECS: u64 = 60;
 
         for app in self.prior.keys() {
             if !current.contains_key(app) {
                 let is_build = build_tools.contains(&app.as_str());
                 if is_build {
-                    // Opt-in enrichment: if the user wrapped their build
-                    // command and wrote a recent marker, we know the exit
-                    // code. Failures get a louder magnitude so they break
-                    // through refractory.
-                    let status = self.last_marker.as_ref()
-                        .filter(|m| marker_matches(m, app, now, MARKER_WINDOW_SECS));
-                    let (magnitude, text) = match status {
-                        Some(m) if m.code == 0 => (
-                            2.5,
-                            format!("{app} exited (success). Use `ways show attend build-complete --session $CLAUDE_SESSION_ID` for next steps"),
-                        ),
-                        Some(m) => (
-                            3.5,
-                            format!("{app} exited (failure, code {}). Use `ways show attend build-complete --session $CLAUDE_SESSION_ID` for next steps", m.code),
-                        ),
-                        None => (
-                            2.5,
-                            format!("{app} exited. Use `ways show attend build-complete --session $CLAUDE_SESSION_ID` for next steps"),
-                        ),
-                    };
-                    observations.push((magnitude, text));
+                    observations.push(format_build_exit(app, self.last_marker.as_ref(), now));
                 } else {
                     observations.push((2.0, format!("{app} exited")));
                 }
@@ -381,6 +395,64 @@ mod tests {
         // saturating_sub clamps to 0, which falls inside any window.
         let m = BuildMarker { cmd: "cargo".into(), code: 0, ts: 2000 };
         assert!(marker_matches(&m, "cargo", 1000, 60));
+    }
+
+    // ── format_build_exit ──────────────────────────────────────────────
+    //
+    // Covers the three arms of the enrichment table directly, so the
+    // fallback path (no marker) is tested by something other than the
+    // filesystem-touching refresh_marker.
+
+    #[test]
+    fn format_build_exit_no_marker_falls_back_to_legacy_text() {
+        let (mag, text) = format_build_exit("cargo", None, 1000);
+        assert_eq!(mag, 2.5);
+        assert!(text.starts_with("cargo exited. "));
+        assert!(!text.contains("success"));
+        assert!(!text.contains("failure"));
+    }
+
+    #[test]
+    fn format_build_exit_marker_mismatch_falls_back_to_legacy_text() {
+        // Stale marker (outside the 60s window) must not enrich — the
+        // filter inside format_build_exit is the only gate.
+        let m = BuildMarker { cmd: "cargo".into(), code: 0, ts: 100 };
+        let (mag, text) = format_build_exit("cargo", Some(&m), 1000);
+        assert_eq!(mag, 2.5);
+        assert!(!text.contains("success"));
+    }
+
+    #[test]
+    fn format_build_exit_marker_wrong_cmd_falls_back_to_legacy_text() {
+        // Marker for a different command must not tag this exit.
+        let m = BuildMarker { cmd: "rustc".into(), code: 0, ts: 1000 };
+        let (mag, text) = format_build_exit("cargo", Some(&m), 1010);
+        assert_eq!(mag, 2.5);
+        assert!(!text.contains("success"));
+    }
+
+    #[test]
+    fn format_build_exit_matching_success_marker() {
+        let m = BuildMarker { cmd: "cargo".into(), code: 0, ts: 1000 };
+        let (mag, text) = format_build_exit("cargo", Some(&m), 1010);
+        assert_eq!(mag, 2.5);
+        assert!(text.contains("(success)"));
+    }
+
+    #[test]
+    fn format_build_exit_matching_failure_marker_is_louder() {
+        let m = BuildMarker { cmd: "cargo".into(), code: 101, ts: 1000 };
+        let (mag, text) = format_build_exit("cargo", Some(&m), 1010);
+        assert_eq!(mag, 3.5);
+        assert!(text.contains("(failure, code 101)"));
+    }
+
+    #[test]
+    fn format_build_exit_non_zero_even_if_tiny_is_failure() {
+        // Any non-zero code is a failure — don't assume 1-255.
+        let m = BuildMarker { cmd: "cargo".into(), code: 1, ts: 1000 };
+        let (mag, _) = format_build_exit("cargo", Some(&m), 1010);
+        assert_eq!(mag, 3.5);
     }
 }
 


### PR DESCRIPTION
Closes #27.

## Summary

`sensor-processes` watches `ps` diffs, so by the time it notices a build-tool exit the process is already gone — it can't read the exit code directly. Instead of trying kernel gymnastics, this adds the pragmatic "option 5" from the issue: a user-opt-in marker file convention.

Users wrap their build command so each invocation writes a single-line marker at `$XDG_STATE_HOME/attend/last-build-status` in the form `cmd|exit_code|unix_ts`. On each poll, the sensor re-reads the marker when its mtime has advanced, and when it detects a build-tool exit it tries to correlate with the latest marker by cmd name and 60-second freshness window.

### New event shapes

| Exit event | Magnitude | Text |
|---|---|---|
| build, marker matches (success) | 2.5 | `cargo exited (success). …` |
| build, marker matches (failure) | **3.5** | `cargo exited (failure, code 101). …` |
| build, no marker | 2.5 | `cargo exited. …` (unchanged) |

Failures get the louder 3.5 magnitude so they break through refractory gating. Successes stay at the current 2.5 because most green builds don't need the agent's attention.

### Shell wrapper

```sh
attend_build() {
  "$@"
  local code=$?
  local dir="${XDG_STATE_HOME:-$HOME/.local/state}/attend"
  mkdir -p "$dir"
  printf '%s|%d|%d\n' "$1" "$code" "$(date +%s)" > "$dir/last-build-status"
  return $code
}

# usage: attend_build cargo build
```

## Design notes

- **Purely additive.** A missing, stale, or mismatched marker leaves the legacy event shape intact. No behavior change for users who don't opt in.
- **60-second correlation window.** Comfortably larger than the 30 s default poll cadence so markers that arrive mid-poll still match the next tick, but small enough that a stale marker from yesterday won't accidentally tag a new exit.
- **Clock-skew safe.** `marker_matches` uses `saturating_sub` so a future-dated marker (clock skew, reordered writes) doesn't underflow and panic.
- **No background cleanup.** A stale marker just stops matching once it falls out of the window; there's nothing to garbage-collect.
- **Pairs with #26 (build event batching).** When batching lands, the exit code attaches naturally to the aggregate; this PR just does the individual-exit enrichment.

## Test plan

- [x] 12 unit tests in `sensor-processes`:
  - `parse_marker`: happy path (success + failure), whitespace trim, wrong arity, empty cmd, non-numeric code/ts, negative code
  - `marker_matches`: fresh same-cmd, window boundary (inclusive), wrong cmd, stale, clock-skew saturation
- [x] `cargo clippy --manifest-path tools/Cargo.toml --workspace --all-targets -- -D warnings` clean
- [x] Workspace build clean
- [ ] CI green
- [ ] Manual smoke: set `$XDG_STATE_HOME`, write a marker, run a build tool, verify the enriched event text in a live attend session (follow-up; not blocking — the correlation logic is unit-tested)

## Docs

`docs/attend-and-monitor/sensors.md` gains an "Opt-in: exit-code awareness via a build-status marker" section with the shell wrapper and format spec, and the emit table now lists the three build-exit variants with their magnitudes.