### PR TITLE
fix(attend): gh-pr-checks interval default 30/10 (from 120/30)

### DIFF
--- a/tools/attend/examples/gh-pr-checks.sh
+++ b/tools/attend/examples/gh-pr-checks.sh
@@ -60,13 +60,22 @@
 #     +gh-pr-checks:
 #       script: ~/.claude/tools/attend/examples/gh-pr-checks.sh
 #       enabled: true
-#       interval: 120       # 2 min at rest — CI is minute-scale anyway
-#       min_interval: 30    # 30 s during change
+#       interval: 30        # fast enough to catch a single CI run in progress
+#       min_interval: 10    # ramp into 10 s polls during active transitions
 #       threshold: 2.0
 #       requires:
 #         - Bash(git:*)
 #         - Bash(gh:*)
 #         - Bash(jq:*)
+#
+# Why 30 s rest and 10 s ramp? The sensor is first-run-silent on every
+# new (repo, branch, pr_number) tuple, so with a slower default the
+# sensor effectively got one chance per CI run to catch a transition —
+# first poll saw `pending`, second poll usually arrived after the user
+# had already merged the PR. 30 s at rest gives the sensor three-to-
+# four polls inside a typical 90 s CI run, and the action-potential
+# ramp drops it to 10 s the moment a state change fires, so bursty CI
+# windows stay responsive without paying that cost while idle.
 #
 # ----------------------------------------------------------------------
 

--- a/tools/attend/examples/gh-pr-checks.sh
+++ b/tools/attend/examples/gh-pr-checks.sh
@@ -3,11 +3,16 @@
 # gh-pr-checks.sh — example attend external sensor
 #
 # Polls `gh pr checks` for the PR attached to the current branch and
-# emits a notification only when the aggregate CI state crosses into a
-# terminal bucket (all passing / any failing). Quiet on first run, quiet
-# on pending-state churn, quiet when there's no PR or the branch is
-# main/master. In practice this means: you push, your CI goes green or
-# red, you get one notification, you move on.
+# emits a notification when the aggregate CI state lands in a terminal
+# bucket (all passing / any failing). Quiet on pending-state churn,
+# quiet when there's no PR, quiet when the branch is main/master. On
+# first observation of a `(repo, branch, pr)` tuple: quiet if the
+# state is still pending (wait for a resolution), emit if the state is
+# already terminal (the resolution already happened, surface it). In
+# practice this means: you push, your CI goes green or red, you get
+# one notification, you move on — and the notification arrives even
+# on fast-CI PRs where the sensor's first poll on the branch catches
+# `pass` directly.
 #
 # Why this exists. The built-in sensors don't observe GitHub — nothing
 # inside attend knows your PR just went red. Without this sensor the
@@ -23,10 +28,20 @@
 #      and emits only on terminal transitions. Users who want the
 #      check-by-check view run `gh pr checks` on demand.
 #
-#   2. **Silent on pending entry.** A new push restarts checks, which
-#      means every push triggers `pass → pending` or `fail → pending`.
-#      Emitting on those would produce "CI is running…" spam; the user
-#      knows they pushed. Only transitions *out* of pending matter.
+#   2. **Terminal-first-run, silent on pending entry.** A new push
+#      restarts checks, which means every push triggers `pass →
+#      pending` or `fail → pending`; emitting on those would produce
+#      "CI is running…" spam. Only transitions *out* of pending
+#      matter. First observation of a `(repo, branch, pr)` tuple is
+#      the interesting edge case: if the state is already `pass` or
+#      `fail` (the common shape on fast CI, because the sensor's
+#      first poll arrives after the run has finished), we *do* emit
+#      — there's nothing to wait for, and the user wants to know.
+#      Only a first observation of `pending` stays silent, because
+#      we don't yet have a resolution to report.
+#      Since the sensor only polls the *current* branch's PR, the
+#      worst case is exactly one notification per attend restart.
+#      No flood.
 #
 #   3. **Loudest event is a regression.** `pass → fail` is magnitude
 #      4.5 because it's unusual (you thought it was green and it
