### PR TITLE
feat(attend-chat): agent legend + @mention routing (#23)

### DIFF
--- a/tools/attend-chat/src/app.rs
+++ b/tools/attend-chat/src/app.rs
@@ -15,8 +15,11 @@ use agent_identity::TermCaps;
 use async_channel::Receiver;
 use iocraft::prelude::*;
 
-use crate::chip::{chip_for, color_for, CHIP_WIDTH};
-use crate::signal::{write_broadcast, Signal};
+use crate::chip::{chip_for, color_for, known_identities, resolve_nickname, CHIP_WIDTH};
+use crate::legend::{
+    apply_completion, best_completion, find_trailing_mention, legend_row, parse_addressed,
+};
+use crate::signal::{cwd_dir, write_broadcast, write_signal, Signal};
 
 #[derive(Default, Props)]
 pub struct AppProps {
@@ -83,13 +86,53 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                 KeyCode::Enter => {
                     let msg = input.read().trim_end().to_string();
                     if !msg.is_empty() {
-                        match write_broadcast(&msg) {
-                            Ok(name) => {
-                                status.set(format!("sent: {}", name));
+                        let caps = TermCaps::detect();
+                        let registry = known_identities(&signals.read(), caps);
+                        let result = match parse_addressed(&msg) {
+                            Some(addressed) => match resolve_nickname(addressed, &registry) {
+                                Some(target_cwd) => {
+                                    write_signal(&cwd_dir(&target_cwd), &msg)
+                                        .map(|n| format!("sent → @{addressed}: {n}"))
+                                }
+                                None => {
+                                    // Unknown nickname — don't silently
+                                    // broadcast; the user likely typed it
+                                    // expecting delivery. Fail loud.
+                                    Err(std::io::Error::new(
+                                        std::io::ErrorKind::NotFound,
+                                        format!("@{addressed}: unknown nickname"),
+                                    ))
+                                }
+                            },
+                            None => write_broadcast(&msg).map(|n| format!("sent: {n}")),
+                        };
+                        match result {
+                            Ok(s) => {
+                                status.set(s);
                                 input.set(String::new());
                                 cursor.set(0);
                             }
                             Err(e) => status.set(format!("send failed: {}", e)),
+                        }
+                    }
+                }
+                KeyCode::Tab => {
+                    // Autocomplete a trailing `@partial`. No-op if the
+                    // caret isn't at the end of the buffer or there's
+                    // no `@` context — avoids surprising edits in the
+                    // middle of a sentence.
+                    let buf = input.read().clone();
+                    let pos = cursor.get();
+                    if pos != buf.chars().count() {
+                        return;
+                    }
+                    let caps = TermCaps::detect();
+                    let registry = known_identities(&signals.read(), caps);
+                    if let Some(mention) = find_trailing_mention(&buf) {
+                        if let Some(hit) = best_completion(mention.partial, &registry) {
+                            let (next, new_cursor) = apply_completion(&buf, &mention, &hit.nickname);
+                            input.set(next);
+                            cursor.set(new_cursor);
                         }
                     }
                 }
@@ -181,6 +224,12 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
     // every chip. Cheap env reads, but doing it in the per-signal map
     // would still be pointless repetition.
     let caps = TermCaps::detect();
+    // Registry and trailing-partial for the legend + completion
+    // highlight. Re-derived each render — `known_identities` dedupes
+    // in O(n) over the capped buffer, so the work is bounded.
+    let known = known_identities(&signals.read(), caps);
+    let current_partial: Option<String> = find_trailing_mention(&input.read())
+        .map(|m| m.partial.to_string());
     let rows: Vec<_> = signals
         .read()
         .iter()
@@ -274,6 +323,7 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                     )
                 }
             }
+            #(legend_row(&known, current_partial.as_deref()))
             View(height: 1, padding_left: 1) {
                 Text(color: Color::DarkGrey, content: status.to_string(), wrap: TextWrap::NoWrap)
             }

--- a/tools/attend-chat/src/chip.rs
+++ b/tools/attend-chat/src/chip.rs
@@ -14,6 +14,8 @@
 use agent_identity::{Identity, PaletteEntry, Style, TermCaps};
 use iocraft::prelude::Color;
 
+use crate::signal::Signal;
+
 /// Width of the chip box in columns. Interior width for text =
 /// `CHIP_WIDTH - 2 (border) - 2 (padding)`.
 pub const CHIP_WIDTH: u32 = 20;
@@ -93,6 +95,87 @@ pub fn color_for(p: PaletteEntry, caps: TermCaps) -> Color {
         TermCaps::Rich => Color::Rgb { r: p.rgb.0, g: p.rgb.1, b: p.rgb.2 },
         TermCaps::Basic | TermCaps::Mono => Color::AnsiValue(p.ansi16),
     }
+}
+
+/// One identity known to the TUI, extracted from buffered signals.
+/// Carries enough to render the legend and resolve an `@name` to its
+/// routing destination.
+#[derive(Clone, Debug)]
+pub struct KnownIdentity {
+    /// Nickname derived from the sender's cwd (claude) or username
+    /// (external). This is what `@foo` in the input matches against.
+    pub nickname: String,
+    /// Full cwd of the sender. For claudes this is the routing key:
+    /// a directed `@Nickname` message writes to `signals_base/<encoded-cwd>/`.
+    /// For humans the cwd is their working directory when they sent —
+    /// we still carry it so the legend can show `@aaron (Projects)`.
+    pub cwd: String,
+    /// Whether this identity is a claude (routable) or an external
+    /// human (not routable to a cwd inbox).
+    pub is_claude: bool,
+    pub palette: PaletteEntry,
+    pub style: Style,
+}
+
+/// Build the registry of known identities from a slice of buffered
+/// signals. Pure function — no IO, no state. Called every render;
+/// the buffer cap keeps the work bounded.
+///
+/// Ordering: most-recently-seen first, then stable by nickname. That
+/// way the legend strip tends to put active peers at the front
+/// without flickering if two peers have the same last-seen tick.
+pub fn known_identities(signals: &[Signal], caps: TermCaps) -> Vec<KnownIdentity> {
+    // Walk from newest to oldest so the first time we see a cwd we
+    // also capture its most-recent-seen position. A HashSet of cwd
+    // strings keeps dedup O(n) without depending on a hasher.
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut out: Vec<KnownIdentity> = Vec::new();
+    for sig in signals.iter().rev() {
+        let (primary_label, is_claude, id) = if sig.from.strip_prefix("claude:").is_some() {
+            let id = Identity::for_cwd(&sig.cwd, caps);
+            (id.nickname.to_string(), true, id)
+        } else if let Some(rest) = sig.from.strip_prefix("external:") {
+            let username = rest.split('@').next().unwrap_or(rest).to_string();
+            let scope = agent_identity::cwd_basename(&sig.cwd);
+            let id = Identity::for_user(&username, &scope, caps);
+            (username, false, id)
+        } else {
+            continue; // unknown prefix — don't pollute the legend
+        };
+
+        // Dedupe on (nickname, is_claude, cwd) — same claude can appear
+        // many times in the buffer; same username across different
+        // cwds should still surface once per cwd so legend can show
+        // them distinctly.
+        let key = format!("{}\x1f{}\x1f{}", primary_label, is_claude as u8, sig.cwd);
+        if seen.insert(key) {
+            out.push(KnownIdentity {
+                nickname: primary_label,
+                cwd: sig.cwd.clone(),
+                is_claude,
+                palette: id.palette,
+                style: id.style,
+            });
+        }
+    }
+    out
+}
+
+/// Resolve an `@Nickname` token to a routable cwd.
+///
+/// Returns `Some(cwd)` only for claude identities — humans don't have
+/// a signal inbox we can post into. Case-insensitive match to be
+/// gentle on typos (the nickname pool is case-distinct, but a user
+/// typing `@tamsin` should still hit `Tamsin`).
+pub fn resolve_nickname(
+    name: &str,
+    known: &[KnownIdentity],
+) -> Option<String> {
+    let lc = name.to_ascii_lowercase();
+    known
+        .iter()
+        .find(|k| k.is_claude && k.nickname.to_ascii_lowercase() == lc)
+        .map(|k| k.cwd.clone())
 }
 
 fn truncate(s: &str, max: usize) -> String {
@@ -190,5 +273,75 @@ mod tests {
             Color::AnsiValue(v) => assert_eq!(v, 9),
             other => panic!("expected AnsiValue, got {other:?}"),
         }
+    }
+
+    fn sig(from: &str, cwd: &str) -> Signal {
+        Signal {
+            id: "t".into(),
+            from: from.into(),
+            project: cwd.rsplit('/').next().unwrap_or("?").into(),
+            cwd: cwd.into(),
+            reply_to: None,
+            message: "msg".into(),
+            ts: 0,
+        }
+    }
+
+    #[test]
+    fn registry_dedupes_repeat_senders() {
+        let buf = vec![
+            sig("claude:a", "/home/x"),
+            sig("claude:a", "/home/x"), // same cwd, should dedup
+            sig("claude:b", "/home/y"),
+        ];
+        let reg = known_identities(&buf, TermCaps::Rich);
+        assert_eq!(reg.len(), 2, "expected 2 unique identities, got {}", reg.len());
+    }
+
+    #[test]
+    fn registry_newest_first() {
+        let buf = vec![
+            sig("claude:a", "/home/x"),
+            sig("claude:b", "/home/y"),
+        ];
+        let reg = known_identities(&buf, TermCaps::Rich);
+        // Buffer order is oldest→newest; registry should surface the
+        // most-recent cwd first so active peers lead the legend.
+        let y_id = Identity::for_cwd("/home/y", TermCaps::Rich);
+        assert_eq!(reg[0].nickname, y_id.nickname);
+    }
+
+    #[test]
+    fn registry_includes_humans() {
+        let buf = vec![sig("external:aaron@kitty", "/home/aaron/Projects")];
+        let reg = known_identities(&buf, TermCaps::Rich);
+        assert_eq!(reg.len(), 1);
+        assert_eq!(reg[0].nickname, "aaron");
+        assert!(!reg[0].is_claude);
+    }
+
+    #[test]
+    fn registry_skips_unknown_prefix() {
+        let buf = vec![sig("mystery:abc", "/tmp")];
+        let reg = known_identities(&buf, TermCaps::Rich);
+        assert!(reg.is_empty(), "unknown prefix should be ignored, got {reg:?}");
+    }
+
+    #[test]
+    fn resolve_nickname_case_insensitive_claude_only() {
+        let buf = vec![
+            sig("claude:a", "/home/repo"),
+            sig("external:aaron@kitty", "/home/aaron/Projects"),
+        ];
+        let reg = known_identities(&buf, TermCaps::Rich);
+        let claude_nick = &reg.iter().find(|k| k.is_claude).unwrap().nickname;
+        // Case-insensitive match hits the claude cwd.
+        let lowered = claude_nick.to_ascii_lowercase();
+        assert_eq!(resolve_nickname(&lowered, &reg), Some("/home/repo".into()));
+        // Humans are not routable — `@aaron` returns None even
+        // though the human appears in the registry.
+        assert_eq!(resolve_nickname("aaron", &reg), None);
+        // Unknown nickname → None.
+        assert_eq!(resolve_nickname("NotReal", &reg), None);
     }
 }

