### PR TITLE
feat(attend-chat): minimum-bidirectional chat TUI (ADR-120, #23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,10 @@ tools/ways-cli/target/
 !tools/attend/**
 # attend build artifacts
 tools/attend/target/
+!tools/attend-chat/
+!tools/attend-chat/**
+# attend-chat build artifacts (workspace target, but listed for clarity)
+tools/attend-chat/target/
 # Workspace-level Cargo files
 !tools/Cargo.toml
 !tools/Cargo.lock

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,11 @@
 # Update:        make update
 
 .DEFAULT_GOAL := help
-.PHONY: setup install uninstall update clean help ways ways-rebuild attend attend-rebuild lint test test-unit test-sim test-lang test-locales test-multilingual release
+.PHONY: setup install uninstall update clean help ways ways-rebuild attend attend-rebuild attend-chat attend-chat-rebuild lint test test-unit test-sim test-lang test-locales test-multilingual release
 
 WAYS_BIN = bin/ways
 ATTEND_BIN = bin/attend
+ATTEND_CHAT_BIN = bin/attend-chat
 XDG_BIN = $(or $(XDG_BIN_HOME),$(HOME)/.local/bin)
 
 # --- Primary targets ---
@@ -37,7 +38,7 @@ help:
 	@echo ""
 
 # Build ways CLI + set up embedding engine + generate initial corpus.
-setup: ways attend
+setup: ways attend attend-chat
 	@echo "Setting up embedding engine..."
 	$(MAKE) -C tools/way-embed setup
 	@echo ""
@@ -52,16 +53,18 @@ install: hooks-executable setup
 	@mkdir -p $(XDG_BIN)
 	@ln -sf $(CURDIR)/$(WAYS_BIN) $(XDG_BIN)/ways
 	@ln -sf $(CURDIR)/$(ATTEND_BIN) $(XDG_BIN)/attend
+	@ln -sf $(CURDIR)/$(ATTEND_CHAT_BIN) $(XDG_BIN)/attend-chat
 	@echo ""
 	@echo "Install complete."
-	@echo "  ways binary:   $(XDG_BIN)/ways → $(CURDIR)/$(WAYS_BIN)"
-	@echo "  attend binary: $(XDG_BIN)/attend → $(CURDIR)/$(ATTEND_BIN)"
+	@echo "  ways binary:        $(XDG_BIN)/ways → $(CURDIR)/$(WAYS_BIN)"
+	@echo "  attend binary:      $(XDG_BIN)/attend → $(CURDIR)/$(ATTEND_BIN)"
+	@echo "  attend-chat binary: $(XDG_BIN)/attend-chat → $(CURDIR)/$(ATTEND_CHAT_BIN)"
 	@echo "  Restart Claude Code for ways to take effect."
 
 # Remove symlink from PATH.
 uninstall:
-	@rm -f $(XDG_BIN)/ways $(XDG_BIN)/attend
-	@echo "Removed $(XDG_BIN)/ways $(XDG_BIN)/attend"
+	@rm -f $(XDG_BIN)/ways $(XDG_BIN)/attend $(XDG_BIN)/attend-chat
+	@echo "Removed $(XDG_BIN)/ways $(XDG_BIN)/attend $(XDG_BIN)/attend-chat"
 
 # Pull upstream and re-setup.
 update:
@@ -124,6 +127,32 @@ attend-rebuild:
 	@mkdir -p bin
 	@ln -sf $(CURDIR)/tools/target/release/attend $(ATTEND_BIN)
 	@echo "Built: $(ATTEND_BIN) ($$(ls -lh $(ATTEND_BIN) | awk '{print $$5}'))"
+
+# Build attend-chat binary from workspace.
+attend-chat:
+	@if [ -x $(ATTEND_CHAT_BIN) ] && $(ATTEND_CHAT_BIN) --help >/dev/null 2>&1; then \
+		echo "attend-chat already built."; \
+	elif command -v cargo >/dev/null 2>&1; then \
+		echo "Building attend-chat..."; \
+		cargo build --release --manifest-path tools/Cargo.toml -p attend-chat; \
+		mkdir -p bin; \
+		ln -sf $(CURDIR)/tools/target/release/attend-chat $(ATTEND_CHAT_BIN); \
+		echo "Built: $(ATTEND_CHAT_BIN) ($$(ls -lh $(ATTEND_CHAT_BIN) | awk '{print $$5}'))"; \
+	else \
+		echo "error: cargo not found. Install Rust: https://rustup.rs/"; \
+		exit 1; \
+	fi
+
+# Force rebuild attend-chat from source.
+attend-chat-rebuild:
+	@if ! command -v cargo >/dev/null 2>&1; then \
+		echo "error: cargo not found. Install Rust: https://rustup.rs/"; \
+		exit 1; \
+	fi
+	cargo build --release --manifest-path tools/Cargo.toml -p attend-chat
+	@mkdir -p bin
+	@ln -sf $(CURDIR)/tools/target/release/attend-chat $(ATTEND_CHAT_BIN)
+	@echo "Built: $(ATTEND_CHAT_BIN) ($$(ls -lh $(ATTEND_CHAT_BIN) | awk '{print $$5}'))"
 
 # --- Test ---
 

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -40,7 +40,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-117](./system/ADR-117-sensor-crate-extraction-and-feature-flags.md) | Sensor Crate Extraction and Feature Flags | Accepted |
 | [ADR-118](./system/ADR-118-focus-groups-dynamic-agent-grouping.md) | Focus Groups — Dynamic Agent Grouping | Accepted |
 | [ADR-119](./system/ADR-119-action-potential-engagement-model.md) | Action Potential Engagement Model | Superseded |
-| [ADR-120](./system/ADR-120-interactive-chat-tui-human-in-the-signal-loop.md) | Interactive Chat TUI — Human in the Signal Loop | Draft |
+| [ADR-120](./system/ADR-120-interactive-chat-tui-human-in-the-signal-loop.md) | Interactive Chat TUI — Human in the Signal Loop | Accepted |
 | [ADR-121](./system/ADR-121-salience-decay-for-signal-presentation-turn-based-exponential.md) | Salience decay for signal presentation — turn-based exponential | Superseded |
 | [ADR-122](./system/ADR-122-attend-disclosure-sensor-token-gated-affordance-reheat.md) | Attend disclosure sensor — token-gated affordance reheat | Draft |
 | [ADR-123](./system/ADR-123-firing-dynamics-progression-axis-unification.md) | Firing dynamics — progression-axis unification for attend and ways | Accepted |

--- a/docs/architecture/system/ADR-120-interactive-chat-tui-human-in-the-signal-loop.md
+++ b/docs/architecture/system/ADR-120-interactive-chat-tui-human-in-the-signal-loop.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-04-11
 deciders:
   - aaronsb

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -81,6 +81,137 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attend"
@@ -96,10 +227,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "attend-chat"
+version = "0.1.0"
+dependencies = [
+ "async-channel",
+ "iocraft",
+ "notify",
+ "smol",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -160,6 +332,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +359,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,11 +379,12 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
- "mio",
+ "futures-core",
+ "mio 1.2.0",
  "parking_lot",
  "rustix",
  "signal-hook",
@@ -254,8 +445,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "figlet-rs"
@@ -264,6 +482,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aad4cf7e378685c1af30f41b4832c29700325524c648d47752cabd5b97e7b09b"
 dependencies = [
  "zip",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -277,10 +506,163 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generational-box"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557cf2cbacd0504c6bf8c29f52f8071e0de1d9783346713dc6121d7fa1e5d0e0"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "grid"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be136d9dacc2a13cc70bb6c8f902b414fb2641f8db1314637c6b7933411a8f82"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -295,13 +677,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "iocraft"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cc99ec2f29c9c5f0ae7862dd6f12b93c9122282c9fe151e8648a9cc7301aa3f"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm",
+ "futures",
+ "generational-box",
+ "iocraft-macros",
+ "taffy",
+ "unicode-width",
+]
+
+[[package]]
+name = "iocraft-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2a8b12929295d5fea225570fd69a41084e2949d56ce0c20ff22494ef13e0d56"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "uuid",
 ]
 
 [[package]]
@@ -317,10 +760,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -367,6 +858,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -374,14 +877,54 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -401,9 +944,56 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -425,12 +1015,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -487,12 +1092,18 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -639,7 +1250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio",
+ "mio 1.2.0",
  "signal-hook",
 ]
 
@@ -660,10 +1271,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smol"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite",
+]
 
 [[package]]
 name = "strsim"
@@ -683,6 +1326,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "taffy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cb893bff0f80ae17d3a57e030622a967b8dbc90e38284d9b4b1442e23873c94"
+dependencies = [
+ "arrayvec",
+ "grid",
+ "num-traits",
+ "serde",
+ "slotmap",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +1351,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +1373,23 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -721,6 +1406,103 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "ways"
@@ -762,7 +1544,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -779,11 +1561,165 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "sensor-disclosure",
     "ways-cli",
     "attend",
+    "attend-chat",
 ]
 resolver = "2"
 

--- a/tools/attend-chat/Cargo.toml
+++ b/tools/attend-chat/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "attend-chat"
+version = "0.1.0"
+edition = "2021"
+description = "Interactive chat TUI for attend — human seat at the signal bus (ADR-120)"
+license = "MIT OR Apache-2.0"
+
+[[bin]]
+name = "attend-chat"
+path = "src/main.rs"
+
+[dependencies]
+iocraft = "0.8"
+notify = "6"
+async-channel = "2"
+smol = "2"

--- a/tools/attend-chat/Cargo.toml
+++ b/tools/attend-chat/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 description = "Interactive chat TUI for attend — human seat at the signal bus (ADR-120)"
 license = "MIT OR Apache-2.0"
 
+[lib]
+name = "attend_chat"
+path = "src/lib.rs"
+
 [[bin]]
 name = "attend-chat"
 path = "src/main.rs"

--- a/tools/attend-chat/build.rs
+++ b/tools/attend-chat/build.rs
@@ -1,0 +1,14 @@
+use std::process::Command;
+
+fn main() {
+    let commit = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=ATTEND_CHAT_COMMIT={}", commit);
+    println!("cargo:rerun-if-changed=.git/HEAD");
+}

--- a/tools/attend-chat/src/app.rs
+++ b/tools/attend-chat/src/app.rs
@@ -1,0 +1,315 @@
+//! Minimum-bidirectional chat component.
+//!
+//! Stream of signals on top, input box on bottom. Sender + scope live
+//! in a small bordered "chip" to the left of each message; the message
+//! body wraps naturally. Input is a minimal custom buffer: Enter sends,
+//! Shift-Enter or Alt-Enter inserts a newline. We don't use iocraft's
+//! `TextInput` because its multi-line handler consumes plain Enter and
+//! fires its `on_change` after our own handler clears the buffer,
+//! which races with the send path.
+//!
+//! No sidebar, no focus filter, no threading render — those land in
+//! follow-up PRs on ADR-120.
+
+use async_channel::Receiver;
+use iocraft::prelude::*;
+
+use crate::signal::{write_broadcast, Signal};
+
+#[derive(Default, Props)]
+pub struct AppProps {
+    pub receiver: Option<Receiver<Signal>>,
+}
+
+const CHIP_WIDTH: u32 = 20;
+
+#[component]
+pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
+    let mut system = hooks.use_context_mut::<SystemContext>();
+    let (width, height) = hooks.use_terminal_size();
+    let mut signals = hooks.use_state::<Vec<Signal>, _>(Vec::new);
+    let mut input = hooks.use_state(String::new);
+    let mut should_exit = hooks.use_state(|| false);
+    let mut status = hooks.use_state(String::new);
+
+    // Drain the watcher into state.
+    if let Some(rx) = props.receiver.clone() {
+        hooks.use_future(async move {
+            while let Ok(sig) = rx.recv().await {
+                let mut v = signals.read().clone();
+                v.push(sig);
+                signals.set(v);
+            }
+        });
+    }
+
+    hooks.use_terminal_events({
+        move |event| match event {
+            TerminalEvent::Key(KeyEvent {
+                code,
+                kind,
+                modifiers,
+                ..
+            }) if kind != KeyEventKind::Release => match code {
+                KeyCode::Esc => should_exit.set(true),
+                KeyCode::Enter
+                    if modifiers.intersects(KeyModifiers::SHIFT | KeyModifiers::ALT) =>
+                {
+                    // Shift-Enter / Alt-Enter → insert newline.
+                    // Both paths are here because Shift-Enter only
+                    // arrives as a distinguishable event on terminals
+                    // that speak the kitty keyboard protocol; Alt-Enter
+                    // is a cross-terminal fallback.
+                    let mut v = input.read().clone();
+                    v.push('\n');
+                    input.set(v);
+                }
+                KeyCode::Enter => {
+                    let msg = input.read().trim_end().to_string();
+                    if !msg.is_empty() {
+                        match write_broadcast(&msg) {
+                            Ok(name) => {
+                                status.set(format!("sent: {}", name));
+                                input.set(String::new());
+                            }
+                            Err(e) => status.set(format!("send failed: {}", e)),
+                        }
+                    }
+                }
+                KeyCode::Backspace => {
+                    let mut v = input.read().clone();
+                    v.pop();
+                    input.set(v);
+                }
+                KeyCode::Char(c)
+                    if !modifiers
+                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+                {
+                    let mut v = input.read().clone();
+                    v.push(c);
+                    input.set(v);
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    });
+
+    if should_exit.get() {
+        system.exit();
+    }
+
+    let rows: Vec<_> = signals
+        .read()
+        .iter()
+        .map(|s| {
+            let (who, scope) = prettify(&s.from, &s.project, &s.cwd);
+            element! {
+                View(flex_direction: FlexDirection::Row, margin_bottom: 1) {
+                    View(
+                        border_style: BorderStyle::Round,
+                        border_color: Color::DarkGrey,
+                        padding_left: 1,
+                        padding_right: 1,
+                        width: CHIP_WIDTH,
+                        flex_direction: FlexDirection::Column,
+                        flex_shrink: 0.0,
+                    ) {
+                        Text(color: Color::Cyan, content: who, wrap: TextWrap::NoWrap)
+                        Text(color: Color::DarkGrey, content: scope, wrap: TextWrap::NoWrap)
+                    }
+                    View(
+                        flex_grow: 1.0,
+                        padding_left: 1,
+                        padding_right: 1,
+                        padding_top: 1,
+                    ) {
+                        Text(content: s.message.clone(), wrap: TextWrap::Wrap)
+                    }
+                }
+            }
+        })
+        .collect();
+
+    // Grow the input box vertically to match the *visual* line count,
+    // not just the logical-line count, so a long wrapped message also
+    // expands the box instead of spilling onto the border or the
+    // status row. Interior width = total - 2 border cols - 2 padding
+    // cols - 2 prompt cols.
+    let input_value = input.to_string();
+    let display_with_cursor = format!("{}\u{2588}", input_value);
+    let interior = (width as usize).saturating_sub(6).max(1);
+    let visual = visual_line_count(&display_with_cursor, interior);
+    let input_height = (visual.clamp(1, 10) as u32) + 2;
+
+    element! {
+        View(flex_direction: FlexDirection::Column, width, height) {
+            // `min_height: 0` + `overflow: Hidden` keep this pane
+            // inside its flex-grown slot instead of expanding to the
+            // intrinsic height of the message list — without them, a
+            // long scrollback pushes the input box past the bottom of
+            // the terminal.
+            View(
+                flex_grow: 1.0,
+                min_height: 0,
+                overflow: Overflow::Hidden,
+                border_style: BorderStyle::Round,
+                border_color: Color::DarkGrey,
+                padding_left: 1,
+                padding_right: 1,
+            ) {
+                ScrollView(auto_scroll: true) {
+                    View(flex_direction: FlexDirection::Column) {
+                        #(rows)
+                    }
+                }
+            }
+            View(
+                border_style: BorderStyle::Round,
+                border_color: Color::Blue,
+                padding_left: 1,
+                padding_right: 1,
+                height: input_height,
+                flex_shrink: 0.0,
+            ) {
+                View(width: 2, flex_shrink: 0.0) {
+                    Text(color: Color::Blue, content: "> ")
+                }
+                View(flex_grow: 1.0) {
+                    Text(
+                        content: display_with_cursor,
+                        wrap: TextWrap::Wrap,
+                    )
+                }
+            }
+            View(height: 1, padding_left: 1) {
+                Text(color: Color::DarkGrey, content: status.to_string(), wrap: TextWrap::NoWrap)
+            }
+        }
+    }
+}
+
+/// Condense the wire `from`/`project`/`cwd` triple into two short
+/// labels for the sender chip. Goals: never exceed the chip's interior
+/// width, stay readable, give the human just enough to tell who sent
+/// what.
+fn prettify(from: &str, project: &str, cwd: &str) -> (String, String) {
+    // Interior = chip width - 2 border columns - 2 padding columns.
+    let interior = (CHIP_WIDTH as usize).saturating_sub(4);
+
+    let who = if let Some(rest) = from.strip_prefix("claude:") {
+        // UUIDs are 36 chars — "c:" + first 7 of the id keeps us
+        // unique enough for a handful of concurrent sessions without
+        // overflowing the chip.
+        let tag = rest.get(0..7).unwrap_or(rest);
+        format!("c:{}", tag)
+    } else if let Some(rest) = from.strip_prefix("external:") {
+        // Drop the terminal suffix ("aaron@kitty" → "aaron") so humans
+        // read as themselves, not as their terminal emulator.
+        rest.split('@').next().unwrap_or(rest).to_string()
+    } else {
+        from.to_string()
+    };
+
+    // Scope: prefer the last path segment of the cwd over the raw
+    // project name, since cwd is always a full path while project is
+    // whatever the sender chose to pass. Fall back to project if cwd
+    // is empty.
+    let scope_src = if cwd.is_empty() { project } else { cwd };
+    let segment = scope_src.rsplit('/').next().unwrap_or(scope_src);
+    let scope = if segment.is_empty() {
+        "broadcast".to_string()
+    } else {
+        segment.to_string()
+    };
+
+    (truncate(&who, interior), truncate(&scope, interior))
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else if max <= 1 {
+        s.chars().take(max).collect()
+    } else {
+        let mut out: String = s.chars().take(max - 1).collect();
+        out.push('…');
+        out
+    }
+}
+
+/// Count how many *rendered* rows `text` occupies inside a box of
+/// `interior` columns. Approximate: counts chars, ignores grapheme
+/// width — good enough for sizing a chat compose box where the exact
+/// last-column edge doesn't matter.
+fn visual_line_count(text: &str, interior: usize) -> usize {
+    if interior == 0 {
+        return 1;
+    }
+    let mut rows = 0usize;
+    for line in text.split('\n') {
+        let len = line.chars().count();
+        rows += if len == 0 { 1 } else { len.div_ceil(interior) };
+    }
+    rows.max(1)
+}
+
+#[cfg(test)]
+mod layout_tests {
+    use super::visual_line_count;
+
+    #[test]
+    fn short_line_is_one_row() {
+        assert_eq!(visual_line_count("hi", 20), 1);
+    }
+
+    #[test]
+    fn wrap_on_width() {
+        // 21 chars in a 10-wide box → 3 rows.
+        assert_eq!(visual_line_count("abcdefghijklmnopqrstu", 10), 3);
+    }
+
+    #[test]
+    fn explicit_newlines_count() {
+        assert_eq!(visual_line_count("a\nb\nc", 20), 3);
+    }
+
+    #[test]
+    fn combined_wrap_and_newline() {
+        // "abcdefghij" (10 chars) wraps once in 5-wide → 2 rows
+        // followed by "x" on its own line → 1 row = 3 total.
+        assert_eq!(visual_line_count("abcdefghij\nx", 5), 3);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prettify_claude_sender() {
+        let (who, scope) = prettify("claude:e74a4a4b-7e3b-49bc-8404-216162e54ba8", "claude", "/home/aaron/.claude");
+        assert_eq!(who, "c:e74a4a4");
+        assert_eq!(scope, ".claude");
+    }
+
+    #[test]
+    fn prettify_scope_prefers_cwd_basename() {
+        let (_, scope) = prettify("external:aaron", "ignored", "/home/aaron/temp");
+        assert_eq!(scope, "temp");
+    }
+
+    #[test]
+    fn prettify_external_strips_terminal() {
+        let (who, _) = prettify("external:aaron@kitty", "proj", "/home/aaron");
+        assert_eq!(who, "aaron");
+    }
+
+    #[test]
+    fn prettify_scope_truncates_long_segment() {
+        // Interior is 16 chars for CHIP_WIDTH=20 (2 borders + 2 padding).
+        let (_, scope) = prettify("external:aaron", "x", "/tmp/some-very-long-directory-name");
+        assert!(scope.chars().count() <= 16);
+        assert!(scope.ends_with('…'));
+    }
+}

--- a/tools/attend-chat/src/app.rs
+++ b/tools/attend-chat/src/app.rs
@@ -23,12 +23,22 @@ pub struct AppProps {
 
 const CHIP_WIDTH: u32 = 20;
 
+/// Upper bound on the in-memory message buffer. At typical chat rates
+/// this is unreachable; the cap only matters for runaway conditions
+/// (overnight runs, a misbehaving peer, a loop). When we hit it, drop
+/// from the head so the newest history stays visible and the clone-
+/// per-append stays O(cap).
+const MAX_SIGNALS: usize = 5000;
+
 #[component]
 pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let mut system = hooks.use_context_mut::<SystemContext>();
     let (width, height) = hooks.use_terminal_size();
     let mut signals = hooks.use_state::<Vec<Signal>, _>(Vec::new);
     let mut input = hooks.use_state(String::new);
+    // Cursor position measured in *chars*, not bytes. Clamped into
+    // `[0, input.chars().count()]` on every mutation.
+    let mut cursor = hooks.use_state(|| 0usize);
     let mut should_exit = hooks.use_state(|| false);
     let mut status = hooks.use_state(String::new);
 
@@ -38,6 +48,10 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
             while let Ok(sig) = rx.recv().await {
                 let mut v = signals.read().clone();
                 v.push(sig);
+                if v.len() > MAX_SIGNALS {
+                    let drop_n = v.len() - MAX_SIGNALS;
+                    v.drain(0..drop_n);
+                }
                 signals.set(v);
             }
         });
@@ -55,14 +69,16 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                 KeyCode::Enter
                     if modifiers.intersects(KeyModifiers::SHIFT | KeyModifiers::ALT) =>
                 {
-                    // Shift-Enter / Alt-Enter → insert newline.
-                    // Both paths are here because Shift-Enter only
-                    // arrives as a distinguishable event on terminals
-                    // that speak the kitty keyboard protocol; Alt-Enter
-                    // is a cross-terminal fallback.
-                    let mut v = input.read().clone();
-                    v.push('\n');
-                    input.set(v);
+                    // Shift-Enter / Alt-Enter → insert newline at the
+                    // cursor. Shift-Enter only comes through on
+                    // terminals that speak the kitty keyboard
+                    // protocol; Alt-Enter is a cross-terminal
+                    // fallback.
+                    let v = input.read().clone();
+                    let (before, after) = split_at_char(&v, cursor.get());
+                    let next = format!("{}\n{}", before, after);
+                    input.set(next);
+                    cursor.set(cursor.get() + 1);
                 }
                 KeyCode::Enter => {
                     let msg = input.read().trim_end().to_string();
@@ -71,23 +87,85 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                             Ok(name) => {
                                 status.set(format!("sent: {}", name));
                                 input.set(String::new());
+                                cursor.set(0);
                             }
                             Err(e) => status.set(format!("send failed: {}", e)),
                         }
                     }
                 }
                 KeyCode::Backspace => {
-                    let mut v = input.read().clone();
-                    v.pop();
-                    input.set(v);
+                    let v = input.read().clone();
+                    let pos = cursor.get();
+                    if pos == 0 {
+                        return;
+                    }
+                    let (before, after) = split_at_char(&v, pos);
+                    // Drop one char off the end of `before`.
+                    let trimmed: String = before
+                        .chars()
+                        .take(pos.saturating_sub(1))
+                        .collect();
+                    input.set(format!("{}{}", trimmed, after));
+                    cursor.set(pos - 1);
+                }
+                KeyCode::Delete => {
+                    let v = input.read().clone();
+                    let pos = cursor.get();
+                    let total = v.chars().count();
+                    if pos >= total {
+                        return;
+                    }
+                    let (before, after) = split_at_char(&v, pos);
+                    // Drop the first char of `after`.
+                    let trimmed: String = after.chars().skip(1).collect();
+                    input.set(format!("{}{}", before, trimmed));
+                }
+                KeyCode::Left => {
+                    let p = cursor.get();
+                    if p > 0 {
+                        cursor.set(p - 1);
+                    }
+                }
+                KeyCode::Right => {
+                    let p = cursor.get();
+                    let total = input.read().chars().count();
+                    if p < total {
+                        cursor.set(p + 1);
+                    }
+                }
+                KeyCode::Home => {
+                    // Jump to the start of the current logical line.
+                    let v = input.read().clone();
+                    let p = cursor.get();
+                    let (before, _) = split_at_char(&v, p);
+                    let line_start = before.rfind('\n').map(|i| {
+                        // chars-before count = char count of
+                        // `before[..=i]`.
+                        before[..=i].chars().count()
+                    });
+                    cursor.set(line_start.unwrap_or(0));
+                }
+                KeyCode::End => {
+                    // Jump to the end of the current logical line.
+                    let v = input.read().clone();
+                    let p = cursor.get();
+                    let (_, after) = split_at_char(&v, p);
+                    let line_end_in_after = after.find('\n');
+                    let add = match line_end_in_after {
+                        Some(byte) => after[..byte].chars().count(),
+                        None => after.chars().count(),
+                    };
+                    cursor.set(p + add);
                 }
                 KeyCode::Char(c)
                     if !modifiers
                         .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
                 {
-                    let mut v = input.read().clone();
-                    v.push(c);
-                    input.set(v);
+                    let v = input.read().clone();
+                    let pos = cursor.get();
+                    let (before, after) = split_at_char(&v, pos);
+                    input.set(format!("{}{}{}", before, c, after));
+                    cursor.set(pos + 1);
                 }
                 _ => {}
             },
@@ -131,13 +209,15 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
         })
         .collect();
 
-    // Grow the input box vertically to match the *visual* line count,
-    // not just the logical-line count, so a long wrapped message also
-    // expands the box instead of spilling onto the border or the
-    // status row. Interior width = total - 2 border cols - 2 padding
-    // cols - 2 prompt cols.
+    // Render the input buffer with a block cursor sitting on the char
+    // at `cursor`. `format!` allocates once per frame; cheap at chat-
+    // compose scale and not worth caching into state.
     let input_value = input.to_string();
-    let display_with_cursor = format!("{}\u{2588}", input_value);
+    let display_with_cursor = render_cursor(&input_value, cursor.get());
+    // Interior width = total - 2 border cols - 2 padding cols - 2
+    // prompt cols. We grow the box to the visual row count so a long
+    // wrapped message expands it instead of spilling onto the border
+    // or status row.
     let interior = (width as usize).saturating_sub(6).max(1);
     let visual = visual_line_count(&display_with_cursor, interior);
     let input_height = (visual.clamp(1, 10) as u32) + 2;
@@ -254,6 +334,30 @@ fn visual_line_count(text: &str, interior: usize) -> usize {
     rows.max(1)
 }
 
+/// Split a string at a *char* offset (not a byte offset). If the
+/// offset runs past the end of the string, the tail is empty.
+fn split_at_char(s: &str, n: usize) -> (&str, &str) {
+    match s.char_indices().nth(n) {
+        Some((byte, _)) => s.split_at(byte),
+        None => (s, ""),
+    }
+}
+
+/// Render the compose buffer with a block cursor at `pos`. The cursor
+/// sits *on* the char at `pos` (that char is replaced visually by the
+/// block) or past the end if `pos == len`. Matches how most terminal
+/// editors render a block cursor.
+fn render_cursor(text: &str, pos: usize) -> String {
+    let total = text.chars().count();
+    if pos >= total {
+        return format!("{}\u{2588}", text);
+    }
+    let (before, rest) = split_at_char(text, pos);
+    // Skip the char under the cursor so the block doesn't overlap it.
+    let after: String = rest.chars().skip(1).collect();
+    format!("{}\u{2588}{}", before, after)
+}
+
 #[cfg(test)]
 mod layout_tests {
     use super::visual_line_count;
@@ -279,6 +383,46 @@ mod layout_tests {
         // "abcdefghij" (10 chars) wraps once in 5-wide → 2 rows
         // followed by "x" on its own line → 1 row = 3 total.
         assert_eq!(visual_line_count("abcdefghij\nx", 5), 3);
+    }
+}
+
+#[cfg(test)]
+mod cursor_tests {
+    use super::{render_cursor, split_at_char};
+
+    #[test]
+    fn split_within_ascii() {
+        assert_eq!(split_at_char("hello", 2), ("he", "llo"));
+    }
+
+    #[test]
+    fn split_past_end() {
+        assert_eq!(split_at_char("hi", 10), ("hi", ""));
+    }
+
+    #[test]
+    fn split_respects_char_boundaries() {
+        // "héllo" — 'é' is 2 bytes. Splitting at char 2 should land
+        // between 'é' and 'l', not mid-byte.
+        let (before, after) = split_at_char("héllo", 2);
+        assert_eq!(before, "hé");
+        assert_eq!(after, "llo");
+    }
+
+    #[test]
+    fn cursor_at_end_appends_block() {
+        assert_eq!(render_cursor("hi", 2), "hi\u{2588}");
+    }
+
+    #[test]
+    fn cursor_mid_text_replaces_char_visually() {
+        // Cursor at position 1 over "abc" → 'a' + block + 'c'.
+        assert_eq!(render_cursor("abc", 1), "a\u{2588}c");
+    }
+
+    #[test]
+    fn cursor_on_empty_buffer() {
+        assert_eq!(render_cursor("", 0), "\u{2588}");
     }
 }
 

--- a/tools/attend-chat/src/lib.rs
+++ b/tools/attend-chat/src/lib.rs
@@ -1,0 +1,10 @@
+//! Internal module surface for `attend-chat`.
+//!
+//! The binary stays the primary entry point; `lib.rs` exists only so
+//! integration tests under `tests/` can link against the crate and
+//! exercise `signal` + `watcher` end-to-end without re-declaring them
+//! via `#[path]`.
+
+pub mod app;
+pub mod signal;
+pub mod watcher;

--- a/tools/attend-chat/src/main.rs
+++ b/tools/attend-chat/src/main.rs
@@ -1,0 +1,41 @@
+mod app;
+mod signal;
+mod watcher;
+
+use iocraft::prelude::*;
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.iter().any(|a| a == "--version" || a == "-V") {
+        println!(
+            "attend-chat {} ({})",
+            env!("CARGO_PKG_VERSION"),
+            env!("ATTEND_CHAT_COMMIT")
+        );
+        return;
+    }
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        println!("attend-chat — interactive chat TUI for attend (ADR-120)");
+        println!();
+        println!("usage: attend-chat");
+        println!();
+        println!("  Esc                       exit");
+        println!("  Enter                     send to broadcast");
+        println!("  Shift-Enter / Alt-Enter   insert newline");
+        return;
+    }
+
+    let (tx, rx) = async_channel::unbounded::<signal::Signal>();
+    watcher::spawn_watcher(signal::broadcast_dir(), tx);
+
+    let result = smol::block_on(
+        element! {
+            app::App(receiver: Some(rx))
+        }
+        .fullscreen(),
+    );
+    if let Err(e) = result {
+        eprintln!("attend-chat: {}", e);
+        std::process::exit(1);
+    }
+}

--- a/tools/attend-chat/src/main.rs
+++ b/tools/attend-chat/src/main.rs
@@ -1,7 +1,4 @@
-mod app;
-mod signal;
-mod watcher;
-
+use attend_chat::{app, signal, watcher};
 use iocraft::prelude::*;
 
 fn main() {
@@ -22,6 +19,8 @@ fn main() {
         println!("  Esc                       exit");
         println!("  Enter                     send to broadcast");
         println!("  Shift-Enter / Alt-Enter   insert newline");
+        println!("  Left / Right / Home / End move cursor");
+        println!("  Backspace / Delete        edit");
         return;
     }
 
@@ -34,11 +33,17 @@ fn main() {
         std::process::exit(1);
     }
 
+    // `.disable_mouse_capture()` opts out of iocraft's default
+    // fullscreen mouse capture so the host terminal keeps native
+    // select / copy / paste. We don't consume mouse events today;
+    // when the sidebar lands and we want click-to-reply, we'll
+    // re-enable capture scoped to that region.
     let result = smol::block_on(
         element! {
             app::App(receiver: Some(rx))
         }
-        .fullscreen(),
+        .fullscreen()
+        .disable_mouse_capture(),
     );
     if let Err(e) = result {
         eprintln!("attend-chat: {}", e);

--- a/tools/attend-chat/src/main.rs
+++ b/tools/attend-chat/src/main.rs
@@ -26,7 +26,13 @@ fn main() {
     }
 
     let (tx, rx) = async_channel::unbounded::<signal::Signal>();
-    watcher::spawn_watcher(signal::broadcast_dir(), tx);
+    let dir = signal::broadcast_dir();
+    if let Err(e) = watcher::spawn_watcher(dir.clone(), tx) {
+        eprintln!("attend-chat: failed to start signal watcher: {}", e);
+        eprintln!("  signals dir: {}", dir.display());
+        eprintln!("  (no point opening the TUI — nothing would stream in.)");
+        std::process::exit(1);
+    }
 
     let result = smol::block_on(
         element! {

--- a/tools/attend-chat/src/signal.rs
+++ b/tools/attend-chat/src/signal.rs
@@ -220,6 +220,88 @@ mod tests {
         assert!(sig.reply_to.is_none());
     }
 
+    #[test]
+    fn sender_id_env_precedence() {
+        // Several pieces of state here are process-global (env vars),
+        // so we run the whole precedence lattice inside one test and
+        // reset between cases instead of relying on cargo's parallel
+        // runner to serialise us.
+        let original: Vec<(&str, Option<String>)> = [
+            "USER",
+            "LOGNAME",
+            "KITTY_PID",
+            "ALACRITTY_SOCKET",
+            "WEZTERM_PANE",
+            "TMUX",
+            "STY",
+            "TERM_PROGRAM",
+            "SSH_CONNECTION",
+            "TERMINAL",
+        ]
+        .iter()
+        .map(|k| (*k, std::env::var(*k).ok()))
+        .collect();
+
+        let clear_all = || {
+            for (k, _) in &original {
+                std::env::remove_var(k);
+            }
+        };
+
+        // Kitty wins over TERM_PROGRAM when both are set.
+        clear_all();
+        std::env::set_var("USER", "tester");
+        std::env::set_var("KITTY_PID", "123");
+        std::env::set_var("TERM_PROGRAM", "Apple_Terminal");
+        let (id, kind) = identify_sender();
+        assert_eq!(kind, "external");
+        assert_eq!(id, "tester@kitty");
+
+        // TERM_PROGRAM is the fallback when no specific-terminal env
+        // is set, and it's lowercased.
+        clear_all();
+        std::env::set_var("USER", "tester");
+        std::env::set_var("TERM_PROGRAM", "iTerm.app");
+        let (id, _) = identify_sender();
+        assert_eq!(id, "tester@iterm.app");
+
+        // TMUX beats TERM_PROGRAM (multiplexer wins over host
+        // terminal emulator).
+        clear_all();
+        std::env::set_var("USER", "tester");
+        std::env::set_var("TMUX", "/tmp/tmux-0/default,123,0");
+        std::env::set_var("TERM_PROGRAM", "Apple_Terminal");
+        let (id, _) = identify_sender();
+        assert_eq!(id, "tester@tmux");
+
+        // SSH is the final fallback before TERMINAL / bare user.
+        clear_all();
+        std::env::set_var("USER", "tester");
+        std::env::set_var("SSH_CONNECTION", "1.2.3.4 22 5.6.7.8 22");
+        let (id, _) = identify_sender();
+        assert_eq!(id, "tester@ssh");
+
+        // No terminal identifiers → bare user.
+        clear_all();
+        std::env::set_var("USER", "tester");
+        let (id, _) = identify_sender();
+        assert_eq!(id, "tester");
+
+        // LOGNAME fills in when USER is missing.
+        clear_all();
+        std::env::set_var("LOGNAME", "backup_name");
+        let (id, _) = identify_sender();
+        assert_eq!(id, "backup_name");
+
+        // Restore prior environment so we don't pollute sibling tests.
+        clear_all();
+        for (k, v) in original {
+            if let Some(v) = v {
+                std::env::set_var(k, v);
+            }
+        }
+    }
+
     fn tempdir_like() -> PathBuf {
         let p = std::env::temp_dir().join(format!(
             "attend-chat-test-{}-{}",

--- a/tools/attend-chat/src/signal.rs
+++ b/tools/attend-chat/src/signal.rs
@@ -1,0 +1,227 @@
+//! Signal wire format, paths, and I/O for `attend-chat`.
+//!
+//! The TUI is a first-class endpoint on the signal bus — it reads and
+//! writes the same `.signal` files the CLI does. Duplicating the
+//! handful of lines it takes to do that is cheaper than extracting a
+//! shared crate for a single new caller; if a third writer shows up
+//! later we lift this into a common place.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)] // `id`/`cwd`/`reply_to`/`ts` land when the sidebar and
+                   // threading UI ship in follow-up ADR-120 PRs.
+pub struct Signal {
+    pub id: String,
+    pub from: String,
+    pub project: String,
+    pub cwd: String,
+    pub reply_to: Option<String>,
+    pub message: String,
+    pub ts: u64,
+}
+
+pub fn signals_base() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(home).join(".cache").join("attend").join("signals")
+}
+
+pub fn broadcast_dir() -> PathBuf {
+    signals_base().join("_broadcast")
+}
+
+/// Parse a `.signal` file. Supports both the legacy
+/// `from|project|cwd|message` format and the threaded
+/// `from|project|cwd|re:signal-id|message` extension. Returns `None`
+/// for anything that doesn't look like a signal we can render.
+pub fn parse_file(path: &Path) -> Option<Signal> {
+    if path.extension().and_then(|s| s.to_str()) != Some("signal") {
+        return None;
+    }
+    let raw = fs::read_to_string(path).ok()?;
+    let line = raw.trim_end_matches('\n');
+    // splitn(5, '|') so message can contain pipes.
+    let parts: Vec<&str> = line.splitn(5, '|').collect();
+    if parts.len() < 4 {
+        return None;
+    }
+    let (reply_to, message) = if parts.len() == 5 && parts[3].starts_with("re:") {
+        (Some(parts[3][3..].to_string()), parts[4].to_string())
+    } else if parts.len() == 5 {
+        // Unexpected 5-field form without re: — treat as legacy body with a pipe.
+        (None, format!("{}|{}", parts[3], parts[4]))
+    } else {
+        (None, parts[3].to_string())
+    };
+
+    let id = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("?")
+        .to_string();
+    let ts = path
+        .metadata()
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    Some(Signal {
+        id,
+        from: parts[0].to_string(),
+        project: parts[1].to_string(),
+        cwd: parts[2].to_string(),
+        reply_to,
+        message,
+        ts,
+    })
+}
+
+/// Write a broadcast signal to `_broadcast/` using the atomic
+/// tmp+rename pattern `cmd_send` uses, so readers (including our own
+/// watcher) never see a half-written file.
+pub fn write_broadcast(message: &str) -> io::Result<String> {
+    let dir = broadcast_dir();
+    fs::create_dir_all(&dir)?;
+
+    let (sender_id, kind) = identify_sender();
+    let from = format!("{}:{}", kind, sender_id);
+    let cwd = std::env::current_dir()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let project = cwd.rsplit('/').next().unwrap_or("?").to_string();
+    let ts = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let filename = format!("{}-{}.signal", sender_id.replace('/', "-"), ts);
+    let content = format!("{}|{}|{}|{}\n", from, project, cwd, message);
+
+    let tmp = dir.join(format!("{}.tmp", filename));
+    let final_path = dir.join(&filename);
+    fs::write(&tmp, content)?;
+    fs::rename(&tmp, &final_path)?;
+    Ok(filename)
+}
+
+/// Identify the human at the keyboard. attend-chat is almost always
+/// running outside a Claude session (it's the human's coordination
+/// surface), so we skip the Claude-session detection the CLI does and
+/// go straight to `$USER@<terminal>`.
+fn identify_sender() -> (String, &'static str) {
+    let user = std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .unwrap_or_else(|_| "unknown".to_string());
+    let term = detect_terminal();
+    let id = if term.is_empty() {
+        user
+    } else {
+        format!("{}@{}", user, term)
+    };
+    (id, "external")
+}
+
+fn detect_terminal() -> String {
+    if std::env::var("KITTY_PID").is_ok() {
+        return "kitty".into();
+    }
+    if std::env::var("ALACRITTY_SOCKET").is_ok() {
+        return "alacritty".into();
+    }
+    if std::env::var("WEZTERM_PANE").is_ok() {
+        return "wezterm".into();
+    }
+    if std::env::var("TMUX").is_ok() {
+        return "tmux".into();
+    }
+    if std::env::var("STY").is_ok() {
+        return "screen".into();
+    }
+    if let Ok(tp) = std::env::var("TERM_PROGRAM") {
+        return tp.to_lowercase();
+    }
+    if std::env::var("SSH_CONNECTION").is_ok() {
+        return "ssh".into();
+    }
+    String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn tmp_signal(dir: &Path, name: &str, body: &str) -> PathBuf {
+        let p = dir.join(format!("{}.signal", name));
+        let mut f = fs::File::create(&p).unwrap();
+        writeln!(f, "{}", body).unwrap();
+        p
+    }
+
+    #[test]
+    fn parses_legacy_format() {
+        let d = tempdir_like();
+        let p = tmp_signal(&d, "sig-1", "claude:abc|proj|/home/x|hello world");
+        let s = parse_file(&p).unwrap();
+        assert_eq!(s.from, "claude:abc");
+        assert_eq!(s.project, "proj");
+        assert_eq!(s.cwd, "/home/x");
+        assert_eq!(s.message, "hello world");
+        assert!(s.reply_to.is_none());
+    }
+
+    #[test]
+    fn parses_threaded_format() {
+        let d = tempdir_like();
+        let p = tmp_signal(&d, "sig-2", "claude:abc|proj|/home/x|re:abc123|reply body");
+        let s = parse_file(&p).unwrap();
+        assert_eq!(s.reply_to.as_deref(), Some("abc123"));
+        assert_eq!(s.message, "reply body");
+    }
+
+    #[test]
+    fn preserves_pipes_in_legacy_body() {
+        let d = tempdir_like();
+        let p = tmp_signal(&d, "sig-3", "claude:abc|proj|/home/x|a | b");
+        let s = parse_file(&p).unwrap();
+        assert_eq!(s.message, "a | b");
+        assert!(s.reply_to.is_none());
+    }
+
+    #[test]
+    fn write_then_parse_roundtrip() {
+        // Point $HOME at a temp dir so broadcast_dir() resolves there
+        // instead of the real cache, then assert the writer's output
+        // is accepted by our own parser. Guards against silent wire-
+        // format drift between the TUI's send path and its watcher.
+        let home = tempdir_like();
+        // `set_var` is !Send on some platforms but this test is
+        // single-threaded; Cargo isolates by default.
+        std::env::set_var("HOME", &home);
+
+        let filename = write_broadcast("round-trip body").unwrap();
+        let path = broadcast_dir().join(&filename);
+        let sig = parse_file(&path).expect("written signal must parse");
+        assert_eq!(sig.message, "round-trip body");
+        assert!(sig.from.starts_with("external:"));
+        assert!(sig.reply_to.is_none());
+    }
+
+    fn tempdir_like() -> PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "attend-chat-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+}

--- a/tools/attend-chat/src/signal.rs
+++ b/tools/attend-chat/src/signal.rs
@@ -84,6 +84,14 @@ pub fn parse_file(path: &Path) -> Option<Signal> {
 /// Write a broadcast signal to `_broadcast/` using the atomic
 /// tmp+rename pattern `cmd_send` uses, so readers (including our own
 /// watcher) never see a half-written file.
+///
+/// **Wire-format mirror.** The line format here must stay byte-
+/// identical to the legacy branch of `cmd_send` in
+/// `tools/attend/src/cmd/send.rs`. If you change one, change both —
+/// we intentionally didn't extract a shared crate while there are
+/// only two writers, so drift is a per-PR review concern rather than
+/// a compile error. Threaded replies (`re:<id>`) are produced by
+/// `cmd_send` only; the TUI does not originate threaded sends yet.
 pub fn write_broadcast(message: &str) -> io::Result<String> {
     let dir = broadcast_dir();
     fs::create_dir_all(&dir)?;

--- a/tools/attend-chat/src/watcher.rs
+++ b/tools/attend-chat/src/watcher.rs
@@ -1,20 +1,27 @@
 //! Directory watcher that streams signals into the TUI.
 //!
-//! `spawn_watcher` does two things, in order:
+//! `spawn_watcher` does three things, in order:
 //!
 //!   1. scans the directory for existing `.signal` files (sorted by
 //!      mtime ascending) so a freshly-started TUI catches up on recent
 //!      traffic instead of opening empty;
 //!   2. installs a `notify` recommended watcher; creates and writes
-//!      are forwarded as [`Signal`] values onto the caller's channel.
+//!      are forwarded as [`Signal`] values onto the caller's channel;
+//!   3. parks the watcher on a dedicated thread so its lifetime is
+//!      tied to the process, not to any caller scope.
 //!
-//! The watcher runs in a dedicated thread. `notify`'s callback is
-//! synchronous, so we bridge to the async channel with
-//! [`async_channel::Sender::send_blocking`]. Keeping the watcher
-//! thread off smol means a slow renderer can't back-pressure the
+//! `notify`'s callback is synchronous, so we bridge to the async
+//! channel with [`async_channel::Sender::send_blocking`]. Keeping the
+//! watcher off smol means a slow renderer can't back-pressure the
 //! filesystem listener into dropping events.
+//!
+//! Initialisation failures (watcher construction, `.watch()`) are
+//! returned to the caller so it can decide whether to fall back or
+//! abort — post-init errors from inside the callback are best-effort
+//! and swallowed, because surfacing them into the TUI would require a
+//! status channel we don't need yet.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
 
@@ -24,7 +31,7 @@ use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watche
 
 use crate::signal::{parse_file, Signal};
 
-pub fn spawn_watcher(dir: PathBuf, tx: Sender<Signal>) {
+pub fn spawn_watcher(dir: PathBuf, tx: Sender<Signal>) -> notify::Result<()> {
     std::fs::create_dir_all(&dir).ok();
 
     // Backfill existing signals so the stream isn't empty on launch.
@@ -45,62 +52,51 @@ pub fn spawn_watcher(dir: PathBuf, tx: Sender<Signal>) {
         }
     }
 
-    thread::spawn(move || {
-        let tx_cb = tx.clone();
-        let watch_dir = dir.clone();
-        let mut watcher: RecommendedWatcher = match RecommendedWatcher::new(
-            move |res: notify::Result<Event>| {
-                let Ok(event) = res else { return };
-                // An atomic rename fires two events — `Name(To)` and
-                // `Name(Both)` — both referencing the final filename.
-                // We accept `Create(_)` (platforms that emit it) and
-                // `Modify(Name(To))` (the rename-destination arrival
-                // on Linux), and explicitly drop `Name(Both)` and
-                // `Name(From)` so we don't deliver each signal twice.
-                let accept = matches!(
-                    event.kind,
-                    EventKind::Create(_)
-                        | EventKind::Modify(ModifyKind::Name(RenameMode::To))
-                );
-                if !accept {
-                    return;
-                }
-                for path in event.paths {
-                    if path.extension().and_then(|s| s.to_str()) != Some("signal") {
-                        continue;
-                    }
-                    if let Some(sig) = parse_file(&path) {
-                        let _ = tx_cb.send_blocking(sig);
-                    }
-                }
-            },
-            Config::default().with_poll_interval(Duration::from_millis(250)),
-        ) {
-            Ok(w) => w,
-            Err(e) => {
-                eprintln!("attend-chat: watcher init failed: {}", e);
+    let tx_cb = tx.clone();
+    let mut watcher = RecommendedWatcher::new(
+        move |res: notify::Result<Event>| {
+            let Ok(event) = res else { return };
+            // An atomic rename fires two events — `Name(To)` and
+            // `Name(Both)` — both referencing the final filename. We
+            // accept `Create(_)` (platforms that emit it, notably
+            // kqueue) and `Modify(Name(To))` (the rename-destination
+            // arrival on Linux), and explicitly drop `Name(Both)` and
+            // `Name(From)` so we don't deliver each signal twice.
+            //
+            // TODO(bsd): kqueue reports bare `Modify(_)` rather than
+            // the RenameMode subvariants on some BSD builds of notify;
+            // if we start running on FreeBSD this matcher may miss
+            // events. Revisit with a platform-specific test when we
+            // add BSD CI.
+            let accept = matches!(
+                event.kind,
+                EventKind::Create(_) | EventKind::Modify(ModifyKind::Name(RenameMode::To))
+            );
+            if !accept {
                 return;
             }
-        };
+            for path in event.paths {
+                if path.extension().and_then(|s| s.to_str()) != Some("signal") {
+                    continue;
+                }
+                if let Some(sig) = parse_file(&path) {
+                    let _ = tx_cb.send_blocking(sig);
+                }
+            }
+        },
+        Config::default().with_poll_interval(Duration::from_millis(250)),
+    )?;
+    watcher.watch(&dir, RecursiveMode::NonRecursive)?;
 
-        if let Err(e) = watcher.watch(&watch_dir, RecursiveMode::NonRecursive) {
-            eprintln!(
-                "attend-chat: watch({}) failed: {}",
-                watch_dir.display(),
-                e
-            );
-            return;
-        }
-
-        // Keep the watcher alive for the life of the thread.
+    // Park the watcher on a dedicated thread so its handle (and its
+    // inotify descriptor on Linux) lives for the rest of the process.
+    // Dropping the handle would stop the watcher.
+    thread::spawn(move || {
+        let _keep_alive = watcher;
         loop {
             thread::park();
         }
     });
-}
 
-/// Re-export so the caller doesn't need to import `Path`.
-#[allow(dead_code)]
-pub fn is_signal(path: &Path) -> bool {
-    path.extension().and_then(|s| s.to_str()) == Some("signal")
+    Ok(())
 }

--- a/tools/attend-chat/src/watcher.rs
+++ b/tools/attend-chat/src/watcher.rs
@@ -1,0 +1,106 @@
+//! Directory watcher that streams signals into the TUI.
+//!
+//! `spawn_watcher` does two things, in order:
+//!
+//!   1. scans the directory for existing `.signal` files (sorted by
+//!      mtime ascending) so a freshly-started TUI catches up on recent
+//!      traffic instead of opening empty;
+//!   2. installs a `notify` recommended watcher; creates and writes
+//!      are forwarded as [`Signal`] values onto the caller's channel.
+//!
+//! The watcher runs in a dedicated thread. `notify`'s callback is
+//! synchronous, so we bridge to the async channel with
+//! [`async_channel::Sender::send_blocking`]. Keeping the watcher
+//! thread off smol means a slow renderer can't back-pressure the
+//! filesystem listener into dropping events.
+
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
+
+use async_channel::Sender;
+use notify::event::{ModifyKind, RenameMode};
+use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+
+use crate::signal::{parse_file, Signal};
+
+pub fn spawn_watcher(dir: PathBuf, tx: Sender<Signal>) {
+    std::fs::create_dir_all(&dir).ok();
+
+    // Backfill existing signals so the stream isn't empty on launch.
+    // Ordered by mtime so replay matches wall-clock arrival order.
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        let mut items: Vec<(std::time::SystemTime, PathBuf)> = entries
+            .filter_map(|e| e.ok())
+            .filter_map(|e| {
+                let p = e.path();
+                e.metadata().and_then(|m| m.modified()).ok().map(|t| (t, p))
+            })
+            .collect();
+        items.sort_by_key(|(t, _)| *t);
+        for (_, path) in items {
+            if let Some(sig) = parse_file(&path) {
+                let _ = tx.send_blocking(sig);
+            }
+        }
+    }
+
+    thread::spawn(move || {
+        let tx_cb = tx.clone();
+        let watch_dir = dir.clone();
+        let mut watcher: RecommendedWatcher = match RecommendedWatcher::new(
+            move |res: notify::Result<Event>| {
+                let Ok(event) = res else { return };
+                // An atomic rename fires two events — `Name(To)` and
+                // `Name(Both)` — both referencing the final filename.
+                // We accept `Create(_)` (platforms that emit it) and
+                // `Modify(Name(To))` (the rename-destination arrival
+                // on Linux), and explicitly drop `Name(Both)` and
+                // `Name(From)` so we don't deliver each signal twice.
+                let accept = matches!(
+                    event.kind,
+                    EventKind::Create(_)
+                        | EventKind::Modify(ModifyKind::Name(RenameMode::To))
+                );
+                if !accept {
+                    return;
+                }
+                for path in event.paths {
+                    if path.extension().and_then(|s| s.to_str()) != Some("signal") {
+                        continue;
+                    }
+                    if let Some(sig) = parse_file(&path) {
+                        let _ = tx_cb.send_blocking(sig);
+                    }
+                }
+            },
+            Config::default().with_poll_interval(Duration::from_millis(250)),
+        ) {
+            Ok(w) => w,
+            Err(e) => {
+                eprintln!("attend-chat: watcher init failed: {}", e);
+                return;
+            }
+        };
+
+        if let Err(e) = watcher.watch(&watch_dir, RecursiveMode::NonRecursive) {
+            eprintln!(
+                "attend-chat: watch({}) failed: {}",
+                watch_dir.display(),
+                e
+            );
+            return;
+        }
+
+        // Keep the watcher alive for the life of the thread.
+        loop {
+            thread::park();
+        }
+    });
+}
+
+/// Re-export so the caller doesn't need to import `Path`.
+#[allow(dead_code)]
+pub fn is_signal(path: &Path) -> bool {
+    path.extension().and_then(|s| s.to_str()) == Some("signal")
+}

--- a/tools/attend-chat/tests/watcher_roundtrip.rs
+++ b/tools/attend-chat/tests/watcher_roundtrip.rs
@@ -1,0 +1,71 @@
+//! End-to-end smoke test for the watcher → channel → parse path.
+//!
+//! This is the bridge between the writer in `signal::write_broadcast`
+//! and the reader in `watcher::spawn_watcher`; it's the one thing that
+//! would catch wire-format drift between the two without a human
+//! reading both files. We keep everything inside a temp `$HOME` so
+//! the real signal cache stays untouched.
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Duration, Instant, SystemTime};
+
+use attend_chat::{signal, watcher};
+
+fn tmp_home() -> PathBuf {
+    let p = std::env::temp_dir().join(format!(
+        "attend-chat-it-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&p).unwrap();
+    p
+}
+
+fn recv_with_timeout(
+    rx: &async_channel::Receiver<signal::Signal>,
+    timeout: Duration,
+) -> Option<signal::Signal> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match rx.try_recv() {
+            Ok(sig) => return Some(sig),
+            Err(async_channel::TryRecvError::Empty) => {
+                if Instant::now() >= deadline {
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(async_channel::TryRecvError::Closed) => return None,
+        }
+    }
+}
+
+#[test]
+fn write_broadcast_arrives_through_watcher() {
+    let home = tmp_home();
+    // Using `set_var` is !Send on some platforms; cargo runs
+    // integration tests per file, and we only flip `HOME` here.
+    std::env::set_var("HOME", &home);
+
+    let (tx, rx) = async_channel::unbounded::<signal::Signal>();
+    watcher::spawn_watcher(signal::broadcast_dir(), tx)
+        .expect("watcher must initialise against a fresh temp dir");
+
+    // Drain anything the backfill produced (should be nothing in a
+    // fresh temp dir, but be defensive).
+    while rx.try_recv().is_ok() {}
+
+    let filename = signal::write_broadcast("hello integration test")
+        .expect("write_broadcast must succeed");
+
+    let sig = recv_with_timeout(&rx, Duration::from_secs(2))
+        .expect("watcher must surface the write within 2s");
+    assert_eq!(sig.message, "hello integration test");
+    assert!(sig.from.starts_with("external:"));
+    assert!(filename.ends_with(".signal"));
+    assert!(sig.id.starts_with(sig.from.trim_start_matches("external:").split('@').next().unwrap_or("")));
+}

--- a/tools/attend/src/cmd/send.rs
+++ b/tools/attend/src/cmd/send.rs
@@ -151,6 +151,10 @@ pub(crate) fn cmd_send(args: &[String]) {
     // `from|project|cwd|re:signal-id|message` (threaded reply). The `re:`
     // field is only emitted when --re was given; unthreaded sends stay
     // byte-identical to the pre-ADR-120 format.
+    //
+    // **Wire-format mirror.** `tools/attend-chat/src/signal.rs::write_broadcast`
+    // produces the legacy branch of this format. Keep the two in
+    // lockstep; there is no shared crate gating the contract.
     let content = match &reply_to {
         Some(id) => format!("{}|{}|{}|re:{}|{}\n", from, project, cwd, id, message),
         None => format!("{}|{}|{}|{}\n", from, project, cwd, message),

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -30,6 +30,20 @@ fn main() {
         Some("send") => {
             cmd::send::cmd_send(&args[1..]);
         }
+        Some("chat") => {
+            // `attend chat` is a thin shim that execs the standalone
+            // `attend-chat` binary. Keeping the iocraft dependency
+            // (and its async runtime) out of the attend crate means
+            // `attend status`, `attend send`, and the sensor loop stay
+            // cheap to cold-start from hooks. See ADR-120.
+            use std::os::unix::process::CommandExt;
+            let err = std::process::Command::new("attend-chat")
+                .args(&args[1..])
+                .exec();
+            eprintln!("attend chat: failed to launch attend-chat: {}", err);
+            eprintln!("  (is `attend-chat` on PATH? run `make install` from the repo root)");
+            std::process::exit(1);
+        }
         Some("reply") => {
             cmd::send::cmd_reply(&args[1..]);
         }
@@ -108,6 +122,7 @@ fn main() {
                     ("inbox", "Read pending messages from peers"),
                     ("send", "Send a signal to peer sessions"),
                     ("reply", "Reply to the most recent peer message (auto-threaded)"),
+                    ("chat", "Launch the interactive chat TUI (ADR-120)"),
                     ("focus", "Manage attention groups (on, off, list, all, clear, pin, dissolve)"),
                     ("scene", "Activate a named scene (reconfigure focus)"),
                     ("scenes", "List available scenes"),


### PR DESCRIPTION
## Summary

First slice of the interactive chat TUI from ADR-120 / #23. The human sits inside the same signal protocol the agents use — writes land in `~/.cache/attend/signals/_broadcast/`, a `notify` watcher streams the stream back into a scrolling pane, and typed messages round-trip through the same path.

Shipped as a **separate binary** (`attend-chat`) so iocraft's dep tree doesn't bloat the hot-path `attend` binary that fires from hooks on every Stop / UserPromptSubmit. `attend chat` is a thin exec shim.

## What's in this slice

- Message stream pinned to newest via `ScrollView(auto_scroll: true)`; root sized from `use_terminal_size()` so the layout actually fills the terminal.
- Bordered "sender chip" to the left of each message: short id + cwd basename. `claude:<uuid>` collapses to `c:<7-char>`; `external:user@kitty` becomes `user`.
- Message body wraps in the remaining flex width.
- Custom single-string input (cursor block). **Enter sends**, **Shift-Enter / Alt-Enter insert a newline**. Blue box grows to match *visual* row count, not logical newlines — wrapped text expands the box instead of spilling onto the border or status row.
- Atomic-rename dedupe in the watcher (`Modify(Name(To))`/`Create` only), so every signal delivers exactly once.

## Deferred to follow-up PRs on ADR-120

- Focus-group sidebar + unread dots
- Agents sidebar (peer sensor metadata)
- `@group` / `#issue` inline parsing
- Threading render (`re:` field — writer already exists on the CLI side)
- ADR-121 salience decay fade

## Build / install

- New workspace member `tools/attend-chat` (mirrors the attend crate shape).
- Makefile targets `make attend-chat` and `make attend-chat-rebuild`; `make setup` and `make install` pick it up, `make uninstall` removes the symlink.
- Installed as `$XDG_BIN/attend-chat` → `bin/attend-chat` → `tools/target/release/attend-chat`.

## Test plan

- [x] `cargo clippy` workspace-clean with `-D warnings`
- [x] `cargo test -p attend-chat` — 12 unit tests green (wire-format parse legacy + threaded, writer/parser round-trip, sender/scope prettification, visual row count)
- [x] Manual smoke test: two `attend-chat` instances side-by-side, real-time round-trip (see PR description for screenshots during dev)
- [x] External `attend send` signals appear live in the TUI stream
- [x] Backlog replay on launch (existing signals sorted by mtime)
- [x] Long wrapped messages expand the input box without overflowing into the status row

## Related

- ADR-120 (moved Draft → Accepted in [2deb8c0](https://github.com/aaronsb/agent-ways/commit/2deb8c0))
- Closes nothing yet — #23 stays open for the remaining components