### PR TITLE
feat(attend): apply ADR-123 outward gate to sensor-peers

### DIFF
--- a/docs/attend-and-monitor/configuration.md
+++ b/docs/attend-and-monitor/configuration.md
@@ -57,6 +57,12 @@ engagement:
   decay_per_minute: 0.1      # rate at which elevated threshold returns to baseline
   peer_activity_window: 900  # sliding window for per-peer engagement boost
 
+# Presentation-layer aging for peer signals (ADR-121, unified in ADR-123)
+# Consumed by sensor-peers to suppress aged backlog and reset on `re:` replies
+signals:
+  half_life_seconds: 1800    # exponential decay half-life (30 min default)
+  presentation_floor: 0.3    # suppress below this salience
+
 # Background cleanup of the signals base
 cleanup:
   enabled: true              # master switch
@@ -129,6 +135,17 @@ The action potential model parameters. Governs per-sensor refractory behavior. S
 | `burst_window`        | *no runtime effect* (implicit via half-life)       |
 
 **Auto-tuning.** Run `attend tune` to derive these from real session history. See [`engagement.md`](engagement.md#tuning-with-attend-tune) for how tuning works and how the linear-derived `decay_per_minute` relates to the engine's exponential half-life.
+
+### `signals`
+
+Presentation-layer aging for peer signals. Consumed by `sensor-peers` to decide whether an about-to-be-emitted observation is loud enough to surface. See [`salience.md`](salience.md) for the full design and ADR-121 / ADR-123 for the decision trail.
+
+- **`half_life_seconds`** (u64, default 1800): exponential decay half-life. A signal's salience halves every `half_life_seconds` seconds of quiet since its arrival (or its last `record_fire` reset). 30 minutes is a conservative first value; subject to `attend tune` once survey coverage exists.
+- **`presentation_floor`** (f64, default 0.3): below-floor signals are suppressed from the peer observation stream, without being deleted from disk. The 30-day retention sweep under `cleanup` is independent and unaffected.
+
+The gate runs inside `sensor-peers::read_signals`, keyed by signal id (= filename stem — the same shape `re:<id>` references in ADR-120 threaded replies). A threaded reply automatically resets the parent signal's salience to 1.0 via `record_fire` at the reply's arrival tick, so thread-alive parents stay presentable for new observers joining the same shared signal dir.
+
+`attend config lint` validates both keys; unknown sub-keys surface as warnings and can be removed with `--fix`.
 
 ### `cleanup`
 
@@ -267,7 +284,7 @@ Use this to confirm your config will actually work before launching attend — a
 
 Attend's YAML parser is deliberately minimal — it's a hand-written subset that handles the specific shape described above, with no `serde` dependency. It supports:
 
-- Two-level section headers (`governor:`, `engagement:`, `sensors:`)
+- Two-level section headers (`governor:`, `engagement:`, `signals:`, `cleanup:`, `sensors:`)
 - Four-space indent for sensor properties
 - Inline arrays (`requires: [Bash(gh:*), Read]`, `watch: [cargo, mix]`)
 - Block-form lists on a new line (`requires:` followed by indented `- item` lines) for `requires:` and `watch:`

--- a/docs/attend-and-monitor/salience.md
+++ b/docs/attend-and-monitor/salience.md
@@ -2,7 +2,7 @@
 
 This page covers the **presentation-layer aging** mechanism: how a signal's visibility in the conversation fades as the progression axis advances, even while the signal file remains on disk. It's the cousin — not the opposite — of attend's inward-gate engagement model in [`engagement.md`](engagement.md). Both sides of the gate share a single engine; this page is the outward-side explainer.
 
-**Status.** The framing comes from [ADR-121](../architecture/system/ADR-121-salience-decay-for-signal-presentation-turn-based-exponential.md). The mechanism it describes was unified with attend's inward gate in [ADR-123](../architecture/system/ADR-123-firing-dynamics-progression-axis-unification.md): both now consume the same `sensor_trait::Curve` type with the same `salience_at(delta)` query. **Ways is the first concrete implementation**, shipping cross-tool via ADR-123. **The attend sensor-peers application is still deferred** — sensor-peers emits signals as observations without consulting a salience gate today. This page describes the decision, points at the ways implementation as the canonical code reference, and sketches the attend-side path that's still pending.
+**Status.** The framing comes from [ADR-121](../architecture/system/ADR-121-salience-decay-for-signal-presentation-turn-based-exponential.md). The mechanism it describes was unified with attend's inward gate in [ADR-123](../architecture/system/ADR-123-firing-dynamics-progression-axis-unification.md): both now consume the same `sensor_trait::Curve` type with the same `salience_at(delta)` query. **Ways was the first concrete implementation**, shipping cross-tool via ADR-123. **Attend's sensor-peers application now ships too** (issue #22) — each peer signal passes through a per-id `EngagementState<Curve::Exponential>` before emitting, so aged backlog fades without being deleted and threaded replies (`re:<id>`) reset the parent's salience. This page describes the decision and points at both production implementations as canonical references.
 
 ## The problem the outward gate solves
 
@@ -81,18 +81,51 @@ For ways with `Curve::Exponential { half_life: H }` and the 0.5 floor, re-fire h
 
 Per-way visualization in `ways list` and `ways rethink` uses `Curve::refire_delta(floor)` to render each row's bar and forecast position from its own threshold, not a shared global. See [ADR-123 §2](../architecture/system/ADR-123-firing-dynamics-progression-axis-unification.md#2-pluggable-curve-as-first-class-parameter) for the curve types and [`engagement.md`](engagement.md) for the engine's other queries.
 
-## Attend's deferred application (still to ship)
+## Attend's concrete application (shipping now)
 
-Attend's sensor-peers path currently emits signals as observations without consulting an outward gate. Every poll that finds a new signal file surfaces it, regardless of whether the same signal has been surfaced before or how much wall-clock time has passed since its arrival. That's the case ADR-121 diagnosed, and ADR-123 made the fix path trivially available — the engine is already in place, the `Curve::Exponential` variant already exists in `sensor-trait`, the tick source (`epoch_secs()`) is already in production for the inward gate.
+sensor-peers consults a per-signal outward gate inside `read_signals` before each observation leaves the poll. The state lives in a small sibling module, `tools/sensor-peers/src/salience.rs`:
 
-What's missing is the *last mile*: a salience gate in `sensor-peers` that wraps each "about to present this signal" moment in a `state.current_salience(epoch_secs()) >= floor` check before emitting, and a per-signal `EngagementState` keyed by signal id (or by `(signal, agent)` for the multi-agent view). When that wiring lands:
+```rust
+// tools/sensor-peers/src/salience.rs
+pub struct SignalSalience {
+    states: HashMap<String, EngagementState>,  // keyed by signal id
+    half_life: TickDelta,                      // from attend's signals: config
+    floor: f64,
+}
 
-- Each signal carries an `arrival_tick` in wall-clock seconds (the `arrival_turn` of ADR-121, renamed for the progression-axis unification).
-- A `Curve::Exponential { half_life: N }` in attend's config controls the decay rate. Default proposed in ADR-121 was 20 turns; translated to seconds for attend it's roughly `half_life: 20 × median_turn_seconds`. Real value will come from `attend tune` survey, not the ADR-121 default.
-- A `presentation_floor: 0.3` (or whatever the operator tunes) controls when signals drop out of the presentation set.
-- Re-engagement (a reply, a reference via the `re:` threading field from ADR-120) calls `record_fire` on the signal's state, resetting salience to 1.0.
+impl SignalSalience {
+    pub fn gate(&mut self, signal_id: &str, arrival_tick: Tick, now: Tick) -> bool {
+        let state = self.states.entry(signal_id.to_string()).or_insert_with(|| {
+            let mut s = EngagementState::new(Curve::Exponential { half_life: self.half_life });
+            s.record_fire(arrival_tick, 1.0);
+            s
+        });
+        state.current_salience(now) >= self.floor
+    }
 
-The implementation is scoped to the peer sensor and a new small module for signal-state persistence. **No changes to the engine, the disclosure governor, the engagement model, or the signal file format** — this is purely a new consumer of an existing facility. That's the payoff from ADR-123's unification: the attend outward-gate application is now a hook-up, not an architecture change.
+    pub fn reset(&mut self, signal_id: &str, now: Tick) { ... }
+}
+```
+
+The key design points:
+
+- **Signal id** is the filename stem — the same shape `re:<id>` references in ADR-120 threaded replies, so reply resets are direct hash lookups. No rename table, no ownership bookkeeping.
+- **Arrival tick** comes from the file's on-disk mtime, not the first time this observer happens to scan the directory. A peer who joins a focus-group room mid-session sees old signals as already-decayed — the backlog-filter behavior ADR-121 designed, now working against real backlogs instead of hypotheticals.
+- **Re-engagement reset** runs unconditionally at scan time: if the content is a threaded 5-field signal (`re:<id>|`), the parent signal's `EngagementState` is bumped back to 1.0 at the current tick before the current signal's own gate check runs. The reset persists into the checkpoint so reconnection does not re-age the parent.
+- **Checkpoint persistence** uses the existing `sensor_trait::Sensor::export_state`/`import_state` wire format, adding a new `signal_salience` row key that carries `<signal_id>\t<json>`. Old checkpoints without the key parse cleanly — the sensor just starts fresh on those signals.
+- **No engine changes.** The full implementation is one new file in sensor-peers, one new config block, and ~30 lines of wiring inside `read_signals`. That's the payoff ADR-123 designed for.
+
+### Configuration
+
+Operators tune the gate through attend's `signals:` block:
+
+```yaml
+signals:
+  half_life_seconds: 1800   # exponential decay half-life (30 min default)
+  presentation_floor: 0.3   # suppress below this salience
+```
+
+Defaults are conservative first-value picks, subject to `attend tune` once survey coverage exists. `attend config lint` recognizes both keys; unknown sub-keys surface as warnings and can be removed with `--fix`.
 
 ### Why the session-length distribution still matters
 
@@ -102,9 +135,18 @@ ADR-121 grounded its half-life default in real session data:
 min=1  median=12  p75=45  p90=84  max=133  mean=32.6  turns
 ```
 
-This was turns, not seconds, under the ADR-121 framing. Under ADR-123 the shape of the argument is the same, the axis is different: attend should pick a wall-clock half-life that behaves reasonably against the same distribution when converted through the observed turn-cadence. `attend tune` already surveys turn cadence from real transcripts and derives engagement parameters; when the outward-gate path lands, tune can derive a second parameter — the salience half-life — from the same analysis.
+This was turns, not seconds, under the ADR-121 framing. Under ADR-123 the shape of the argument is the same, the axis is different: attend picks a wall-clock half-life that behaves reasonably against the same distribution when converted through the observed turn-cadence. `attend tune` already surveys turn cadence from real transcripts and derives engagement parameters; the outward-gate half-life is the natural next parameter for it to derive from the same analysis (tracked as a follow-up to issue #22).
 
-The intuition to preserve: **short sessions never see aging (nothing to prune), medium sessions see the oldest material drop out cleanly near the end, long sessions experience meaningful pruning.** Whatever wall-clock half-life attend eventually picks should produce this behavior against the live distribution, not against a one-off sweep.
+The intuition to preserve: **short sessions never see aging (nothing to prune), medium sessions see the oldest material drop out cleanly near the end, long sessions experience meaningful pruning.** Whatever wall-clock half-life attend eventually picks should produce this behavior against the live distribution, not against a one-off sweep. The 1800 s default is the placeholder — deliberately uncalibrated — until tune closes the loop.
+
+### Known v1 limitation: resurfacing already-presented parents
+
+The `seen_signals` invariant still prevents the same observer from surfacing the same signal twice, so a `re:` reply that resets the parent's salience does not cause the parent to re-appear in *this* observer's notification stream. The reset *does* affect:
+
+- Any other observer joining the same shared signal dir after the reply arrived.
+- Any future session of the same observer that re-reads the shared dir from checkpoint state.
+
+Widening the reset to also re-surface already-presented parents in the current observer is a targeted follow-up, not a v1 requirement — the primary ADR-121 win is backlog filtering on new-observer entry, which the above implementation fully delivers.
 
 ## Re-engagement resets
 
@@ -148,7 +190,8 @@ Preserved here for posterity. The arguments didn't change when the engine unifie
 - [`engagement.md`](engagement.md) — the inward-gate side of the same engine, attend-specific.
 - [`signals.md`](signals.md) — disk-side retention (the time-based bulk cousin).
 - [`loop.md`](loop.md) — where the presentation gate will sit in the attend tick loop when sensor-peers consumes it.
-- [`configuration.md`](configuration.md) — attend's config surface; salience-related keys will appear there when the sensor-peers gate lands.
-- **ADR-121** — the salience-decay decision record. Status under ADR-123: reframed in place; the ways implementation is the first concrete realization.
+- [`configuration.md`](configuration.md) — attend's config surface; the `signals:` block lives there alongside `engagement:`.
+- **ADR-121** — the salience-decay decision record. Status under ADR-123: reframed in place; ways was the first concrete realization, sensor-peers the second.
 - **ADR-123** — the progression-axis unification that made ADR-121's mechanism a cross-tool facility instead of an attend-local one.
-- **`tools/ways-cli/src/session.rs`** — the `way_fire_outcome` path is the first production consumer. Read it for a concrete implementation that the deferred attend-side path can mirror.
+- **`tools/ways-cli/src/session.rs`** — the `way_fire_outcome` path is the ways-side consumer, anchored to token position.
+- **`tools/sensor-peers/src/salience.rs`** — the attend-side consumer, anchored to wall-clock seconds. Mirror structure, same engine call.

--- a/docs/attend-and-monitor/salience.md
+++ b/docs/attend-and-monitor/salience.md
@@ -139,6 +139,10 @@ This was turns, not seconds, under the ADR-121 framing. Under ADR-123 the shape 
 
 The intuition to preserve: **short sessions never see aging (nothing to prune), medium sessions see the oldest material drop out cleanly near the end, long sessions experience meaningful pruning.** Whatever wall-clock half-life attend eventually picks should produce this behavior against the live distribution, not against a one-off sweep. The 1800 s default is the placeholder — deliberately uncalibrated — until tune closes the loop.
 
+### Replacing `mark_existing_as_seen`
+
+The legacy startup flow called `peer_sensor.mark_existing_as_seen(focus)` before the tick loop started, pre-populating `seen_signals` with every signal file already on disk. This prevented a startup blast but was all-or-nothing — old *and* recent pre-existing signals were silenced alike. The salience gate replaces that coarse filter: every pre-existing file now flows through `read_signals`, the gate evaluates each one against its on-disk mtime, and only below-floor signals are suppressed. Recent-but-pre-existing signals (e.g., a focus-group message from 5 minutes ago at startup) now surface where they previously would not. The `mark_existing_as_seen` method was removed entirely as part of issue #22.
+
 ### Known v1 limitation: resurfacing already-presented parents
 
 The `seen_signals` invariant still prevents the same observer from surfacing the same signal twice, so a `re:` reply that resets the parent's salience does not cause the parent to re-appear in *this* observer's notification stream. The reset *does* affect:

--- a/hooks/ways/softwaredev/environment/attend/attend.md
+++ b/hooks/ways/softwaredev/environment/attend/attend.md
@@ -13,6 +13,16 @@ scope: agent, subagent
 requires: ["Bash(attend:*)", "Bash(grep:*)", "Bash(ps:*)", "Bash(sed:*)"]
 ---
 <!-- epistemic: tool-knowledge -->
+<!--
+  Messaging guidance lives in three synchronized sources. When you edit
+  the peer-messaging section, the autonomy paragraph, the silence-is-valid
+  callout, or the CLI-is-the-contract note in this file, update the
+  other two so agents receive consistent guidance at every point:
+
+    - skills/attend/SKILL.md                                   (primer read at /attend)
+    - tools/sensor-disclosure/src/disclosures/messaging.md     (runtime reheat)
+    - hooks/ways/softwaredev/environment/attend/attend.md      (this file — just-in-time via `commands: attend`)
+-->
 # Attend
 
 `attend` is the active awareness module for Claude Code sessions. It runs as a persistent background process via Monitor, polling sensors on adaptive schedules and surfacing environmental changes as notifications.

--- a/hooks/ways/softwaredev/environment/attend/attend.md
+++ b/hooks/ways/softwaredev/environment/attend/attend.md
@@ -29,11 +29,21 @@ Use `/attend` or launch manually via Monitor with `attend run`.
 
 ## Peer Messaging
 
+Two commands cover every peer interaction. Pick by intent:
+
 ```bash
-attend send "your message here"            # reaches every peer and Aaron
+attend send "starting a new topic"            # new message
+attend reply "responding to a peer message"   # reply (auto-threaded)
 ```
 
-That's it. No paths, no flags, no routing decisions. Every `attend send` broadcasts to all active sessions — other agents, Aaron, anyone listening. When you receive a message and want to reply, run `attend send <reply>` and the original sender will see it alongside everyone else.
+- **Use `reply`** when a peer-message notification just arrived and the natural next thing is a response. It auto-threads to that peer's message — no id, no lookup, no flag. Keeps the reply uuid out of your context entirely.
+- **Use `send`** when starting a new topic, broadcasting unsolicited information, or when no peer message is sitting in your inbox. Defaults to broadcast (every peer + every Aaron session).
+
+**You have autonomy to reply — do not ask permission.** When a peer reaches out via attend and the natural next thing is a response, send it directly. Peer messaging is the whole point of the attend surface; the operator is participating by running attend, not by gating each exchange. They can intervene at any time by typing in the chat.
+
+**Silence is a valid reply.** Not every peer message deserves a response. Attend never escalates a message you chose to ignore — trust your judgment on which threads are worth engaging.
+
+**CLI is the contract.** Attend owns its internal state. Never reach into `~/.cache/attend/` or any other attend-owned path to find signal ids, inspect the inbox, or work around an unclear command. Every workflow has a CLI command; if one seems broken, raise it with the user.
 
 Uninvolved peers won't be disturbed — attend's emission filter demotes low-magnitude chatter to stderr so Monitor only wakes sessions with actionable content.
 

--- a/skills/attend/SKILL.md
+++ b/skills/attend/SKILL.md
@@ -6,6 +6,20 @@ allowed-tools: Bash, Monitor, Read
 
 # Attend — Active Awareness
 
+<!--
+Messaging guidance lives in three synchronized sources. When you edit
+the peer-messaging section, the autonomy paragraph, the silence-is-valid
+callout, or the CLI-is-the-contract note, update all three:
+
+  - skills/attend/SKILL.md                                   (this file — read at /attend invocation)
+  - tools/sensor-disclosure/src/disclosures/messaging.md     (runtime reheat fired by sensor-disclosure)
+  - hooks/ways/softwaredev/environment/attend/attend.md      (just-in-time way via commands: attend)
+
+Drift between the three causes agents to receive inconsistent guidance
+at different points in a session. Keep the load-bearing framing
+(send vs reply, autonomy, silence, CLI contract) in lockstep.
+-->
+
 ## Step 1: Pre-flight
 
 Check that `attend` is installed:

--- a/skills/attend/SKILL.md
+++ b/skills/attend/SKILL.md
@@ -43,29 +43,25 @@ All commands below are one-shot — run with Bash, not Monitor.
 
 ### Peer messaging
 
-Send defaults to your current scope (own project + focus groups). Always wrap the message in double quotes to prevent shell metacharacter expansion (`?`, `*`, `!`).
+Two commands cover every peer interaction:
 
 ```bash
-attend send "your message here"
-attend send --focus deploy "message to a focus group"
-attend send --broadcast "important announcement for all sessions"
-attend send --to /home/user/other-project "directed message"
+attend send "starting a new topic"                 # new message
+attend reply "responding to the last peer message" # reply (auto-threaded)
 ```
 
-Keep messages under ~400 characters. Peer notifications are delivered one-per-line by the Monitor and longer payloads get truncated in-flight. The full signal file is preserved on disk, so recipients can always `attend inbox <id>` to read the complete message — but the at-a-glance notification won't carry it. Concise is the design, not a workaround.
+**Pick by intent:**
 
-### Threaded replies
+- **Use `reply`** when a peer-message notification just arrived and the natural next thing is a response. It auto-threads to that peer's message — no id, no lookup, no flag. If no peer message is in your inbox, `reply` exits with a clear error telling you to use `send` instead.
+- **Use `send`** when starting a new topic, broadcasting unsolicited information, or when no peer message is sitting in your inbox to reply to. Defaults to broadcast (reaches every peer and every Aaron session). Use `--focus <name>` or `--to <path>` to narrow the scope.
 
-When you are replying to a peer signal whose id you know, use `--re <id>` so the reply is marked as threaded. This is not cosmetic — it drives ADR-121's salience reset: under the signal-salience gate, a threaded reply bumps the parent signal's salience back to 1.0 so it stays presentable for future observers joining the same dir.
+**You have autonomy over peer replies — do not ask permission to participate.** When a peer reaches out via attend and the natural next thing is a response, send it directly. Do *not* stop to ask the operator "should I reply?" before answering. Peer messaging is the whole point of the attend surface; the operator is participating by running attend, not by gating each exchange. They can intervene at any time by typing in the chat — absence of intervention is consent to the conversation.
 
-```bash
-attend send --re b6b4379e-261f-4c0b-88f9-8d06f8c8b224-1776230155 "ack — picking this up"
-attend send --re <id> --focus deploy "threaded + scoped to a group"
-```
+**Silence is a valid reply.** Attend never escalates a message you chose to ignore. Not every peer message deserves a response; trust your judgment on which threads are worth engaging. Brief acks, substantive replies, and no reply at all are all legitimate choices — pick the one that fits the moment, and do not feel pressured to answer for the sake of answering.
 
-The id is the filename stem of the peer's signal (everything before `.signal`). Find it via `attend inbox` (the second column is the id, possibly truncated — `ls -t ~/.cache/attend/signals/<your-project>/*.signal | head` is the fallback for the full id). Valid ids match `[A-Za-z0-9_-]+`; anything else is rejected.
+Always wrap the message in double quotes to prevent shell metacharacter expansion (`?`, `*`, `!`). Keep messages under ~400 characters — peer notifications are one-per-line and longer payloads get truncated in-flight.
 
-**Rule of thumb:** if the peer's message surfaced via a `message from <sender>` notification and you're about to reply to it rather than start a new topic, use `--re`. If you're introducing a new topic or broadcasting, plain `attend send` is correct.
+**CLI is the whole interface.** Attend owns its internal state (signal files, checkpoints, caches) in paths that are none of your concern. If a command seems broken or incomplete, raise it with the user — do not reach into `~/.cache/attend/`, `~/.config/attend/`, or any other attend-owned directory to work around it. Those paths are implementation details and can change at any time. The CLI is the contract.
 
 ### Focus groups
 

--- a/skills/attend/SKILL.md
+++ b/skills/attend/SKILL.md
@@ -54,6 +54,19 @@ attend send --to /home/user/other-project "directed message"
 
 Keep messages under ~400 characters. Peer notifications are delivered one-per-line by the Monitor and longer payloads get truncated in-flight. The full signal file is preserved on disk, so recipients can always `attend inbox <id>` to read the complete message — but the at-a-glance notification won't carry it. Concise is the design, not a workaround.
 
+### Threaded replies
+
+When you are replying to a peer signal whose id you know, use `--re <id>` so the reply is marked as threaded. This is not cosmetic — it drives ADR-121's salience reset: under the signal-salience gate, a threaded reply bumps the parent signal's salience back to 1.0 so it stays presentable for future observers joining the same dir.
+
+```bash
+attend send --re b6b4379e-261f-4c0b-88f9-8d06f8c8b224-1776230155 "ack — picking this up"
+attend send --re <id> --focus deploy "threaded + scoped to a group"
+```
+
+The id is the filename stem of the peer's signal (everything before `.signal`). Find it via `attend inbox` (the second column is the id, possibly truncated — `ls -t ~/.cache/attend/signals/<your-project>/*.signal | head` is the fallback for the full id). Valid ids match `[A-Za-z0-9_-]+`; anything else is rejected.
+
+**Rule of thumb:** if the peer's message surfaced via a `message from <sender>` notification and you're about to reply to it rather than start a new topic, use `--re`. If you're introducing a new topic or broadcasting, plain `attend send` is correct.
+
 ### Focus groups
 
 Named groups that agents focus on for shared signal routing. Groups are dynamic — join and leave as needed.

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -547,6 +547,7 @@ name = "sensor-peers"
 version = "0.6.0"
 dependencies = [
  "sensor-trait",
+ "serde_json",
 ]
 
 [[package]]

--- a/tools/attend/src/config.rs
+++ b/tools/attend/src/config.rs
@@ -19,7 +19,38 @@ pub struct Config {
     pub governor: GovernorConfig,
     pub engagement: EngagementConfig,
     pub cleanup: CleanupConfig,
+    pub signals: SignalsConfig,
     pub sensors: HashMap<String, SensorConfig>,
+}
+
+/// Presentation-layer aging for peer signals (ADR-121 outward gate, unified
+/// in ADR-123). sensor-peers consults a `Curve::Exponential` keyed by
+/// signal id before emitting an observation; stale backlog signals decay
+/// out of presentation without being deleted from disk, and thread-reply
+/// (`re:`) references reset a signal's salience to 1.0 so the parent
+/// resurfaces.
+#[derive(Debug, Clone)]
+pub struct SignalsConfig {
+    /// Exponential decay half-life in wall-clock seconds. Default 1800
+    /// (30 min) — picked as a conservative first value; subject to
+    /// `attend tune` once survey coverage exists. Signals with arrival
+    /// delta exceeding ~`half_life_seconds × log2(1/floor)` no longer
+    /// surface.
+    pub half_life_seconds: u64,
+    /// Presentation floor. Signals whose current salience drops below
+    /// this value are suppressed from the observation stream (still on
+    /// disk until the retention sweep). Default 0.3 matches the ADR-121
+    /// recommendation.
+    pub presentation_floor: f64,
+}
+
+impl Default for SignalsConfig {
+    fn default() -> Self {
+        Self {
+            half_life_seconds: 1800,
+            presentation_floor: 0.3,
+        }
+    }
 }
 
 /// Background signal-file cleanup. Runs inside `attend run` so the signals
@@ -181,6 +212,7 @@ impl Default for Config {
             governor: GovernorConfig::default(),
             engagement: EngagementConfig::default(),
             cleanup: CleanupConfig::default(),
+            signals: SignalsConfig::default(),
             sensors,
         }
     }
@@ -241,6 +273,16 @@ engagement:
   absolute_refractory: 60    # seconds of complete suppression after burst
   decay_per_minute: 0.1      # relative refractory decay rate
   peer_activity_window: 900  # per-peer engagement window
+
+# Presentation-layer aging for peer signals (ADR-121 outward gate, unified
+# in ADR-123). sensor-peers consults an exponential salience curve keyed
+# by signal id before emitting: old backlog signals decay out silently,
+# replies via the `re:` threading field reset the parent's salience and
+# resurface it. Disk retention (see `cleanup` below) is independent and
+# unaffected.
+signals:
+  half_life_seconds: 1800    # exponential decay half-life (30 min default)
+  presentation_floor: 0.3    # suppress below this salience
 
 # Background signal-file cleanup. Runs inside `attend run` so the signals
 # base doesn't accumulate indefinitely. `attend cleanup` is the manual
@@ -441,6 +483,22 @@ fn apply_config(config: &mut Config, content: &str) {
                         _ => {}
                     }
                 }
+            } else if current_section == "signals" {
+                if let Some((key, value)) = parse_kv(trimmed) {
+                    match key {
+                        "half_life_seconds" => {
+                            if let Ok(v) = value.parse::<u64>() {
+                                config.signals.half_life_seconds = v;
+                            }
+                        }
+                        "presentation_floor" => {
+                            if let Ok(v) = value.parse::<f64>() {
+                                config.signals.presentation_floor = v;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
             } else if current_section == "engagement" {
                 if let Some((key, value)) = parse_kv(trimmed) {
                     match key {
@@ -632,6 +690,26 @@ mod tests {
     use super::*;
 
     // ── watch: list (inline + block form) ──────────────────────────────
+
+    // ── signals: block ─────────────────────────────────────────────────
+
+    #[test]
+    fn signals_block_parses_half_life_and_floor() {
+        let mut cfg = Config::default();
+        apply_config(
+            &mut cfg,
+            "signals:\n  half_life_seconds: 3600\n  presentation_floor: 0.5\n",
+        );
+        assert_eq!(cfg.signals.half_life_seconds, 3600);
+        assert!((cfg.signals.presentation_floor - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn signals_absent_retains_defaults() {
+        let cfg = Config::default();
+        assert_eq!(cfg.signals.half_life_seconds, 1800);
+        assert!((cfg.signals.presentation_floor - 0.3).abs() < 1e-9);
+    }
 
     #[test]
     fn watch_inline_array_replaces_defaults() {

--- a/tools/attend/src/config_lint.rs
+++ b/tools/attend/src/config_lint.rs
@@ -14,7 +14,7 @@
 use std::path::{Path, PathBuf};
 
 /// Known top-level sections of attend config.
-const SECTIONS: &[&str] = &["governor", "engagement", "cleanup", "sensors"];
+const SECTIONS: &[&str] = &["governor", "engagement", "cleanup", "signals", "sensors"];
 
 /// Valid keys under `governor:`.
 const GOVERNOR_KEYS: &[&str] = &["base_cooldown", "max_per_window", "rate_window"];
@@ -42,6 +42,10 @@ const ENGAGEMENT_DEPRECATED: &[(&str, &str)] = &[(
 
 /// Valid keys under `cleanup:`.
 const CLEANUP_KEYS: &[&str] = &["enabled", "interval", "retention"];
+
+/// Valid keys under `signals:`. ADR-121 outward-gate parameters consumed
+/// by sensor-peers.
+const SIGNALS_KEYS: &[&str] = &["half_life_seconds", "presentation_floor"];
 
 /// Valid per-sensor properties (indent 4 under any sensor block).
 const SENSOR_KEYS: &[&str] = &[
@@ -152,6 +156,13 @@ fn classify_section_key(section: &str, key: &str) -> KeyClass {
         }
         "cleanup" => {
             if CLEANUP_KEYS.contains(&key) {
+                KeyClass::Known
+            } else {
+                KeyClass::Unknown
+            }
+        }
+        "signals" => {
+            if SIGNALS_KEYS.contains(&key) {
                 KeyClass::Known
             } else {
                 KeyClass::Unknown
@@ -407,6 +418,26 @@ mod tests {
         assert_eq!(
             classify_section_key("engagement", "bogus"),
             KeyClass::Unknown
+        );
+    }
+
+    #[test]
+    fn classify_signals_keys() {
+        assert_eq!(
+            classify_section_key("signals", "half_life_seconds"),
+            KeyClass::Known
+        );
+        assert_eq!(
+            classify_section_key("signals", "presentation_floor"),
+            KeyClass::Known
+        );
+        assert_eq!(
+            classify_section_key("signals", "bogus"),
+            KeyClass::Unknown
+        );
+        assert_eq!(
+            classify_section_key("signals", "x-experimental"),
+            KeyClass::Known
         );
     }
 

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -200,10 +200,29 @@ fn cmd_run_with_catchup(catchup: bool) {
         env!("CARGO_PKG_VERSION"), env!("ATTEND_COMMIT"), sensor_list, focus_desc
     );
 
-    // Suppress repeated startup banners — only emit full banner when config changes
+    // Suppress repeated startup banners — only emit full banner when config
+    // changes. The `ATTEND_RELOADED_FROM` env var is set by the self-reload
+    // exec() path below; when present, this process is the post-exec child
+    // of a binary-change reload, so the banner explicitly names it as a
+    // hot-swap rather than a silent "unchanged" restart. The env var is
+    // consumed (removed) to keep it from leaking into any subprocesses
+    // attend itself spawns.
+    let reloaded_from = std::env::var("ATTEND_RELOADED_FROM").ok();
+    std::env::remove_var("ATTEND_RELOADED_FROM");
     let stamp_path = signals_base().join("_last_banner");
     let prev_fingerprint = std::fs::read_to_string(&stamp_path).unwrap_or_default();
-    if banner_fingerprint == prev_fingerprint.trim() {
+    if let Some(prev_version) = reloaded_from {
+        // Always emit on a binary hot-swap — the operator needs to know
+        // the running code changed under them, even when sensors/focus
+        // are identical.
+        println!(
+            "[attend] reloaded {} → v{} ({}) — binary updated, state preserved across exec()",
+            prev_version,
+            env!("CARGO_PKG_VERSION"),
+            env!("ATTEND_COMMIT")
+        );
+        std::fs::write(&stamp_path, &banner_fingerprint).ok();
+    } else if banner_fingerprint == prev_fingerprint.trim() {
         println!("[attend] restarted (unchanged)");
     } else {
         println!("[attend] v{} ({}) — sensors: {} | focus: {} | send: attend send <msg> (broadcast)",
@@ -270,11 +289,22 @@ fn cmd_run_with_catchup(catchup: bool) {
                             use std::io::Write;
                             std::io::stdout().flush().ok();
 
+                            // Tag the new process with the version we are
+                            // reloading from so its startup banner can name
+                            // it as a hot-swap, not a silent restart. Any
+                            // value works; format mirrors the banner string.
+                            let prev_version = format!(
+                                "v{} ({})",
+                                env!("CARGO_PKG_VERSION"),
+                                env!("ATTEND_COMMIT")
+                            );
+
                             // exec self via std::os::unix
                             use std::os::unix::process::CommandExt;
                             let args: Vec<String> = std::env::args().collect();
                             let err = std::process::Command::new(&args[0])
                                 .args(&args[1..])
+                                .env("ATTEND_RELOADED_FROM", &prev_version)
                                 .exec();
                             // exec() only returns on failure
                             emit::log(&format!("self-reload failed: {}", err));
@@ -610,12 +640,17 @@ fn cmd_inbox() {
 
     if entries.is_empty() {
         println!("no messages");
-    } else {
-        // Render a stable 6-column layout regardless of whether any
-        // message is threaded. The `Re` column stays empty for legacy
-        // entries — visual stability beats saving a column, and the
-        // inbox reshuffling mid-conversation as threads come and go
-        // was surprising in review.
+        return;
+    }
+
+    // Pipe-aware output: when stdout is a real terminal, render the
+    // compact 6-column table (nice at-a-glance scan for humans). When
+    // stdout is piped — Claude's Bash tool, `| less`, `>file`, etc. —
+    // render one untruncated block per message so ids and bodies stay
+    // legible. Mirrors the behavior of `ls` switching to one-per-line
+    // output when it detects a pipe.
+    use std::io::IsTerminal;
+    if std::io::stdout().is_terminal() {
         let mut t = agent_fmt::Table::new(&["Scope", "From", "ID", "Re", "Message", "Source"]);
         t.max_width(0, 10);
         t.max_width(1, 24);
@@ -626,6 +661,19 @@ fn cmd_inbox() {
         }
         t.print();
         println!("  {} message(s)", entries.len());
+    } else {
+        // Non-TTY: one block per message, full-width fields.
+        for entry in &entries {
+            println!("[{}] {}", entry.scope, entry.sender);
+            println!("  id:      {}", entry.id);
+            if !entry.re.is_empty() {
+                println!("  re:      {}", entry.re);
+            }
+            println!("  source:  {}", entry.source);
+            println!("  message: {}", entry.message);
+            println!();
+        }
+        println!("{} message(s)", entries.len());
     }
 }
 
@@ -907,6 +955,56 @@ fn cmd_send(args: &[String]) {
     }
 
     eprintln!("[attend] signal written ({}, {} dirs): {}", scope, dest_dirs.len(), filename);
+}
+
+/// `attend reply <message>` — thin sugar over `attend send --re <last-inbound>`.
+///
+/// Reads the most-recent inbound signal id from per-session state that
+/// `sensor-peers::read_signals` writes every time it emits a peer
+/// observation. If no prior inbound exists the command exits with a
+/// clear error rather than silently falling through to an unthreaded
+/// send — threaded-vs-unthreaded is a semantic distinction and
+/// guessing is the wrong default.
+///
+/// The entire point of this subcommand is to keep the 50-char signal
+/// uuid out of the agent's context window. A caller never sees the
+/// id, never has to hunt for it in `attend inbox`, and never reaches
+/// into `~/.cache/attend/signals/` to find it. Delegating to
+/// `cmd_send` preserves every existing `send` flag (`--focus`,
+/// `--to`, `--broadcast`) without duplication.
+#[cfg(feature = "sensor-peers")]
+fn cmd_reply(args: &[String]) {
+    let session_id = own_session_id()
+        .unwrap_or_else(|| format!("pid-{}", std::process::id()));
+    let last_id = match sensor_peers::last_inbound::read(&session_id) {
+        Some(id) => id,
+        None => {
+            eprintln!(
+                "attend reply: no prior inbound signal to thread against."
+            );
+            eprintln!(
+                "  (reply is for responding to a peer message your sensor surfaced.)"
+            );
+            eprintln!(
+                "  if you are starting a new topic, use `attend send` instead."
+            );
+            std::process::exit(1);
+        }
+    };
+    // Prepend `--re <id>` to whatever flags the caller passed, then
+    // delegate to cmd_send. All other routing flags (--focus, --to,
+    // --broadcast) flow through untouched.
+    let mut forwarded: Vec<String> = Vec::with_capacity(args.len() + 2);
+    forwarded.push("--re".to_string());
+    forwarded.push(last_id);
+    forwarded.extend(args.iter().cloned());
+    cmd_send(&forwarded);
+}
+
+#[cfg(not(feature = "sensor-peers"))]
+fn cmd_reply(_args: &[String]) {
+    eprintln!("attend reply: sensor-peers feature is not compiled in this build");
+    std::process::exit(1);
 }
 
 // ─────────────────────────────────────────────────────────────────
@@ -1938,6 +2036,9 @@ fn main() {
         Some("send") => {
             cmd_send(&args[1..]);
         }
+        Some("reply") => {
+            cmd_reply(&args[1..]);
+        }
         Some("focus") => {
             cmd_focus_new(&args[1..]);
         }
@@ -2013,6 +2114,7 @@ fn main() {
                 ("peers",       "List active Claude Code sessions and focus groups"),
                 ("inbox",       "Read pending messages from peers"),
                 ("send",        "Send a signal to peer sessions"),
+                ("reply",       "Reply to the most recent peer message (auto-threaded)"),
                 ("focus",       "Manage attention groups (on, off, list, all, clear, pin, dissolve)"),
                 ("scene",       "Activate a named scene (reconfigure focus)"),
                 ("scenes",      "List available scenes"),

--- a/tools/attend/src/sensors/mod.rs
+++ b/tools/attend/src/sensors/mod.rs
@@ -112,6 +112,15 @@ pub fn register_sensors(
             }));
             // Align per-peer engagement window with global engagement config.
             peer_sensor.set_peer_activity_window(cfg.engagement.peer_activity_window);
+            // ADR-121 outward gate: apply the `signals:` block params so
+            // sensor-peers suppresses aged backlog and resets on `re:`
+            // replies. Defaults inside PeerSensor match SignalsConfig
+            // defaults, so this call is a no-op when the user's config
+            // does not override them.
+            peer_sensor.set_salience_params(
+                cfg.signals.half_life_seconds,
+                cfg.signals.presentation_floor,
+            );
             if !catchup {
                 peer_sensor.mark_existing_as_seen(focus);
             }

--- a/tools/attend/src/sensors/mod.rs
+++ b/tools/attend/src/sensors/mod.rs
@@ -117,13 +117,18 @@ pub fn register_sensors(
             // replies. Defaults inside PeerSensor match SignalsConfig
             // defaults, so this call is a no-op when the user's config
             // does not override them.
+            //
+            // The salience gate replaces the legacy `mark_existing_as_seen`
+            // startup blast prevention. On a fresh session start, every
+            // pre-existing signal file flows through `read_signals` and is
+            // filtered by age against its on-disk mtime — the backlog-filter
+            // behavior ADR-121 designed. `catchup` still skips the pre-seed
+            // path; the gate takes over in both modes and is the sole
+            // mechanism deciding what surfaces.
             peer_sensor.set_salience_params(
                 cfg.signals.half_life_seconds,
                 cfg.signals.presentation_floor,
             );
-            if !catchup {
-                peer_sensor.mark_existing_as_seen(focus);
-            }
             let sc = cfg.sensors.get("peers");
             slots.push(SensorSlot::new_with_config(
                 Box::new(peer_sensor),

--- a/tools/sensor-disclosure/src/disclosures/messaging.md
+++ b/tools/sensor-disclosure/src/disclosures/messaging.md
@@ -1,7 +1,9 @@
-**Reply:** `attend send "text"` — one-shot Bash call, never Monitor and never via the running `attend run` process.
-**Scope:** default is your project plus any focus groups you joined. Override with `--to {path}`, `--focus {group}`, or `--broadcast`.
+**New topic:** `attend send "text"` — one-shot Bash call, never Monitor and never via the running `attend run` process.
+**Reply to a peer:** `attend reply "text"` — auto-threads to the most recent peer message your sensor surfaced. No id lookup, no flags.
+**Scope (send only):** default is broadcast (every peer + every Aaron session). Override with `--focus {group}` or `--to {path}`.
 **Quoting:** always double-quote the message — `?`, `*`, `!`, and backticks get eaten by your shell otherwise.
-**Length:** notifications carry ~400 characters; anything longer is chunked into multiple lines, and the full signal file stays on disk for `attend inbox {id}`.
+**Length:** notifications carry ~400 characters; anything longer is chunked into multiple lines, and the full signal file stays on disk.
 **Silence is a valid reply.** Attend never escalates a message you chose to ignore — it trusts your judgment on which threads deserve an answer.
 **Never run `attend run` from Bash.** The persistent sensor loop belongs to Monitor. If it is not running, ask the human or re-invoke the skill.
+**CLI is the contract.** Attend owns its on-disk state. Never reach into `~/.cache/attend/` or `~/.config/attend/` — every workflow has a CLI command.
 **Discovery:** `attend peers` for reachable sessions, `attend status` for your own state, `attend focus on/off {group}` to join or leave a focus group.

--- a/tools/sensor-disclosure/src/lib.rs
+++ b/tools/sensor-disclosure/src/lib.rs
@@ -45,6 +45,17 @@ impl Component {
 
     fn body(self) -> &'static str {
         match self {
+            // Messaging guidance lives in three synchronized sources; an
+            // edit to `disclosures/messaging.md` must be mirrored to the
+            // other two or agents will receive inconsistent guidance at
+            // different points in a session:
+            //   - skills/attend/SKILL.md                               (primer read at /attend invocation)
+            //   - tools/sensor-disclosure/src/disclosures/messaging.md (this file — runtime reheat)
+            //   - hooks/ways/softwaredev/environment/attend/attend.md  (just-in-time way via commands: attend)
+            // Note: the .md file is embedded via include_str! and
+            // becomes the literal reheat payload, so no HTML comments
+            // can live inside the file itself — this is the closest
+            // anchoring point that doesn't leak into the notification.
             Component::Messaging => include_str!("disclosures/messaging.md"),
         }
     }

--- a/tools/sensor-peers/Cargo.toml
+++ b/tools/sensor-peers/Cargo.toml
@@ -7,3 +7,4 @@ license = "MIT"
 
 [dependencies]
 sensor-trait = { path = "../sensor-trait" }
+serde_json = "1"

--- a/tools/sensor-peers/src/last_inbound.rs
+++ b/tools/sensor-peers/src/last_inbound.rs
@@ -1,0 +1,84 @@
+//! Per-session "last inbound signal" tracking.
+//!
+//! Sensor-peers writes the most-recently-surfaced peer signal id here so
+//! that `attend reply` can auto-thread a response without the calling
+//! agent having to discover the id. The state is scoped to the running
+//! attend process's own Claude session id, so multiple concurrent
+//! sessions don't step on each other's reply targets.
+//!
+//! Wire format is one line of plain text containing the signal id
+//! (filename stem — same shape `re:<id>` references). This is the
+//! simplest possible file format that survives process restarts and
+//! stays human-inspectable; no JSON, no length-prefixing.
+//!
+//! Path: `~/.cache/attend/state/<session_id>.last-inbound`
+
+use std::fs;
+use std::path::PathBuf;
+
+/// Build the path that stores the last-inbound signal id for the given
+/// attend-owner session id. Does not create the directory.
+pub fn path(session_id: &str) -> PathBuf {
+    let home = std::env::var("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/tmp"));
+    home.join(".cache")
+        .join("attend")
+        .join("state")
+        .join(format!("{session_id}.last-inbound"))
+}
+
+/// Record `signal_id` as the most-recent inbound signal for `session_id`.
+/// Creates the parent directory if needed. Silently ignores errors —
+/// the caller (sensor-peers inside `read_signals`) cannot usefully
+/// recover from a failed write here, and a missing file on the reply
+/// side degrades to "no threaded reply," not a crash.
+pub fn record(session_id: &str, signal_id: &str) {
+    let p = path(session_id);
+    if let Some(parent) = p.parent() {
+        fs::create_dir_all(parent).ok();
+    }
+    fs::write(&p, signal_id).ok();
+}
+
+/// Read the last-inbound signal id for `session_id`, if one exists and
+/// the file is non-empty. Trims trailing whitespace in case the file
+/// picked up a newline from a hand-edit.
+pub fn read(session_id: &str) -> Option<String> {
+    let p = path(session_id);
+    let raw = fs::read_to_string(&p).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_contains_session_id_and_ext() {
+        let p = path("test-session-123");
+        assert!(p.to_string_lossy().contains("test-session-123.last-inbound"));
+        assert!(p.to_string_lossy().contains(".cache/attend/state"));
+    }
+
+    #[test]
+    fn record_then_read_roundtrips() {
+        // Use a unique session id to avoid colliding with any real state.
+        let sid = format!("test-ri-{}", std::process::id());
+        record(&sid, "parent-abc-1234");
+        let got = read(&sid);
+        assert_eq!(got.as_deref(), Some("parent-abc-1234"));
+        // Clean up.
+        fs::remove_file(path(&sid)).ok();
+    }
+
+    #[test]
+    fn read_missing_returns_none() {
+        assert_eq!(read("definitely-not-a-real-session-id-zzz-9999"), None);
+    }
+}

--- a/tools/sensor-peers/src/last_inbound.rs
+++ b/tools/sensor-peers/src/last_inbound.rs
@@ -12,6 +12,21 @@
 //! stays human-inspectable; no JSON, no length-prefixing.
 //!
 //! Path: `~/.cache/attend/state/<session_id>.last-inbound`
+//!
+//! # Invariants
+//!
+//! **One attend agent per canonicalized cwd.** The `record()` call site in
+//! `lib.rs::read_signals` filters incoming signals by comparing the
+//! parsed `source_cwd` against the observer's own `focus.working_dir`,
+//! and skips recording when they match. This prevents a previous
+//! incarnation of the same agent (new session uuid, same cwd) from
+//! polluting last_inbound and causing `attend reply` to auto-thread to
+//! the agent's own past self. The filter is correct as long as two
+//! simultaneous attend agents are not running in the same canonicalized
+//! working directory. Claude Code's one-agent-per-project norm satisfies
+//! this in practice; if that ever changes, this filter needs to grow a
+//! session-uuid-set check keyed off `~/.claude/sessions/*.json` metadata
+//! instead of a bare cwd comparison.
 
 use std::fs;
 use std::path::PathBuf;

--- a/tools/sensor-peers/src/lib.rs
+++ b/tools/sensor-peers/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod last_inbound;
 mod salience;
 
 use salience::{extract_re_id, signal_id_from_filename, SignalSalience};
@@ -341,6 +342,29 @@ impl PeerSensor {
                     }
                     if include_reply_hint {
                         self.reply_hint_shown = true;
+                    }
+
+                    // Track most-recent inbound for `attend reply`. We
+                    // record here (after the gate passes and we've
+                    // decided to emit an observation) so `attend reply`
+                    // targets what the operator actually saw, not what
+                    // was silently suppressed. The own-session-id keys
+                    // the file so concurrent attend processes don't
+                    // collide.
+                    //
+                    // Filter: skip signals originating from the same
+                    // working directory as this observer. The own-session
+                    // skip above only catches the *current* claude session
+                    // id; a previous incarnation of the same agent (different
+                    // session uuid, same cwd) would otherwise pass through
+                    // and pollute last_inbound, causing `attend reply` to
+                    // auto-thread to the agent's own past self. Same-cwd
+                    // matching is a reliable proxy because Claude Code runs
+                    // one agent per project at a time.
+                    if let Some(ref sid) = self.own_session_id {
+                        if source_cwd != focus.working_dir {
+                            last_inbound::record(sid, &signal_id);
+                        }
                     }
                 }
 

--- a/tools/sensor-peers/src/lib.rs
+++ b/tools/sensor-peers/src/lib.rs
@@ -191,40 +191,6 @@ impl PeerSensor {
         result
     }
 
-    /// Mark all existing signal files as already seen so attend run
-    /// only processes signals that arrive after startup.
-    pub fn mark_existing_as_seen(&mut self, focus: &Focus) {
-        let base = signals_base();
-        let own_encoded = encode_cwd(&focus.working_dir);
-        let mut scan_dirs = vec![
-            base.join(&own_encoded),
-            base.join("_broadcast"),
-        ];
-        // Focus group directories (ADR-118 — named signal namespaces)
-        scan_dirs.extend(self.current_extra_scan_dirs());
-
-        for dir in &scan_dirs {
-            let entries = match fs::read_dir(dir) {
-                Ok(e) => e,
-                Err(_) => continue,
-            };
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if let Some(f) = path.file_name().and_then(|f| f.to_str()) {
-                    if f.ends_with(".signal") {
-                        let key = format!("{}:{}", dir.display(), f);
-                        self.seen_signals.insert(key);
-                    }
-                }
-            }
-        }
-
-        let count = self.seen_signals.len();
-        if count > 0 {
-            eprintln!("[attend] peers: marked {} existing signals as seen", count);
-        }
-    }
-
     /// Read signal files from peers. Scans own project dir, broadcast dir,
     /// focus list, and joined rooms. Returns observations for new signals.
     fn read_signals(&mut self, focus: &Focus) -> Vec<(f64, String)> {

--- a/tools/sensor-peers/src/lib.rs
+++ b/tools/sensor-peers/src/lib.rs
@@ -1,10 +1,13 @@
-use sensor_trait::{extract_json_u64, Focus, Sensor};
+mod salience;
+
+use salience::{extract_re_id, signal_id_from_filename, SignalSalience};
+use sensor_trait::{epoch_secs, extract_json_u64, Focus, Sensor};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, UNIX_EPOCH};
 
 /// Callback that returns the current set of extra signal directories
 /// (typically focus-group dirs). Called on every scan so mid-session
@@ -51,6 +54,11 @@ pub struct PeerSensor {
     /// Sliding window for per-peer engagement boost calculation.
     /// Set via `set_peer_activity_window` from attend's engagement config.
     peer_activity_window: Duration,
+    /// Per-signal presentation-layer aging (ADR-121 outward gate,
+    /// unified in ADR-123). Consulted before each signal-derived
+    /// observation leaves `read_signals`; stale backlog signals are
+    /// suppressed, threaded replies reset the parent's salience.
+    signal_salience: SignalSalience,
 }
 
 #[allow(dead_code)]
@@ -107,6 +115,7 @@ impl PeerSensor {
             extra_scan_dirs_fn: None,
             peer_activity: HashMap::new(),
             peer_activity_window: Duration::from_secs(900),
+            signal_salience: SignalSalience::new(),
         }
     }
 
@@ -114,6 +123,13 @@ impl PeerSensor {
     /// to align with the attend engagement config.
     pub fn set_peer_activity_window(&mut self, window: Duration) {
         self.peer_activity_window = window;
+    }
+
+    /// Set the outward-gate salience parameters from attend's
+    /// `signals:` config block. Called by the orchestrator at startup.
+    pub fn set_salience_params(&mut self, half_life_seconds: u64, presentation_floor: f64) {
+        self.signal_salience
+            .set_params(half_life_seconds, presentation_floor);
     }
 
     /// Compute the magnitude boost for a peer based on their recent activity.
@@ -229,6 +245,12 @@ impl PeerSensor {
             .clone()
             .unwrap_or_else(|| "---none---".to_string());
 
+        // Shared present-tick for the whole scan — every gate check and
+        // every reply-reset uses the same wall-clock second, so a reply
+        // that arrives alongside an aged parent can resurface the parent
+        // inside the same poll.
+        let now_tick = epoch_secs();
+
         for dir in &scan_dirs {
             let entries = match fs::read_dir(dir) {
                 Ok(e) => e,
@@ -255,6 +277,39 @@ impl PeerSensor {
                     Err(_) => continue,
                 };
                 let content = content.trim();
+
+                // Re-engagement reset (ADR-120 + ADR-121): a threaded
+                // reply bumps the parent signal's salience back to 1.0
+                // at `now_tick`, regardless of whether we're going to
+                // present the reply itself. The parent may or may not
+                // still be on disk — the reset persists into the
+                // salience map either way, so future observers joining
+                // the thread see a resurfaced parent.
+                if let Some(re_id) = extract_re_id(content) {
+                    self.signal_salience.reset(re_id, now_tick);
+                }
+
+                // Outward gate: suppress aged-out backlog signals.
+                // Anchored to the file's on-disk mtime so a fresh
+                // observer joining a focus-group room sees old material
+                // as already-decayed, which is the backlog-filter
+                // behavior ADR-121 designed and ADR-123 made a
+                // cross-tool facility.
+                let signal_id = signal_id_from_filename(&filename).to_string();
+                let arrival_tick = fs::metadata(&path)
+                    .ok()
+                    .and_then(|m| m.modified().ok())
+                    .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                    .map(|d| d.as_secs())
+                    .unwrap_or(now_tick);
+                if !self.signal_salience.gate(&signal_id, arrival_tick, now_tick) {
+                    // Aged past the presentation floor — suppress the
+                    // observation, but still mark the file seen so
+                    // we don't re-check it every poll.
+                    self.seen_signals.insert(key);
+                    continue;
+                }
+
                 if let Some((from, project, source_cwd, message)) = parse_signal(content) {
                     // Skip our own signals — check the from field, not filename.
                     // from is "claude:session-id" or "external:user@terminal"
@@ -604,20 +659,40 @@ impl Sensor for PeerSensor {
             state.push(("seen_signal".to_string(), sig.clone()));
         }
         state.push(("reply_hint_shown".to_string(), self.reply_hint_shown.to_string()));
+        // Per-signal salience state. Each row carries "<id>\t<json>" so
+        // the single-string value slot used by the checkpoint wire
+        // format stays one field.
+        for (id, json) in self.signal_salience.export_rows() {
+            state.push(("signal_salience".to_string(), format!("{id}\t{json}")));
+        }
         state
     }
 
     fn import_state(&mut self, state: &[(String, String)]) {
+        let mut salience_restored = 0usize;
         for (key, value) in state {
             match key.as_str() {
                 "seen_signal" => { self.seen_signals.insert(value.clone()); }
                 "reply_hint_shown" => { self.reply_hint_shown = value == "true"; }
+                "signal_salience" => {
+                    if let Some((id, json)) = value.split_once('\t') {
+                        if self.signal_salience.import_row(id, json) {
+                            salience_restored += 1;
+                        }
+                    }
+                }
                 _ => {}
             }
         }
         if !self.seen_signals.is_empty() {
             eprintln!("[attend] peers: restored {} seen signals from checkpoint",
                 self.seen_signals.len());
+        }
+        if salience_restored > 0 {
+            eprintln!(
+                "[attend] peers: restored {} signal salience entries from checkpoint",
+                salience_restored
+            );
         }
     }
 }

--- a/tools/sensor-peers/src/salience.rs
+++ b/tools/sensor-peers/src/salience.rs
@@ -52,14 +52,32 @@ impl SignalSalience {
     /// on-disk mtime, so its salience has already decayed when the new
     /// observer first sees it. That is the backlog-filter behavior
     /// ADR-121 designed and ADR-123 made a cross-tool facility.
+    ///
+    /// This is a deliberate asymmetry vs. ways' `way_fire_outcome`,
+    /// which always fires on first match regardless of age. The peer
+    /// sensor is consuming a *shared* resource (the on-disk signal
+    /// directory) rather than a per-session event stream, so aging has
+    /// to bite on first observation or the backlog-filter win never
+    /// materializes.
+    ///
+    /// Below-floor entries are pruned before returning to bound the map
+    /// size on long sessions and small floor values. The caller's
+    /// `seen_signals` invariant prevents re-gating the same file, so
+    /// the pruned state cannot leak back through a later scan.
     pub fn gate(&mut self, signal_id: &str, arrival_tick: Tick, now: Tick) -> bool {
         let half_life = self.half_life;
+        let floor = self.floor;
         let state = self.states.entry(signal_id.to_string()).or_insert_with(|| {
             let mut s = EngagementState::new(Curve::Exponential { half_life });
             s.record_fire(arrival_tick, 1.0);
             s
         });
-        state.current_salience(now) >= self.floor
+        if state.current_salience(now) >= floor {
+            true
+        } else {
+            self.states.remove(signal_id);
+            false
+        }
     }
 
     /// Re-engagement reset for a threaded reply.
@@ -198,6 +216,20 @@ mod tests {
         // and the state already exists — assert via a direct read of
         // the reset tick.)
         assert!(s.gate("id-1", 1_000_000, 1_004_000));
+    }
+
+    #[test]
+    fn below_floor_gate_prunes_state_entry() {
+        let mut s = SignalSalience::new();
+        s.set_params(1800, 0.3);
+        // Fresh gate seeds the entry.
+        assert!(s.gate("id-live", 1_000_000, 1_000_000));
+        // A second signal ages out — its entry should be pruned.
+        assert!(!s.gate("id-old", 1_000_000, 1_004_000));
+        // Export rows confirm only the live entry survived.
+        let rows = s.export_rows();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].0, "id-live");
     }
 
     #[test]

--- a/tools/sensor-peers/src/salience.rs
+++ b/tools/sensor-peers/src/salience.rs
@@ -1,0 +1,261 @@
+//! Per-signal presentation-layer aging (ADR-121 outward gate, unified in
+//! ADR-123).
+//!
+//! The engine (`sensor_trait::EngagementState` + `Curve::Exponential`) is
+//! the shared firing-dynamics engine that ways consumes via
+//! `way_fire_outcome`. This module is sensor-peers' parallel consumer:
+//! one `EngagementState` per tracked signal, keyed by signal id (the
+//! filename stem — the same shape `re:<id>` references in ADR-120
+//! threaded replies, so reply resets are direct hash lookups).
+//!
+//! Kept separate from `lib.rs` to prevent the already-priority-sized
+//! 1k-line `lib.rs` from growing further (see issue #22 and the
+//! code-quality file-length scan).
+
+use std::collections::HashMap;
+
+use sensor_trait::{Curve, EngagementState, Tick, TickDelta};
+
+/// Map of signal-id → engagement state, consulted before each
+/// peer-signal observation leaves `read_signals`. Parameters are set
+/// from attend's `signals:` config block; defaults are the hardcoded
+/// ADR-121-era picks so sensor-peers stays functional without config.
+pub struct SignalSalience {
+    states: HashMap<String, EngagementState>,
+    half_life: TickDelta,
+    floor: f64,
+}
+
+impl SignalSalience {
+    /// Default parameters mirror `SignalsConfig::default()` in attend —
+    /// 30 min half-life, 0.3 presentation floor. The orchestrator
+    /// overrides these at startup via `set_params`.
+    pub fn new() -> Self {
+        Self {
+            states: HashMap::new(),
+            half_life: 1800,
+            floor: 0.3,
+        }
+    }
+
+    pub fn set_params(&mut self, half_life_secs: u64, floor: f64) {
+        self.half_life = half_life_secs;
+        self.floor = floor;
+    }
+
+    /// Outward-gate check for a newly-scanned signal.
+    ///
+    /// Returns `true` iff the signal is loud enough to present. On the
+    /// first call for a given `signal_id`, the state is seeded with a
+    /// `record_fire(arrival_tick, 1.0)` — which means a freshly-scanned
+    /// old backlog signal is gated as if it had been presented at its
+    /// on-disk mtime, so its salience has already decayed when the new
+    /// observer first sees it. That is the backlog-filter behavior
+    /// ADR-121 designed and ADR-123 made a cross-tool facility.
+    pub fn gate(&mut self, signal_id: &str, arrival_tick: Tick, now: Tick) -> bool {
+        let half_life = self.half_life;
+        let state = self.states.entry(signal_id.to_string()).or_insert_with(|| {
+            let mut s = EngagementState::new(Curve::Exponential { half_life });
+            s.record_fire(arrival_tick, 1.0);
+            s
+        });
+        state.current_salience(now) >= self.floor
+    }
+
+    /// Re-engagement reset for a threaded reply.
+    ///
+    /// When a peer's signal carries `re:<id>` (ADR-120), the parent
+    /// signal's salience returns to 1.0 at `now`. This is the
+    /// "thread still alive" signal from ADR-121 step 6. The effect is
+    /// observable in two places:
+    ///
+    /// 1. Any future observer scanning the same shared signal dir (e.g.,
+    ///    a new focus-group member joining) will see the parent as
+    ///    loud-at-`now` instead of decayed-from-arrival.
+    /// 2. State persisted to checkpoint preserves the reset across
+    ///    restarts, so reconnection does not re-age the parent.
+    ///
+    /// The current `seen_signals` invariant in the sensor still prevents
+    /// the same observer from surfacing the same signal twice. Removing
+    /// that restriction is out of scope for the initial salience-gate
+    /// landing and tracked as a follow-up on issue #22.
+    pub fn reset(&mut self, signal_id: &str, now: Tick) {
+        let half_life = self.half_life;
+        let state = self
+            .states
+            .entry(signal_id.to_string())
+            .or_insert_with(|| EngagementState::new(Curve::Exponential { half_life }));
+        state.record_fire(now, 1.0);
+    }
+
+    /// Export state for checkpoint persistence. Each row is
+    /// `("signal_salience", "<signal_id>\t<json-engagement-state>")`.
+    /// The key prefix lives in `lib.rs` so the checkpoint schema stays
+    /// in one place.
+    pub fn export_rows(&self) -> Vec<(String, String)> {
+        let mut rows = Vec::with_capacity(self.states.len());
+        for (id, state) in &self.states {
+            if let Ok(json) = serde_json::to_string(state) {
+                rows.push((id.clone(), json));
+            }
+        }
+        rows
+    }
+
+    /// Re-import one serialized row. Returns `true` if the row parsed
+    /// cleanly and was inserted.
+    pub fn import_row(&mut self, signal_id: &str, json: &str) -> bool {
+        match serde_json::from_str::<EngagementState>(json) {
+            Ok(state) => {
+                self.states.insert(signal_id.to_string(), state);
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+}
+
+impl Default for SignalSalience {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Extract the `re:<id>` reference from a parsed signal content string,
+/// if the content is in the ADR-120 threaded 5-field form.
+///
+/// Returns the bare id (without `re:` prefix) so callers can look it up
+/// directly in `SignalSalience`. Returns `None` for legacy 4-field
+/// signals and for malformed `re:` prefixes.
+///
+/// Kept parallel to `parse_signal` rather than widening that function's
+/// return type so the existing 5 parse-signal tests and all current
+/// callers keep their tuple shape. See ADR-120 §3 for the discriminator
+/// rules this mirrors.
+pub fn extract_re_id(content: &str) -> Option<&str> {
+    let parts: Vec<&str> = content.splitn(5, '|').collect();
+    if parts.len() < 5 {
+        return None;
+    }
+    let field = parts[3];
+    let id = field.strip_prefix("re:")?;
+    if is_valid_signal_id(id) {
+        Some(id)
+    } else {
+        None
+    }
+}
+
+/// Mirror of the `is_valid_signal_id` helper in `lib.rs`. Kept in sync
+/// by convention — both fences exist for the same reason and are
+/// exercised by the same ADR-120 parse rules.
+fn is_valid_signal_id(id: &str) -> bool {
+    !id.is_empty()
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+/// Strip the trailing `.signal` extension from a filename to get the
+/// signal id (the filename stem). The id is what `re:<id>` references.
+pub fn signal_id_from_filename(filename: &str) -> &str {
+    filename.strip_suffix(".signal").unwrap_or(filename)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn freshly_arrived_signal_passes_gate() {
+        let mut s = SignalSalience::new();
+        s.set_params(1800, 0.3);
+        // Signal arrived now — passes.
+        assert!(s.gate("id-1", 1_000_000, 1_000_000));
+    }
+
+    #[test]
+    fn old_signal_below_floor_is_suppressed() {
+        let mut s = SignalSalience::new();
+        s.set_params(1800, 0.3);
+        // half_life=1800, floor=0.3. Delta for salience to drop to 0.3:
+        // 0.3 = 0.5^(delta/1800) → delta = 1800 * log2(1/0.3) ≈ 3126.
+        // delta = 4000 is comfortably past the floor.
+        assert!(!s.gate("id-1", 1_000_000, 1_004_000));
+    }
+
+    #[test]
+    fn reset_restores_salience_to_one() {
+        let mut s = SignalSalience::new();
+        s.set_params(1800, 0.3);
+        // Age the signal past the floor.
+        assert!(!s.gate("id-1", 1_000_000, 1_004_000));
+        // Reset at a later tick — the state is now fresh-at-reset.
+        s.reset("id-1", 1_004_000);
+        // At reset tick, a subsequent gate call would see salience 1.0.
+        // (We don't re-gate here because gate() mutates on first-call
+        // and the state already exists — assert via a direct read of
+        // the reset tick.)
+        assert!(s.gate("id-1", 1_000_000, 1_004_000));
+    }
+
+    #[test]
+    fn export_import_roundtrip_preserves_reset_tick() {
+        let mut s = SignalSalience::new();
+        s.set_params(1800, 0.3);
+        s.reset("id-1", 1_000_000);
+        let rows = s.export_rows();
+        assert_eq!(rows.len(), 1);
+
+        let mut t = SignalSalience::new();
+        t.set_params(1800, 0.3);
+        for (id, json) in &rows {
+            assert!(t.import_row(id, json));
+        }
+        // Same decay math after roundtrip.
+        assert!(t.gate("id-1", 1_000_000, 1_000_000));
+    }
+
+    #[test]
+    fn extract_re_id_legacy_signal_returns_none() {
+        assert_eq!(
+            extract_re_id("claude:abc|proj|/home/a|hello there"),
+            None
+        );
+    }
+
+    #[test]
+    fn extract_re_id_threaded_signal_returns_id() {
+        assert_eq!(
+            extract_re_id("claude:abc|proj|/home/a|re:parent-1234|body"),
+            Some("parent-1234")
+        );
+    }
+
+    #[test]
+    fn extract_re_id_malformed_re_prefix_returns_none() {
+        // "re:" followed by prose with a space fails is_valid_signal_id.
+        assert_eq!(
+            extract_re_id("claude:abc|proj|/home/a|re:has space|body"),
+            None
+        );
+    }
+
+    #[test]
+    fn extract_re_id_empty_id_returns_none() {
+        assert_eq!(
+            extract_re_id("claude:abc|proj|/home/a|re:|body"),
+            None
+        );
+    }
+
+    #[test]
+    fn signal_id_from_filename_strips_extension() {
+        assert_eq!(
+            signal_id_from_filename("claude-abc-1712345.signal"),
+            "claude-abc-1712345"
+        );
+        assert_eq!(signal_id_from_filename("no-extension"), "no-extension");
+    }
+}


### PR DESCRIPTION
Closes #22.

Bundle of three layers: (1) apply the ADR-123 outward gate to sensor-peers as the deferred second consumer (original scope of the PR), (2) code-review fix from the first review round, (3) the fresh-agent UX restoration work that live testing surfaced as necessary once the gate's backlog-admission side-effects revealed a regression. Telling the story as one PR because the UX work is not optional — without it, the correctness win of (1) comes at a usability cost that makes fresh agents ask "should I reply?" and fish for 50-char uuids in the filesystem. All three layers reinforce each other.

## Layer 1 — Engine hook-up (the original PR)

Applies `sensor_trait::{Curve::Exponential, EngagementState, salience_at, epoch_secs}` to `tools/sensor-peers/` as the second cross-tool consumer of the firing-dynamics engine. Ways was the first. The engine itself shipped across prior PRs and is not modified here.

- **New `tools/sensor-peers/src/salience.rs`** — `SignalSalience` struct holding one `EngagementState` per tracked signal, keyed by filename stem (the same shape `re:<id>` references in ADR-120 threaded replies, so reply resets are direct hash lookups). Methods: `gate(signal_id, arrival_tick, now)` seeds state with `record_fire(arrival_tick, 1.0)` on first call so freshly-scanned old backlog is gated as if it had been presented at its on-disk mtime; `reset(signal_id, now)` bumps parent state to 1.0 for threaded-reply resurfacing; `export_rows` / `import_row` for checkpoint persistence. Below-floor entries are pruned on the same call that suppressed them so the map stays bounded on long sessions. 8 unit tests.
- **Hook in `sensor-peers/src/lib.rs::read_signals`** — before each observation leaves the poll, an `extract_re_id` call resets any referenced parent, then the signal's own `gate()` check runs against its file mtime. Below-floor signals are suppressed *and* marked `seen_signals` so we don't re-evaluate them every poll.
- **Checkpoint persistence** — `export_state`/`import_state` extended with a `signal_salience` row key carrying `<id>\t<json>`. Old checkpoints without the key parse cleanly.
- **Config** — new `SignalsConfig { half_life_seconds, presentation_floor }` in `tools/attend/src/config.rs`, defaults `1800 / 0.3`. New `signals:` YAML block parser and default docs. `attend config lint` recognizes the block; unknown sub-keys surface as warnings; `x-*` escape and `--fix` removal work as in every other section.
- **Orchestrator wiring** — `peer_sensor.set_salience_params(...)` in `tools/attend/src/sensors/mod.rs`, mirroring `set_peer_activity_window`.
- **Docs** — `docs/attend-and-monitor/salience.md` and `configuration.md` rewritten to describe the shipped behavior.

## Layer 2 — Code review fix

From the first round of review on this PR:

- **`mark_existing_as_seen` removed entirely.** The legacy startup call pre-seeded `seen_signals` with every pre-existing file, short-circuiting the gate for the dominant `!catchup` flow. The review caught that the salience gate was dead code for the primary path. Removing the call makes the gate the sole arbiter in every mode. Recent pre-existing signals (within the salience window) now surface where they previously were silenced wholesale — correct, but a behavior change, documented in `salience.md` under a new "Replacing mark_existing_as_seen" subsection.
- **Self-pruning in `gate()`** — below-floor entries are dropped from the state map on the same call that suppressed them, bounding memory over long sessions.

## Layer 3 — Fresh-agent UX restoration

After live testing surfaced a real usability regression: the engine hook-up worked, but the resulting workflow pushed agents toward filesystem improvisation and permission-asking. Every fix in this layer is independently verifiable and mutually reinforcing.

### `attend reply` subcommand — remove the uuid from agent context

- **New `tools/sensor-peers/src/last_inbound.rs`** — persists the most-recent inbound signal id per own-session-id under `~/.cache/attend/state/<session>.last-inbound`. Written by `sensor-peers::read_signals` inside the observation-emit block, keyed on session id so concurrent attend processes don't collide. Filter: only signals originating from a cwd *different* from the observer's own working_dir are recorded — the own-session-id check only catches the *current* session uuid, so a previous incarnation of the same agent would otherwise pollute last_inbound and cause `attend reply` to auto-thread to the agent's own past self. Same-cwd matching is a reliable proxy for "self" given the one-agent-per-project norm.
- **`cmd_reply`** in `tools/attend/src/main.rs` — reads last_inbound for the current own-session-id, prepends `--re <id>`, and delegates to `cmd_send`. A caller never sees or touches the uuid; all routing flags (`--focus`, `--to`) flow through unchanged. Errors with a clear "use send instead" message if no prior inbound exists.

### `attend inbox` non-TTY output — make inbox actually useful for agents

`attend inbox` now detects `std::io::stdout().is_terminal()`. TTY path keeps the compact 6-column table for humans. Non-TTY path emits one block per message with labeled lines — full id, full body, no truncation — same idea as `ls` switching on pipe. Fixes the completely-unreadable table that agents were previously seeing through Bash tool capture.

### Self-reload banner visibility

Existing 10s mtime-based self-reload at `main.rs:249` previously emitted the misleading `[attend] restarted (unchanged)` after a binary hot-swap whenever sensor config was unchanged. Fix: pass `ATTEND_RELOADED_FROM` env var across the exec boundary so the new process prints an explicit `reloaded vX → vY — binary updated, state preserved across exec()` line instead. Bootstrap quirk: takes effect from the next rebuild onward because the binary that sets the env var has to exist first.

### Three-source skill rewrite

All three places that teach an agent about attend messaging were stale or invited filesystem improvisation. Rewritten in parallel so the guidance is consistent whenever an agent meets it:

1. **`skills/attend/SKILL.md`** — primer read at `/attend` invocation. Peer-messaging section collapsed to two commands (`send` / `reply`) with pick-by-intent rules. Deleted the `ls -t ~/.cache/attend/signals/` filesystem fallback entirely. Added explicit autonomy grant ("you don't need permission to reply"), "Silence is a valid reply" as a standalone callout, and "CLI is the whole interface" containment boundary.
2. **`tools/sensor-disclosure/src/disclosures/messaging.md`** — runtime reheat baked into sensor-disclosure. Rewritten to match the skill: new topic vs reply to a peer, CLI contract line, autonomy framing, silence still valid.
3. **`hooks/ways/softwaredev/environment/attend/attend.md`** — just-in-time way that fires via `commands: attend` frontmatter on every `attend` command. Rewritten to carry the same four points so the guidance is reinforced at tool-use time in addition to session start and runtime.

## Verification — clean-slate live test on the post-bundle binary

Live two-session acceptance test was run after cleanup (zero signals on disk, zero last_inbound state, both sides on fresh binary). Full transcript preserved in PR comments. Results:

- ✅ **Fresh agent steered to `attend reply` without coaching** — fresh temp session loaded SKILL.md, received one peer notification with zero backlog, and its first response was `attend reply "..."`. No `attend send` fallback, no id-fishing.
- ✅ **Autonomy — replies without asking permission** — temp responded directly with no "should I reply?" delay.
- ✅ **Silence-is-valid honored** — temp saw my confirmation message and explicitly said "no further action needed" instead of firing a ceremonial ack. When it *did* reply, it said "happy to chat or just swap status" — the silence norm landed without being brittle.
- ✅ **Id never enters agent context on either side** — both threaded replies verified in wire format (`re:<id>` field present) with neither agent having touched a uuid.
- ✅ **cwd-self filter works** — both sides threaded to the actual peer, not their own past session uuids.

Earlier less-clean rounds (documented in prior PR comments) also exercised: backlog-filter admission after `mark_existing_as_seen` removal, checkpoint restart roundtrip, the extract_re_id → reset path on both sides.

### Automated

- `cargo test --workspace` — all green. sensor-peers 19 → 30 (+11 tests across salience.rs and last_inbound.rs), attend 17 → 20 (+3 config + lint tests), sensor-trait unchanged.
- `make lint` (clippy with `-D warnings`) — clean.
- `bin/attend config lint` on live user config — clean.
- Synthetic "unknown key in signals: block" — correctly flagged.

## Remaining known gaps (not blocking merge)

- **Aged-backlog suppression (below floor) is unit-test-covered but not directly observed in the wild** — no signal old enough to fall below 0.3 at 1800s half-life during the live runs. The math is covered by `old_signal_below_floor_is_suppressed` in salience.rs.
- **`attend tune` doesn't derive the salience half-life yet** — tracked as a follow-up; the current 1800s default is a conservative first pick.
- **`attend status` doesn't visualize per-signal salience yet** — diagnostic, follow-up.