### PR TITLE
feat(agent-identity): shared nickname + palette crate (#23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,8 @@ hooks/ways/.obsidian/
 !tools/mmaid/*
 !tools/agent-fmt/
 !tools/agent-fmt/**
+!tools/agent-identity/
+!tools/agent-identity/**
 !tools/sensor-trait/
 !tools/sensor-trait/**
 !tools/sensor-git/

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -18,6 +18,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent-identity"
+version = "0.1.0"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +222,7 @@ name = "attend"
 version = "0.6.0"
 dependencies = [
  "agent-fmt",
+ "agent-identity",
  "sensor-context",
  "sensor-disclosure",
  "sensor-git",
@@ -230,6 +235,7 @@ dependencies = [
 name = "attend-chat"
 version = "0.1.0"
 dependencies = [
+ "agent-identity",
  "async-channel",
  "iocraft",
  "notify",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "agent-fmt",
+    "agent-identity",
     "sensor-trait",
     "sensor-git",
     "sensor-context",

--- a/tools/agent-identity/Cargo.toml
+++ b/tools/agent-identity/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "agent-identity"
+version = "0.1.0"
+edition = "2021"
+description = "Display-layer identity for agent-ways tools: stable nicknames, color palette, and terminal capability detection"
+license = "MIT OR Apache-2.0"
+
+[lib]
+name = "agent_identity"
+path = "src/lib.rs"

--- a/tools/agent-identity/src/ansi.rs
+++ b/tools/agent-identity/src/ansi.rs
@@ -1,0 +1,111 @@
+//! Raw ANSI escape rendering for terminals that don't use a component
+//! framework.
+//!
+//! Consumers that render to iocraft/ratatui/etc. should map the
+//! `PaletteEntry` onto their own types instead — `ansi::wrap` is for
+//! `println!`-style callers (attend's `peers` table, banners, status
+//! output, etc.).
+
+use crate::palette::{PaletteEntry, Style, TermCaps};
+
+/// Wrap `text` in ANSI SGR codes that express `entry` and `style`
+/// under the given capability level.
+///
+/// On `Mono` terminals the color is dropped and only `style` survives —
+/// a monochrome terminal still speaks bold/italic.
+pub fn wrap(text: &str, entry: &PaletteEntry, style: Style, caps: TermCaps) -> String {
+    let mut prefix = String::new();
+    if style.bold {
+        prefix.push_str("\x1b[1m");
+    }
+    if style.italic {
+        prefix.push_str("\x1b[3m");
+    }
+    match caps {
+        TermCaps::Rich => {
+            prefix.push_str(&format!(
+                "\x1b[38;2;{};{};{}m",
+                entry.rgb.0, entry.rgb.1, entry.rgb.2
+            ));
+        }
+        TermCaps::Basic => {
+            // ANSI 16-color codes: 30–37 for normal, 90–97 for bright.
+            let code = if entry.ansi16 < 8 {
+                30 + entry.ansi16
+            } else {
+                90 + (entry.ansi16 - 8)
+            };
+            prefix.push_str(&format!("\x1b[{code}m"));
+        }
+        TermCaps::Mono => {
+            // No color. Style-only prefix already set above; fall
+            // through to the reset suffix.
+        }
+    }
+    format!("{prefix}{text}\x1b[0m")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::palette::RICH_PALETTE;
+
+    #[test]
+    fn rich_emits_truecolor_sgr() {
+        let e = RICH_PALETTE[0];
+        let out = wrap(
+            "hi",
+            &e,
+            Style { bold: false, italic: false },
+            TermCaps::Rich,
+        );
+        let rgb_code = format!("\x1b[38;2;{};{};{}m", e.rgb.0, e.rgb.1, e.rgb.2);
+        assert!(out.contains(&rgb_code), "missing truecolor SGR: {out:?}");
+        assert!(out.ends_with("\x1b[0m"), "missing reset: {out:?}");
+    }
+
+    #[test]
+    fn basic_emits_16color_sgr() {
+        let e = PaletteEntry {
+            rgb: (0, 0, 0),
+            ansi16: 12, // bright blue
+            name: "bblue",
+        };
+        let out = wrap(
+            "x",
+            &e,
+            Style { bold: true, italic: false },
+            TermCaps::Basic,
+        );
+        // 12 is bright (>= 8) so we emit 90+(12-8) = 94.
+        assert!(out.contains("\x1b[94m"), "missing 94 code: {out:?}");
+        assert!(out.contains("\x1b[1m"), "missing bold: {out:?}");
+    }
+
+    #[test]
+    fn mono_keeps_style_drops_color() {
+        let e = RICH_PALETTE[0];
+        let out = wrap(
+            "x",
+            &e,
+            Style { bold: true, italic: true },
+            TermCaps::Mono,
+        );
+        assert!(out.contains("\x1b[1m"));
+        assert!(out.contains("\x1b[3m"));
+        assert!(!out.contains("\x1b[38;"), "mono leaked color: {out:?}");
+    }
+
+    #[test]
+    fn plain_style_on_mono_is_nearly_empty() {
+        let e = RICH_PALETTE[0];
+        let out = wrap(
+            "hello",
+            &e,
+            Style::default(),
+            TermCaps::Mono,
+        );
+        // No SGR prefix, just reset at the end (harmless but present).
+        assert_eq!(out, "hello\x1b[0m");
+    }
+}

--- a/tools/agent-identity/src/identity.rs
+++ b/tools/agent-identity/src/identity.rs
@@ -1,0 +1,222 @@
+//! Per-agent display identity derived purely from identifying inputs.
+//!
+//! The contract: same inputs → same `Identity`, across runs, across
+//! hosts, across crates. Two agents in different working directories
+//! with the same basename still land on different nicknames because
+//! the hash seed is the full path, not the basename.
+//!
+//! We intentionally use our own FNV-1a here rather than `std`'s
+//! `DefaultHasher`: `DefaultHasher` is SipHash with a process-random
+//! seed, so its output is not stable across runs. For display
+//! identity we need determinism, not cryptographic strength.
+
+use crate::names;
+use crate::palette::{resolve, PaletteEntry, Resolved, Style, TermCaps};
+
+/// Everything a consumer needs to render an agent's identity chip.
+#[derive(Clone, Debug)]
+pub struct Identity {
+    /// Stable nickname. Lives for the life of the working directory —
+    /// a claude restarting in the same cwd keeps the same name.
+    pub nickname: &'static str,
+    /// Last path segment of the agent's cwd, already truncated for
+    /// display. Callers that want the raw cwd have it on the `Signal`.
+    pub cwd_basename: String,
+    /// Color + style resolved at the capability level the caller
+    /// passed in. If the caller re-resolves under a different `caps`,
+    /// they'll get a different entry but the same nickname.
+    pub palette: PaletteEntry,
+    pub style: Style,
+    /// The 64-bit seed used to derive this identity. Exposed for
+    /// callers that want to key their own data (e.g. unread counts) by
+    /// the same identity without re-hashing.
+    pub seed: u64,
+}
+
+impl Identity {
+    /// Derive identity for an agent keyed on its **full** cwd path.
+    ///
+    /// Pass `user` if the sender is a human (from the `external:<user>`
+    /// form) — users get an identity too, keyed on their username, so
+    /// the human's avatar is consistent with how peers address them.
+    pub fn for_cwd(cwd_path: &str, caps: TermCaps) -> Self {
+        Self::for_key(cwd_path, cwd_basename(cwd_path), caps)
+    }
+
+    /// Derive identity for a human user, keyed on username. Basename
+    /// for display is the passed-in `label` (typically a cwd basename
+    /// so the human's chip reads "<user> / <projdir>").
+    pub fn for_user(user: &str, label: &str, caps: TermCaps) -> Self {
+        // Prefix the hash domain so a user named "Monet" and a cwd
+        // hashing to "Monet" don't collide on the same nickname. Same
+        // principle as namespacing HMAC inputs.
+        let key = format!("user:{user}");
+        Self::for_key(&key, label.to_string(), caps)
+    }
+
+    fn for_key(hash_input: &str, label: String, caps: TermCaps) -> Self {
+        let seed = fnv1a_64(hash_input.as_bytes());
+        let nickname = names::pick(seed);
+        // Stir the seed before asking for palette + style so nickname
+        // and color aren't trivially correlated — two agents that land
+        // on the same color should still tend to differ on nickname
+        // and vice versa.
+        let Resolved { entry, style } = resolve(seed ^ 0x9e37_79b9_7f4a_7c15, caps);
+        Identity {
+            nickname,
+            cwd_basename: label,
+            palette: entry,
+            style,
+            seed,
+        }
+    }
+}
+
+/// Extract the last non-empty path segment from a cwd string. Pure
+/// string work — we don't touch the filesystem.
+pub fn cwd_basename(path: &str) -> String {
+    if path.is_empty() {
+        return "(home)".to_string();
+    }
+    let trimmed = path.trim_end_matches('/');
+    if trimmed.is_empty() {
+        return "/".to_string();
+    }
+    trimmed.rsplit('/').next().unwrap_or(trimmed).to_string()
+}
+
+/// FNV-1a 64-bit. Deterministic across runs and targets — this is the
+/// property we need, and why we don't use `std::hash::DefaultHasher`.
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = OFFSET;
+    for &b in bytes {
+        hash ^= b as u64;
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_cwd_same_identity() {
+        let a = Identity::for_cwd("/home/aaron/.claude", TermCaps::Rich);
+        let b = Identity::for_cwd("/home/aaron/.claude", TermCaps::Rich);
+        assert_eq!(a.nickname, b.nickname);
+        assert_eq!(a.cwd_basename, b.cwd_basename);
+        assert_eq!(a.palette, b.palette);
+        assert_eq!(a.style, b.style);
+        assert_eq!(a.seed, b.seed);
+    }
+
+    #[test]
+    fn different_cwds_different_seeds() {
+        // Different paths must produce different seeds. We don't
+        // assert different nicknames — the pool is finite and
+        // collisions are allowed — but the seed itself must differ or
+        // all downstream derivations collapse.
+        let a = Identity::for_cwd("/home/a", TermCaps::Rich);
+        let b = Identity::for_cwd("/home/b", TermCaps::Rich);
+        assert_ne!(a.seed, b.seed);
+    }
+
+    #[test]
+    fn same_basename_different_paths_differ() {
+        // Two repos both named "src" must not share an identity.
+        let a = Identity::for_cwd("/home/me/proj-a/src", TermCaps::Rich);
+        let b = Identity::for_cwd("/home/me/proj-b/src", TermCaps::Rich);
+        assert_ne!(a.seed, b.seed);
+        assert_eq!(a.cwd_basename, b.cwd_basename); // basename matches
+    }
+
+    #[test]
+    fn user_namespace_separate_from_cwd() {
+        // A username happening to equal a cwd path must not collide —
+        // the `user:` prefix in the hash key enforces this.
+        let a = Identity::for_user("aaron", "Projects", TermCaps::Rich);
+        let b = Identity::for_cwd("aaron", TermCaps::Rich);
+        assert_ne!(a.seed, b.seed);
+    }
+
+    #[test]
+    fn basename_handles_trailing_slash() {
+        assert_eq!(cwd_basename("/home/aaron/"), "aaron");
+        assert_eq!(cwd_basename("/home/aaron"), "aaron");
+    }
+
+    #[test]
+    fn basename_handles_root_and_empty() {
+        assert_eq!(cwd_basename("/"), "/");
+        assert_eq!(cwd_basename(""), "(home)");
+    }
+
+    #[test]
+    fn basename_handles_single_segment() {
+        assert_eq!(cwd_basename(".claude"), ".claude");
+    }
+
+    #[test]
+    fn caps_affects_palette_not_nickname() {
+        // Same cwd rendered under two different caps must keep the
+        // nickname — it's the stable part of identity — but may pick
+        // a different entry from a differently-sized palette.
+        let rich = Identity::for_cwd("/x/y/z", TermCaps::Rich);
+        let basic = Identity::for_cwd("/x/y/z", TermCaps::Basic);
+        assert_eq!(rich.nickname, basic.nickname);
+        assert_eq!(rich.cwd_basename, basic.cwd_basename);
+    }
+
+    #[test]
+    fn mono_caps_produces_mono_entry() {
+        let id = Identity::for_cwd("/x/y/z", TermCaps::Mono);
+        assert_eq!(id.palette.name, "mono");
+    }
+
+    #[test]
+    fn nickname_is_ascii() {
+        // Sanity: any derivation must produce an ASCII-safe nickname,
+        // since downstream `@<name>` autocomplete depends on it.
+        for path in [
+            "/home/a",
+            "/home/b/c/d",
+            "/tmp/x",
+            "/home/me/code/rust/project-42",
+        ] {
+            let id = Identity::for_cwd(path, TermCaps::Rich);
+            assert!(id.nickname.is_ascii(), "{:?} derived non-ASCII nickname {:?}", path, id.nickname);
+        }
+    }
+
+    #[test]
+    fn fnv1a_matches_reference_vector() {
+        // FNV-1a of "foo" is the canonical test vector from the spec —
+        // if we ever accidentally break our hash (e.g., swap offset/
+        // prime, wrong order of ops), this catches it before real
+        // identity drift hits a user.
+        assert_eq!(fnv1a_64(b"foo"), 0xdcb27518_fed9d577);
+    }
+
+    #[test]
+    fn collision_rate_is_reasonable() {
+        // Over a synthetic population of 1000 cwd-like strings the
+        // nickname collision rate should stay well under a visible
+        // threshold. This is a smoke test for pool size × hash quality,
+        // not a formal bound.
+        use std::collections::HashMap;
+        let mut counts: HashMap<&str, usize> = HashMap::new();
+        for i in 0..1000 {
+            let path = format!("/home/user/project-{i:04}/src");
+            let id = Identity::for_cwd(&path, TermCaps::Rich);
+            *counts.entry(id.nickname).or_insert(0) += 1;
+        }
+        let unique = counts.len();
+        // With ~200 names and 1000 samples, perfect uniformity would
+        // put every name around 5. We just want coverage — at least
+        // half the pool touched.
+        assert!(unique >= names::NAMES.len() / 2, "only {unique} nicknames used from pool of {}", names::NAMES.len());
+    }
+}

--- a/tools/agent-identity/src/lib.rs
+++ b/tools/agent-identity/src/lib.rs
@@ -1,0 +1,31 @@
+//! Display-layer identity for agent-ways tools.
+//!
+//! Given a working directory (for a claude) or a username (for a
+//! human), produces a stable nickname, color, and style. Pure
+//! derivation — no filesystem, no network, no state. Callers render
+//! with whatever stack they have (iocraft, crossterm, raw ANSI); this
+//! crate does not pick one.
+//!
+//! Why a separate crate: attend and attend-chat both need the same
+//! mapping so a claude sees the same nickname in its own banner that
+//! its peers see when the peer renders a signal from it. Duplicating
+//! the derivation risked drift the moment either side tweaked a
+//! constant.
+//!
+//! Non-goals:
+//! - Identity does **not** ride the wire. Signals keep carrying
+//!   `claude:<uuid>` / `external:<user>` / cwd exactly as before.
+//!   Receivers derive the display identity locally. Claude is never
+//!   forced to use or publish a nickname — this is a view layer.
+//! - No opinion on how focus groups form or are discovered. That lives
+//!   in ADR-118 and the consumer crates.
+
+pub mod ansi;
+pub mod identity;
+pub mod names;
+pub mod palette;
+
+pub use identity::{cwd_basename, Identity};
+pub use palette::{
+    resolve, PaletteEntry, Resolved, Style, TermCaps, BASIC_PALETTE, RICH_PALETTE,
+};

--- a/tools/agent-identity/src/names.rs
+++ b/tools/agent-identity/src/names.rs
@@ -1,0 +1,131 @@
+//! Curated nickname pool for agent display identities.
+//!
+//! Constraints:
+//! - ASCII only. No diacritics. A user typing `@` autocomplete should
+//!   never be blocked by a keyboard that can't produce é, ü, ø, etc.
+//!   Names that would normally carry a mark are transliterated plainly
+//!   (Rene, not René; Zoe, not Zoé).
+//! - Real given names or real historical/literary proper nouns. No
+//!   fantasy-quirky Docker-style adjective+noun concoctions.
+//! - Slight literary/historical leaning — claude-ish in spirit without
+//!   being all variants of "Claude". Famous Claudes (Monet, Debussy,
+//!   Shannon) are included as a nod, not the anchor.
+//! - Short to mid-length; most 4–8 characters. Long enough to be
+//!   distinctive, short enough to render in a 16-col chip.
+//!
+//! Size: aim for ~200. Larger pools reduce collisions among concurrent
+//! peers but pay diminishing returns past the point where humans
+//! distinguish by color+style as well as name. With 20 palette colors
+//! and ~3 style variants this gives ~12k effective identities before
+//! collisions even start to matter.
+
+pub const NAMES: &[&str] = &[
+    // Claude variants and direct nods.
+    "Claudette", "Claudio", "Claudia", "Claudine", "Claudius", "Clovis",
+    // Famous Claudes (transliterated to ASCII).
+    "Monet", "Debussy", "Shannon", "Rains", "Levi", "Chabrol", "Garamond",
+    "Lorrain", "Bernard", "McKay", "Akins",
+    // Adjacent-sounding whimsical picks.
+    "Clement", "Clarice", "Clelia", "Cleo", "Clio", "Clover", "Chaucer",
+    // A–C
+    "Alden", "Anwen", "Aria", "Aster", "Auden", "August", "Aurora", "Avery",
+    "Basil", "Beatrix", "Benedict", "Bernadette", "Blaise", "Bruno",
+    "Calista", "Calliope", "Camille", "Cassio", "Cato", "Celeste", "Celia",
+    "Ceres", "Chiron", "Cicero", "Cora", "Cosima", "Cyrano", "Cyril", "Cyrus",
+    // D–F
+    "Dahlia", "Dante", "Daphne", "Darius", "Delta", "Desmond", "Dimitri",
+    "Dorian", "Dulcie",
+    "Edison", "Edmund", "Edwin", "Elio", "Elise", "Elora", "Emeric", "Emilio",
+    "Enzo", "Esme", "Ezra",
+    "Fable", "Felix", "Finnian", "Fiora", "Flora", "Florian", "Fox",
+    // G–I
+    "Gable", "Galen", "Gareth", "Garnet", "Genevieve", "Gideon", "Gilbert",
+    "Giselle", "Godfrey",
+    "Halcyon", "Hana", "Harlan", "Harper", "Heloise", "Hesper", "Hollis",
+    "Horatio",
+    "Idris", "Igor", "Inigo", "Iris", "Isadora", "Ivo",
+    // J–L
+    "Jasper", "Jericho", "Jessamine", "Jovan", "Jubilee", "Jules", "Juniper",
+    "Kenna", "Kestrel", "Kieran", "Kit",
+    "Lachlan", "Larkin", "Laszlo", "Lavinia", "Leander", "Leopold", "Linnea",
+    "Lior", "Lorcan", "Lucian", "Luna", "Lyra",
+    // M–O
+    "Mabel", "Magnus", "Malachi", "Marigold", "Mateo", "Matilda", "Maude",
+    "Maxim", "Mercer", "Miles", "Minerva", "Mira", "Miroslav", "Monroe", "Moss",
+    "Nadia", "Neven", "Nicolai", "Niko", "Nina", "Nolan", "Nora", "Nyx",
+    "Octavia", "Odessa", "Odin", "Olive", "Omar", "Orion", "Osmund", "Otto",
+    "Ovid", "Owain",
+    // P–S
+    "Pascal", "Perrin", "Petra", "Phaedra", "Phineas", "Poppy", "Primrose",
+    "Prosper",
+    "Quinn", "Quill", "Quincy",
+    "Rafael", "Ramona", "Raphael", "Raven", "Reinette", "Remy", "Rhea",
+    "Roland", "Roman", "Rosalind", "Roscoe", "Rowan", "Rufus", "Rune",
+    "Sable", "Saffron", "Saoirse", "Saskia", "Seraphine", "Severin", "Shea",
+    "Sidra", "Silas", "Sloane", "Solveig", "Soren", "Stellan", "Sylvan",
+    // T–Z
+    "Tamsin", "Tarquin", "Tatiana", "Tavish", "Teague", "Thaddeus", "Thea",
+    "Thora", "Tiernan", "Tobias", "Torsten",
+    "Ulric", "Una", "Urban", "Uriel",
+    "Vala", "Valentin", "Vera", "Veronica", "Vesper", "Victor", "Vivienne",
+    "Wallace", "Walden", "Wells", "Wilmot", "Winifred", "Wren",
+    "Xander", "Xenia", "Ximena",
+    "Yara", "Yolanda", "Yuri", "Yvette",
+    "Zephyr", "Zinnia", "Zoe", "Zora",
+];
+
+/// Pick a nickname deterministically from a seed.
+///
+/// `seed` is expected to already be mixed (e.g. an FNV-1a of the
+/// identity key). This function is a pure modulo, so callers are
+/// responsible for distribution.
+pub fn pick(seed: u64) -> &'static str {
+    NAMES[(seed as usize) % NAMES.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pool_is_reasonably_large() {
+        // Below 128 we start seeing visible collisions among everyday
+        // peer counts. The concrete floor here is a smoke test — the
+        // real contract is "collisions are rare enough that humans
+        // don't notice them on a typical session".
+        assert!(NAMES.len() >= 128, "nickname pool shrunk below safety floor: {}", NAMES.len());
+    }
+
+    #[test]
+    fn all_names_are_ascii() {
+        for n in NAMES {
+            assert!(
+                n.is_ascii(),
+                "{n:?} contains non-ASCII — strip diacritics before adding"
+            );
+        }
+    }
+
+    #[test]
+    fn all_names_nonempty_and_capitalized() {
+        for n in NAMES {
+            assert!(!n.is_empty(), "empty name");
+            let first = n.chars().next().unwrap();
+            assert!(first.is_ascii_uppercase(), "{n:?} should start capitalized");
+        }
+    }
+
+    #[test]
+    fn no_duplicates() {
+        let mut sorted: Vec<&str> = NAMES.to_vec();
+        sorted.sort_unstable();
+        for pair in sorted.windows(2) {
+            assert_ne!(pair[0], pair[1], "duplicate nickname: {:?}", pair[0]);
+        }
+    }
+
+    #[test]
+    fn pick_is_stable() {
+        assert_eq!(pick(42), pick(42));
+    }
+}

--- a/tools/agent-identity/src/palette.rs
+++ b/tools/agent-identity/src/palette.rs
@@ -1,0 +1,279 @@
+//! Color palette + terminal capability detection + style axes.
+//!
+//! We don't depend on a terminal crate here — capability detection is
+//! a couple of env-var probes, and we emit colors as palette indices
+//! that the consumer maps onto its own rendering layer (iocraft `Color`,
+//! crossterm `Color`, raw ANSI, etc.). That keeps this crate free of a
+//! rendering opinion.
+//!
+//! Philosophy: use **color** as the primary identity signal, and
+//! reserve **style bits** (bold / italic / underline) as secondary
+//! axes that grow the identity space when the palette alone isn't
+//! enough. Italic renders inconsistently across terminals (some
+//! italicize, some invert, some ignore), so we use it sparingly and
+//! always paired with color so a broken italic doesn't break identity.
+
+/// What the terminal can render.
+///
+/// We probe env vars only — a PTY round-trip would be more accurate
+/// but adds latency and complexity we don't need for picking from
+/// three palette sizes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TermCaps {
+    /// Truecolor or 256-color: full 20-entry palette available.
+    Rich,
+    /// 16-color ANSI with bright variants.
+    Basic,
+    /// Monochrome or unknown. We still emit style bits.
+    Mono,
+}
+
+impl TermCaps {
+    /// Detect capability from the current process environment.
+    pub fn detect() -> Self {
+        Self::detect_from(|k| std::env::var(k).ok())
+    }
+
+    /// Detection driven by an injectable env getter. Tests use this to
+    /// exercise every branch without mutating the global process env.
+    pub fn detect_from<F: Fn(&str) -> Option<String>>(get: F) -> Self {
+        if let Some(v) = get("NO_COLOR") {
+            if !v.is_empty() {
+                return TermCaps::Mono;
+            }
+        }
+        if let Some(v) = get("COLORTERM") {
+            let v = v.to_ascii_lowercase();
+            if v.contains("truecolor") || v.contains("24bit") {
+                return TermCaps::Rich;
+            }
+        }
+        if let Some(term) = get("TERM") {
+            let term = term.to_ascii_lowercase();
+            if term.contains("256color") || term.contains("direct") {
+                return TermCaps::Rich;
+            }
+            if term == "dumb" {
+                return TermCaps::Mono;
+            }
+            if !term.is_empty() {
+                return TermCaps::Basic;
+            }
+        }
+        TermCaps::Mono
+    }
+}
+
+/// One palette entry: an RGB triple *and* the nearest ANSI bright code.
+///
+/// Callers pick the right form for their renderer: iocraft accepts
+/// `Color::Rgb { r, g, b }` on rich terminals; on basic terminals the
+/// ANSI bright index maps to its `Color::AnsiValue` or a named variant.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PaletteEntry {
+    pub rgb: (u8, u8, u8),
+    /// ANSI 16-color code (0–15). 8–15 are the bright half.
+    pub ansi16: u8,
+    /// Short human name for debugging and tests.
+    pub name: &'static str,
+}
+
+/// 20 distinct colors tuned for readability on both light and dark
+/// terminal backgrounds. Saturation kept mid-to-high, lightness around
+/// 0.55 — so neither white-on-white nor black-on-black renders.
+pub const RICH_PALETTE: &[PaletteEntry] = &[
+    PaletteEntry { rgb: (0xff, 0x6b, 0x6b), ansi16: 9,  name: "coral"     },
+    PaletteEntry { rgb: (0xff, 0xa5, 0x4c), ansi16: 11, name: "amber"     },
+    PaletteEntry { rgb: (0xf4, 0xd0, 0x3f), ansi16: 11, name: "gold"      },
+    PaletteEntry { rgb: (0xc9, 0xe2, 0x65), ansi16: 10, name: "lime"      },
+    PaletteEntry { rgb: (0x7d, 0xd8, 0x7d), ansi16: 10, name: "mint"      },
+    PaletteEntry { rgb: (0x4e, 0xc9, 0xb0), ansi16: 14, name: "teal"      },
+    PaletteEntry { rgb: (0x5a, 0xc8, 0xfa), ansi16: 14, name: "sky"       },
+    PaletteEntry { rgb: (0x7a, 0xa2, 0xf7), ansi16: 12, name: "azure"     },
+    PaletteEntry { rgb: (0xa3, 0x8c, 0xff), ansi16: 12, name: "iris"      },
+    PaletteEntry { rgb: (0xc6, 0x7e, 0xff), ansi16: 13, name: "orchid"    },
+    PaletteEntry { rgb: (0xff, 0x8a, 0xd4), ansi16: 13, name: "rose"      },
+    PaletteEntry { rgb: (0xff, 0xb3, 0xa1), ansi16: 9,  name: "peach"     },
+    PaletteEntry { rgb: (0xd4, 0x9a, 0x6a), ansi16: 11, name: "bronze"    },
+    PaletteEntry { rgb: (0xb0, 0xbe, 0xc5), ansi16: 15, name: "slate"     },
+    PaletteEntry { rgb: (0x9e, 0xa7, 0xad), ansi16: 7,  name: "pewter"    },
+    PaletteEntry { rgb: (0x6b, 0xc7, 0x9a), ansi16: 10, name: "sage"      },
+    PaletteEntry { rgb: (0xe0, 0x7b, 0x7b), ansi16: 9,  name: "brick"     },
+    PaletteEntry { rgb: (0xe6, 0xc3, 0x8c), ansi16: 11, name: "wheat"     },
+    PaletteEntry { rgb: (0x9a, 0xd9, 0xd0), ansi16: 14, name: "seafoam"   },
+    PaletteEntry { rgb: (0xba, 0xa6, 0xff), ansi16: 12, name: "lavender"  },
+];
+
+/// 12-color ANSI fallback (bright 8..15 + 4 from the standard set to
+/// round it out). Skips black/white/bright-black/bright-white since
+/// those disappear on most backgrounds.
+pub const BASIC_PALETTE: &[PaletteEntry] = &[
+    PaletteEntry { rgb: (0xcd, 0x00, 0x00), ansi16: 1,  name: "red"       },
+    PaletteEntry { rgb: (0x00, 0xcd, 0x00), ansi16: 2,  name: "green"     },
+    PaletteEntry { rgb: (0xcd, 0xcd, 0x00), ansi16: 3,  name: "yellow"    },
+    PaletteEntry { rgb: (0x00, 0x00, 0xee), ansi16: 4,  name: "blue"      },
+    PaletteEntry { rgb: (0xcd, 0x00, 0xcd), ansi16: 5,  name: "magenta"   },
+    PaletteEntry { rgb: (0x00, 0xcd, 0xcd), ansi16: 6,  name: "cyan"      },
+    PaletteEntry { rgb: (0xff, 0x5c, 0x5c), ansi16: 9,  name: "bred"      },
+    PaletteEntry { rgb: (0x5c, 0xff, 0x5c), ansi16: 10, name: "bgreen"    },
+    PaletteEntry { rgb: (0xff, 0xff, 0x5c), ansi16: 11, name: "byellow"   },
+    PaletteEntry { rgb: (0x5c, 0x5c, 0xff), ansi16: 12, name: "bblue"     },
+    PaletteEntry { rgb: (0xff, 0x5c, 0xff), ansi16: 13, name: "bmagenta"  },
+    PaletteEntry { rgb: (0x5c, 0xff, 0xff), ansi16: 14, name: "bcyan"     },
+];
+
+/// Style axes that combine with color to grow the identity space.
+///
+/// Italic is intentionally rare — some terminals render it as reverse
+/// video or ignore it entirely, and we don't want identity to hinge on
+/// it. Underline is reserved for transient UI state (hover, focus) in
+/// consumers; we do *not* include it in identity style bits.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct Style {
+    pub bold: bool,
+    pub italic: bool,
+}
+
+/// Palette resolution result: which table to index into, plus the
+/// style bits applied on top.
+#[derive(Clone, Copy, Debug)]
+pub struct Resolved {
+    pub entry: PaletteEntry,
+    pub style: Style,
+}
+
+/// Pick a palette entry + style deterministically from a seed and the
+/// detected capability.
+///
+/// Contract: identical `(seed, caps)` → identical `Resolved`. Different
+/// caps levels may produce different entries — we tune per-palette.
+pub fn resolve(seed: u64, caps: TermCaps) -> Resolved {
+    let palette: &[PaletteEntry] = match caps {
+        TermCaps::Rich => RICH_PALETTE,
+        TermCaps::Basic => BASIC_PALETTE,
+        TermCaps::Mono => {
+            // No color — identity carries entirely on style. Return a
+            // neutral entry and vary style bits across the full range.
+            let neutral = PaletteEntry {
+                rgb: (0xc0, 0xc0, 0xc0),
+                ansi16: 7,
+                name: "mono",
+            };
+            return Resolved {
+                entry: neutral,
+                style: style_from_seed(seed, /*mono=*/ true),
+            };
+        }
+    };
+    let entry = palette[(seed as usize) % palette.len()];
+    // Derive style from the *next* hash step so two identities that
+    // land on the same color still distinguish on bold.
+    let style = style_from_seed(seed.rotate_left(17), /*mono=*/ false);
+    Resolved { entry, style }
+}
+
+fn style_from_seed(seed: u64, mono: bool) -> Style {
+    // Color-capable terminals: bold is cheap, italic rare (roughly 1/4
+    // of seeds) so the italic terminals-that-misrender-it case stays
+    // visually in the minority.
+    // Monochrome: lean harder on bold + italic so style alone can
+    // distinguish a handful of peers.
+    let bold = (seed & 0b1) == 1;
+    let italic = if mono {
+        (seed & 0b10) == 0b10
+    } else {
+        (seed & 0b111) == 0b111
+    };
+    Style { bold, italic }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env<'a>(map: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |k| map.iter().find(|(kk, _)| *kk == k).map(|(_, v)| v.to_string())
+    }
+
+    #[test]
+    fn truecolor_is_rich() {
+        let e = env(&[("COLORTERM", "truecolor"), ("TERM", "xterm")]);
+        assert_eq!(TermCaps::detect_from(e), TermCaps::Rich);
+    }
+
+    #[test]
+    fn term_256color_is_rich() {
+        let e = env(&[("TERM", "xterm-256color")]);
+        assert_eq!(TermCaps::detect_from(e), TermCaps::Rich);
+    }
+
+    #[test]
+    fn bare_xterm_is_basic() {
+        let e = env(&[("TERM", "xterm")]);
+        assert_eq!(TermCaps::detect_from(e), TermCaps::Basic);
+    }
+
+    #[test]
+    fn dumb_is_mono() {
+        let e = env(&[("TERM", "dumb")]);
+        assert_eq!(TermCaps::detect_from(e), TermCaps::Mono);
+    }
+
+    #[test]
+    fn no_color_wins() {
+        // NO_COLOR overrides any rich signal — the spec at no-color.org
+        // says any non-empty value disables color.
+        let e = env(&[("NO_COLOR", "1"), ("COLORTERM", "truecolor")]);
+        assert_eq!(TermCaps::detect_from(e), TermCaps::Mono);
+    }
+
+    #[test]
+    fn no_env_is_mono() {
+        let e = env(&[]);
+        assert_eq!(TermCaps::detect_from(e), TermCaps::Mono);
+    }
+
+    #[test]
+    fn resolve_is_stable() {
+        let a = resolve(12345, TermCaps::Rich);
+        let b = resolve(12345, TermCaps::Rich);
+        assert_eq!(a.entry, b.entry);
+        assert_eq!(a.style, b.style);
+    }
+
+    #[test]
+    fn resolve_distributes_across_rich_palette() {
+        // Run a handful of seeds and verify we touch a reasonable slice
+        // of the palette. This isn't a uniformity test, just a sanity
+        // check that we don't collapse onto one color.
+        use std::collections::HashSet;
+        let colors: HashSet<&str> = (0u64..200)
+            .map(|s| resolve(s, TermCaps::Rich).entry.name)
+            .collect();
+        assert!(
+            colors.len() >= 12,
+            "rich palette coverage too low: {} of {}",
+            colors.len(),
+            RICH_PALETTE.len()
+        );
+    }
+
+    #[test]
+    fn mono_returns_neutral_but_still_styles() {
+        // Cycle seeds and confirm both bold=true and bold=false appear.
+        let mut saw_bold = false;
+        let mut saw_plain = false;
+        for s in 0u64..32 {
+            let r = resolve(s, TermCaps::Mono);
+            assert_eq!(r.entry.name, "mono");
+            if r.style.bold { saw_bold = true; } else { saw_plain = true; }
+        }
+        assert!(saw_bold && saw_plain, "mono style not varying across seeds");
+    }
+
+    #[test]
+    fn palette_sizes_match_doc() {
+        assert_eq!(RICH_PALETTE.len(), 20);
+        assert_eq!(BASIC_PALETTE.len(), 12);
+    }
+}

