### PR TITLE
feat(sensor-processes): configurable watch list (#28)

### DIFF
--- a/docs/attend-and-monitor/configuration.md
+++ b/docs/attend-and-monitor/configuration.md
@@ -182,6 +182,10 @@ All sensors (built-in or script) accept:
 - **`script`** (path, script sensors only): path to the executable
 - **`requires`** (list): permission strings audited against `settings.json` (ADR-116)
 
+Some sensors accept additional sensor-specific keys:
+
+- **`processes.watch`** (list): overrides the default build-tool watch list. Only processes on this list get exit-code enrichment (success/failure magnitudes, marker correlation); everything else produces a plain `X exited`. Explicit-replace — passing `watch:` drops the defaults. See [`sensors.md`](sensors.md#watched-processes) for the default list and format examples.
+
 ## Overlay semantics
 
 The overlay layers project-scope on top of user-scope. For each setting:
@@ -242,8 +246,9 @@ Attend's YAML parser is deliberately minimal — it's a hand-written subset that
 
 - Two-level section headers (`governor:`, `engagement:`, `sensors:`)
 - Four-space indent for sensor properties
-- Inline arrays for `requires:` (`requires: [Bash(gh:*), Read]`)
-- Comments (`#`) and blank lines
+- Inline arrays (`requires: [Bash(gh:*), Read]`, `watch: [cargo, mix]`)
+- Block-form lists on a new line (`requires:` followed by indented `- item` lines) for `requires:` and `watch:`
+- Comments (`#`) and blank lines (they don't terminate a block-form list)
 - `+name:` and `-name:` sensor prefixes
 
 It does **not** support:

--- a/docs/attend-and-monitor/sensors.md
+++ b/docs/attend-and-monitor/sensors.md
@@ -116,6 +116,8 @@ Tracks specific dev-tool processes running under the user's session. Not a gener
 
 ### Watched processes
 
+The sensor enriches a specific list of build/dev tools with "exited (success/failure)" events. The default list covers common toolchains:
+
 ```
 cargo, rustc, make, cmake, ninja,
 gcc, g++, cc, c++, clang, clang++,
@@ -123,7 +125,30 @@ go, npm, yarn, pnpm, tsc,
 mvn, gradle, pip, pip3
 ```
 
-A future extension could make this list configurable; today it's hardcoded.
+Any process *not* on this list still produces a plain `X exited` at magnitude 2.0 when it disappears from the snapshot — the watch list only controls who gets the marker-correlated enrichment (success/failure codes, louder magnitudes). Process **start** events are not gated by the watch list.
+
+**Overriding the list.** Set `sensors.processes.watch:` in your attend config. Both YAML shapes are accepted:
+
+```yaml
+sensors:
+  processes:
+    watch:
+      - cargo
+      - rustc
+      - mix          # elixir
+      - zig
+      - ./build.sh
+```
+
+Or inline:
+
+```yaml
+sensors:
+  processes:
+    watch: [cargo, rustc, mix, zig]
+```
+
+The explicit list **replaces** the defaults verbatim — no merging. If you want the defaults plus one extra entry, you list all of them. If you want to disable enrichment entirely, pass an empty list (`watch: []`). This contract makes the config the single source of truth: what you write is what the sensor runs.
 
 ### What it emits
 

--- a/tools/attend/src/config.rs
+++ b/tools/attend/src/config.rs
@@ -693,4 +693,37 @@ mod tests {
             vec!["cargo", "mix"]
         );
     }
+
+    #[test]
+    fn block_list_terminates_across_sensor_boundary() {
+        // Regression test flagged in code review: a block-form list in
+        // one sensor block must not bleed into the next sensor block
+        // when they're adjacent. The new sensor line clears
+        // `current_list_key` via the "any other line" path before
+        // `current_sensor` is reassigned.
+        let mut cfg = Config::default();
+        apply_config(
+            &mut cfg,
+            // processes.watch ends on the blank before git.requires
+            "sensors:\n  \
+             processes:\n    \
+             watch:\n      \
+             - cargo\n      \
+             - rustc\n  \
+             git:\n    \
+             requires:\n      \
+             - Bash(git:*)\n      \
+             - Read\n",
+        );
+        let processes = cfg.sensors.get("processes").unwrap();
+        let git = cfg.sensors.get("git").unwrap();
+        assert_eq!(processes.watch.clone().unwrap(), vec!["cargo", "rustc"]);
+        // The git requires list must contain exactly what was written
+        // under its own block — no leakage of "cargo" / "rustc" from
+        // the previous sensor's watch list.
+        assert_eq!(
+            git.requires,
+            vec!["Bash(git:*)".to_string(), "Read".to_string()]
+        );
+    }
 }

--- a/tools/attend/src/config.rs
+++ b/tools/attend/src/config.rs
@@ -113,6 +113,11 @@ pub struct SensorConfig {
     pub script: Option<String>,
     /// Permission requirements (ADR-116) — tool permissions this sensor needs.
     pub requires: Vec<String>,
+    /// Sensor-specific watch list (consumed by individual sensors; the
+    /// processes sensor uses it for its build-event enrichment list).
+    /// `None` means "use the sensor's built-in default"; an explicit
+    /// (possibly empty) list means "replace defaults verbatim."
+    pub watch: Option<Vec<String>>,
 }
 
 impl Default for GovernorConfig {
@@ -136,6 +141,7 @@ impl Default for Config {
             decay_threshold: 3,
             script: None,
             requires: vec!["Read".to_string()],
+            watch: None,
         });
         sensors.insert("git".to_string(), SensorConfig {
             enabled: true,
@@ -145,6 +151,7 @@ impl Default for Config {
             decay_threshold: 4,
             script: None,
             requires: vec!["Bash(git:*)".to_string()],
+            watch: None,
         });
         sensors.insert("peers".to_string(), SensorConfig {
             enabled: true,
@@ -154,6 +161,7 @@ impl Default for Config {
             decay_threshold: 5,
             script: None,
             requires: vec!["Read".to_string()],
+            watch: None,
         });
         sensors.insert("processes".to_string(), SensorConfig {
             enabled: true,
@@ -163,6 +171,7 @@ impl Default for Config {
             decay_threshold: 5,
             script: None,
             requires: vec!["Bash(ps:*)".to_string()],
+            watch: None,
         });
         Self {
             governor: GovernorConfig::default(),
@@ -314,16 +323,44 @@ fn user_config_path() -> PathBuf {
 fn apply_config(config: &mut Config, content: &str) {
     let mut current_section = String::new();
     let mut current_sensor = String::new();
+    // Tracks the list field we're currently populating in block form
+    // (e.g., "requires" or "watch"). Cleared the moment we see a line
+    // that isn't a `- item` continuation. Empty string = not in a list.
+    let mut current_list_key = String::new();
 
     for line in content.lines() {
         let trimmed = line.trim();
 
-        // Skip comments and empty lines
+        // Skip comments and empty lines — don't let them reset list state.
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
         }
 
         let indent = line.len() - line.trim_start().len();
+
+        // Block-form list item (`  - value`) — must come before the
+        // indent dispatch so we don't try to parse `- foo` as a sensor
+        // name at indent 2.
+        if trimmed.starts_with("- ") && !current_list_key.is_empty() && !current_sensor.is_empty() {
+            let item = trimmed[2..].trim().trim_matches('"').trim_matches('\'');
+            if !item.is_empty() {
+                if let Some(sensor) = config.sensors.get_mut(&current_sensor) {
+                    match current_list_key.as_str() {
+                        "requires" => sensor.requires.push(item.to_string()),
+                        "watch" => {
+                            sensor
+                                .watch
+                                .get_or_insert_with(Vec::new)
+                                .push(item.to_string());
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            continue;
+        }
+        // Any other line ends the current block-form list.
+        current_list_key.clear();
 
         // Top-level section
         if indent == 0 && trimmed.ends_with(':') {
@@ -431,6 +468,7 @@ fn apply_config(config: &mut Config, content: &str) {
                         decay_threshold: 4,
                         script: None,
                         requires: Vec::new(),
+                        watch: None,
                     });
                     current_sensor = name;
                 } else {
@@ -443,6 +481,30 @@ fn apply_config(config: &mut Config, content: &str) {
 
         // Third-level: sensor properties
         if indent == 4 && !current_sensor.is_empty() {
+            // Bare `key:` with no inline value opens a block-form list.
+            // The current_list_key state then consumes the subsequent
+            // `- item` lines at greater indent.
+            if let Some(bare_key) = trimmed.strip_suffix(':') {
+                let bare_key = bare_key.trim();
+                match bare_key {
+                    "requires" => {
+                        if let Some(sensor) = config.sensors.get_mut(&current_sensor) {
+                            sensor.requires.clear();
+                        }
+                        current_list_key = "requires".to_string();
+                        continue;
+                    }
+                    "watch" => {
+                        if let Some(sensor) = config.sensors.get_mut(&current_sensor) {
+                            sensor.watch = Some(Vec::new());
+                        }
+                        current_list_key = "watch".to_string();
+                        continue;
+                    }
+                    _ => {}
+                }
+            }
+
             if let Some((key, value)) = parse_kv(trimmed) {
                 if let Some(sensor) = config.sensors.get_mut(&current_sensor) {
                     match key {
@@ -476,11 +538,14 @@ fn apply_config(config: &mut Config, content: &str) {
                             // Inline array: requires: [Bash(gh:*), Read]
                             if value.starts_with('[') && value.ends_with(']') {
                                 let inner = &value[1..value.len() - 1];
-                                sensor.requires = inner
-                                    .split(',')
-                                    .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
-                                    .filter(|s| !s.is_empty())
-                                    .collect();
+                                sensor.requires = parse_inline_list(inner);
+                            }
+                        }
+                        "watch" => {
+                            // Inline array: watch: [cargo, rustc, mix]
+                            if value.starts_with('[') && value.ends_with(']') {
+                                let inner = &value[1..value.len() - 1];
+                                sensor.watch = Some(parse_inline_list(inner));
                             }
                         }
                         _ => {}
@@ -489,6 +554,17 @@ fn apply_config(config: &mut Config, content: &str) {
             }
         }
     }
+}
+
+/// Split an inline-array body (the text between `[` and `]`) into trimmed,
+/// unquoted items, dropping empties. Shared by `requires:` and `watch:`
+/// so the quoting/whitespace rules stay in one place.
+fn parse_inline_list(inner: &str) -> Vec<String> {
+    inner
+        .split(',')
+        .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
 }
 
 /// Expand `$HOME`, `~`, `$XDG_CONFIG_HOME`, `$XDG_DATA_HOME`, and
@@ -519,4 +595,102 @@ fn parse_kv(line: &str) -> Option<(&str, &str)> {
         return None;
     }
     Some((key, value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── watch: list (inline + block form) ──────────────────────────────
+
+    #[test]
+    fn watch_inline_array_replaces_defaults() {
+        let mut cfg = Config::default();
+        apply_config(
+            &mut cfg,
+            "sensors:\n  processes:\n    watch: [mix, zig, ./build.sh]\n",
+        );
+        let watch = cfg.sensors.get("processes").unwrap().watch.clone().unwrap();
+        assert_eq!(watch, vec!["mix", "zig", "./build.sh"]);
+    }
+
+    #[test]
+    fn watch_block_form_replaces_defaults() {
+        let mut cfg = Config::default();
+        apply_config(
+            &mut cfg,
+            "sensors:\n  processes:\n    watch:\n      - cargo\n      - mix\n      - zig\n",
+        );
+        let watch = cfg.sensors.get("processes").unwrap().watch.clone().unwrap();
+        assert_eq!(watch, vec!["cargo", "mix", "zig"]);
+    }
+
+    #[test]
+    fn watch_absent_stays_none() {
+        // If the user doesn't set watch, the sensor config carries None
+        // and the sensor itself falls back to DEFAULT_WATCH at startup.
+        let mut cfg = Config::default();
+        apply_config(
+            &mut cfg,
+            "sensors:\n  processes:\n    interval: 45\n",
+        );
+        assert!(cfg.sensors.get("processes").unwrap().watch.is_none());
+    }
+
+    #[test]
+    fn watch_block_form_terminates_on_next_property() {
+        // Make sure the block-form list doesn't swallow subsequent sibling
+        // properties at the same indent level.
+        let mut cfg = Config::default();
+        apply_config(
+            &mut cfg,
+            "sensors:\n  processes:\n    watch:\n      - cargo\n    interval: 45\n",
+        );
+        let p = cfg.sensors.get("processes").unwrap();
+        assert_eq!(p.watch.clone().unwrap(), vec!["cargo"]);
+        assert_eq!(p.interval, Duration::from_secs(45));
+    }
+
+    // ── requires: block form (bonus fix unlocked by the same parser change)
+
+    #[test]
+    fn requires_block_form_populates_list() {
+        // Regression test: prior to the block-form extension, block-form
+        // `requires:` was silently dropped because the parser only
+        // recognised inline arrays. This test locks in the fix.
+        let mut cfg = Config::default();
+        apply_config(
+            &mut cfg,
+            "sensors:\n  +gh-pr-checks:\n    script: ./gh.sh\n    requires:\n      - Bash(git:*)\n      - Bash(gh:*)\n",
+        );
+        let r = &cfg.sensors.get("gh-pr-checks").unwrap().requires;
+        assert_eq!(r, &vec!["Bash(git:*)".to_string(), "Bash(gh:*)".to_string()]);
+    }
+
+    #[test]
+    fn requires_inline_array_still_works() {
+        // Older configs use the inline form — must stay supported.
+        let mut cfg = Config::default();
+        apply_config(
+            &mut cfg,
+            "sensors:\n  +foo:\n    script: ./foo.sh\n    requires: [Bash(gh:*), Read]\n",
+        );
+        let r = &cfg.sensors.get("foo").unwrap().requires;
+        assert_eq!(r, &vec!["Bash(gh:*)".to_string(), "Read".to_string()]);
+    }
+
+    #[test]
+    fn block_list_items_survive_blank_lines_and_comments() {
+        // Comments and blank lines inside a block list are skipped early
+        // in the parser, so they must not terminate the list.
+        let mut cfg = Config::default();
+        apply_config(
+            &mut cfg,
+            "sensors:\n  processes:\n    watch:\n      - cargo\n\n      # elixir\n      - mix\n",
+        );
+        assert_eq!(
+            cfg.sensors.get("processes").unwrap().watch.clone().unwrap(),
+            vec!["cargo", "mix"]
+        );
+    }
 }

--- a/tools/attend/src/sensors/mod.rs
+++ b/tools/attend/src/sensors/mod.rs
@@ -78,7 +78,16 @@ pub fn register_sensors(
     register_builtin!("context", ContextSensor::new(), 60, 20, 3);
 
     #[cfg(feature = "sensor-processes")]
-    register_builtin!("processes", ProcessSensor::new(), 30, 5, 5);
+    {
+        // Resolve the watch list once at startup: if config provides one,
+        // it replaces the defaults verbatim (explicit-replace contract).
+        // Otherwise the sensor's `new()` uses `DEFAULT_WATCH`.
+        let processes_sensor = match cfg.sensors.get("processes").and_then(|s| s.watch.clone()) {
+            Some(list) => ProcessSensor::with_watch(list),
+            None => ProcessSensor::new(),
+        };
+        register_builtin!("processes", processes_sensor, 30, 5, 5);
+    }
 
     #[cfg(feature = "sensor-git")]
     register_builtin!("git", GitSensor::new(), 30, 10, 4);

--- a/tools/sensor-processes/src/lib.rs
+++ b/tools/sensor-processes/src/lib.rs
@@ -28,6 +28,18 @@ fn marker_matches(marker: &BuildMarker, cmd: &str, now: u64, window_secs: u64) -
     marker.cmd == cmd && now.saturating_sub(marker.ts) <= window_secs
 }
 
+/// Default watch list — process names whose exits get enriched build-event
+/// treatment (success/failure magnitude tiers, marker correlation). Covers
+/// the common build and package tools out of the box; users working in
+/// other toolchains (elixir, zig, custom scripts) override via
+/// `sensors.processes.watch:` in attend config.
+pub const DEFAULT_WATCH: &[&str] = &[
+    "cargo", "rustc", "make", "cmake", "ninja",
+    "gcc", "g++", "cc", "c++", "clang", "clang++",
+    "go", "npm", "yarn", "pnpm", "tsc",
+    "mvn", "gradle", "pip", "pip3",
+];
+
 /// Parse a single-line marker file. Format: `cmd|code|unix_ts`. Any other
 /// shape (extra fields, missing fields, non-numeric code) parses to None
 /// — we'd rather silently ignore a malformed marker than surface a fake
@@ -105,16 +117,35 @@ pub struct ProcessSensor {
     /// Marker file mtime on the previous read — lets us skip re-parsing
     /// when the file hasn't changed between polls.
     last_marker_mtime: Option<SystemTime>,
+    /// Exact process names whose exits get enriched build-event treatment.
+    /// Resolved once at construction: either from the user's config or
+    /// from `DEFAULT_WATCH`. Not merged — explicit-replace is the
+    /// documented contract.
+    watch: Vec<String>,
 }
 
 impl ProcessSensor {
+    /// Build with the default watch list (`DEFAULT_WATCH`).
     pub fn new() -> Self {
+        Self::with_watch(DEFAULT_WATCH.iter().map(|s| s.to_string()).collect())
+    }
+
+    /// Build with an explicit watch list. Passing an empty list disables
+    /// build-event enrichment entirely — all process exits fall through
+    /// to the plain `X exited` path.
+    pub fn with_watch(watch: Vec<String>) -> Self {
         Self {
             prior: HashMap::new(),
             baseline_established: false,
             last_marker: None,
             last_marker_mtime: None,
+            watch,
         }
+    }
+
+    /// Is `name` one of the processes we enrich on exit?
+    fn is_watched(&self, name: &str) -> bool {
+        self.watch.iter().any(|w| w == name)
     }
 
     /// Refresh `self.last_marker` from the marker file if it has been
@@ -259,14 +290,10 @@ impl Sensor for ProcessSensor {
             }
         }
 
-        // Exited applications (were in prior, gone now)
-        // Build tools: exact match on process name (comm field from /proc)
-        let build_tools = [
-            "cargo", "rustc", "make", "cmake", "ninja",
-            "gcc", "g++", "cc", "c++", "clang", "clang++",
-            "go", "npm", "yarn", "pnpm", "tsc",
-            "mvn", "gradle", "pip", "pip3",
-        ];
+        // Exited applications (were in prior, gone now). Processes on the
+        // watch list get enriched build-event treatment (success/failure
+        // magnitudes, marker correlation); everything else gets a plain
+        // `X exited` at 2.0.
         let now = SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())
@@ -274,8 +301,7 @@ impl Sensor for ProcessSensor {
 
         for app in self.prior.keys() {
             if !current.contains_key(app) {
-                let is_build = build_tools.contains(&app.as_str());
-                if is_build {
+                if self.is_watched(app) {
                     observations.push(format_build_exit(app, self.last_marker.as_ref(), now));
                 } else {
                     observations.push((2.0, format!("{app} exited")));
@@ -453,6 +479,53 @@ mod tests {
         let m = BuildMarker { cmd: "cargo".into(), code: 1, ts: 1000 };
         let (mag, _) = format_build_exit("cargo", Some(&m), 1010);
         assert_eq!(mag, 3.5);
+    }
+
+    // ── watch list ─────────────────────────────────────────────────────
+
+    #[test]
+    fn new_uses_default_watch_list() {
+        let s = ProcessSensor::new();
+        // Spot-check the defaults that appear in docs and old hardcoded list.
+        assert!(s.is_watched("cargo"));
+        assert!(s.is_watched("rustc"));
+        assert!(s.is_watched("go"));
+        assert!(s.is_watched("npm"));
+        // And something that's *not* in the default list — a Rust dev
+        // shouldn't accidentally start getting enriched exits for python.
+        assert!(!s.is_watched("python"));
+        assert!(!s.is_watched("mix"));
+    }
+
+    #[test]
+    fn with_watch_replaces_defaults() {
+        // Explicit-replace contract: passing `watch:` drops the defaults.
+        // An elixir dev who lists only `mix` should NOT still see cargo
+        // enriched — their config is the single source of truth.
+        let s = ProcessSensor::with_watch(vec!["mix".into(), "zig".into()]);
+        assert!(s.is_watched("mix"));
+        assert!(s.is_watched("zig"));
+        assert!(!s.is_watched("cargo"));
+        assert!(!s.is_watched("rustc"));
+    }
+
+    #[test]
+    fn with_watch_empty_disables_enrichment() {
+        // An empty watch list is a documented way to turn off build-event
+        // enrichment entirely — every process exit becomes plain 2.0.
+        let s = ProcessSensor::with_watch(Vec::new());
+        assert!(!s.is_watched("cargo"));
+        assert!(!s.is_watched("anything"));
+    }
+
+    #[test]
+    fn default_watch_const_matches_expected_members() {
+        // Locks in the set so we notice at review time if someone silently
+        // adds or removes a default. New defaults are fine; this just
+        // forces the discussion.
+        assert_eq!(DEFAULT_WATCH.len(), 20);
+        assert!(DEFAULT_WATCH.contains(&"cargo"));
+        assert!(DEFAULT_WATCH.contains(&"pip3"));
     }
 }
 


### PR DESCRIPTION
Closes #28.

## Summary

Replaces the hardcoded build-tool list in `sensor-processes` with a configurable `sensors.processes.watch` entry in attend config. An explicit list **replaces** the defaults verbatim — no merging — so the config is the single source of truth. An elixir dev who lists \`mix\` does not silently keep getting \`cargo\` enrichment.

## What changed

### Plumbing

- **`sensor-processes::DEFAULT_WATCH`** now exposes the default list as a `const &[&str]`, used by `ProcessSensor::new()`. A new `ProcessSensor::with_watch(Vec<String>)` takes an explicit list (empty vec = disable enrichment entirely), and a private \`is_watched()\` helper replaces the inline \`contains\`-check in \`poll()\`. The hardcoded array literal is gone.
- **`attend::config::SensorConfig`** gains \`watch: Option<Vec<String>>\`. \`None\` means "use the sensor's built-in default"; \`Some(list)\` is the explicit override.
- **\`attend::sensors::mod::register_all\`** resolves the watch list once at startup — if config provides one it calls \`with_watch\`, otherwise \`new()\`.

### Parser extension (unlocks a real bug fix for \`requires:\` too)

The hand-rolled YAML parser now accepts **block-form list syntax** — the \`key:\` followed by indented \`- item\` lines style — for both \`watch:\` and \`requires:\`. Previously only inline arrays worked, so a perfectly reasonable YAML

\`\`\`yaml
requires:
  - Bash(git:*)
  - Bash(gh:*)
\`\`\`

was being silently dropped. The new code path tracks a \`current_list_key\` across lines, consumes \`- item\` continuations, and terminates on the next non-list line. Blank lines and comments inside a block list don't terminate it.

A shared \`parse_inline_list()\` helper now powers the inline form for both \`requires:\` and \`watch:\` so the quoting/whitespace rules stay in one place.

## Config shapes

Both YAML forms are accepted:

\`\`\`yaml
sensors:
  processes:
    watch:
      - cargo
      - rustc
      - mix          # elixir
      - zig
      - ./build.sh
\`\`\`

\`\`\`yaml
sensors:
  processes:
    watch: [cargo, rustc, mix, zig]
\`\`\`

Disable enrichment entirely:

\`\`\`yaml
sensors:
  processes:
    watch: []
\`\`\`

## Test plan

- [x] \`sensor-processes\`: 22 tests pass (18 pre-existing + 4 new — \`new_uses_default_watch_list\`, \`with_watch_replaces_defaults\`, \`with_watch_empty_disables_enrichment\`, \`default_watch_const_matches_expected_members\`)
- [x] \`attend\`: 12 tests pass (5 pre-existing + 7 new config tests). New coverage: inline watch, block-form watch, absent watch, watch terminating before a sibling property, **regression test for block-form requires** (which was silently broken before), inline requires (still works), and blank-line/comment tolerance inside a block list.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [ ] CI green
- [ ] Dogfood: drop \`watch: [cargo, rustc]\` into my own config, restart attend, verify no cargo exits are enriched by a \`mix\` marker (and vice versa). Not blocking — the unit tests cover the same paths.

## Docs

- **\`sensors.md\`** "Watched processes" section now explains the override, shows both YAML shapes, and calls out the explicit-replace contract (empty list = disable enrichment). Removed the "future extension" / "hardcoded" note.
- **\`configuration.md\`** adds \`processes.watch\` to the per-sensor keys table and updates the parser-notes section to list block-form lists as supported.

## Relationship to prior PRs

Composes cleanly with #27's marker correlation — a process on the user's custom watch list still gets the success/failure enrichment via the marker. The watch list only controls *which* processes participate in enrichment, not *how* enrichment works.