@@ -68,14 +83,13 @@
 #         - Bash(gh:*)
 #         - Bash(jq:*)
 #
-# Why 30 s rest and 10 s ramp? The sensor is first-run-silent on every
-# new (repo, branch, pr_number) tuple, so with a slower default the
-# sensor effectively got one chance per CI run to catch a transition —
-# first poll saw `pending`, second poll usually arrived after the user
-# had already merged the PR. 30 s at rest gives the sensor three-to-
-# four polls inside a typical 90 s CI run, and the action-potential
-# ramp drops it to 10 s the moment a state change fires, so bursty CI
-# windows stay responsive without paying that cost while idle.
+# Why 30 s rest and 10 s ramp? Combined with the terminal-first-run
+# rule (see design note #2 below), 30 s at rest gives the sensor
+# three-to-four polls inside a typical 90 s CI run — enough to
+# observe a true `pending → pass` transition when the user is
+# actively pushing — and the action-potential ramp drops it to
+# 10 s the moment a state change fires, so bursty CI windows stay
+# responsive without paying that cost while idle.
 #
 # ----------------------------------------------------------------------
 
@@ -173,20 +187,31 @@ prev=""
 # exited; if we get here the state is a known bucket.
 printf '%s\n' "$state" > "$MARKER"
 
-# First run — record state but don't emit. Prevents a flood of
-# "checks passing" notifications whenever attend restarts.
-[[ -z "$prev" ]] && exit 0
+# First run rule: if the marker didn't exist (new branch, new PR, or
+# attend restart), suppress only when the state is `pending`. A pending
+# first-run means "CI is still in progress and we haven't seen the
+# resolution yet, wait for one." A terminal first-run means "the
+# resolution already happened and the user wants to know" — emit it
+# with the empty-prev path through the case statement below, which
+# correctly picks the fresh-observation magnitudes (3.0 for pass, 4.0
+# for fail). Because the sensor only polls the current branch's PR,
+# the worst case on restart is exactly one notification — no flood.
+if [[ -z "$prev" && "$state" == "pending" ]]; then
+  exit 0
+fi
 
 # No transition, no news.
 [[ "$state" == "$prev" ]] && exit 0
 
 # Magnitude table:
 #
-#   pass  after fail     → 3.5  (recovered — notable, not an alarm)
-#   pass  after pending  → 3.0  (green on a fresh push — good news)
-#   fail  after pass     → 4.5  (regression — break refractory hard)
-#   fail  after pending  → 4.0  (broke on push — break refractory)
-#   pending              → silent (user just pushed; they know)
+#   pass  (first observation) → 3.0  (green, no prior history)
+#   pass  after pending       → 3.0  (green on a fresh push — good news)
+#   pass  after fail          → 3.5  (recovered — notable, not an alarm)
+#   fail  (first observation) → 4.0  (red, no prior history)
+#   fail  after pending       → 4.0  (broke on push — break refractory)
+#   fail  after pass          → 4.5  (regression — break refractory hard)
+#   pending (any time)        → silent (user just pushed; they know)
 #
 # Failures sit above the refractory ceiling so they break through even
 # when the agent is deep in another task. Passes are quieter — they

--- a/tools/attend/src/config.rs
+++ b/tools/attend/src/config.rs
@@ -304,8 +304,8 @@ sensors:
   #+gh-pr-checks:
   #  script: $XDG_DATA_HOME/attend/sensors/gh-pr-checks.sh
   #  enabled: false
-  #  interval: 120
-  #  min_interval: 30
+  #  interval: 30        # fast enough to catch a single CI run in progress
+  #  min_interval: 10    # ramps to 10 s during active transitions
   #  threshold: 2.0
 
   # Third shipped example: gh-notifications. Watches the authenticated


### PR DESCRIPTION
Expanded from "just tune the interval" to "make the dogfood loop actually work." Two changes, same file, same motivating observation.