--- a/tools/attend-chat/Cargo.toml
+++ b/tools/attend-chat/Cargo.toml
@@ -18,3 +18,4 @@ iocraft = "0.8"
 notify = "6"
 async-channel = "2"
 smol = "2"
+agent-identity = { path = "../agent-identity" }

--- a/tools/attend-chat/src/app.rs
+++ b/tools/attend-chat/src/app.rs
@@ -11,17 +11,17 @@
 //! No sidebar, no focus filter, no threading render — those land in
 //! follow-up PRs on ADR-120.
 
+use agent_identity::TermCaps;
 use async_channel::Receiver;
 use iocraft::prelude::*;
 
+use crate::chip::{chip_for, color_for, CHIP_WIDTH};
 use crate::signal::{write_broadcast, Signal};
 
 #[derive(Default, Props)]
 pub struct AppProps {
     pub receiver: Option<Receiver<Signal>>,
 }
-
-const CHIP_WIDTH: u32 = 20;
 
 /// Upper bound on the in-memory message buffer. At typical chat rates
 /// this is unreachable; the cap only matters for runaway conditions
@@ -177,11 +177,17 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
         system.exit();
     }
 
+    // Detect terminal capability once per render pass and reuse for
+    // every chip. Cheap env reads, but doing it in the per-signal map
+    // would still be pointless repetition.
+    let caps = TermCaps::detect();
     let rows: Vec<_> = signals
         .read()
         .iter()
         .map(|s| {
-            let (who, scope) = prettify(&s.from, &s.project, &s.cwd);
+            let chip = chip_for(&s.from, &s.project, &s.cwd, caps);
+            let weight = if chip.style.bold { Weight::Bold } else { Weight::Normal };
+            let color = color_for(chip.palette, caps);
             element! {
                 View(flex_direction: FlexDirection::Row, margin_bottom: 1) {
                     View(
@@ -193,8 +199,14 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                         flex_direction: FlexDirection::Column,
                         flex_shrink: 0.0,
                     ) {
-                        Text(color: Color::Cyan, content: who, wrap: TextWrap::NoWrap)
-                        Text(color: Color::DarkGrey, content: scope, wrap: TextWrap::NoWrap)
+                        Text(
+                            color,
+                            weight,
+                            italic: chip.style.italic,
+                            content: chip.primary,
+                            wrap: TextWrap::NoWrap,
+                        )
+                        Text(color: Color::DarkGrey, content: chip.secondary, wrap: TextWrap::NoWrap)
                     }
                     View(
                         flex_grow: 1.0,
@@ -266,55 +278,6 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                 Text(color: Color::DarkGrey, content: status.to_string(), wrap: TextWrap::NoWrap)
             }
         }
-    }
-}
-
-/// Condense the wire `from`/`project`/`cwd` triple into two short
-/// labels for the sender chip. Goals: never exceed the chip's interior
-/// width, stay readable, give the human just enough to tell who sent
-/// what.
-fn prettify(from: &str, project: &str, cwd: &str) -> (String, String) {
-    // Interior = chip width - 2 border columns - 2 padding columns.
-    let interior = (CHIP_WIDTH as usize).saturating_sub(4);
-
-    let who = if let Some(rest) = from.strip_prefix("claude:") {
-        // UUIDs are 36 chars — "c:" + first 7 of the id keeps us
-        // unique enough for a handful of concurrent sessions without
-        // overflowing the chip.
-        let tag = rest.get(0..7).unwrap_or(rest);
-        format!("c:{}", tag)
-    } else if let Some(rest) = from.strip_prefix("external:") {
-        // Drop the terminal suffix ("aaron@kitty" → "aaron") so humans
-        // read as themselves, not as their terminal emulator.
-        rest.split('@').next().unwrap_or(rest).to_string()
-    } else {
-        from.to_string()
-    };
-
-    // Scope: prefer the last path segment of the cwd over the raw
-    // project name, since cwd is always a full path while project is
-    // whatever the sender chose to pass. Fall back to project if cwd
-    // is empty.
-    let scope_src = if cwd.is_empty() { project } else { cwd };
-    let segment = scope_src.rsplit('/').next().unwrap_or(scope_src);
-    let scope = if segment.is_empty() {
-        "broadcast".to_string()
-    } else {
-        segment.to_string()
-    };
-
-    (truncate(&who, interior), truncate(&scope, interior))
-}
-
-fn truncate(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        s.to_string()
-    } else if max <= 1 {
-        s.chars().take(max).collect()
-    } else {
-        let mut out: String = s.chars().take(max - 1).collect();
-        out.push('…');
-        out
     }
 }
 
