### PR TITLE
fix(ci): build-attend path filter covers sensor crates

### DIFF
--- a/.github/workflows/build-attend.yml
+++ b/.github/workflows/build-attend.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'tools/attend/**'
       - 'tools/agent-fmt/**'
+      - 'tools/sensor-*/**'
       - 'tools/Cargo.toml'
       - 'tools/Cargo.lock'
       - '.github/workflows/build-attend.yml'
@@ -14,6 +15,7 @@ on:
     paths:
       - 'tools/attend/**'
       - 'tools/agent-fmt/**'
+      - 'tools/sensor-*/**'
       - 'tools/Cargo.toml'
       - 'tools/Cargo.lock'
       - '.github/workflows/build-attend.yml'


### PR DESCRIPTION
One-line fix (well, two lines — push and pull_request filters). Noticed during PR #38 (sensor-processes exit-code marker), where the clippy gate correctly fired on the change but `build-attend.yml`'s build/test jobs didn't — because the workflow's path filter was narrower than attend's actual dependency tree.

## The gap

\`tools/attend/Cargo.toml\` depends on:

\`\`\`
agent-fmt     (path)
sensor-trait  (path)
sensor-git    (path, optional)
sensor-context (path, optional)
sensor-peers  (path, optional)
sensor-processes (path, optional)
sensor-disclosure (path, optional)
\`\`\`

All six of those sensor crates are in the default feature set, so changes to any of them affect the built attend binary. But the old filter only covered \`tools/attend/**\` and \`tools/agent-fmt/**\`:

\`\`\`yaml
paths:
  - 'tools/attend/**'
  - 'tools/agent-fmt/**'
  - 'tools/Cargo.toml'
  - 'tools/Cargo.lock'
  - '.github/workflows/build-attend.yml'
\`\`\`

A PR that touched only \`tools/sensor-processes/**\` (like PR #38) would:
- Fire the clippy gate ✅ (its filter is \`tools/**\`)
- Skip the per-crate build matrix ❌
- Skip attend's unit tests ❌

Clippy green was enough to convince me the PR was safe at merge time, but the actual per-crate build/test jobs never got a chance to run. Real coverage gap.

## Fix

Add \`tools/sensor-*/**\` to both the \`push\` and \`pull_request\` path filters:

\`\`\`yaml
paths:
  - 'tools/attend/**'
  - 'tools/agent-fmt/**'
  - 'tools/sensor-*/**'      # ← new
  - 'tools/Cargo.toml'
  - 'tools/Cargo.lock'
  - '.github/workflows/build-attend.yml'
\`\`\`

The glob covers every existing sensor crate (sensor-context, sensor-disclosure, sensor-git, sensor-peers, sensor-processes, sensor-trait — verified via \`ls tools/ | grep ^sensor-\`) and will pick up any future sensor crate automatically. No change to \`build-ways.yml\` — ways-cli doesn't depend on sensor crates, its narrower filter is correct.

## Test plan

- [x] YAML parses clean (\`python3 -c "import yaml; yaml.safe_load(...)"\` ok)
- [x] This very PR touches \`.github/workflows/build-attend.yml\`, which matches the existing filter, so the workflow will trigger on this PR as a self-test
- [ ] A follow-up PR that touches only \`tools/sensor-*/**\` will actually validate the new glob in practice — this PR can't prove the glob works without also touching sensor code