## Motivation

The session that shipped #30/#24/#27/#28/#32/#33 + the three shipped reference sensors was the first real dogfood of this sensor against live CI. The sensor **never emitted a single notification** across ten merges' worth of green CI runs. Root cause turned out to be two compounding bugs — one tuning, one logic — so this PR fixes both.

## Change 1 — Interval tuning (30/10 from 120/30)

With the old \`interval: 120\`, the sensor got one poll per typical CI run. First poll saw \`pending\`, second poll usually arrived after the user had already merged and switched branches. Drop to \`interval: 30\` and the sensor gets three-to-four polls inside a 90 s CI run, with the action-potential ramp dropping to 10 s during active transitions.

## Change 2 — Emit on terminal first-run

Turned out the interval fix alone was insufficient. Tracing through the Monitor output file showed the sensor was running and writing markers, but **never emitting** — because the old first-run-silent rule suppressed *every* first observation, even ones that landed on a terminal state directly.

Old behaviour:

- First poll on a new \`(repo, branch, pr)\` marker key with \`state=pending\`: silent, write marker. **Correct** — we're waiting for a resolution.
- First poll on a new marker key with \`state=pass\` or \`fail\`: ALSO silent, write marker. **Bug.** The resolution already happened and we want to know about it.

This silently swallowed every common case where the sensor's first observation caught the terminal state directly:

- attend restarts while a PR is already green
- branch-switch onto a PR whose CI finished before you got there
- fast-CI PR whose \`pending → pass\` transition completes inside a single poll interval

New behaviour: first-run suppresses **only when** \`state == pending\`. Terminal states fall through to the case statement, which already handles an empty \`prev\` correctly — \`pass\` with no prior emits 3.0 ("checks all passing"), \`fail\` with no prior emits 4.0 ("checks failing"). The existing 3.5 "recovered" and 4.5 "regressed" paths require a non-empty prior, so they only fire on observed transitions — which is what they're meant for.

No flood risk: the sensor only polls the current branch's PR, so the worst case on restart is exactly one notification for whatever PR you happen to be on.

## Updated magnitude table

| state | prior | magnitude | message |
|---|---|---|---|
| pass | *(first observation)* | **3.0** | checks all passing |
| pass | pending | 3.0 | checks all passing |
| pass | fail | 3.5 | recovered — all checks passing |
| fail | *(first observation)* | **4.0** | checks failing |
| fail | pending | 4.0 | checks failing |
| fail | pass | 4.5 | regressed to failing |
| pending | *(any)* | — | silent |

The two new rows are the first-observation cases this PR unlocks.

## What changed

- \`tools/attend/examples/gh-pr-checks.sh\`:
  - recipe block in the header: \`interval: 30\` and \`min_interval: 10\` with an explanatory paragraph
  - opener now says "quiet on pending-state churn" instead of "quiet on first run"
  - design note #2 renamed to "Terminal-first-run, silent on pending entry" with an explanation of why terminal first-observation is different from pending
  - the first-run check in the emit block is now gated on \`state == pending\`
  - the magnitude table comment adds the two new first-observation rows
- \`tools/attend/src/config.rs\`: the commented-out \`+gh-pr-checks:\` stub in \`default_yaml()\` matches the new interval

## Test plan

- [x] \`bash -n\` syntax check clean
- [x] \`cargo build -p attend\` clean
- [x] Dry-run against PR #43 with a fresh \`\$XDG_STATE_HOME\` emits \`3.0|PR #43 checks all passing\` — this is the exact case the old behaviour swallowed
- [x] Second dry-run on the same marker correctly stays silent (no transition)
- [x] Live user-scope \`~/.config/attend/config.yaml\` already updated to the new interval; Monitor restarted
- [ ] This very PR (once CI reruns on the new push) should produce a real live notification via the running attend instance. If we see \`[attend sensor=gh-pr-checks] PR #43 checks all passing\` in the session after this push, the dogfood loop is fully verified end-to-end.