--- a/tools/attend-chat/src/legend.rs
+++ b/tools/attend-chat/src/legend.rs
@@ -1,0 +1,315 @@
+//! Agent legend strip — the `@Name @Name ...` row below the input.
+//!
+//! Two jobs:
+//! - **Display**: render every known identity as its own styled chip
+//!   so the user can see who's addressable and in what color.
+//! - **Completion**: given a partial `@xxx` at the end of the input
+//!   buffer, return the best-matching nickname so Tab can complete
+//!   to a full `@Nickname `.
+//!
+//! The strip is *always* the completion UI — no popover, no arrow
+//! navigation. Keeps the surface small and keeps the visible color
+//! table doing double duty as the autocomplete cue.
+
+use agent_identity::TermCaps;
+use iocraft::prelude::*;
+
+use crate::chip::{color_for, KnownIdentity};
+
+/// Output of parsing the input buffer for a trailing `@partial`.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Mention<'a> {
+    /// The part of the input up to (and including) the `@` sigil.
+    /// Completion replaces everything after the `@` without touching
+    /// what came before.
+    pub prefix: &'a str,
+    /// The characters already typed after the `@`, or `""` if the
+    /// user just typed `@` and hasn't typed anything else yet.
+    pub partial: &'a str,
+}
+
+/// Parse a trailing mention at the end of `input`.
+///
+/// A mention is `@<word>` where `<word>` contains only ASCII alnum
+/// characters (mirrors what our nickname pool allows). Returns `None`
+/// if the last word doesn't start with `@`, or if there's a space
+/// after the `@<word>` (caret isn't inside the mention any more).
+///
+/// Cursor position isn't consulted — we only offer completion when
+/// the cursor is at the end of the buffer, which the caller enforces.
+pub fn find_trailing_mention(input: &str) -> Option<Mention<'_>> {
+    let at_pos = input.rfind('@')?;
+    let after_at = &input[at_pos + 1..];
+    // Everything after the `@` must be ASCII alnum (no spaces, no
+    // punctuation) for us to treat it as a mention in progress.
+    if !after_at.chars().all(|c| c.is_ascii_alphanumeric()) {
+        return None;
+    }
+    // The char *before* the `@` must be whitespace or start-of-input —
+    // otherwise we're inside an email address or URL, not a mention.
+    if at_pos > 0 {
+        let prev = input[..at_pos].chars().last().unwrap();
+        if !prev.is_whitespace() {
+            return None;
+        }
+    }
+    Some(Mention {
+        prefix: &input[..=at_pos],
+        partial: after_at,
+    })
+}
+
+/// Find the best completion for `partial` among `known` identities.
+///
+/// Case-insensitive prefix match. Prefers longer existing matches
+/// over shorter ones — if `partial="Ta"` and both `Tamsin` and `Tal`
+/// are in the registry, we pick neither deterministically unless one
+/// is strictly a prefix of the user's typing. First hit in registry
+/// order wins; the registry is already ordered most-recent-first so
+/// this favors active peers.
+pub fn best_completion<'a>(
+    partial: &str,
+    known: &'a [KnownIdentity],
+) -> Option<&'a KnownIdentity> {
+    let lc = partial.to_ascii_lowercase();
+    known
+        .iter()
+        .find(|k| k.nickname.to_ascii_lowercase().starts_with(&lc))
+}
+
+/// If `msg` is addressed to an `@Nickname` as its first token,
+/// return the nickname (without the `@`). Routing uses this to
+/// decide whether to broadcast or direct-send to that claude's cwd
+/// dir. Keeps the `@Nickname` in the outgoing body so receivers
+/// still see the address.
+pub fn parse_addressed(msg: &str) -> Option<&str> {
+    let trimmed = msg.trim_start();
+    let rest = trimmed.strip_prefix('@')?;
+    // First alnum run is the nickname; anything after must be
+    // whitespace or nothing. Matches the nickname pool's constraints
+    // (ASCII letters only, short).
+    let end = rest
+        .char_indices()
+        .find(|(_, c)| !c.is_ascii_alphanumeric())
+        .map(|(i, _)| i)
+        .unwrap_or(rest.len());
+    if end == 0 {
+        return None;
+    }
+    let nick = &rest[..end];
+    let after = &rest[end..];
+    // Allow `@Nick` alone (entire message is the address, followed by
+    // nothing) — lets users send a bare ping. Otherwise require a
+    // space so `@Nick,` doesn't route.
+    if after.is_empty() || after.starts_with(char::is_whitespace) {
+        Some(nick)
+    } else {
+        None
+    }
+}
+
+/// Render one legend row: `@Name @Name ...` across the width of the
+/// input, each name in its own identity color. If the user is in the
+/// middle of typing a mention (`current_partial` is `Some`), names
+/// that prefix-match get an underline so the Tab target is visible.
+///
+/// Returns a `Vec` so the caller can splat it into an `element!`
+/// children slot with `#(...)`.
+pub fn legend_row(
+    known: &[KnownIdentity],
+    current_partial: Option<&str>,
+) -> Vec<AnyElement<'static>> {
+    let caps = TermCaps::detect();
+    let lc_partial = current_partial.map(|p| p.to_ascii_lowercase());
+    let chips: Vec<AnyElement<'static>> = known
+        .iter()
+        .map(|k| {
+            let matches = lc_partial
+                .as_ref()
+                .map(|p| !p.is_empty() && k.nickname.to_ascii_lowercase().starts_with(p))
+                .unwrap_or(false);
+            let color = color_for(k.palette, caps);
+            let weight = if k.style.bold || matches { Weight::Bold } else { Weight::Normal };
+            let italic = k.style.italic;
+            let decoration = if matches {
+                TextDecoration::Underline
+            } else {
+                TextDecoration::None
+            };
+            let content = format!("@{} ", k.nickname);
+            element! {
+                Text(color, weight, italic, decoration, content, wrap: TextWrap::NoWrap)
+            }
+            .into_any()
+        })
+        .collect();
+    vec![element! {
+        View(
+            flex_direction: FlexDirection::Row,
+            padding_left: 1,
+            padding_right: 1,
+            height: 1u32,
+            flex_shrink: 0.0,
+            overflow: Overflow::Hidden,
+        ) {
+            #(chips)
+        }
+    }
+    .into_any()]
+}
+
+/// Apply a completion to `input`: replace the trailing `@partial`
+/// with `@<full> ` so the caret lands past a trailing space ready for
+/// the message body.
+///
+/// Returns the new buffer and the new char-cursor position.
+pub fn apply_completion(input: &str, mention: &Mention<'_>, full_name: &str) -> (String, usize) {
+    // `prefix` already includes the `@`. Drop the `@` and append the
+    // expansion so we control whether there's a space after it.
+    let prefix_no_at = &mention.prefix[..mention.prefix.len() - 1];
+    let mut out = String::with_capacity(input.len() + full_name.len() + 1);
+    out.push_str(prefix_no_at);
+    out.push('@');
+    out.push_str(full_name);
+    out.push(' ');
+    let new_cursor = out.chars().count();
+    (out, new_cursor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agent_identity::{PaletteEntry, Style};
+
+    fn ident(nick: &str, cwd: &str, is_claude: bool) -> KnownIdentity {
+        KnownIdentity {
+            nickname: nick.to_string(),
+            cwd: cwd.to_string(),
+            is_claude,
+            palette: PaletteEntry { rgb: (0, 0, 0), ansi16: 7, name: "t" },
+            style: Style::default(),
+        }
+    }
+
+    #[test]
+    fn trailing_mention_after_space() {
+        let m = find_trailing_mention("hi @Tam").unwrap();
+        assert_eq!(m.prefix, "hi @");
+        assert_eq!(m.partial, "Tam");
+    }
+
+    #[test]
+    fn trailing_mention_at_start() {
+        let m = find_trailing_mention("@Tam").unwrap();
+        assert_eq!(m.prefix, "@");
+        assert_eq!(m.partial, "Tam");
+    }
+
+    #[test]
+    fn bare_at_sign_is_empty_partial() {
+        let m = find_trailing_mention("hello @").unwrap();
+        assert_eq!(m.partial, "");
+    }
+
+    #[test]
+    fn no_mention_on_plain_text() {
+        assert_eq!(find_trailing_mention("hello world"), None);
+        assert_eq!(find_trailing_mention(""), None);
+    }
+
+    #[test]
+    fn mention_rejected_if_followed_by_space() {
+        // "@Tam " is complete — don't offer completion anymore.
+        assert_eq!(find_trailing_mention("hi @Tam "), None);
+    }
+
+    #[test]
+    fn at_in_email_is_not_a_mention() {
+        // "hello aaron@kitty" — the char before `@` is `n`, not
+        // whitespace, so it's an email/handle and we leave it alone.
+        assert_eq!(find_trailing_mention("mail aaron@kitty"), None);
+    }
+
+    #[test]
+    fn mention_with_punctuation_rejected() {
+        // Nickname pool is ASCII alnum only; `@Tam,` is not a
+        // mention-in-progress because `,` isn't alnum.
+        assert_eq!(find_trailing_mention("@Tam,"), None);
+    }
+
+    #[test]
+    fn completion_picks_case_insensitive_prefix() {
+        let known = vec![ident("Tamsin", "/a", true), ident("Urban", "/b", true)];
+        let m = best_completion("tam", &known).unwrap();
+        assert_eq!(m.nickname, "Tamsin");
+    }
+
+    #[test]
+    fn completion_returns_none_if_no_match() {
+        let known = vec![ident("Tamsin", "/a", true)];
+        assert!(best_completion("zzz", &known).is_none());
+    }
+
+    #[test]
+    fn completion_on_empty_partial_picks_first() {
+        let known = vec![ident("Tamsin", "/a", true), ident("Urban", "/b", true)];
+        let m = best_completion("", &known).unwrap();
+        assert_eq!(m.nickname, "Tamsin");
+    }
+
+    #[test]
+    fn apply_completion_replaces_partial_and_adds_space() {
+        let m = find_trailing_mention("hi @Tam").unwrap();
+        let (out, cursor) = apply_completion("hi @Tam", &m, "Tamsin");
+        assert_eq!(out, "hi @Tamsin ");
+        assert_eq!(cursor, "hi @Tamsin ".chars().count());
+    }
+
+    #[test]
+    fn apply_completion_at_start() {
+        let m = find_trailing_mention("@Tam").unwrap();
+        let (out, _) = apply_completion("@Tam", &m, "Tamsin");
+        assert_eq!(out, "@Tamsin ");
+    }
+
+    #[test]
+    fn apply_completion_on_bare_at() {
+        let m = find_trailing_mention("hi @").unwrap();
+        let (out, _) = apply_completion("hi @", &m, "Urban");
+        assert_eq!(out, "hi @Urban ");
+    }
+
+    #[test]
+    fn addressed_at_start_with_body() {
+        assert_eq!(parse_addressed("@Tamsin hello"), Some("Tamsin"));
+    }
+
+    #[test]
+    fn addressed_bare_ping() {
+        // `@Nick` with nothing after is a valid addressed ping.
+        assert_eq!(parse_addressed("@Urban"), Some("Urban"));
+    }
+
+    #[test]
+    fn addressed_with_leading_whitespace() {
+        assert_eq!(parse_addressed("   @Tamsin hello"), Some("Tamsin"));
+    }
+
+    #[test]
+    fn not_addressed_if_not_at_start() {
+        assert_eq!(parse_addressed("hi @Tamsin"), None);
+    }
+
+    #[test]
+    fn not_addressed_if_trailing_punctuation() {
+        // `@Tamsin,` — punctuation immediately after the name means
+        // the user isn't really addressing, just referring.
+        assert_eq!(parse_addressed("@Tamsin, hi"), None);
+    }
+
+    #[test]
+    fn not_addressed_on_bare_at_sign() {
+        assert_eq!(parse_addressed("@ hi"), None);
+        assert_eq!(parse_addressed("@"), None);
+    }
+}

--- a/tools/attend-chat/src/legend.rs
+++ b/tools/attend-chat/src/legend.rs
@@ -48,7 +48,13 @@ pub fn find_trailing_mention(input: &str) -> Option<Mention<'_>> {
     // The char *before* the `@` must be whitespace or start-of-input —
     // otherwise we're inside an email address or URL, not a mention.
     if at_pos > 0 {
-        let prev = input[..at_pos].chars().last().unwrap();
+        // `at_pos > 0` means `input[..at_pos]` is non-empty, so
+        // `.chars().last()` always yields Some — the unwrap is safe
+        // by construction.
+        let prev = input[..at_pos]
+            .chars()
+            .last()
+            .expect("at_pos > 0 implies non-empty prefix");
         if !prev.is_whitespace() {
             return None;
         }
@@ -61,12 +67,13 @@ pub fn find_trailing_mention(input: &str) -> Option<Mention<'_>> {
 
 /// Find the best completion for `partial` among `known` identities.
 ///
-/// Case-insensitive prefix match. Prefers longer existing matches
-/// over shorter ones — if `partial="Ta"` and both `Tamsin` and `Tal`
-/// are in the registry, we pick neither deterministically unless one
-/// is strictly a prefix of the user's typing. First hit in registry
-/// order wins; the registry is already ordered most-recent-first so
-/// this favors active peers.
+/// Case-insensitive prefix match. First hit in registry order wins —
+/// because `known_identities` surfaces the most-recent-seen identity
+/// first, that means active peers beat quiet ones. When several
+/// identities share the same prefix (e.g. `partial="Ta"` against a
+/// registry containing `Tamsin` and `Tal`), the caller gets whichever
+/// appears first. No longer-is-better heuristic; recency is the
+/// tiebreak.
 pub fn best_completion<'a>(
     partial: &str,
     known: &'a [KnownIdentity],

--- a/tools/attend-chat/src/lib.rs
+++ b/tools/attend-chat/src/lib.rs
@@ -7,5 +7,6 @@
 
 pub mod app;
 pub mod chip;
+pub mod legend;
 pub mod signal;
 pub mod watcher;

--- a/tools/attend-chat/src/signal.rs
+++ b/tools/attend-chat/src/signal.rs
@@ -33,6 +33,26 @@ pub fn broadcast_dir() -> PathBuf {
     signals_base().join("_broadcast")
 }
 
+/// Encode a cwd path into the signal directory name the peer sensor
+/// scans. Must stay byte-identical to `attend::util::encode_project`
+/// (same `/`, `_`, `.` → `-` transform). See the mirror note on
+/// `write_broadcast` — same contract, different layer.
+pub fn encode_cwd(path: &str) -> String {
+    path.chars()
+        .map(|c| match c {
+            '/' | '_' | '.' => '-',
+            _ => c,
+        })
+        .collect()
+}
+
+/// Directory that delivers signals to the claude session rooted at
+/// `cwd`. The peer sensor scans `signals_base/<encoded>/` for
+/// messages addressed specifically to it.
+pub fn cwd_dir(cwd: &str) -> PathBuf {
+    signals_base().join(encode_cwd(cwd))
+}
+
 /// Parse a `.signal` file. Supports both the legacy
 /// `from|project|cwd|message` format and the threaded
 /// `from|project|cwd|re:signal-id|message` extension. Returns `None`
@@ -93,8 +113,14 @@ pub fn parse_file(path: &Path) -> Option<Signal> {
 /// a compile error. Threaded replies (`re:<id>`) are produced by
 /// `cmd_send` only; the TUI does not originate threaded sends yet.
 pub fn write_broadcast(message: &str) -> io::Result<String> {
-    let dir = broadcast_dir();
-    fs::create_dir_all(&dir)?;
+    write_signal(&broadcast_dir(), message)
+}
+
+/// Write a signal into an arbitrary destination directory. The
+/// broadcast and directed (`@Nickname`) paths both ride this — same
+/// wire format, same atomic tmp+rename, only the target differs.
+pub fn write_signal(dest: &Path, message: &str) -> io::Result<String> {
+    fs::create_dir_all(dest)?;
 
     let (sender_id, kind) = identify_sender();
     let from = format!("{}:{}", kind, sender_id);
@@ -110,8 +136,8 @@ pub fn write_broadcast(message: &str) -> io::Result<String> {
     let filename = format!("{}-{}.signal", sender_id.replace('/', "-"), ts);
     let content = format!("{}|{}|{}|{}\n", from, project, cwd, message);
 
-    let tmp = dir.join(format!("{}.tmp", filename));
-    let final_path = dir.join(&filename);
+    let tmp = dest.join(format!("{}.tmp", filename));
+    let final_path = dest.join(&filename);
     fs::write(&tmp, content)?;
     fs::rename(&tmp, &final_path)?;
     Ok(filename)
@@ -300,6 +326,34 @@ mod tests {
                 std::env::set_var(k, v);
             }
         }
+    }
+
+    #[test]
+    fn encode_cwd_matches_attend_convention() {
+        // Same transform as attend::util::encode_project — `/`, `_`,
+        // `.` collapse to `-`. This is the path the peer sensor
+        // scans when looking for messages directed at a specific
+        // cwd, so drift here breaks direct routing silently.
+        assert_eq!(encode_cwd("/home/aaron/.claude"), "-home-aaron--claude");
+        assert_eq!(encode_cwd("/tmp/foo_bar"), "-tmp-foo-bar");
+        assert_eq!(encode_cwd(""), "");
+    }
+
+    #[test]
+    fn cwd_dir_is_under_signals_base() {
+        // Point $HOME at a temp dir so signals_base resolves there.
+        let home = tempdir_like();
+        std::env::set_var("HOME", &home);
+        let d = cwd_dir("/home/aaron/proj");
+        assert!(
+            d.starts_with(signals_base()),
+            "cwd_dir {d:?} should live under {:?}",
+            signals_base()
+        );
+        assert_eq!(
+            d.file_name().and_then(|s| s.to_str()),
+            Some("-home-aaron-proj")
+        );
     }
 
     fn tempdir_like() -> PathBuf {


### PR DESCRIPTION
## Summary

PR 2 of the #23 sequence. Gives the chat TUI its addressability layer on top of the identity crate from #62.

Stacked on `feat/agent-identity` — merge #62 first and this PR's base auto-rebases to main.

## What changed

**Legend strip** below the input: every agent seen in recent signals as `@Nickname` in its identity color. Mid-mention matches (`@Tam` → Tamsin) get an underline so the Tab target is visible.

**Tab completion**: trailing `@partial` + Tab → first matching nickname + trailing space. No-op when cursor isn't at buffer end or there's no `@` context, so it doesn't surprise mid-sentence.

**Directed send**: a message beginning with `@Nickname ` resolves the nickname against the registry and writes the signal to `~/.cache/attend/signals/<encoded-cwd>/` (matching attend's `encode_project` transform). Unknown nickname → fail loud, don't silently broadcast. Humans aren't routable; they appear in the legend but `resolve_nickname` returns None for them.

## Design

- **Pure re-derive each render**: `known_identities` walks the capped signal buffer (≤5000) and dedupes on `(nickname, kind, cwd)` — bounded work, no hidden state. Newest-seen first so active peers lead the legend.
- **ASCII-alnum-only mention grammar**: `@Tam,` doesn't route (trailing punctuation). `@Nick` alone is a valid bare ping. `@` in `aaron@kitty` is not a mention (char before `@` must be whitespace).
- **Wire-format mirror preserved**: `write_signal` factors out the atomic tmp+rename; `write_broadcast` stays a thin wrapper. Still must match `attend::cmd::send` byte-for-byte.

## Tests

49 unit + 1 integration, all green. New:
- `legend`: 13 tests — trailing-mention parser (space/start/bare-`@`/punctuation/email), `best_completion` (case-insensitive, empty partial, no match), `apply_completion` (start/mid/bare), `parse_addressed` (leading ws, bare ping, punctuation rejects).
- `chip`: 5 tests — registry dedup, newest-first ordering, humans included, unknown-prefix skipped, `resolve_nickname` case-insensitive claude-only.
- `signal`: 2 tests — `encode_cwd` matches attend convention byte-for-byte, `cwd_dir` under `signals_base`.

## Test plan

- [x] `cargo test -p attend-chat` — all green
- [x] `make attend-chat-rebuild` — clean release binary
- [ ] Visual smoke: two `./bin/attend-chat` instances, verify legend appears, Tab completes `@partial`, `@Nickname body` round-trips to the addressed peer only
- [ ] Edge: send `@UnknownName foo` — status line should show "send failed: @UnknownName: unknown nickname"

## Explicitly deferred

- Mouse click on legend entry → insert mention (PR 5, paired with scoped mouse capture — click-to-filter without breaking terminal select/copy).
- `@groupname` routing (PR 3, paired with group model + group discovery design).
- Threading gutter (PR 4).