### PR TITLE
docs: ADR-123 firing dynamics + context-decay consistency sweep

### DIFF
--- a/docs/architecture/system/ADR-123-firing-dynamics-progression-axis-unification.md
+++ b/docs/architecture/system/ADR-123-firing-dynamics-progression-axis-unification.md
@@ -1,0 +1,297 @@
+---
+status: Draft
+date: 2026-04-14
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-113
+  - ADR-114
+  - ADR-117
+  - ADR-119
+  - ADR-121
+---
+
+# ADR-123: Firing dynamics — progression-axis unification for attend and ways
+
+## Context
+
+Two tools in this workspace implement firing dynamics independently:
+
+- **attend** has landed the action-potential engagement model (ADR-119) as `EngagementState` in `sensor-trait`, and has a drafted salience decay for signal presentation (ADR-121). Both use wall-clock time — `Instant`, `Duration`, `decay_per_minute`.
+- **ways** has a rudimentary model in `ways-cli/src/session.rs`: token-position distance as a percentage of the context window, per-way markers, epoch counters, and a fire-count counter. The suppression is a step function — `REDISCLOSE_PCT: u64 = 25` — with no curves, multiplier decay, burst detection beyond the flat counter, or re-engagement reset.
+
+The math is identical across both tools: exponential decay, refractory-period multipliers, burst detection over a windowed history. Only the units differ — seconds for attend, token positions for ways. A naive unification would generalize the engine over a `Clock` trait (`Instant` for attend, `TokenPosition` for ways), but that smuggles time semantics into the engine where none exist.
+
+There is a cleaner abstraction hiding under the question: **attend's wall clock and ways' token count are both instances of the same thing — a monotonic progression axis supplied by the caller.** Neither is privileged. The engine doesn't need to know what progression means; it only needs a `u64` that strictly increases. Each caller labels the axis for its own context.
+
+This reframe matters beyond the refactor. It means:
+
+- **Future progression axes come for free.** Turn count, commits-since-branch, bytes-written, lines-changed — any monotonic can be wired in without touching the engine. ways itself is designed to be hostable by any turn-based coding agent that exposes the necessary data; different hosts may expose different natural axes, and the engine must not assume any single one.
+- **Ways' axis choice is motivated by the host's own addressing unit, not by any specific decay theory.** Firing decisions should be keyed on the axis the host uses to address what ways is injecting. For transformer-based hosts, that axis is token position — it is the unit attention uses to address content, regardless of what decay shape attention happens to apply (see Decision 4 for the full argument, including its limits). Wall clock is external to the host's addressing; turn count is a coarser aggregate; token position is the host's own unit. This generalizes: a future host that addresses content differently supplies a different axis, and the engine adapts automatically.
+- **Curves become first-class.** When the engine stops owning time semantics, the shape of decay/refractory becomes a parameter instead of a built-in — which enables progressive disclosure, staircase re-firing, and other patterns that ADR-119 and ADR-121 could not express because they were each hard-coded to one curve.
+- **Event-count burst detection, not tick-windowed.** A subtle consequence of progression-axis genericity: some axes are granular (wall-clock seconds), others chunky (token position can jump thousands in a single tool call). Time-windowed burst detection degenerates on chunky axes — a single event can swallow the window in one step. Burst detection therefore must be event-count based with its window defined implicitly by the decay curve itself, not by a separate tick span. This is developed in Decision 2.
+
+Additionally, ways currently only fires predictively — against user prompts (`check-prompt.sh`), task spawns (`check-task-pre.sh`), about-to-edit file paths (`check-file-pre.sh`), about-to-run bash commands (`check-bash-pre.sh`). It has no reactive firing path. Observations like "the file that was just written is now 900 lines long" are structurally invisible. Extending into `PostToolUse` and `PostToolUseFailure` requires an evaluation model that isn't semantic embedding — it's metric predicates over observed state. Both modes should compose under the same firing-dynamics engine rather than growing a parallel track.
+
+## Decision
+
+### 1. Unit-agnostic progression-axis engine
+
+The firing-dynamics engine operates over a caller-supplied monotonic progression axis. The public API uses progression-flavored types, not time-flavored ones:
+
+```rust
+pub type Tick = u64;
+pub type TickDelta = u64;
+
+pub struct EngagementState {
+    curve: Curve,
+    history: VecDeque<(Tick, f64)>,  // (tick, magnitude) per fire
+    last_fire: Option<Tick>,
+}
+```
+
+All curve-specific parameters live inside the `Curve` variant (Decision 2). `EngagementState` itself holds only the curve plus the event history. Burst detection, refractory, decay, and salience are all derived by the curve from `(current_tick, history)`.
+
+No `Instant`, no `Duration`, no `decay_per_minute`. The word "clock" does not appear in the engine surface. Each caller supplies its own meaning:
+
+- **attend** interprets ticks as wall-clock seconds. `epoch_secs()` replaces `Instant::now()` at call sites.
+- **ways** interprets ticks as token positions. `get_token_position()` supplies ticks.
+- **Future callers** interpret ticks as whatever monotonic matches their cadence.
+
+Burst detection and decay evaluation are derived from the tick history — `current_tick - entry_tick` compared against `burst_window`, curve evaluated against tick delta. The engine cannot and does not distinguish between "two seconds" and "two tokens" — both are `2u64`, and the curve parameters are in the same unit as the ticks.
+
+### 2. Pluggable curve as first-class parameter
+
+`Curve` is a sealed enum — cheap to match, serializable in frontmatter, no trait-object dispatch. All decay parameters across all variants are expressed as **`half_life` in caller ticks**, for a single consistent mental model:
+
+```rust
+pub enum Curve {
+    /// Smooth exponential decay. Salience = 0.5^(delta / half_life).
+    Exponential { half_life: TickDelta },
+
+    /// Action potential — event-count burst detection raises a refractory
+    /// multiplier which decays back toward 1.0 over tick distance.
+    ///
+    /// The "burst window" is NOT a tick span. It is defined implicitly by
+    /// which history entries still have non-trivial multiplier contribution
+    /// (via multiplier_half_life). This is robust to chunky progression axes
+    /// where a single event can advance the tick by thousands.
+    ActionPotential {
+        burst_threshold: usize,             // fires in recent history to trigger a burst
+        peak_multiplier: f64,               // multiplier at burst peak (e.g., 1.5 or 2.0)
+        absolute_refractory: TickDelta,     // hard suppression after a burst
+        multiplier_half_life: TickDelta,    // half-life of multiplier decay toward 1.0
+    },
+
+    /// Explicit re-fire schedule at tick deltas with diminishing salience.
+    /// Progressive disclosure as a first-class pattern.
+    ProgressiveStaircase { steps: Vec<(TickDelta, f64)> },
+
+    /// Discontinuous step: suppressed for N ticks, then fully recovered.
+    /// Valid shape for ways that want all-or-nothing suppression without decay.
+    Flat { suppression: TickDelta },
+}
+
+impl Curve {
+    pub fn salience_at(&self, delta: TickDelta) -> f64 { /* ... */ }
+    pub fn multiplier_at(&self, delta: TickDelta, history: &[(Tick, f64)], current: Tick) -> f64 { /* ... */ }
+}
+```
+
+- **`Exponential`** — primary salience-decay shape. Ways' likely default once tuned.
+- **`ActionPotential`** — the ADR-119 engagement model, ported via event-count burst detection (see below). Usable for attend's current sensors and for ways that want inward-gate refractory on top of outward-gate decay.
+- **`ProgressiveStaircase`** — new shape. A way declares `[(0, 1.0), (15_000, 0.5), (40_000, 0.2)]` and re-fires at those deltas with the declared salience.
+- **`Flat`** — explicit step function. Not a shim, not a backward-compatibility translation. A valid first-class opt-in for ways that genuinely want discontinuous behavior.
+
+**Burst detection is event-count based, not tick-windowed.** This is the critical adaptation for chunky progression axes. Time-windowed burst detection (ADR-119's original form) assumed events progress smoothly against the tick axis. On wall-clock axes this holds. On token-position axes it does not — a single `Read` tool call can advance the tick by 5k–20k in one step, swallowing any reasonable `burst_window` in one event. Burst detection therefore windows by *event count in recent history*, with "recent" defined implicitly by the decay of the refractory multiplier itself: once an event's contribution has decayed past a small epsilon (e.g., multiplier drops back below 1.01), it no longer counts toward burst detection. Attend's time-windowed behavior is preserved as a degenerate case — short `multiplier_half_life` produces a tight effective window; chunky ways use longer `multiplier_half_life` and event count stays meaningful regardless of tick jumps.
+
+This is why `EngagementState` holds only `(curve, history, last_fire)` — there is no separate `burst_window` field. The window is a derived property of the curve's multiplier decay, not a standalone parameter.
+
+### 3. Inward and outward gates, cleanly separated
+
+The engine exposes two query methods that answer different questions against the same state:
+
+- **`should_fire(current_tick, stimulus_magnitude) -> bool`** — the inward gate. "Should this new event be allowed to fire?" Consults the refractory portion of the curve. This is the question ADR-119 answers for attend sensors.
+- **`current_salience(current_tick) -> f64`** — the outward gate. "Has the last-fired guidance faded enough that re-injection is warranted?" Consults the decay portion of the curve. This is the question ADR-121 answers for attend signals.
+
+ways' current flat `redisclose` conflates these. The unified engine separates them cleanly so pre- and post-firing decisions consult the same state and curve but ask different questions. `Curve::Flat` collapses them into the same answer (binary suppressed/allowed), preserving current semantics for ways that don't opt in to a richer shape.
+
+### 4. Ways' tick unit: host addressing, not a decay theory
+
+Ways' tick is token position for transformer-based hosts. The justification is the host's addressing unit, not a specific theory of how attention decays.
+
+**The principle:** firing dynamics should be keyed on the axis the host agent uses to address what ways is injecting. For a transformer, that axis is token position — it is the unit the model uses to locate and refer to content via its attention mechanism, regardless of what decay shape attention happens to apply in practice. Wall clock is external to the host's addressing (the model cannot observe it). Turn count is an aggregate over token positions that wobbles with per-turn context density (a long think turn and a short reply both count as "one turn" but displace very different amounts of addressable context). Token position is the host's own unit.
+
+**On RoPE specifically:** rotary positional embedding does provide a baseline long-term inner-product decay with relative distance, which is a convenient piece of theoretical grounding — it means token distance is not an arbitrary choice but corresponds to a real axis the model uses. However, this should not be overstated. Modern attention heads in trained LLMs (Claude included) are demonstrably capable of overriding RoPE's baseline decay via needle-in-a-haystack retrieval — a highly salient token at position `P - 100_000` can still receive near-full attention when the current decision depends on it. The model's attention does *not* fade on a clean exponential curve along token distance; it fades until a specific attention head decides the content is critical, at which point the effective salience spikes back up internally.
+
+What this means for ways: token position is the *closest available proxy* for "how much context has accumulated between a way's injection and the current decision point," which is the quantity firing dynamics should track. It is not a direct model of attention decay. The firing engine assumes the guidance fades in effective impact as context accumulates; the model's actual attention mechanism may or may not honor that assumption for any specific token. That's fine — the firing decision is about *presentation economics* (when to re-inject guidance so it's freshly available), not about *modeling attention internals*.
+
+**Generalization beyond transformers:** ways is designed to be hostable by any turn-based coding agent that exposes the needed hooks and data. Different hosts may address content differently — a sliding-window chunked-conversation agent might use chunk count; a stateless agent might only expose turn count. The principle holds: use whatever axis the host uses to address injected content. Token position is the right answer for transformer hosts; it is not the right answer for all possible hosts. The engine's unit-agnosticism is what makes this portability possible.
+
+**For attend:** wall clock is correct because attend steers external timing — peer-conversation cadence, build events, ambient awareness — which lives outside the host's token space entirely. Attend's wall-clock axis is correct for attend's domain for the same reason ways' token-position axis is correct for ways' domain: each axis matches the addressing unit of the thing being steered.
+
+There is a deeper reason wall clock earns its meaning in attend specifically — one that explains *why* ways cannot simply adopt the same axis even if it wanted to. **Wall clock only becomes a meaningful coordinate when there is more than one observer.** A single agent running its own monotonic token counter has a single progression axis, a 1-D line; there is no second axis to project onto, and wall clock adds no information that token position does not already encode. Ways is single-observer — one session, one monotonic token stream — so wall clock is superfluous.
+
+Attend introduces the second observer. Each peer has its own internal progression (its own session, its own token count, its own turn stream) that is disconnected from every other peer's. Peer A's "token position 5000" and peer B's "token position 3000" are not comparable — they live in different coordinate systems with different origins. The *only* axis that is shared across peers, and therefore the only axis on which their events can be meaningfully compared, is wall clock. "Peer A said X at t=100s, peer B said Y at t=102s" places both events in a common frame; "peer A at its own position 5000, peer B at its own position 3000" does not, because the positions are on non-overlapping number lines.
+
+This is a dimensionality argument: two disparate monotonic counts, when compared in the same space, require an additional shared axis to form a coordinate system in which their relationship can be expressed. Wall clock is that shared axis — not because time is metaphysically special, but because it is the coordinate frame that is guaranteed to be common across all peers regardless of their internal progression. Attend's wall-clock axis is not arbitrary; it is the *unique* axis that multi-peer coordination requires. In a single-observer system, that requirement does not exist, and wall clock collapses to a redundant label on the one monotonic that already exists.
+
+This is the clean division: single-observer systems need one progression axis (whatever the host uses internally — token position for transformer-hosted ways); multi-observer systems need wall clock on top as the shared coordinate frame that lets disparate internal progressions be compared. Both choices are emergent from the observer topology, not from any preference about units.
+
+### 5. Reactive firing via `postcheck.sh`
+
+Hooks are extended with `PostToolUse` and `PostToolUseFailure` matchers. A new hook script — `hooks/ways/check-post.sh` — is wired to these events. Each way may ship an optional `postcheck.sh` alongside its `macro.sh`:
+
+```
+hooks/ways/softwaredev/code/quality/
+├── quality.md
+├── macro.sh          (existing)
+└── postcheck.sh      (new, optional)
+```
+
+On `PostToolUse` / `PostToolUseFailure`, `check-post.sh` walks ways with a `postcheck.sh`, runs each with `tool_response` as stdin, and treats exit 0 as "request firing." The firing request then flows through the standard inward gate — the engine's `should_fire` consults the way's curve and current refractory state. Postcheck reactive requests are not privileged over predictive matches; both go through the same gate.
+
+Reactive firing uses the observed post-state, not intent. A `postcheck.sh` can check file size after a write, test exit codes after a test run, `gh pr` status after a merge, or any other metric its way cares about. The evaluation is metric-predicate style — cheap, deterministic, side-effect-free — not semantic re-embedding.
+
+The two modes compose without any extra machinery: a way that fires predictively at turn T (inward gate passes, salience = 1.0) will not re-fire reactively at turn T+1 unless salience has decayed below the re-injection floor. The engine already handles this via the curve query; the reactive path just adds another set of match sources.
+
+### 6. Shared-crate home and refactor strategy
+
+The firing-dynamics core lives in `sensor-trait` (or migrates to a renamed `firing-dynamics` crate if the scope outgrows the current name — naming question decided during implementation). Both attend and ways-cli depend on it.
+
+The refactor touches three crates in sequence:
+
+1. Rename progression types inside `sensor-trait` — `Instant`/`Duration` → `Tick`/`TickDelta` (both `u64`). Factor the curve enum. Adapt attend's internal uses to go through the renamed API.
+2. Port attend's call sites (`SensorSlot::poll`, `ready_to_disclose`, `current_multiplier`, etc.) to supply `epoch_secs()` as the tick source. Existing attend parameters map onto `Curve::Exponential` (for signal salience) and `Curve::ActionPotential` (for engagement). Semantics preserved exactly.
+3. Wire ways-cli to the shared crate. Per-way `EngagementState<Curve>` replaces the current flat `token_distance_exceeded` check. Tick source is `get_token_position()`. Existing `redisclose: N` frontmatter is parsed as `Curve::Flat { suppression: N }` for backward compatibility.
+
+### 7. Frontmatter schema migration — no shims
+
+Way frontmatter gains a required `curve:` field. The existing `redisclose: N` field is **removed from the schema entirely**. There is no shim layer, no dual-parser, no silent translation of old syntax. Existing ways are migrated to explicit `curve:` declarations as an explicit step of the implementation plan, and the old `redisclose` parser is deleted.
+
+```yaml
+curve:
+  type: Exponential
+  half_life: 50000   # tokens
+```
+
+Or:
+
+```yaml
+curve:
+  type: ProgressiveStaircase
+  steps:
+    - [0,      1.0]
+    - [15000,  0.5]
+    - [40000,  0.2]
+```
+
+Or (explicit step function, for ways that want discontinuous behavior):
+
+```yaml
+curve:
+  type: Flat
+  suppression: 15000   # tokens
+```
+
+**Why no shim:** shims are carryovers from older, pre-unified thinking and carry a translation burden that obscures the actual choice each way is making. Forcing explicit `curve:` declarations during migration is a one-time cost that leaves every way in the codebase with a single, self-documenting firing model. The translation layer is tech debt the moment it ships. Every way must declare its curve; the migration step is part of the refactor, not a deferred clean-up.
+
+### 8. Empirical tuning: `ways tune`
+
+A new `ways tune` subcommand mirrors `attend tune`. It surveys recent sessions via `~/.claude/stats/events.jsonl` (which already captures way-fire events via `log_event` in `session.rs` and the `inject-subagent.sh` logging path), computes per-way cadence statistics, and suggests curve parameters grounded in the user's actual usage. `--apply` rewrites the relevant `curve:` entries in frontmatter or a centralized overrides file.
+
+Tuning parameters come from real session distributions, not guesses — the same discipline ADR-119 used when it sized attend's parameters to "Claude's actual turn cadence, not biological neuron kinetics."
+
+## Consequences
+
+### Positive
+
+- **Single source of truth for firing dynamics.** The math lives in one crate. Drift between attend and ways is structurally impossible.
+- **RoPE-aligned semantics for ways.** The firing engine operates on the same axis the model's attention decays on. Firing decisions are mechanistically matched to how the model treats the injected content.
+- **Progressive disclosure as a first-class pattern.** Not a workaround, not a special-case hack — a named curve variant that any way can opt into.
+- **Reactive firing composes cleanly.** Post-tool-use evaluation uses the same inward/outward gates as predictive firing. No parallel system, no new state to reconcile.
+- **Empirical tunability.** `ways tune` grounds curve parameters in the user's actual session distribution. Defaults are starting points, not final answers.
+- **Future axes for free.** Turn count, commit count, line count — any future trigger surface supplies a monotonic and picks parameters in its own unit. No engine change.
+- **Inward/outward separation preserves ADR-119/121's clarity argument.** "Should this new event fire?" and "Should this already-fired signal still be visible?" are different questions, answered against the same state but through different queries.
+
+### Negative
+
+- **Refactor footprint spans three crates.** `sensor-trait`, `attend`, `ways-cli`. The rename from time-flavored to progression-flavored types touches attend's entire engagement path. This must land as a coherent change or a carefully staged sequence — partial adoption leaves the code confused about what "tick" means.
+- **Curve enum adds one match layer.** Cheap, but not free. Each `salience_at` / `multiplier_at` is a dispatch per call.
+- **Tuning defaults are guesses until real session data is surveyed.** Initial ways parameters will be rough — the calibration pass after landing is where the real defaults come from.
+- **Schema migration is a required step, not optional.** Every existing way must be rewritten to declare `curve:` explicitly before the new parser can land. This is one-time work with no graceful rollout — the old and new parsers cannot coexist. The upside is zero shim tech debt; the downside is one high-risk migration commit.
+- **Exponential parameter conversion at the rename boundary is non-trivial.** Attend's existing parameters are expressed as `decay_per_minute` rates; converting them to `half_life` in ticks requires `half_life = ln(0.5) / ln(1 - rate_per_minute)` then a unit conversion into seconds. For `decay_per_minute = 0.1`, the half-life is `ln(0.5) / ln(0.9) ≈ 6.58 minutes ≈ 395 seconds`. **This is not `0.1 / 60`** — that would only be correct for linear decay; exponential decay requires the compounding formula. Every attend parameter needs recomputation through this formula at the rename boundary, and the migration must validate behavior is preserved (not just syntactically, but numerically).
+
+### Neutral
+
+- **Not backward-compatible — and intentionally so.** `redisclose: N` is removed. Every existing way migrates to explicit `curve:`. This is tech-debt-free by construction; the ADR commits to one coherent schema rather than a dual-parser shim.
+- **Crate naming question deferred.** The firing-dynamics core lives somewhere — either `sensor-trait` (kept as a home) or a renamed/extracted crate. Decision falls out of implementation, not ADR.
+- **Reactive firing can land in stages.** The progression-axis unification and the `PostToolUse` hook extension are independent work items that can sequence separately if staging helps. This ADR establishes both as a single architectural direction; the implementation can still split along natural seams.
+
+## Alternatives Considered
+
+### `Clock` trait generic over `Instant` and `TokenPosition`
+
+Parameterize the engine over a `Clock` trait with associated types for `Time` and `Duration`. Each tool supplies a `Clock` impl. Rejected because this keeps time semantics inside the engine — the type names themselves ("Clock", "Time", "Duration") imply wall-clock reasoning, and the engine has no business reasoning about wall clock for ways. The progression-flavored rename is the same refactor without the conceptual leak.
+
+### Separate implementations per tool
+
+Keep attend's engagement model in `sensor-trait`, add a parallel model to `ways-cli`. Rejected because the math is identical; two implementations would drift, and the code reuse Aaron surfaced in this conversation is real and worth capturing.
+
+### Turn count as ways' axis
+
+Use the number of user turns as ways' progression unit, matching ADR-121's choice for attend signals. Rejected because token position is mechanistically matched to the transformer's attention decay (RoPE) and turn count is not. A think turn and a short reply both count as one turn but displace different amounts of context; token position is the exact measure.
+
+### Wall clock for ways
+
+Use wall-clock seconds for ways' axis, matching attend. Rejected because the model's attention mechanism has no wall-clock dimension. Firing decisions should be made on an axis the model actually observes. Wall clock is external to the thing ways is shaping.
+
+### Keep flat `redisclose`, add reactive firing only
+
+Land `postcheck.sh` and `PostToolUse` hooks without the dynamics unification. Rejected because flat suppression cannot express the inward/outward gate separation that ADR-119 and ADR-121 demonstrated is necessary — and because the reactive firing path needs the same inward gate to avoid spam-firing on every tool call.
+
+### LLM-based reactive evaluation via `type: prompt` hooks
+
+Use Claude Code's `"type": "prompt"` hook as a PostToolUse filter. Run an LLM pass on the tool result and ask which ways to fire. Rejected as the default path because of cost per tool call. Reserved for specific high-value hooks (likely `PostToolUse:Task` on subagent returns, where the tool call is expensive enough that one more LLM eval is noise). The primary reactive path is `postcheck.sh` metric predicates — cheap and deterministic.
+
+### Tick-windowed burst detection
+
+Use `burst_window: TickDelta` to scope which history entries count toward a burst, matching ADR-119's original shape. Rejected because progression axes with chunky advancement (token position in ways) can jump thousands of ticks in a single event, swallowing any reasonable window in one step and breaking burst detection. Event-count-based windowing with the implicit bound defined by the decay curve's multiplier collapse is robust to axis granularity — it works identically for attend's smooth seconds and ways' chunky tokens.
+
+### Backward-compatible `redisclose → Flat` shim
+
+Keep `redisclose: N` in the schema as sugar that translates to `Curve::Flat { suppression: N }`. Rejected on Aaron's direction: shims are carryovers from older, pre-unified thinking. Forcing an explicit `curve:` migration is a one-time cost that leaves the codebase self-documenting. A translation layer obscures what each way is actually declaring and would need to be cleaned up eventually anyway.
+
+## Implementation Plan
+
+1. **sensor-trait rename pass.** Introduce `Tick: u64`, `TickDelta: u64`. Replace `Instant` / `Duration` with `u64` throughout `EngagementState`. Remove `decay_per_minute` and `burst_window` as engine concepts — they move into `Curve::ActionPotential` as `multiplier_half_life` and are derived from event-count windowing.
+2. **Curve enum.** Factor the existing burst/multiplier/decay math into `Curve::ActionPotential` (with event-count burst detection), `Curve::Exponential`, `Curve::ProgressiveStaircase`, and `Curve::Flat`. Expose `salience_at` and `multiplier_at` as the two queries. All decay across all variants is parameterized by `half_life`.
+3. **attend parameter conversion.** Convert attend's existing `decay_per_minute` values to `multiplier_half_life` in ticks using `half_life_seconds = (ln(0.5) / ln(1 - rate_per_minute)) × 60`. Recompute every engagement parameter; do not simple-divide. Validate preserved behavior via existing refractory tests before renaming anything else.
+4. **attend migration.** Adapt `SensorSlot` and its consumers to the renamed API. Tick source wraps `SystemTime::now()` → seconds-since-epoch as `u64`. Verify refractory and salience behavior is unchanged end-to-end on a real session replay.
+5. **ways frontmatter migration (required, no shim).** Rewrite every existing way's frontmatter to declare explicit `curve:`. Ways with `redisclose: N` become either `Curve::Flat { suppression: N }` (if N was chosen for step-function reasons) or `Curve::Exponential { half_life: N }` (if smooth decay is wanted). Remove the `redisclose` field from every way and from the schema.
+6. **ways-cli integration.** Per-way `EngagementState` in `session.rs`. Tick source is `get_token_position()`. Replace `token_distance_exceeded` with `curve.salience_at(delta) >= floor`. Delete the old `REDISCLOSE_PCT` constant and its consumers.
+7. **Frontmatter schema update.** Extend `frontmatter.rs` to parse the new `curve:` block. Delete the `redisclose` parser entirely — no dual-parser. Lint-ways validates the new schema and errors loudly on any leftover `redisclose:` field.
+8. **Hook wiring.** Update `check-prompt.sh`, `check-task-pre.sh`, `check-file-pre.sh`, `check-bash-pre.sh` to consult the engine's inward gate before injecting. Stamp tick on fire via the renamed API.
+9. **Reactive firing path.** Add `PostToolUse` and `PostToolUseFailure` to `settings.json`. New `check-post.sh` walks ways with `postcheck.sh`, runs each, pipes through the inward gate.
+10. **`ways tune`.** Subcommand that surveys `events.jsonl`, computes per-way cadence, suggests curve parameters. `--apply` writes them into frontmatter.
+11. **Empirical calibration.** After landing, run `ways tune` against real session data and commit the calibrated defaults as the production starting point.
+
+## Open Questions
+
+- **Crate home.** Generalize `sensor-trait` in place, or extract a new crate? Lean: keep in `sensor-trait` until the scope clearly outgrows the name. Renaming is a follow-up, not this ADR.
+- **Curve dispatch.** Enum (chosen here) vs trait object. Enum wins on serialization and cheap matching; trait object would be needed only if third-party curves matter. Not yet.
+- **Default curve for ways with no `curve:` field after migration.** After the migration step deletes `redisclose`, the schema could either (a) require every way to declare `curve:` explicitly and error on omission, or (b) provide a sensible default (e.g., `Curve::Exponential { half_life: <25% of context window in tokens for the active model> }`). Lean: (a). Explicit over implicit, matches the "no shim" directive.
+- **Whether `ProgressiveStaircase` ships in the initial implementation or lands as a follow-up once `Exponential` and `ActionPotential` are proven portable.** Lean: ship it in the initial implementation because it demonstrates that the curve-as-parameter shape actually buys something beyond refactoring.
+- **Validation test for attend parameter conversion.** The exponential-decay conversion formula is straightforward, but validating that the renamed attend produces numerically equivalent refractory/salience curves on real session replays is the actual acceptance criterion. How is that validated — side-by-side simulation, golden trace, or live comparison? Decide during implementation.
+- **Epsilon for "event has decayed out of burst consideration".** Event-count burst detection needs a small threshold below which a history entry stops contributing. `multiplier > 1.01` is a reasonable first pick but arbitrary. Empirical tuning via `ways tune` should inform the final value.
+
+## References
+
+- **ADR-113** — attend active awareness module; origin of the disclosure governor.
+- **ADR-114** — attend as insistent way trigger type; the integration point.
+- **ADR-117** — sensor crate extraction and feature flags; precedent for cargo-workspace splits.
+- **ADR-119** — action potential engagement model; the inward gate, currently shipping in attend.
+- **ADR-121** (Draft) — salience decay for signal presentation; the outward gate for attend signals.
+- **Cognitive Frameworks paper** — cognitive economics principle (`cheapest path = correct path`); the reason ways wants model-aligned decay rather than a parallel steering layer.
+- **Rotary Positional Embedding (RoPE)** — Su et al., *RoFormer: Enhanced Transformer with Rotary Position Embedding* (arXiv:2104.09864) — the mechanism that makes token position the correct axis for ways.

--- a/docs/hooks-and-ways/context-decay-formal-foundations.md
+++ b/docs/hooks-and-ways/context-decay-formal-foundations.md
@@ -2,6 +2,10 @@
 
 **A companion to [The Context Decay Model: Why Timed Injection Beats Front-Loading](context-decay.md)**
 
+**See also:** [ADR-123: Firing dynamics — progression-axis unification](../architecture/system/ADR-123-firing-dynamics-progression-axis-unification.md) — the architecture that operationalizes this model for ways and attend, including why token position (not turn count, not wall clock) is the correct progression axis for transformer-hosted ways.
+
+> **Read section 1.1a before citing this document.** The RoPE decay derivation below is the *baseline positional prior*, not a complete model of trained-attention retrieval behavior. Modern LLMs override the baseline for salient content via head specialization, and empirical retention is substantially better than the baseline curve predicts. The decay model is used here as an approximation of *aggregate presentation economics*, which is the right quantity for firing decisions — but it is not a direct model of attention internals.
+
 ## In Plain Terms
 
 AI assistants like Claude forget their instructions as conversations get longer. Not because they're broken — it's how the underlying attention mechanism works. The further away an instruction is from what the model is currently generating, the less influence it has. Research confirms this: information in the middle of a long conversation can lose over 30% of its effectiveness.
@@ -16,15 +20,15 @@ This document maps the context decay model to established research in transforme
 
 ---
 
-## 1. Positional Attention Decay: From Intuition to Proof
+## 1. Positional Attention Decay: Baseline Prior and Its Limits
 
 The context decay model posits that system prompt adherence follows a damped sawtooth:
 
 $$A(t) \approx A_0 \cdot n^{-\alpha} \cdot t_\mathrm{local}^{\ -\beta}$$
 
-This is not a heuristic. It is a direct consequence of how positional encodings modulate attention scores in transformer architectures.
+This is a presentation-economics approximation of a more complex underlying mechanism. It captures the **baseline positional prior** that transformer architectures impose on attention — a prior that is real, measurable, and architecturally grounded. What it does *not* capture is the ability of trained attention heads to override that prior for specific content they have learned to retrieve. Both halves of this picture matter, and the sections below lay out both.
 
-### 1.1 The Mechanism: Positional Encoding Decay
+### 1.1 The Baseline Mechanism: Positional Encoding Decay
 
 Modern LLMs use Rotary Position Embeddings (RoPE), which encode relative position by rotating query and key vectors. The attention score between tokens at positions $i$ and $j$ is modulated by a function of their distance $|i - j|$.
 
@@ -42,11 +46,21 @@ where $b$ is the base (typically 10000) and $d$ is the model dimension. Each fre
 
 $$a_{ij} \propto \sum_k \cos\left((i - j)\,\theta_k\right)$$
 
-Low-frequency components (small $\theta_k$) decay slowly and distinguish distant positions. High-frequency components decay rapidly and encode fine-grained local structure. The aggregate effect is that **attention weights diminish severely beyond approximately 20 tokens of distance**, after which the model struggles to learn useful positional patterns (Attention Needs to Focus, 2026).
+Low-frequency components (small $\theta_k$) decay slowly and distinguish distant positions. High-frequency components decay rapidly and encode fine-grained local structure. The aggregate structural effect is that **the baseline attention prior diminishes with distance**, reaching the point where the encoding alone cannot distinguish useful positional patterns beyond roughly 20 tokens (Attention Needs to Focus, 2026). This is the structural *prior*, not the final attention weight.
 
 <img src="../images/formal-rope-decay.png" alt="RoPE positional decay: frequency band decomposition showing how high-frequency bands oscillate rapidly while low-frequency bands decay slowly, with the aggregate attention score dropping sharply beyond ~20 tokens" width="100%" />
 
-This is the $t_\mathrm{local}^{\ -\beta}$ term: within a single generation, each new token the model produces increases its distance from the system prompt, and the attention weight assigned to those prompt tokens decreases monotonically.
+### 1.1a Why the Baseline Is Not the Whole Story
+
+If the baseline prior were the whole story, long-context models would be useless and needle-in-a-haystack retrieval would be impossible. Neither is true. Trained attention heads — especially in instruction-tuned models like Claude — *learn to override the RoPE-imposed baseline* for specific token patterns the training objective rewards retrieving from distance. A head that has learned "retrieve rule tokens when generating commit messages" applies near-full attention to rule tokens 100k+ positions back, effectively ignoring the structural decay.
+
+This is empirically confirmed. Anthropic's Claude 4.6 model card ([model-context-decay/README.md](../reference/model-context-decay/README.md)) reports that Opus 4.6 retains **78.3% retrieval accuracy at 1M tokens** on MRCR v2 (8-needle). A clean exponential or inverse-power decay along token distance would predict accuracy in the single digits at that range. The gap between "what RoPE's structural prior predicts" and "what trained models actually achieve" is the entire story of attention head specialization for retrieval.
+
+**What this means for the decay model:** the $A(t) \approx A_0 \cdot n^{-\alpha} \cdot t_\mathrm{local}^{\ -\beta}$ formula is most usefully read as an approximation of **aggregate effective adherence across a mixture of attention heads** — some of which honor the baseline decay, some of which override it. For decisions about *when to re-inject a way* (presentation economics), this aggregate is the right thing to track: we don't care whether some specific head could still retrieve the guidance, we care whether the overall generation behavior is still being steered by it. For decisions about *whether a model can retrieve a specific fact from distance* (the needle-in-haystack question), the formula significantly underestimates actual performance.
+
+Firing dynamics operate on the aggregate, not the specific retrieval curve. This is why the model below remains useful despite the gap between it and what attention actually does.
+
+This is the $t_\mathrm{local}^{\ -\beta}$ term — with the caveat that "$\beta$ under trained retrieval" is not the same as "$\beta$ under the pure RoPE baseline." The formula compresses both into one exponent; reality separates them.
 
 ### 1.2 Multi-Layer Amplification: Why Decay Compounds
 
@@ -80,6 +94,8 @@ Key findings:
 The U-shape corresponds to two competing biases: RoPE's recency bias (favoring tokens near the generation cursor) and causal masking's primacy bias (favoring early tokens). The system prompt, being at position zero, benefits from primacy but is vulnerable to distance decay as the context grows.
 
 In the context decay model's terms: the system prompt starts with high effective adherence ($A_0$) due to primacy, but the $n^{-\alpha}$ envelope eventually pushes it below the noise floor where neither primacy nor recency can rescue it.
+
+**Caveat from section 1.1a:** Liu et al. were studying models from 2023; attention retrieval behavior has improved substantially since. Later benchmarks ([model-context-decay/README.md](../reference/model-context-decay/README.md)) show Opus 4.6 at 78% retrieval at 1M tokens — well above the "lost in the middle" curve's predictions. The U-shape still exists but is much shallower in well-trained modern models. This does not invalidate the decay model for presentation economics (which tracks the aggregate, not the specific retrieval curve), but it does mean any quantitative claim derived from Lost in the Middle should be read as a 2023-era baseline, not current performance.
 
 ```mermaid
 graph TD

--- a/docs/hooks-and-ways/context-decay.md
+++ b/docs/hooks-and-ways/context-decay.md
@@ -1,14 +1,29 @@
 # The Context Decay Model: Why Timed Injection Beats Front-Loading
 
-Ways are a progressive disclosure system for LLM context. This document explains the attention mechanics that make timed injection outperform monolithic system prompts — not as analogy, but as a description of the inference dynamics that govern how models use instructions. A companion document, [Formal Foundations](context-decay-formal-foundations.md), grounds each claim here in published transformer research, control theory, and human operator modeling.
+Ways are a progressive disclosure system for LLM context. This document explains why timed injection outperforms monolithic system prompts by modeling the *presentation economics* of long-context inference: how guidance retains or loses its effective influence on generation as context accumulates. A companion document, [Formal Foundations](context-decay-formal-foundations.md), grounds each claim here in published transformer research, control theory, and human operator modeling. The architectural decisions that operationalize this model for firing dynamics live in [ADR-123: Firing dynamics — progression-axis unification for attend and ways](../architecture/system/ADR-123-firing-dynamics-progression-axis-unification.md).
+
+## What this model captures — and what it doesn't
+
+Before the formulas: a note on scope. The decay model below is a pedagogical approximation of *presentation economics*, not a literal description of what happens inside a trained transformer's attention mechanism. It answers the question **"on aggregate, how much effective influence does a piece of guidance retain as context accumulates past it?"** It does not answer "what does attention actually do with this specific token at this specific layer?"
+
+Two separate things can be true:
+
+1. **The baseline positional prior** for attention decays with distance. RoPE (rotary positional embedding) imposes a long-term decay in the inner product of query/key vectors as their positional distance grows. This is a structural property of the encoding, and it's what the model below is approximating.
+2. **Trained attention heads override the baseline** for content they've learned is salient. Modern LLMs — Claude included — are explicitly trained for needle-in-a-haystack retrieval. An attention head that has learned a pattern like "retrieve specific rule tokens when generating commit messages" will reach back 100k+ tokens with near-full salience, ignoring the baseline decay prior. The empirical retention curves in [model-context-decay/README.md](../reference/model-context-decay/README.md) show exactly this: Opus 4.6 retains ~78% retrieval accuracy at 1M tokens, which is much better than any smooth exponential would predict.
+
+Both facts matter, but for *firing decisions* — deciding when to re-inject a way so its guidance is freshly available — what we care about is the **aggregate effective retention** across the mix of attention heads that will actually run during generation. That aggregate is close enough to the baseline decay prior that the model below is a useful decision rule. Firing on token-distance is *presentation economics*, not *attention internals*. We inject when the aggregate has faded below useful, regardless of whether some specific head could still retrieve it.
+
+The rest of this document describes the presentation-economics model. Read the formulas as useful approximations, not as direct claims about transformer mechanics.
 
 ## The Decay Problem
 
-During inference, a model's adherence to system prompt instructions decays with two independent factors:
+During inference, a model's adherence to system prompt instructions drops as context accumulates past it. The drop can be decomposed into two granularities of the same underlying thing — accumulated token distance since the guidance was injected:
 
-1. **Turn decay** ($n^{-\alpha}$): As conversation turns accumulate, the system prompt recedes in positional distance. Each turn pushes it further from the attention cursor. The model's peak adherence to those instructions drops monotonically.
+1. **Turn decay** ($n^{-\alpha}$): Each additional conversation turn pushes the system prompt further from the attention cursor in token distance. Turn count is a coarse proxy for token accumulation — a convenient one because it's easy to count and humans think in turns, but the underlying measure is tokens.
 
-2. **Within-generation decay** ($t_\mathrm{local}^{\ -\beta}$): Within a single generation, attention to the system prompt fades as more tokens are produced. Each token the model generates competes for the same attention budget.
+2. **Within-generation decay** ($t_\mathrm{local}^{\ -\beta}$): Within a single generation, each token the model produces advances the distance from the system prompt. Same mechanism as turn decay, just observed at finer granularity.
+
+**Turn count and local token count are not independent axes — they are the same axis at different zoom levels.** A very long turn, by itself, can close the salience window for guidance injected before it, because the token advance that happens *during* that turn is indistinguishable from the token advance that would happen *across several turns* of equivalent total length. One deep-reasoning turn that generates 8k tokens displaces earlier context the same way eight shorter turns of 1k each would. The $n^{-\alpha}$ and $t_\mathrm{local}^{\ -\beta}$ terms in the formula are not physically separate; they are a two-scale approximation of a single process — **monotonic token advance since injection**.
 
 The combined effect:
 
@@ -113,9 +128,13 @@ The system prompt provides the baseline. Ways provide the reinforcement signal t
 
 ## Relationship to Other Documentation
 
-This document describes the attention mechanics — the *how* of context decay and injection topology.
+This document describes the presentation-economics model — the *how* of context decay and injection topology, framed as useful approximation rather than claims about attention internals.
 
-For the formal mathematical proofs — RoPE decay derivations, multi-layer amplification, cascade control theory, McRuer's crossover model applied to human-LLM steering, and steady-state adherence conditions — see [context-decay-formal-foundations.md](context-decay-formal-foundations.md).
+For the architecture that operationalizes this model for firing dynamics across ways and attend — including the progression-axis framing, curve-as-first-class-parameter, and why ways' tick is token position while attend's is wall-clock — see [ADR-123: Firing dynamics — progression-axis unification](../architecture/system/ADR-123-firing-dynamics-progression-axis-unification.md). That ADR is the canonical source for how this model gets converted into actual firing decisions.
+
+For the formal mathematical grounding — RoPE decay derivations, multi-layer amplification, cascade control theory, McRuer's crossover model applied to human-LLM steering, and steady-state adherence conditions — see [context-decay-formal-foundations.md](context-decay-formal-foundations.md). Note that the RoPE section there should be read alongside the "What this model captures" section above: RoPE gives the baseline positional prior, but trained attention heads can override it for salient retrieval.
+
+For empirical retention benchmarks across models (Opus/Sonnet MRCR v2 and GraphWalks BFS at 128K–1M context) — see [model-context-decay/README.md](../reference/model-context-decay/README.md). These numbers quantify the aggregate effective retention that the formulas above approximate.
 
 For the cognitive science foundations — active inference, predictive processing, situated cognition — see [rationale.md](rationale.md).
 

--- a/docs/hooks-and-ways/observed-behavior.md
+++ b/docs/hooks-and-ways/observed-behavior.md
@@ -1,0 +1,75 @@
+# Observed Behavior: Vanilla vs Ways Claude Code on a Long-Running Supertask
+
+**Date of observation:** ~2026-03-17
+**Operator:** Aaron Bockelie (single operator, two machines, same starting prompt)
+**Status:** n=1 self-observation. Existence proof, not benchmark. Documented here so it exists outside the operator's head.
+
+## Why this file exists
+
+The theoretical scaffolding in [`context-decay.md`](context-decay.md) and [`ADR-123`](../architecture/system/ADR-123-firing-dynamics-progression-axis-unification.md) describes *why* ways should help with long-context instruction adherence. It does not, on its own, show *that* ways help. This note closes the empirical grounding gap so the theory is not resting entirely on internal plausibility.
+
+This is a single observation, not a controlled benchmark. It's n=1, the operator is the author of the system, and there is no blind condition. Treat it as a lab notebook entry, not a study. The value is that the observation is specific enough to be testable by anyone else running the same comparison, and specific enough to discriminate between mechanistic hypotheses.
+
+## Setup
+
+The operator had just started a new job and installed a fresh Claude Code instance on the new-job machine. On the previous machine, the full ways/attend stack had been running for months. Both instances were given the same starting prompt for the same task — a code-review-into-release workflow that involved maintaining a supertask ("publish the new version") while handling a stream of detour work ("fix issues surfaced during review").
+
+- **Machine A — vanilla Claude Code.** Fresh install, no ways, no attend, no custom hooks, no subagent prompts.
+- **Machine B — ways Claude Code.** The full stack as of early March 2026 — ways firing on predictive matches, core guidance via SessionStart hooks, the usual subagent set.
+
+Same starting prompt, same task, same Claude model, same operator.
+
+## Observations
+
+The task completed on both machines. The differences were large enough to be unambiguous on a single trial.
+
+| | Vanilla Claude | Ways Claude |
+|---|---|---|
+| **Context used at task end** | ~275k tokens | ~200k tokens |
+| **Redirections required from operator** | Constant — almost every response needed a nudge to stay on the supertask | Minimal — the supertask held |
+| **Final output quality** | Many scattered inconsistencies across the work | Coherent and consistent |
+| **Operator experience** | Steering cost high; felt like wrestling | Steering cost low; "sailed through" |
+
+The ~27% context-cost reduction is meaningful on its own, but the more telling signal was the qualitative gap in steering cost. Vanilla Claude was burning context on cycles of drift-and-correct. Ways Claude was not.
+
+## The mechanism observation
+
+The operator's direct observation of *what* was going wrong with vanilla Claude, lightly cleaned up from his original description:
+
+> Without steering, Claude kept treating my redirections as the direction to follow — not as detours to resolve inconsistencies I'd surfaced. I think that's because a hint of whatever it was working on — say, resolving issues found during a code review while needing to stay on the supertask of publishing the new version — had drifted far enough from the attention cursor that Claude treated each new instruction as top-of-stack. With ways, the context injection kept the supertask's semantic footprint fresh near the cursor. So when I said something like "fix this inconsistency," Claude could correctly classify it as a detour within the active task rather than a new task to pivot onto. The ways disclosure peaks attention on whatever's semantically related to the current action, which pulls the supertask frame back into effective attention at exactly the moment a detour arrives.
+
+The mechanism in short form: **task hierarchy preservation under redirection.** Vanilla Claude flattens the stack — every new user instruction becomes the new top, because older task context has decayed out of effective attention. Ways Claude maintains the stack — the supertask stays semantically live via re-injection, so new instructions can be correctly framed as detours within a preserved frame rather than replacements for it.
+
+## What this tests (and what it doesn't)
+
+### What the observation supports
+
+1. **Re-injection helps on long-running tasks.** The ~27% context savings and the quality gap are both in the predicted direction. Not proof — compatible with simpler explanations like "more context pressure on vanilla" — but the direction matches theory.
+
+2. **Task-hierarchy preservation is a concrete mechanism, not just a vibe.** The operator could point at *specific* failure modes in vanilla Claude (redirection-as-new-top-of-stack) and *specific* success modes in ways Claude (redirection-as-detour-within-active-task). That specificity is what makes the mechanism falsifiable — anyone running the same comparison can check whether they see the same pattern, not just whether "ways felt better."
+
+3. **Semantically-matched re-injection is doing more than generic reminder spam.** A simpler theory would predict that *any* periodic re-injection — random, rotating, irrelevant — would help roughly equally. This observation is compatible with the stronger claim that ways-style *semantic targeting* matters, because the effect shows up specifically at moments of topic-continuity-vs-topic-change ambiguity. Random re-injection would not be expected to help task classification at those moments.
+
+### What the observation does not test
+
+1. **Parameter calibration.** The observation says "ways helped"; it says nothing about whether the specific curve shapes, half-lives, or firing thresholds in the current implementation are optimal. Those are still empirical questions for [`ways tune`](../architecture/system/ADR-123-firing-dynamics-progression-axis-unification.md) to answer.
+
+2. **Which ways were load-bearing.** The full stack was active on Machine B. This observation cannot discriminate between "quality.md was load-bearing" and "github.md was load-bearing" and "it was all of them together." Ablation by individual way would be needed for that.
+
+3. **Reproducibility across operators.** The operator was the author of the system. Familiarity effects, confirmation bias, and working-style matching to the tool are all uncontrolled. A different operator running the same setup might see a smaller or differently-shaped gap.
+
+4. **Magnitude across models.** This was one Claude model on one task. Retention curves differ across models ([`model-context-decay/README.md`](../reference/model-context-decay/README.md) shows Opus 4.6 retains 78% at 1M vs Sonnet 4.6 at 65%); the observed gap is likely model-dependent.
+
+## Why this is worth keeping
+
+This note is the only place in the project where the empirical grounding for the entire firing-dynamics scaffolding is written down rather than held in the operator's memory. Every time future-us reads [`context-decay.md`](context-decay.md) or [`ADR-123`](../architecture/system/ADR-123-firing-dynamics-progression-axis-unification.md) and wonders whether the theoretical elaboration is justified, the answer should be traceable to a concrete observation with a concrete mechanism — not "I remember noticing once that it helped."
+
+It is also protection against theory-drift. If we later change the implementation in a way that would not have produced the effect observed here, this note is a pre-registered target: the new implementation should still, in principle, pass the same A/B test. If it wouldn't, that's a signal something load-bearing has been lost.
+
+## Related
+
+- [`context-decay.md`](context-decay.md) — the presentation-economics model this observation grounds.
+- [`context-decay-formal-foundations.md`](context-decay-formal-foundations.md) — the mathematical scaffolding, tempered to distinguish baseline attention prior from trained retrieval behavior.
+- [`ADR-123`](../architecture/system/ADR-123-firing-dynamics-progression-axis-unification.md) — the firing-dynamics architecture informed by this model.
+- [`model-context-decay/README.md`](../reference/model-context-decay/README.md) — the empirical retention benchmarks across Claude models.
+- **Convergent external work.** As of April 2026, several independent communities are describing the same underlying pattern from different angles — security ("safety heartbeat" constraint re-injection for long-running agents), prompt engineering (strategic repetition to counter the recency bias), agent research (identity stabilization failures in agent-to-agent conversation without human grounding signals), and memory systems (prune-and-decay architectures with selective top-N injection). These are separate discoveries, not one crowd citing each other. Ways sits in the same shape of the design space but earlier in the calibration cycle.


### PR DESCRIPTION
## Summary

Drafts **ADR-123** unifying attend's action potential + salience decay (ADR-119, ADR-121) and ways' rudimentary token-position redisclose under a single unit-agnostic progression-axis engine. Curves become first-class enum variants; the engine takes `u64` ticks supplied by the caller — wall-clock seconds for attend, token position for ways. Event-count burst detection replaces tick-window burst detection to handle chunky progression axes where a single tool call can advance the tick by thousands. No backward-compat shim — ways migrate to explicit `curve:` frontmatter in a single coherent refactor.

Sweeps context-decay docs for consistency with the tempered RoPE framing: the positional decay model is a pedagogical approximation of presentation economics, not a literal model of attention internals. Trained attention heads override the baseline for salient retrieval (Opus 4.6 retains 78% at 1M tokens, impossible under pure RoPE).

Adds an empirical grounding note (`observed-behavior.md`) documenting the 2026-03-17 vanilla vs ways A/B observation — the single concrete data point that justifies the theoretical scaffolding.

## Commits

- `7d2ecdb` — ADR-123 draft + context-decay.md + context-decay-formal-foundations.md consistency sweep
- `8852654` — observed-behavior.md (task hierarchy preservation mechanism, n=1 self-observation, convergent external evidence)

## Status

ADR-123 is **Draft**. This PR merges the draft so the thinking lands in main and is visible to future work. The implementation follows on a separate `feat/firing-dynamics` branch.

## Test plan

- [x] Docs-only change — no code affected
- [x] All markdown renders in preview
- [x] Internal links resolve
- [x] Mechanism paragraph in observed-behavior.md preserves operator's voice (cleaned grammar only)