@@ -426,34 +389,3 @@ mod cursor_tests {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn prettify_claude_sender() {
-        let (who, scope) = prettify("claude:e74a4a4b-7e3b-49bc-8404-216162e54ba8", "claude", "/home/aaron/.claude");
-        assert_eq!(who, "c:e74a4a4");
-        assert_eq!(scope, ".claude");
-    }
-
-    #[test]
-    fn prettify_scope_prefers_cwd_basename() {
-        let (_, scope) = prettify("external:aaron", "ignored", "/home/aaron/temp");
-        assert_eq!(scope, "temp");
-    }
-
-    #[test]
-    fn prettify_external_strips_terminal() {
-        let (who, _) = prettify("external:aaron@kitty", "proj", "/home/aaron");
-        assert_eq!(who, "aaron");
-    }
-
-    #[test]
-    fn prettify_scope_truncates_long_segment() {
-        // Interior is 16 chars for CHIP_WIDTH=20 (2 borders + 2 padding).
-        let (_, scope) = prettify("external:aaron", "x", "/tmp/some-very-long-directory-name");
-        assert!(scope.chars().count() <= 16);
-        assert!(scope.ends_with('…'));
-    }
-}

--- a/tools/attend-chat/src/chip.rs
+++ b/tools/attend-chat/src/chip.rs
@@ -1,0 +1,194 @@
+//! Sender chip: the small bordered box to the left of each message
+//! that identifies who sent it.
+//!
+//! Pure display logic — takes the wire `from`/`project`/`cwd` triple,
+//! derives a stable nickname + color + style via `agent_identity`, and
+//! returns a `ChipInfo` the renderer can feed into iocraft components.
+//!
+//! Lives in its own module because PR 2 (agent legend) and later PRs
+//! (@ autocomplete, focus-group sidebar) will layer on top of the same
+//! identity derivation — keeping the chip logic separate from the
+//! iocraft component tree means one reviewable seam per PR rather
+//! than a growing `app.rs`.
+
+use agent_identity::{Identity, PaletteEntry, Style, TermCaps};
+use iocraft::prelude::Color;
+
+/// Width of the chip box in columns. Interior width for text =
+/// `CHIP_WIDTH - 2 (border) - 2 (padding)`.
+pub const CHIP_WIDTH: u32 = 20;
+
+/// Display-layer facts for one signal's sender chip.
+pub struct ChipInfo {
+    /// First line — bold, colored with the identity palette.
+    pub primary: String,
+    /// Second line — dim, cwd basename or the broadcast fallback.
+    pub secondary: String,
+    pub palette: PaletteEntry,
+    pub style: Style,
+}
+
+/// Derive the chip from the wire `from`/`project`/`cwd` triple.
+///
+/// Claudes get a stable nickname keyed on their full cwd path (see
+/// `agent_identity::Identity::for_cwd`). Humans keep their username
+/// but still pick up a color + style from the identity table so the
+/// avatar is visually consistent everywhere the same user shows up.
+///
+/// This function never touches the wire format — identity is pure
+/// receiver-side rendering. If the signal's `from` doesn't match a
+/// known prefix, we fall through to showing the raw value.
+pub fn chip_for(from: &str, project: &str, cwd: &str, caps: TermCaps) -> ChipInfo {
+    let interior = (CHIP_WIDTH as usize).saturating_sub(4);
+    let scope_src = if cwd.is_empty() { project } else { cwd };
+    let scope_segment = scope_src.rsplit('/').next().unwrap_or(scope_src);
+    let scope = if scope_segment.is_empty() {
+        "broadcast".to_string()
+    } else {
+        scope_segment.to_string()
+    };
+
+    if from.strip_prefix("claude:").is_some() {
+        // For claude senders the cwd is the stable identity key. We
+        // don't hash the session UUID — two sequential claudes in the
+        // same dir should wear the same name, matching the user's
+        // mental model of "the agent that lives here".
+        let id = Identity::for_cwd(cwd, caps);
+        ChipInfo {
+            primary: truncate(id.nickname, interior),
+            secondary: truncate(&scope, interior),
+            palette: id.palette,
+            style: id.style,
+        }
+    } else if let Some(rest) = from.strip_prefix("external:") {
+        // Strip the terminal suffix ("aaron@kitty" → "aaron") so the
+        // chip reads as the human, not their terminal emulator.
+        let username = rest.split('@').next().unwrap_or(rest);
+        let id = Identity::for_user(username, &scope, caps);
+        ChipInfo {
+            primary: truncate(username, interior),
+            secondary: truncate(&scope, interior),
+            palette: id.palette,
+            style: id.style,
+        }
+    } else {
+        // Unknown sender kind — key the color off the raw `from` so
+        // different unknowns at least colorise differently instead of
+        // all landing on a default.
+        let id = Identity::for_user(from, &scope, caps);
+        ChipInfo {
+            primary: truncate(from, interior),
+            secondary: truncate(&scope, interior),
+            palette: id.palette,
+            style: id.style,
+        }
+    }
+}
+
+/// Map a palette entry to an iocraft `Color`. Rich terminals get
+/// RGB; basic ones get a named ANSI bright to avoid truecolor on
+/// terminals that would approximate it poorly.
+pub fn color_for(p: PaletteEntry, caps: TermCaps) -> Color {
+    match caps {
+        TermCaps::Rich => Color::Rgb { r: p.rgb.0, g: p.rgb.1, b: p.rgb.2 },
+        TermCaps::Basic | TermCaps::Mono => Color::AnsiValue(p.ansi16),
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else if max <= 1 {
+        s.chars().take(max).collect()
+    } else {
+        let mut out: String = s.chars().take(max - 1).collect();
+        out.push('…');
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_sender_uses_derived_nickname() {
+        // A claude in /home/aaron/.claude gets a nickname from the
+        // agent-identity pool, scope comes from cwd basename.
+        let chip = chip_for(
+            "claude:e74a4a4b-7e3b-49bc-8404-216162e54ba8",
+            "claude",
+            "/home/aaron/.claude",
+            TermCaps::Rich,
+        );
+        let expected = Identity::for_cwd("/home/aaron/.claude", TermCaps::Rich);
+        assert_eq!(chip.primary, expected.nickname);
+        assert_eq!(chip.secondary, ".claude");
+    }
+
+    #[test]
+    fn claude_nickname_stable_across_session_ids() {
+        // Two sequential claudes in the same cwd should show the same
+        // name — the session UUID changes but identity is keyed on
+        // cwd, not session.
+        let a = chip_for("claude:aaaa-1", "p", "/home/x", TermCaps::Rich);
+        let b = chip_for("claude:bbbb-2", "p", "/home/x", TermCaps::Rich);
+        assert_eq!(a.primary, b.primary);
+    }
+
+    #[test]
+    fn scope_prefers_cwd_basename_over_project() {
+        let chip = chip_for("external:aaron", "ignored", "/home/aaron/temp", TermCaps::Rich);
+        assert_eq!(chip.secondary, "temp");
+    }
+
+    #[test]
+    fn external_strips_terminal_suffix() {
+        let chip = chip_for("external:aaron@kitty", "proj", "/home/aaron", TermCaps::Rich);
+        assert_eq!(chip.primary, "aaron");
+    }
+
+    #[test]
+    fn scope_truncates_long_segment() {
+        // Interior is 16 chars for CHIP_WIDTH=20 (2 borders + 2 padding).
+        let chip = chip_for(
+            "external:aaron",
+            "x",
+            "/tmp/some-very-long-directory-name",
+            TermCaps::Rich,
+        );
+        assert!(chip.secondary.chars().count() <= 16);
+        assert!(chip.secondary.ends_with('…'));
+    }
+
+    #[test]
+    fn unknown_sender_still_colored() {
+        // Something that isn't claude: or external: — we don't crash,
+        // we show the raw value and pick a color off it.
+        let a = chip_for("mystery:abc", "", "/tmp", TermCaps::Rich);
+        let b = chip_for("mystery:xyz", "", "/tmp", TermCaps::Rich);
+        // Different senders → different colors most of the time. We
+        // don't assert inequality (palette is finite), just that the
+        // code path doesn't panic and produces valid output.
+        assert_eq!(a.primary, "mystery:abc");
+        assert_eq!(b.primary, "mystery:xyz");
+    }
+
+    #[test]
+    fn color_for_rich_is_rgb() {
+        let p = PaletteEntry { rgb: (10, 20, 30), ansi16: 3, name: "test" };
+        match color_for(p, TermCaps::Rich) {
+            Color::Rgb { r, g, b } => assert_eq!((r, g, b), (10, 20, 30)),
+            other => panic!("expected Rgb, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn color_for_basic_is_ansi() {
+        let p = PaletteEntry { rgb: (10, 20, 30), ansi16: 9, name: "test" };
+        match color_for(p, TermCaps::Basic) {
+            Color::AnsiValue(v) => assert_eq!(v, 9),
+            other => panic!("expected AnsiValue, got {other:?}"),
+        }
+    }
+}

--- a/tools/attend-chat/src/lib.rs
+++ b/tools/attend-chat/src/lib.rs
@@ -6,5 +6,6 @@
 //! via `#[path]`.
 
 pub mod app;
+pub mod chip;
 pub mod signal;
 pub mod watcher;

--- a/tools/attend/Cargo.toml
+++ b/tools/attend/Cargo.toml
@@ -19,6 +19,7 @@ sensor-disclosure = ["dep:sensor-disclosure"]
 
 [dependencies]
 agent-fmt = { path = "../agent-fmt" }
+agent-identity = { path = "../agent-identity" }
 sensor-trait = { path = "../sensor-trait" }
 sensor-git = { path = "../sensor-git", optional = true }
 sensor-context = { path = "../sensor-context", optional = true }

--- a/tools/attend/src/cmd/inbox.rs
+++ b/tools/attend/src/cmd/inbox.rs
@@ -6,7 +6,9 @@
 //! the right direction of dependency: the parser owns what a valid id
 //! looks like, senders consult it.
 
+use crate::identity_view::render_sender_label;
 use crate::util::{encode_project, get_groups, own_session_id, signals_base};
+use agent_identity::TermCaps;
 
 /// Parsed signal record (ADR-120 wire format).
 ///
@@ -15,6 +17,8 @@ use crate::util::{encode_project, get_groups, own_session_id, signals_base};
 /// allocation-free at the hot path.
 pub(crate) struct ParsedSignal<'a> {
     pub(crate) from: &'a str,
+    #[allow(dead_code)] // Retained in the parse so callers that need it
+    // (e.g. non-cwd sender hints) can read it without re-parsing.
     pub(crate) project: &'a str,
     pub(crate) cwd: &'a str,
     pub(crate) reply_to: Option<&'a str>,
@@ -101,15 +105,8 @@ pub(crate) fn cmd_inbox_read(msg_id: &str) {
                 return;
             }
         };
-        let from = sig.from;
-        let project = sig.project;
-        let source_cwd = sig.cwd;
-        let (kind, identity) = from.split_once(':').unwrap_or(("?", from));
-        let sender = match kind {
-            "claude" => format!("claude/{source_cwd}"),
-            "external" => identity.to_string(),
-            _ => format!("{project} ({from})"),
-        };
+        let caps = TermCaps::detect();
+        let sender = render_sender_label(sig.from, sig.cwd, caps);
         println!("From: {sender}");
         println!("ID:   {msg_id}");
         if let Some(re_id) = sig.reply_to {
@@ -202,12 +199,8 @@ pub(crate) fn cmd_inbox() {
                 }
             }
 
-            let (kind, identity) = sig.from.split_once(':').unwrap_or(("unknown", sig.from));
-            let sender = match kind {
-                "claude" => format!("claude/{}", sig.cwd),
-                "external" => identity.to_string(),
-                _ => format!("{} ({})", sig.project, sig.from),
-            };
+            let caps = TermCaps::detect();
+            let sender = render_sender_label(sig.from, sig.cwd, caps);
 
             let id = path.file_stem().and_then(|s| s.to_str()).unwrap_or("").to_string();
 

--- a/tools/attend/src/cmd/inbox.rs
+++ b/tools/attend/src/cmd/inbox.rs
@@ -17,8 +17,9 @@ use agent_identity::TermCaps;
 /// allocation-free at the hot path.
 pub(crate) struct ParsedSignal<'a> {
     pub(crate) from: &'a str,
-    #[allow(dead_code)] // Retained in the parse so callers that need it
-    // (e.g. non-cwd sender hints) can read it without re-parsing.
+    /// Parsed but currently unread by any caller. Retained so future
+    /// sender-hint rendering (non-cwd) can read it without re-parsing.
+    #[allow(dead_code)]
     pub(crate) project: &'a str,
     pub(crate) cwd: &'a str,
     pub(crate) reply_to: Option<&'a str>,

--- a/tools/attend/src/cmd/peers.rs
+++ b/tools/attend/src/cmd/peers.rs
@@ -1,9 +1,11 @@
 //! `attend peers` — list active Claude Code sessions and focus groups.
 
 use crate::util::get_groups;
+use agent_identity::{ansi, Identity, TermCaps};
 
 pub(crate) fn cmd_peers() {
     let r = get_groups();
+    let caps = TermCaps::detect();
 
     #[cfg(feature = "sensor-peers")]
     let peers = {
@@ -16,14 +18,21 @@ pub(crate) fn cmd_peers() {
     let my_focus = r.my_groups();
 
     let mut t = agent_fmt::Table::new(&["Focus", "Agent", "Status", "Context"]);
-    t.max_width(1, 24);
+    t.max_width(1, 28);
 
-    // Show self in project group
+    // Self row: derive identity from our cwd so the nickname matches
+    // what peers see when they render a signal from us.
     let cwd = std::env::current_dir()
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_default();
-    let self_project = cwd.rsplit('/').next().unwrap_or("?");
-    t.add(vec!["(project)", self_project, "working", ""]);
+    let self_id = Identity::for_cwd(&cwd, caps);
+    let self_label = render_agent_label(&self_id, caps);
+    t.add_owned(vec![
+        "(project)".to_string(),
+        self_label,
+        "working".to_string(),
+        String::new(),
+    ]);
 
     // Show named groups we're focused on
     for (name, pinned) in &my_focus {
@@ -35,13 +44,20 @@ pub(crate) fn cmd_peers() {
     // Show peers
     if !peers.is_empty() {
         t.add(vec!["", "", "", ""]);
-        for (peer_cwd, project, status, ctx) in &peers {
+        for (peer_cwd, _project, status, ctx) in &peers {
             let focus_label = if *peer_cwd == cwd {
                 "(project)".to_string()
             } else {
                 String::new()
             };
-            t.add(vec![&focus_label, project, status, &format!("{ctx:.0}%")]);
+            let peer_id = Identity::for_cwd(peer_cwd, caps);
+            let label = render_agent_label(&peer_id, caps);
+            t.add_owned(vec![
+                focus_label,
+                label,
+                status.clone(),
+                format!("{ctx:.0}%"),
+            ]);
         }
     }
 
@@ -54,4 +70,14 @@ pub(crate) fn cmd_peers() {
         peer_count + 1,
         focus_count + 1
     );
+}
+
+/// Compose the "Agent" column cell: nickname in identity color, cwd
+/// basename in parens in dim. The agent-fmt table measures visible
+/// length correctly even with ANSI codes embedded, so we can style
+/// freely without breaking alignment.
+fn render_agent_label(id: &Identity, caps: TermCaps) -> String {
+    let nick = ansi::wrap(id.nickname, &id.palette, id.style, caps);
+    let dim_basename = format!("\x1b[2m({})\x1b[0m", id.cwd_basename);
+    format!("{nick} {dim_basename}")
 }

--- a/tools/attend/src/identity_view.rs
+++ b/tools/attend/src/identity_view.rs
@@ -1,0 +1,75 @@
+//! Shared helpers that turn a signal's sender into an identity-styled
+//! label for attend's terminal output.
+//!
+//! attend-chat has its own renderer (targeting iocraft), and attend
+//! renders to raw ANSI via `agent_fmt::Table`. We keep the derivation
+//! identical by routing both sides through `agent_identity` — this
+//! module is just the glue that picks the right constructor (user vs.
+//! cwd) per sender kind.
+
+use agent_identity::{ansi, Identity, TermCaps};
+
+/// Render a sender label from the wire `from`/`cwd` pair.
+///
+/// Claudes get `Nickname (cwd_basename)` with the nickname in their
+/// identity color. Humans get `user (cwd_basename)` styled the same
+/// way — keyed on username, not cwd, so the same human shows up
+/// consistently across projects. Unknown prefixes fall through
+/// showing the raw `from` value, colored off its own hash.
+pub(crate) fn render_sender_label(from: &str, cwd: &str, caps: TermCaps) -> String {
+    if from.strip_prefix("claude:").is_some() {
+        let id = Identity::for_cwd(cwd, caps);
+        compose(&id.nickname.to_string(), &id.cwd_basename, &id, caps)
+    } else if let Some(rest) = from.strip_prefix("external:") {
+        let username = rest.split('@').next().unwrap_or(rest);
+        let scope = agent_identity::cwd_basename(cwd);
+        let id = Identity::for_user(username, &scope, caps);
+        compose(username, &id.cwd_basename, &id, caps)
+    } else {
+        let scope = agent_identity::cwd_basename(cwd);
+        let id = Identity::for_user(from, &scope, caps);
+        compose(from, &id.cwd_basename, &id, caps)
+    }
+}
+
+fn compose(primary: &str, secondary: &str, id: &Identity, caps: TermCaps) -> String {
+    let coloured = ansi::wrap(primary, &id.palette, id.style, caps);
+    format!("{coloured} \x1b[2m({})\x1b[0m", secondary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_label_uses_nickname() {
+        let label = render_sender_label("claude:abc", "/home/me/repo", TermCaps::Rich);
+        let expected = Identity::for_cwd("/home/me/repo", TermCaps::Rich);
+        assert!(
+            label.contains(expected.nickname),
+            "label {label:?} should carry nickname {:?}",
+            expected.nickname
+        );
+        assert!(label.contains("(repo)"), "label {label:?} missing cwd basename");
+    }
+
+    #[test]
+    fn external_label_keeps_username() {
+        let label = render_sender_label("external:aaron@kitty", "/home/aaron/Projects", TermCaps::Rich);
+        assert!(label.contains("aaron"));
+        assert!(label.contains("(Projects)"));
+    }
+
+    #[test]
+    fn unknown_sender_renders_without_panic() {
+        let label = render_sender_label("weird-prefix:xyz", "/tmp", TermCaps::Rich);
+        assert!(label.contains("weird-prefix:xyz"));
+    }
+
+    #[test]
+    fn mono_caps_produces_label_without_color() {
+        let label = render_sender_label("claude:abc", "/home/me/repo", TermCaps::Mono);
+        // Mono path: no truecolor SGR, but style + reset still present.
+        assert!(!label.contains("\x1b[38;2;"), "mono leaked color: {label:?}");
+    }
+}

--- a/tools/attend/src/identity_view.rs
+++ b/tools/attend/src/identity_view.rs
@@ -16,6 +16,15 @@ use agent_identity::{ansi, Identity, TermCaps};
 /// way — keyed on username, not cwd, so the same human shows up
 /// consistently across projects. Unknown prefixes fall through
 /// showing the raw `from` value, colored off its own hash.
+///
+/// Scope derivation deliberately differs from `attend-chat::chip::chip_for`:
+/// that renderer falls back to the `project` field when `cwd` is
+/// empty (because the chat TUI has room for a secondary line and
+/// wants the best-effort label). This label is a single-line CLI
+/// output where `(home)` is an acceptable empty-cwd marker, so we
+/// keep the code simple and ignore `project`. Production signals
+/// populate `cwd` either way — the divergence only manifests on
+/// hand-crafted signals, which shouldn't be a hot path.
 pub(crate) fn render_sender_label(from: &str, cwd: &str, caps: TermCaps) -> String {
     if from.strip_prefix("claude:").is_some() {
         let id = Identity::for_cwd(cwd, caps);

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod config_lint;
 mod emit;
 mod groups;
+mod identity_view;
 mod scenes;
 mod sensors;
 mod state;


### PR DESCRIPTION
## Summary

New `tools/agent-identity/` crate — shared display-layer identity for attend and attend-chat. Pure receiver-side: wire format unchanged, claude is never forced to publish a nickname.

## What changed

- **`agent-identity` crate** — stable nickname pool (~200 ASCII-only real names, claude-adjacent flavor), 20-color rich palette + 12-color ANSI fallback, terminal capability detection (`COLORTERM`/`TERM`/`NO_COLOR`), style axes (bold/italic), ANSI SGR emitter for non-iocraft callers. All derivation is FNV-1a deterministic so the same cwd reliably yields the same nickname + color.
- **`attend-chat`** — sender chip now shows `Nickname / cwd-basename` in the identity color with optional bold/italic. Chip rendering extracted into `chip.rs` so `app.rs` stays under the 500-line review threshold with sidebars/legend/threading still to land on #23.
- **`attend`** — `peers` and `inbox` render the same identity via a shared `identity_view` helper, so a claude appears as the same name in every view that mentions it.

## Design

- **Stable-per-cwd**: a claude relaunching in the same directory keeps its name. Two agents in different cwds that share a basename still land on different identities (hash keyed on full path).
- **ASCII-only names**: `@name` autocomplete in PR 2 needs to be typeable without special characters.
- **Claude not forced to name itself**: nicknames are computed receiver-side from signal fields already on the wire (`claude:<id>|project|cwd|msg`). Existing conventions are untouched.
- **Mono still works**: on `dumb`/`NO_COLOR` terminals, identity still carries via bold/italic style.

## Tests

- 31 agent-identity unit tests (FNV-1a reference vector, palette fallback, ASCII check, collision distribution over 1000 synthetic cwds).
- 12 new chip tests in attend-chat (nickname stability across session IDs, terminal-suffix stripping, truncation, rich/basic color mapping).
- 4 identity_view tests in attend (claude/external/unknown/mono paths).

Pre-existing: sensor-disclosure has one unrelated test failing on main (`component_registry_has_messaging_body` — missing `--broadcast` assertion). Not touched by this PR.

## Test plan

- [x] `cargo test -p agent-identity -p attend-chat -p attend` — all green
- [x] `cargo build --workspace` — clean
- [x] `make attend-rebuild && make attend-chat-rebuild` — both produce release binaries
- [x] Smoke: `./bin/attend peers` shows colored nicknames (Tamsin/Horatio)
- [x] Smoke: `./bin/attend inbox` shows consistent nicknames across multiple messages from same cwd
- [ ] Visual smoke on live `attend chat` two-instance roundtrip (reviewer, easier than in CI)

## Next on #23

1. Agent legend strip + `@name` parser (PR 2)
2. Group legend across top (PR 3)
3. Threading gutter (PR 4)
4. Mouse scoping — click-to-filter without breaking select/copy (PR 5)