### PR TITLE
feat(attend-chat): focus groups — top legend, #routing, chip glyphs (#23)

### DIFF
--- a/tools/agent-identity/src/groups.rs
+++ b/tools/agent-identity/src/groups.rs
@@ -1,0 +1,132 @@
+//! Display identity for focus groups.
+//!
+//! Parallel to `Identity` for agents: take a group name, produce a
+//! stable glyph + color + style. Different derivation *kind* (glyph
+//! pool, not nickname pool) but same shape so call sites render
+//! groups and agents with the same primitives.
+//!
+//! Like agents, everything is receiver-side. Groups are identified
+//! on the wire by the directory name (`@groupname/`); the glyph is a
+//! display convenience, never quoted or typed. Users still address
+//! groups by name (`#deploy`), not by glyph.
+
+use crate::identity::fnv1a_64;
+use crate::palette::{resolve, PaletteEntry, Resolved, Style, TermCaps};
+
+/// Curated glyph pool — ~20 distinctive Unicode symbols chosen for
+/// broad font coverage. Avoiding anything that commonly degrades to
+/// `?` or U+FFFD on default terminal fonts: no emoji, no rare script
+/// glyphs, no ASCII-art double-widths.
+///
+/// If a specific glyph proves unreadable in the wild, swap it rather
+/// than adding a new one — the hash-to-index keeps seats stable.
+pub const GLYPHS: &[char] = &[
+    '●', '○', '◆', '◇', '■', '□', '▲', '△', '▼', '▽',
+    '★', '☆', '♦', '♠', '♣', '♥', '⬢', '⬡', '✦', '✧',
+];
+
+/// Everything a renderer needs to paint a group.
+#[derive(Clone, Debug)]
+pub struct Group {
+    /// The group's name as it appears in the signal bus
+    /// (`@<name>/`). Case sensitive — `deploy` and `Deploy` are
+    /// different groups. Users address with `#<name>`.
+    pub name: String,
+    /// Single-char visual marker. Users never type it; it's purely
+    /// a glance-cue.
+    pub glyph: char,
+    pub palette: PaletteEntry,
+    pub style: Style,
+    /// Seed available for callers that want to derive their own
+    /// per-group state (e.g., unread counts) consistently.
+    pub seed: u64,
+}
+
+impl Group {
+    /// Derive a group's display identity from its name under the
+    /// given terminal capability.
+    ///
+    /// Same hash as `Identity::for_user`, but namespaced so a group
+    /// named "aaron" doesn't land on the same palette entry as a
+    /// human user named "aaron".
+    pub fn for_name(name: &str, caps: TermCaps) -> Self {
+        let key = format!("group:{name}");
+        let seed = fnv1a_64(key.as_bytes());
+        let glyph = GLYPHS[(seed as usize) % GLYPHS.len()];
+        // Stir before resolving so glyph and color aren't trivially
+        // correlated — same trick as `Identity::for_key`.
+        let Resolved { entry, style } = resolve(seed ^ 0x9e37_79b9_7f4a_7c15, caps);
+        Group {
+            name: name.to_string(),
+            glyph,
+            palette: entry,
+            style,
+            seed,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_name_same_group() {
+        let a = Group::for_name("deploy", TermCaps::Rich);
+        let b = Group::for_name("deploy", TermCaps::Rich);
+        assert_eq!(a.glyph, b.glyph);
+        assert_eq!(a.palette, b.palette);
+        assert_eq!(a.style, b.style);
+        assert_eq!(a.seed, b.seed);
+    }
+
+    #[test]
+    fn different_names_differ() {
+        let a = Group::for_name("deploy", TermCaps::Rich);
+        let b = Group::for_name("infra", TermCaps::Rich);
+        assert_ne!(a.seed, b.seed);
+    }
+
+    #[test]
+    fn group_namespace_disjoint_from_user() {
+        // A group called "aaron" and a user called "aaron" must
+        // resolve to different palette seats — the `group:` prefix
+        // in the hash input is what guarantees this.
+        use crate::identity::Identity;
+        let g = Group::for_name("aaron", TermCaps::Rich);
+        let u = Identity::for_user("aaron", "ignored", TermCaps::Rich);
+        assert_ne!(g.seed, u.seed);
+    }
+
+    #[test]
+    fn glyph_pool_reasonable_size() {
+        // Too-small pool guarantees collisions. Sanity check only.
+        assert!(GLYPHS.len() >= 16, "glyph pool shrunk: {}", GLYPHS.len());
+    }
+
+    #[test]
+    fn glyphs_are_single_char_non_ascii() {
+        // We don't want ASCII here — the whole point is distinctive
+        // visual markers. But every entry must be one code point so
+        // single-column rendering is safe.
+        for g in GLYPHS {
+            assert!(!g.is_ascii(), "glyph {g:?} is ASCII — use `char` shapes");
+            assert_eq!(g.len_utf8() >= 3, true, "glyph {g:?} unexpectedly narrow");
+        }
+    }
+
+    #[test]
+    fn case_sensitive_group_names() {
+        // Group names follow the dir name on disk; filesystems are
+        // case-sensitive on Linux, so we treat the names that way.
+        let a = Group::for_name("Deploy", TermCaps::Rich);
+        let b = Group::for_name("deploy", TermCaps::Rich);
+        assert_ne!(a.seed, b.seed);
+    }
+
+    #[test]
+    fn mono_produces_mono_entry() {
+        let g = Group::for_name("deploy", TermCaps::Mono);
+        assert_eq!(g.palette.name, "mono");
+    }
+}

--- a/tools/agent-identity/src/groups.rs
+++ b/tools/agent-identity/src/groups.rs
@@ -54,7 +54,9 @@ impl Group {
         let seed = fnv1a_64(key.as_bytes());
         let glyph = GLYPHS[(seed as usize) % GLYPHS.len()];
         // Stir before resolving so glyph and color aren't trivially
-        // correlated — same trick as `Identity::for_key`.
+        // correlated — same trick as `Identity::for_key`. Constant is
+        // φ·2^64 (golden-ratio hash), matching the mixing pattern in
+        // `boost::hash_combine` and the Rust standard-library hasher.
         let Resolved { entry, style } = resolve(seed ^ 0x9e37_79b9_7f4a_7c15, caps);
         Group {
             name: name.to_string(),
@@ -111,7 +113,7 @@ mod tests {
         // single-column rendering is safe.
         for g in GLYPHS {
             assert!(!g.is_ascii(), "glyph {g:?} is ASCII — use `char` shapes");
-            assert_eq!(g.len_utf8() >= 3, true, "glyph {g:?} unexpectedly narrow");
+            assert!(g.len_utf8() >= 3, "glyph {g:?} unexpectedly narrow");
         }
     }
 

--- a/tools/agent-identity/src/identity.rs
+++ b/tools/agent-identity/src/identity.rs
@@ -87,7 +87,10 @@ pub fn cwd_basename(path: &str) -> String {
 
 /// FNV-1a 64-bit. Deterministic across runs and targets — this is the
 /// property we need, and why we don't use `std::hash::DefaultHasher`.
-fn fnv1a_64(bytes: &[u8]) -> u64 {
+/// Crate-internal (`pub(crate)`) so the groups module shares the exact
+/// same hash; any divergence would make group / user / cwd seats
+/// silently non-comparable.
+pub(crate) fn fnv1a_64(bytes: &[u8]) -> u64 {
     const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
     const PRIME: u64 = 0x0000_0100_0000_01b3;
     let mut hash = OFFSET;

--- a/tools/agent-identity/src/lib.rs
+++ b/tools/agent-identity/src/lib.rs
@@ -21,10 +21,12 @@
 //!   in ADR-118 and the consumer crates.
 
 pub mod ansi;
+pub mod groups;
 pub mod identity;
 pub mod names;
 pub mod palette;
 
+pub use groups::{Group, GLYPHS};
 pub use identity::{cwd_basename, Identity};
 pub use palette::{
     resolve, PaletteEntry, Resolved, Style, TermCaps, BASIC_PALETTE, RICH_PALETTE,

--- a/tools/attend-chat/src/app.rs
+++ b/tools/attend-chat/src/app.rs
@@ -17,7 +17,7 @@ use iocraft::prelude::*;
 
 use crate::chip::{chip_for, color_for, known_identities, resolve_nickname, CHIP_WIDTH};
 use crate::text_layout::{render_cursor, split_at_char, visual_line_count};
-use crate::groups::{groups_for_session, resolve_group_dir, scan as scan_groups};
+use crate::groups::{resolve_group_dir, scan as scan_groups};
 use crate::legend::{
     apply_completion, best_completion, best_group_completion, find_trailing_mention,
     group_legend_row, legend_row, parse_addressed, Addressed, Sigil,
@@ -250,6 +250,20 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
     //   do anyway. Simpler than caching with invalidation.
     let known = known_identities(&signals.read(), caps);
     let groups_known = scan_groups(caps);
+    // Pre-index session-id → groups once per render so the chip
+    // loop is O(signals) instead of O(signals · groups · members).
+    // At today's scale neither form matters, but the render path is
+    // hot and the reindex is trivial.
+    let session_to_groups: std::collections::HashMap<&str, Vec<&crate::groups::KnownGroup>> = {
+        let mut m: std::collections::HashMap<&str, Vec<&crate::groups::KnownGroup>> =
+            std::collections::HashMap::new();
+        for kg in &groups_known {
+            for member in &kg.membership.members {
+                m.entry(member.as_str()).or_default().push(kg);
+            }
+        }
+        m
+    };
     // `input.read()` returns a read guard — borrow it into a local
     // binding so `find_trailing_mention`'s `&str` doesn't outlive
     // the temporary guard.
@@ -275,23 +289,27 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
             // Humans have no session_id yet, so their chips stay
             // glyph-less until PR 4 derives a membership key for
             // them.
-            let group_chips: Vec<AnyElement<'static>> = match chip.session_id.as_deref() {
-                Some(uuid) => groups_for_session(uuid, &groups_known)
-                    .into_iter()
-                    .map(|kg| {
-                        let gcolor = color_for(kg.group.palette, caps);
-                        element! {
-                            Text(
-                                color: gcolor,
-                                content: format!("{} ", kg.group.glyph),
-                                wrap: TextWrap::NoWrap,
-                            )
-                        }
-                        .into_any()
-                    })
-                    .collect(),
-                None => Vec::new(),
-            };
+            let group_chips: Vec<AnyElement<'static>> = chip
+                .session_id
+                .as_deref()
+                .and_then(|uuid| session_to_groups.get(uuid))
+                .map(|groups| {
+                    groups
+                        .iter()
+                        .map(|kg| {
+                            let gcolor = color_for(kg.group.palette, caps);
+                            element! {
+                                Text(
+                                    color: gcolor,
+                                    content: format!("{} ", kg.group.glyph),
+                                    wrap: TextWrap::NoWrap,
+                                )
+                            }
+                            .into_any()
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
             element! {
                 View(flex_direction: FlexDirection::Row, margin_bottom: 1) {
                     View(

--- a/tools/attend-chat/src/app.rs
+++ b/tools/attend-chat/src/app.rs
@@ -16,8 +16,11 @@ use async_channel::Receiver;
 use iocraft::prelude::*;
 
 use crate::chip::{chip_for, color_for, known_identities, resolve_nickname, CHIP_WIDTH};
+use crate::text_layout::{render_cursor, split_at_char, visual_line_count};
+use crate::groups::{groups_for_session, resolve_group_dir, scan as scan_groups};
 use crate::legend::{
-    apply_completion, best_completion, find_trailing_mention, legend_row, parse_addressed,
+    apply_completion, best_completion, best_group_completion, find_trailing_mention,
+    group_legend_row, legend_row, parse_addressed, Addressed, Sigil,
 };
 use crate::signal::{cwd_dir, write_broadcast, write_signal, Signal};
 
@@ -87,22 +90,25 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                     let msg = input.read().trim_end().to_string();
                     if !msg.is_empty() {
                         let caps = TermCaps::detect();
-                        let registry = known_identities(&signals.read(), caps);
+                        let agents = known_identities(&signals.read(), caps);
                         let result = match parse_addressed(&msg) {
-                            Some(addressed) => match resolve_nickname(addressed, &registry) {
-                                Some(target_cwd) => {
-                                    write_signal(&cwd_dir(&target_cwd), &msg)
-                                        .map(|n| format!("sent → @{addressed}: {n}"))
-                                }
-                                None => {
-                                    // Unknown nickname — don't silently
-                                    // broadcast; the user likely typed it
-                                    // expecting delivery. Fail loud.
-                                    Err(std::io::Error::new(
+                            Some(Addressed::Agent(name)) => {
+                                match resolve_nickname(name, &agents) {
+                                    Some(target_cwd) => write_signal(&cwd_dir(&target_cwd), &msg)
+                                        .map(|n| format!("sent → @{name}: {n}")),
+                                    None => Err(std::io::Error::new(
                                         std::io::ErrorKind::NotFound,
-                                        format!("@{addressed}: unknown nickname"),
-                                    ))
+                                        format!("@{name}: unknown nickname"),
+                                    )),
                                 }
+                            }
+                            Some(Addressed::Group(name)) => match resolve_group_dir(name) {
+                                Some(dir) => write_signal(&dir, &msg)
+                                    .map(|n| format!("sent → #{name}: {n}")),
+                                None => Err(std::io::Error::new(
+                                    std::io::ErrorKind::NotFound,
+                                    format!("#{name}: unknown group"),
+                                )),
                             },
                             None => write_broadcast(&msg).map(|n| format!("sent: {n}")),
                         };
@@ -117,23 +123,33 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                     }
                 }
                 KeyCode::Tab => {
-                    // Autocomplete a trailing `@partial`. No-op if the
-                    // caret isn't at the end of the buffer or there's
-                    // no `@` context — avoids surprising edits in the
-                    // middle of a sentence.
+                    // Autocomplete a trailing mention. Dispatches by
+                    // sigil: `@partial` → agent pool, `#partial` →
+                    // group pool. No-op if the caret isn't at the end
+                    // of the buffer or there's no mention context —
+                    // avoids surprising edits mid-sentence.
                     let buf = input.read().clone();
                     let pos = cursor.get();
                     if pos != buf.chars().count() {
                         return;
                     }
                     let caps = TermCaps::detect();
-                    let registry = known_identities(&signals.read(), caps);
-                    if let Some(mention) = find_trailing_mention(&buf) {
-                        if let Some(hit) = best_completion(mention.partial, &registry) {
-                            let (next, new_cursor) = apply_completion(&buf, &mention, &hit.nickname);
-                            input.set(next);
-                            cursor.set(new_cursor);
+                    let Some(mention) = find_trailing_mention(&buf) else { return };
+                    let completed: Option<(String, usize)> = match mention.sigil {
+                        Sigil::Agent => {
+                            let agents = known_identities(&signals.read(), caps);
+                            best_completion(mention.partial, &agents)
+                                .map(|hit| apply_completion(&buf, &mention, &hit.nickname))
                         }
+                        Sigil::Group => {
+                            let groups = scan_groups(caps);
+                            best_group_completion(mention.partial, &groups)
+                                .map(|hit| apply_completion(&buf, &mention, &hit.group.name))
+                        }
+                    };
+                    if let Some((next, new_cursor)) = completed {
+                        input.set(next);
+                        cursor.set(new_cursor);
                     }
                 }
                 KeyCode::Backspace => {
@@ -224,11 +240,28 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
     // every chip. Cheap env reads, but doing it in the per-signal map
     // would still be pointless repetition.
     let caps = TermCaps::detect();
-    // Registry and trailing-partial for the legend + completion
-    // highlight. Re-derived each render — `known_identities` dedupes
-    // in O(n) over the capped buffer, so the work is bounded.
+    // Registries and trailing-partial for the legend + completion
+    // highlight. Re-derived each render:
+    // - `known_identities`: dedupes in O(n) over the capped signal
+    //   buffer; bounded.
+    // - `scan_groups`: one `read_dir` + one YAML parse per render.
+    //   The YAML is tiny (it has per-group membership, not message
+    //   history), so the cost is negligible next to the render we'd
+    //   do anyway. Simpler than caching with invalidation.
     let known = known_identities(&signals.read(), caps);
-    let current_partial: Option<String> = find_trailing_mention(&input.read())
+    let groups_known = scan_groups(caps);
+    // `input.read()` returns a read guard — borrow it into a local
+    // binding so `find_trailing_mention`'s `&str` doesn't outlive
+    // the temporary guard.
+    let input_snapshot = input.read().clone();
+    let mention_ctx = find_trailing_mention(&input_snapshot);
+    let agent_partial: Option<String> = mention_ctx
+        .as_ref()
+        .filter(|m| m.sigil == Sigil::Agent)
+        .map(|m| m.partial.to_string());
+    let group_partial: Option<String> = mention_ctx
+        .as_ref()
+        .filter(|m| m.sigil == Sigil::Group)
         .map(|m| m.partial.to_string());
     let rows: Vec<_> = signals
         .read()
@@ -237,6 +270,28 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
             let chip = chip_for(&s.from, &s.project, &s.cwd, caps);
             let weight = if chip.style.bold { Weight::Bold } else { Weight::Normal };
             let color = color_for(chip.palette, caps);
+            // Group glyphs for this chip: cross-reference the
+            // sender's session UUID against _groups.yaml membership.
+            // Humans have no session_id yet, so their chips stay
+            // glyph-less until PR 4 derives a membership key for
+            // them.
+            let group_chips: Vec<AnyElement<'static>> = match chip.session_id.as_deref() {
+                Some(uuid) => groups_for_session(uuid, &groups_known)
+                    .into_iter()
+                    .map(|kg| {
+                        let gcolor = color_for(kg.group.palette, caps);
+                        element! {
+                            Text(
+                                color: gcolor,
+                                content: format!("{} ", kg.group.glyph),
+                                wrap: TextWrap::NoWrap,
+                            )
+                        }
+                        .into_any()
+                    })
+                    .collect(),
+                None => Vec::new(),
+            };
             element! {
                 View(flex_direction: FlexDirection::Row, margin_bottom: 1) {
                     View(
@@ -256,6 +311,9 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                             wrap: TextWrap::NoWrap,
                         )
                         Text(color: Color::DarkGrey, content: chip.secondary, wrap: TextWrap::NoWrap)
+                        View(flex_direction: FlexDirection::Row) {
+                            #(group_chips)
+                        }
                     }
                     View(
                         flex_grow: 1.0,
@@ -285,6 +343,11 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
 
     element! {
         View(flex_direction: FlexDirection::Column, width, height) {
+            // Group legend strip at the top — fixed one-row height.
+            // Each group renders `<glyph> #name` in its hashed color,
+            // so the user can see at a glance which focus groups
+            // exist and in what color they'll appear on agent chips.
+            #(group_legend_row(&groups_known, group_partial.as_deref()))
             // `min_height: 0` + `overflow: Hidden` keep this pane
             // inside its flex-grown slot instead of expanding to the
             // intrinsic height of the message list — without them, a
@@ -323,7 +386,7 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                     )
                 }
             }
-            #(legend_row(&known, current_partial.as_deref()))
+            #(legend_row(&known, agent_partial.as_deref()))
             View(height: 1, padding_left: 1) {
                 Text(color: Color::DarkGrey, content: status.to_string(), wrap: TextWrap::NoWrap)
             }
@@ -331,111 +394,4 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
     }
 }
 
-/// Count how many *rendered* rows `text` occupies inside a box of
-/// `interior` columns. Approximate: counts chars, ignores grapheme
-/// width — good enough for sizing a chat compose box where the exact
-/// last-column edge doesn't matter.
-fn visual_line_count(text: &str, interior: usize) -> usize {
-    if interior == 0 {
-        return 1;
-    }
-    let mut rows = 0usize;
-    for line in text.split('\n') {
-        let len = line.chars().count();
-        rows += if len == 0 { 1 } else { len.div_ceil(interior) };
-    }
-    rows.max(1)
-}
-
-/// Split a string at a *char* offset (not a byte offset). If the
-/// offset runs past the end of the string, the tail is empty.
-fn split_at_char(s: &str, n: usize) -> (&str, &str) {
-    match s.char_indices().nth(n) {
-        Some((byte, _)) => s.split_at(byte),
-        None => (s, ""),
-    }
-}
-
-/// Render the compose buffer with a block cursor at `pos`. The cursor
-/// sits *on* the char at `pos` (that char is replaced visually by the
-/// block) or past the end if `pos == len`. Matches how most terminal
-/// editors render a block cursor.
-fn render_cursor(text: &str, pos: usize) -> String {
-    let total = text.chars().count();
-    if pos >= total {
-        return format!("{}\u{2588}", text);
-    }
-    let (before, rest) = split_at_char(text, pos);
-    // Skip the char under the cursor so the block doesn't overlap it.
-    let after: String = rest.chars().skip(1).collect();
-    format!("{}\u{2588}{}", before, after)
-}
-
-#[cfg(test)]
-mod layout_tests {
-    use super::visual_line_count;
-
-    #[test]
-    fn short_line_is_one_row() {
-        assert_eq!(visual_line_count("hi", 20), 1);
-    }
-
-    #[test]
-    fn wrap_on_width() {
-        // 21 chars in a 10-wide box → 3 rows.
-        assert_eq!(visual_line_count("abcdefghijklmnopqrstu", 10), 3);
-    }
-
-    #[test]
-    fn explicit_newlines_count() {
-        assert_eq!(visual_line_count("a\nb\nc", 20), 3);
-    }
-
-    #[test]
-    fn combined_wrap_and_newline() {
-        // "abcdefghij" (10 chars) wraps once in 5-wide → 2 rows
-        // followed by "x" on its own line → 1 row = 3 total.
-        assert_eq!(visual_line_count("abcdefghij\nx", 5), 3);
-    }
-}
-
-#[cfg(test)]
-mod cursor_tests {
-    use super::{render_cursor, split_at_char};
-
-    #[test]
-    fn split_within_ascii() {
-        assert_eq!(split_at_char("hello", 2), ("he", "llo"));
-    }
-
-    #[test]
-    fn split_past_end() {
-        assert_eq!(split_at_char("hi", 10), ("hi", ""));
-    }
-
-    #[test]
-    fn split_respects_char_boundaries() {
-        // "héllo" — 'é' is 2 bytes. Splitting at char 2 should land
-        // between 'é' and 'l', not mid-byte.
-        let (before, after) = split_at_char("héllo", 2);
-        assert_eq!(before, "hé");
-        assert_eq!(after, "llo");
-    }
-
-    #[test]
-    fn cursor_at_end_appends_block() {
-        assert_eq!(render_cursor("hi", 2), "hi\u{2588}");
-    }
-
-    #[test]
-    fn cursor_mid_text_replaces_char_visually() {
-        // Cursor at position 1 over "abc" → 'a' + block + 'c'.
-        assert_eq!(render_cursor("abc", 1), "a\u{2588}c");
-    }
-
-    #[test]
-    fn cursor_on_empty_buffer() {
-        assert_eq!(render_cursor("", 0), "\u{2588}");
-    }
-}
 

--- a/tools/attend-chat/src/chip.rs
+++ b/tools/attend-chat/src/chip.rs
@@ -28,6 +28,12 @@ pub struct ChipInfo {
     pub secondary: String,
     pub palette: PaletteEntry,
     pub style: Style,
+    /// Session UUID for claude senders, `None` for humans or
+    /// unknown prefixes. The chip's group-glyph decoration cross-
+    /// references this against `_groups.yaml` membership. Humans
+    /// will get their own derivable key in PR 4 once the CRUD
+    /// path needs to address them.
+    pub session_id: Option<String>,
 }
 
 /// Derive the chip from the wire `from`/`project`/`cwd` triple.
@@ -50,17 +56,20 @@ pub fn chip_for(from: &str, project: &str, cwd: &str, caps: TermCaps) -> ChipInf
         scope_segment.to_string()
     };
 
-    if from.strip_prefix("claude:").is_some() {
+    if let Some(uuid) = from.strip_prefix("claude:") {
         // For claude senders the cwd is the stable identity key. We
         // don't hash the session UUID — two sequential claudes in the
         // same dir should wear the same name, matching the user's
-        // mental model of "the agent that lives here".
+        // mental model of "the agent that lives here". The UUID
+        // flows to ChipInfo.session_id so the chip can look up
+        // group membership against _groups.yaml.
         let id = Identity::for_cwd(cwd, caps);
         ChipInfo {
             primary: truncate(id.nickname, interior),
             secondary: truncate(&scope, interior),
             palette: id.palette,
             style: id.style,
+            session_id: Some(uuid.to_string()),
         }
     } else if let Some(rest) = from.strip_prefix("external:") {
         // Strip the terminal suffix ("aaron@kitty" → "aaron") so the
@@ -72,6 +81,7 @@ pub fn chip_for(from: &str, project: &str, cwd: &str, caps: TermCaps) -> ChipInf
             secondary: truncate(&scope, interior),
             palette: id.palette,
             style: id.style,
+            session_id: None,
         }
     } else {
         // Unknown sender kind — key the color off the raw `from` so
@@ -83,6 +93,7 @@ pub fn chip_for(from: &str, project: &str, cwd: &str, caps: TermCaps) -> ChipInf
             secondary: truncate(&scope, interior),
             palette: id.palette,
             style: id.style,
+            session_id: None,
         }
     }
 }

--- a/tools/attend-chat/src/groups.rs
+++ b/tools/attend-chat/src/groups.rs
@@ -1,0 +1,289 @@
+//! Focus-group discovery and membership reads for the TUI.
+//!
+//! Read-only mirror of the data model owned by `attend::groups`. We
+//! enumerate `@*/` subdirectories under the signals base (the source
+//! of truth for "a group exists") and parse `_groups.yaml` for
+//! membership (the source of truth for "who's in it").
+//!
+//! **Format mirror.** `_groups.yaml` is written by
+//! `tools/attend/src/groups.rs::serialize_groups_yaml`. Our parser
+//! mirrors its shape one-to-one — two-space indent, list items at
+//! four-space indent, no comments emitted — so any format change
+//! here requires the same change there. We re-parse rather than
+//! share because this crate only *reads* the file today; a shared
+//! I/O layer lands with PR 4's `/join` write path.
+//!
+//! Everything in this module is pure file reads. Callers re-invoke
+//! `scan` each render; it's cheap (one `read_dir` + one
+//! `read_to_string`) and always sees the current state without
+//! invalidation bookkeeping.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use agent_identity::{Group, TermCaps};
+
+use crate::signal::signals_base;
+
+const GROUP_PREFIX: &str = "@";
+const STATE_FILE: &str = "_groups.yaml";
+
+/// Membership entry for one group.
+#[derive(Debug, Clone, Default)]
+pub struct GroupMembership {
+    pub pinned: bool,
+    /// Session IDs currently in this group. For claude sessions these
+    /// are UUIDs; for future human entries they'll be derived hashes.
+    pub members: Vec<String>,
+}
+
+/// One discovered group with its display identity baked in.
+#[derive(Debug, Clone)]
+pub struct KnownGroup {
+    pub group: Group,
+    pub membership: GroupMembership,
+}
+
+/// Scan the signals base for groups.
+///
+/// Returns every `@<name>/` directory that exists on disk, each
+/// paired with its membership entry from `_groups.yaml` (or an empty
+/// membership if the yaml doesn't mention it — a group dir can exist
+/// before `_groups.yaml` catches up).
+pub fn scan(caps: TermCaps) -> Vec<KnownGroup> {
+    scan_in(&signals_base(), caps)
+}
+
+/// Scan under an arbitrary base. Exists so tests can drive the scan
+/// against a scratch directory without touching `$HOME`.
+pub fn scan_in(base: &Path, caps: TermCaps) -> Vec<KnownGroup> {
+    let memberships = load_memberships(base);
+    let Ok(entries) = fs::read_dir(base) else {
+        return Vec::new();
+    };
+    let mut out: Vec<KnownGroup> = entries
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            if !e.file_type().ok()?.is_dir() {
+                return None;
+            }
+            let name = e.file_name().to_string_lossy().to_string();
+            let bare = name.strip_prefix(GROUP_PREFIX)?.to_string();
+            if bare.is_empty() {
+                return None;
+            }
+            let membership = memberships.get(&bare).cloned().unwrap_or_default();
+            Some(KnownGroup {
+                group: Group::for_name(&bare, caps),
+                membership,
+            })
+        })
+        .collect();
+    // Alphabetical order so the legend is stable across renders.
+    // Groups aren't temporally ordered the way agents are (no
+    // "newest-seen" concept) — alpha is the least-surprising default.
+    out.sort_by(|a, b| a.group.name.cmp(&b.group.name));
+    out
+}
+
+/// Return the set of group names a given session (by its ID) is in.
+/// Pure map lookup over the parsed yaml.
+pub fn groups_for_session<'a>(
+    session_id: &str,
+    known: &'a [KnownGroup],
+) -> Vec<&'a KnownGroup> {
+    known
+        .iter()
+        .filter(|k| k.membership.members.iter().any(|m| m == session_id))
+        .collect()
+}
+
+fn load_memberships(base: &Path) -> HashMap<String, GroupMembership> {
+    let path = base.join(STATE_FILE);
+    let Ok(content) = fs::read_to_string(&path) else {
+        return HashMap::new();
+    };
+    parse_groups_yaml(&content)
+}
+
+/// Parse the narrowly-shaped `_groups.yaml` attend writes.
+///
+/// Mirrors `attend::groups::parse_groups_yaml` exactly. We could pull
+/// in a YAML crate, but the schema is two levels deep and a full
+/// parser would burn compile time and binary size for nothing.
+fn parse_groups_yaml(content: &str) -> HashMap<String, GroupMembership> {
+    let mut out: HashMap<String, GroupMembership> = HashMap::new();
+    let mut current: Option<String> = None;
+    let mut pinned = false;
+    let mut members: Vec<String> = Vec::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let indent = line.len() - line.trim_start().len();
+
+        if indent == 0 && trimmed.ends_with(':') {
+            if let Some(name) = current.take() {
+                out.insert(
+                    name,
+                    GroupMembership {
+                        pinned,
+                        members: std::mem::take(&mut members),
+                    },
+                );
+            }
+            current = Some(trimmed.trim_end_matches(':').to_string());
+            pinned = false;
+            continue;
+        }
+
+        if indent == 2 {
+            if let Some((key, value)) = trimmed.split_once(':') {
+                if key.trim() == "pinned" {
+                    pinned = value.trim() == "true";
+                }
+                // `members:` is an array header — items follow at
+                // indent=4. Other keys we silently ignore so future
+                // fields don't make old readers panic.
+            }
+        }
+
+        if indent == 4 {
+            if let Some(m) = trimmed.strip_prefix("- ") {
+                members.push(m.to_string());
+            }
+        }
+    }
+
+    if let Some(name) = current {
+        out.insert(name, GroupMembership { pinned, members });
+    }
+    out
+}
+
+/// Resolve a `#name` addressed send to the group's signal directory.
+/// Returns `None` if the named group has no on-disk dir (i.e. the
+/// user typed an unknown group name).
+pub fn resolve_group_dir(name: &str) -> Option<PathBuf> {
+    let dir = signals_base().join(format!("{GROUP_PREFIX}{name}"));
+    if dir.is_dir() {
+        Some(dir)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn tempdir_like() -> PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "attend-chat-groups-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    fn write_yaml(base: &Path, content: &str) {
+        let mut f = fs::File::create(base.join("_groups.yaml")).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn scan_finds_at_prefixed_dirs() {
+        let base = tempdir_like();
+        fs::create_dir_all(base.join("@deploy")).unwrap();
+        fs::create_dir_all(base.join("@infra")).unwrap();
+        fs::create_dir_all(base.join("_broadcast")).unwrap(); // ignored
+        fs::create_dir_all(base.join("-home-x")).unwrap(); // cwd dir, ignored
+        let groups = scan_in(&base, TermCaps::Rich);
+        let names: Vec<_> = groups.iter().map(|g| g.group.name.as_str()).collect();
+        assert_eq!(names, vec!["deploy", "infra"]);
+    }
+
+    #[test]
+    fn scan_pairs_membership_from_yaml() {
+        let base = tempdir_like();
+        fs::create_dir_all(base.join("@deploy")).unwrap();
+        write_yaml(
+            &base,
+            "deploy:\n  pinned: true\n  members:\n    - sess-a\n    - sess-b\n",
+        );
+        let groups = scan_in(&base, TermCaps::Rich);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].group.name, "deploy");
+        assert!(groups[0].membership.pinned);
+        assert_eq!(groups[0].membership.members.len(), 2);
+    }
+
+    #[test]
+    fn scan_empty_if_no_base() {
+        let base = tempdir_like().join("nope"); // never created
+        let groups = scan_in(&base, TermCaps::Rich);
+        assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn scan_dir_without_yaml_has_empty_membership() {
+        let base = tempdir_like();
+        fs::create_dir_all(base.join("@orphan")).unwrap();
+        // no _groups.yaml at all
+        let groups = scan_in(&base, TermCaps::Rich);
+        assert_eq!(groups.len(), 1);
+        assert!(groups[0].membership.members.is_empty());
+        assert!(!groups[0].membership.pinned);
+    }
+
+    #[test]
+    fn groups_for_session_filters_by_uuid() {
+        let base = tempdir_like();
+        fs::create_dir_all(base.join("@deploy")).unwrap();
+        fs::create_dir_all(base.join("@infra")).unwrap();
+        write_yaml(
+            &base,
+            "deploy:\n  pinned: false\n  members:\n    - sess-a\ninfra:\n  pinned: false\n  members:\n    - sess-b\n",
+        );
+        let groups = scan_in(&base, TermCaps::Rich);
+        let mine = groups_for_session("sess-a", &groups);
+        assert_eq!(mine.len(), 1);
+        assert_eq!(mine[0].group.name, "deploy");
+    }
+
+    #[test]
+    fn parse_yaml_handles_blank_lines_and_comments() {
+        let yaml = "\n# a comment\ndeploy:\n  pinned: true\n  members:\n    - sess-a\n\n# another comment\ninfra:\n  pinned: false\n  members: []\n";
+        let parsed = parse_groups_yaml(yaml);
+        assert_eq!(parsed.len(), 2);
+        assert!(parsed["deploy"].pinned);
+        assert_eq!(parsed["deploy"].members, vec!["sess-a"]);
+        assert!(parsed["infra"].members.is_empty());
+    }
+
+    #[test]
+    fn parse_yaml_unknown_keys_ignored() {
+        // Forward compatibility: if attend adds a field, we shouldn't
+        // panic — just skip it.
+        let yaml = "deploy:\n  pinned: false\n  magic_flag: true\n  members:\n    - sess-a\n";
+        let parsed = parse_groups_yaml(yaml);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed["deploy"].members, vec!["sess-a"]);
+    }
+
+    #[test]
+    fn empty_name_dir_ignored() {
+        let base = tempdir_like();
+        fs::create_dir_all(base.join("@")).unwrap();
+        let groups = scan_in(&base, TermCaps::Rich);
+        assert!(groups.is_empty());
+    }
+}

--- a/tools/attend-chat/src/groups.rs
+++ b/tools/attend-chat/src/groups.rs
@@ -286,4 +286,42 @@ mod tests {
         let groups = scan_in(&base, TermCaps::Rich);
         assert!(groups.is_empty());
     }
+
+    /// Mirror of `tools/attend/src/groups.rs::tests::GROUPS_YAML_GOLDEN`.
+    /// Any edit here requires the matching edit there — both parsers
+    /// must agree on the identical byte sequence. Drift-detection via
+    /// `golden_matches_mirror_parser` below.
+    const GROUPS_YAML_GOLDEN: &str = concat!(
+        "\n",
+        "# leading comment\n",
+        "deploy:\n",
+        "  pinned: true\n",
+        "  members:\n",
+        "    - sess-a\n",
+        "    - sess-b\n",
+        "\n",
+        "infra:\n",
+        "  pinned: false\n",
+        "  members: []\n",
+        "collab:\n",
+        "  pinned: false\n",
+        "  members:\n",
+        "    - sess-c\n",
+    );
+
+    #[test]
+    fn golden_matches_mirror_parser() {
+        // Wire-format drift guard. `tools/attend/src/groups.rs` has
+        // an identical test with the same golden string — if either
+        // parser stops producing this exact HashMap, the mirror
+        // contract is broken and one side has drifted.
+        let parsed = parse_groups_yaml(GROUPS_YAML_GOLDEN);
+        assert_eq!(parsed.len(), 3);
+        assert!(parsed["deploy"].pinned);
+        assert_eq!(parsed["deploy"].members, vec!["sess-a", "sess-b"]);
+        assert!(!parsed["infra"].pinned);
+        assert!(parsed["infra"].members.is_empty());
+        assert!(!parsed["collab"].pinned);
+        assert_eq!(parsed["collab"].members, vec!["sess-c"]);
+    }
 }

--- a/tools/attend-chat/src/legend.rs
+++ b/tools/attend-chat/src/legend.rs
@@ -15,53 +15,79 @@ use agent_identity::TermCaps;
 use iocraft::prelude::*;
 
 use crate::chip::{color_for, KnownIdentity};
+use crate::groups::KnownGroup;
 
-/// Output of parsing the input buffer for a trailing `@partial`.
+/// Which sigil-kind of mention we're matching. A single grammar
+/// serves both `@agent` and `#group`; they differ only in the sigil
+/// char and the completion pool.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Sigil {
+    Agent,
+    Group,
+}
+
+/// Output of parsing the input buffer for a trailing `<sigil>partial`.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Mention<'a> {
-    /// The part of the input up to (and including) the `@` sigil.
-    /// Completion replaces everything after the `@` without touching
+    /// The part of the input up to (and including) the sigil.
+    /// Completion replaces everything after it without touching
     /// what came before.
     pub prefix: &'a str,
-    /// The characters already typed after the `@`, or `""` if the
-    /// user just typed `@` and hasn't typed anything else yet.
+    /// The characters already typed after the sigil, or `""` if the
+    /// user just typed the sigil and hasn't typed anything else yet.
     pub partial: &'a str,
+    /// Which sigil kicked this mention off.
+    pub sigil: Sigil,
 }
 
 /// Parse a trailing mention at the end of `input`.
 ///
-/// A mention is `@<word>` where `<word>` contains only ASCII alnum
-/// characters (mirrors what our nickname pool allows). Returns `None`
-/// if the last word doesn't start with `@`, or if there's a space
-/// after the `@<word>` (caret isn't inside the mention any more).
+/// A mention is `@<word>` or `#<word>` where `<word>` contains only
+/// ASCII alnum characters plus `-` (mirrors what attend's group-name
+/// validator allows; nicknames are a strict subset). Returns `None`
+/// if the last word doesn't start with a mention sigil, or if there's
+/// a space after it (caret isn't inside the mention any more).
+///
+/// When both `@` and `#` appear trailing, the rightmost sigil wins —
+/// that's the one the caret is adjacent to.
 ///
 /// Cursor position isn't consulted — we only offer completion when
 /// the cursor is at the end of the buffer, which the caller enforces.
 pub fn find_trailing_mention(input: &str) -> Option<Mention<'_>> {
-    let at_pos = input.rfind('@')?;
-    let after_at = &input[at_pos + 1..];
-    // Everything after the `@` must be ASCII alnum (no spaces, no
-    // punctuation) for us to treat it as a mention in progress.
-    if !after_at.chars().all(|c| c.is_ascii_alphanumeric()) {
+    let (pos, sigil) = [
+        (input.rfind('@'), Sigil::Agent),
+        (input.rfind('#'), Sigil::Group),
+    ]
+    .into_iter()
+    .filter_map(|(p, s)| p.map(|p| (p, s)))
+    .max_by_key(|(p, _)| *p)?;
+    let after = &input[pos + 1..];
+    // Everything after the sigil must be ASCII alnum or `-` for
+    // us to treat it as a mention in progress. `-` is allowed
+    // because attend's group-name validator permits it
+    // (`my-group` is a real thing).
+    if !after.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
         return None;
     }
-    // The char *before* the `@` must be whitespace or start-of-input —
-    // otherwise we're inside an email address or URL, not a mention.
-    if at_pos > 0 {
-        // `at_pos > 0` means `input[..at_pos]` is non-empty, so
-        // `.chars().last()` always yields Some — the unwrap is safe
-        // by construction.
-        let prev = input[..at_pos]
+    // The char *before* the sigil must be whitespace or
+    // start-of-input — otherwise we're inside an email address,
+    // a URL, or the middle of some other token, not a mention.
+    if pos > 0 {
+        // `pos > 0` means `input[..pos]` is non-empty, so
+        // `.chars().last()` always yields Some — the expect is
+        // safe by construction.
+        let prev = input[..pos]
             .chars()
             .last()
-            .expect("at_pos > 0 implies non-empty prefix");
+            .expect("pos > 0 implies non-empty prefix");
         if !prev.is_whitespace() {
             return None;
         }
     }
     Some(Mention {
-        prefix: &input[..=at_pos],
-        partial: after_at,
+        prefix: &input[..=pos],
+        partial: after,
+        sigil,
     })
 }
 
@@ -84,41 +110,76 @@ pub fn best_completion<'a>(
         .find(|k| k.nickname.to_ascii_lowercase().starts_with(&lc))
 }
 
-/// If `msg` is addressed to an `@Nickname` as its first token,
-/// return the nickname (without the `@`). Routing uses this to
-/// decide whether to broadcast or direct-send to that claude's cwd
-/// dir. Keeps the `@Nickname` in the outgoing body so receivers
-/// still see the address.
-pub fn parse_addressed(msg: &str) -> Option<&str> {
+/// Find the best completion for `partial` among `known` groups.
+///
+/// Parallel to `best_completion` for agents — shared grammar, two
+/// distinct registries. The `-` is tolerated in group names so
+/// `#my-g` → `my-group` matches.
+pub fn best_group_completion<'a>(
+    partial: &str,
+    known: &'a [KnownGroup],
+) -> Option<&'a KnownGroup> {
+    let lc = partial.to_ascii_lowercase();
+    known
+        .iter()
+        .find(|k| k.group.name.to_ascii_lowercase().starts_with(&lc))
+}
+
+/// Parsed routing hint extracted from a message's first token.
+/// Either the message addresses a specific agent (`@Nick body`) or
+/// a focus group (`#group body`), or neither. The routing layer in
+/// `app.rs` dispatches on this.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Addressed<'a> {
+    Agent(&'a str),
+    Group(&'a str),
+}
+
+/// If `msg` starts with an addressing sigil + name, return the kind
+/// + name (without the sigil). Both `@Name` and `#Name` work. Keeps
+/// the original token in the outgoing body so receivers still see
+/// the address they were matched on.
+pub fn parse_addressed(msg: &str) -> Option<Addressed<'_>> {
     let trimmed = msg.trim_start();
-    let rest = trimmed.strip_prefix('@')?;
-    // First alnum run is the nickname; anything after must be
-    // whitespace or nothing. Matches the nickname pool's constraints
-    // (ASCII letters only, short).
+    let mut chars = trimmed.chars();
+    let sigil = chars.next()?;
+    let kind = match sigil {
+        '@' => Sigil::Agent,
+        '#' => Sigil::Group,
+        _ => return None,
+    };
+    let rest = &trimmed[sigil.len_utf8()..];
+    // First alnum + `-` run is the name; anything after must be
+    // whitespace or nothing. Groups allow `-`; nicknames don't use
+    // it today but accepting it in both keeps the grammar uniform
+    // (and worst case the resolver just returns None).
     let end = rest
         .char_indices()
-        .find(|(_, c)| !c.is_ascii_alphanumeric())
+        .find(|(_, c)| !(c.is_ascii_alphanumeric() || *c == '-'))
         .map(|(i, _)| i)
         .unwrap_or(rest.len());
     if end == 0 {
         return None;
     }
-    let nick = &rest[..end];
+    let name = &rest[..end];
     let after = &rest[end..];
-    // Allow `@Nick` alone (entire message is the address, followed by
-    // nothing) — lets users send a bare ping. Otherwise require a
-    // space so `@Nick,` doesn't route.
+    // Allow sigil-plus-name alone (a bare ping), otherwise require a
+    // space so `@Nick,` or `#group.` don't route.
     if after.is_empty() || after.starts_with(char::is_whitespace) {
-        Some(nick)
+        Some(match kind {
+            Sigil::Agent => Addressed::Agent(name),
+            Sigil::Group => Addressed::Group(name),
+        })
     } else {
         None
     }
 }
 
-/// Render one legend row: `@Name @Name ...` across the width of the
-/// input, each name in its own identity color. If the user is in the
-/// middle of typing a mention (`current_partial` is `Some`), names
-/// that prefix-match get an underline so the Tab target is visible.
+/// Render the **agent** legend row: `@Name @Name ...` across the
+/// width of the input, each name in its own identity color. If the
+/// user is in the middle of typing an agent mention (`@partial`),
+/// names that prefix-match get an underline so the Tab target is
+/// visible.
 ///
 /// Returns a `Vec` so the caller can splat it into an `element!`
 /// children slot with `#(...)`.
@@ -144,6 +205,55 @@ pub fn legend_row(
                 TextDecoration::None
             };
             let content = format!("@{} ", k.nickname);
+            element! {
+                Text(color, weight, italic, decoration, content, wrap: TextWrap::NoWrap)
+            }
+            .into_any()
+        })
+        .collect();
+    vec![element! {
+        View(
+            flex_direction: FlexDirection::Row,
+            padding_left: 1,
+            padding_right: 1,
+            height: 1u32,
+            flex_shrink: 0.0,
+            overflow: Overflow::Hidden,
+        ) {
+            #(chips)
+        }
+    }
+    .into_any()]
+}
+
+/// Render the **group** legend row: `<glyph> #name` per group, each
+/// in its own hashed color. Sits at the top of the TUI so the user
+/// can see at a glance what focus groups exist and in what color
+/// they'll appear on agent chips.
+///
+/// If the user is mid-`#partial`, prefix-matching group names get
+/// an underline so Tab-target is obvious. Glyphs stay single-width;
+/// the name-color matches the glyph-color (same palette entry) so
+/// visual recognition carries even if the glyph degrades on a
+/// limited terminal.
+pub fn group_legend_row(
+    known: &[KnownGroup],
+    current_partial: Option<&str>,
+) -> Vec<AnyElement<'static>> {
+    let caps = TermCaps::detect();
+    let lc_partial = current_partial.map(|p| p.to_ascii_lowercase());
+    let chips: Vec<AnyElement<'static>> = known
+        .iter()
+        .map(|k| {
+            let matches = lc_partial
+                .as_ref()
+                .map(|p| !p.is_empty() && k.group.name.to_ascii_lowercase().starts_with(p))
+                .unwrap_or(false);
+            let color = color_for(k.group.palette, caps);
+            let weight = if k.group.style.bold || matches { Weight::Bold } else { Weight::Normal };
+            let italic = k.group.style.italic;
+            let decoration = if matches { TextDecoration::Underline } else { TextDecoration::None };
+            let content = format!("{} #{} ", k.group.glyph, k.group.name);
             element! {
                 Text(color, weight, italic, decoration, content, wrap: TextWrap::NoWrap)
             }
@@ -203,6 +313,7 @@ mod tests {
         let m = find_trailing_mention("hi @Tam").unwrap();
         assert_eq!(m.prefix, "hi @");
         assert_eq!(m.partial, "Tam");
+        assert_eq!(m.sigil, Sigil::Agent);
     }
 
     #[test]
@@ -210,12 +321,40 @@ mod tests {
         let m = find_trailing_mention("@Tam").unwrap();
         assert_eq!(m.prefix, "@");
         assert_eq!(m.partial, "Tam");
+        assert_eq!(m.sigil, Sigil::Agent);
     }
 
     #[test]
     fn bare_at_sign_is_empty_partial() {
         let m = find_trailing_mention("hello @").unwrap();
         assert_eq!(m.partial, "");
+        assert_eq!(m.sigil, Sigil::Agent);
+    }
+
+    #[test]
+    fn trailing_hash_is_group_mention() {
+        let m = find_trailing_mention("hi #dep").unwrap();
+        assert_eq!(m.partial, "dep");
+        assert_eq!(m.sigil, Sigil::Group);
+    }
+
+    #[test]
+    fn group_with_dash_accepted() {
+        // attend's validator permits `-` in group names; the
+        // mention grammar must match so `#my-g` is a valid
+        // prefix of `my-group`.
+        let m = find_trailing_mention("#my-g").unwrap();
+        assert_eq!(m.partial, "my-g");
+    }
+
+    #[test]
+    fn rightmost_sigil_wins() {
+        // If both sigils appear and are both trailing-legal,
+        // whichever is closer to the caret is the mention.
+        let m = find_trailing_mention("#dep @Tam").unwrap();
+        assert_eq!(m.sigil, Sigil::Agent);
+        let m = find_trailing_mention("@Tam #dep").unwrap();
+        assert_eq!(m.sigil, Sigil::Group);
     }
 
     #[test]
@@ -288,18 +427,18 @@ mod tests {
 
     #[test]
     fn addressed_at_start_with_body() {
-        assert_eq!(parse_addressed("@Tamsin hello"), Some("Tamsin"));
+        assert_eq!(parse_addressed("@Tamsin hello"), Some(Addressed::Agent("Tamsin")));
     }
 
     #[test]
     fn addressed_bare_ping() {
         // `@Nick` with nothing after is a valid addressed ping.
-        assert_eq!(parse_addressed("@Urban"), Some("Urban"));
+        assert_eq!(parse_addressed("@Urban"), Some(Addressed::Agent("Urban")));
     }
 
     #[test]
     fn addressed_with_leading_whitespace() {
-        assert_eq!(parse_addressed("   @Tamsin hello"), Some("Tamsin"));
+        assert_eq!(parse_addressed("   @Tamsin hello"), Some(Addressed::Agent("Tamsin")));
     }
 
     #[test]
@@ -318,5 +457,25 @@ mod tests {
     fn not_addressed_on_bare_at_sign() {
         assert_eq!(parse_addressed("@ hi"), None);
         assert_eq!(parse_addressed("@"), None);
+    }
+
+    #[test]
+    fn addressed_group_with_body() {
+        assert_eq!(parse_addressed("#deploy rollout at 3pm"), Some(Addressed::Group("deploy")));
+    }
+
+    #[test]
+    fn addressed_group_with_dash() {
+        assert_eq!(parse_addressed("#my-team ping"), Some(Addressed::Group("my-team")));
+    }
+
+    #[test]
+    fn addressed_group_bare_ping() {
+        assert_eq!(parse_addressed("#infra"), Some(Addressed::Group("infra")));
+    }
+
+    #[test]
+    fn addressed_group_rejects_punctuation() {
+        assert_eq!(parse_addressed("#deploy, now"), None);
     }
 }

--- a/tools/attend-chat/src/lib.rs
+++ b/tools/attend-chat/src/lib.rs
@@ -7,6 +7,8 @@
 
 pub mod app;
 pub mod chip;
+pub mod groups;
 pub mod legend;
 pub mod signal;
+pub mod text_layout;
 pub mod watcher;

--- a/tools/attend-chat/src/main.rs
+++ b/tools/attend-chat/src/main.rs
@@ -25,10 +25,14 @@ fn main() {
     }
 
     let (tx, rx) = async_channel::unbounded::<signal::Signal>();
-    let dir = signal::broadcast_dir();
-    if let Err(e) = watcher::spawn_watcher(dir.clone(), tx) {
+    let base = signal::signals_base();
+    let own_cwd = std::env::current_dir()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let own_encoded = signal::encode_cwd(&own_cwd);
+    if let Err(e) = watcher::spawn_watcher(base.clone(), own_encoded, tx) {
         eprintln!("attend-chat: failed to start signal watcher: {}", e);
-        eprintln!("  signals dir: {}", dir.display());
+        eprintln!("  signals base: {}", base.display());
         eprintln!("  (no point opening the TUI — nothing would stream in.)");
         std::process::exit(1);
     }

--- a/tools/attend-chat/src/text_layout.rs
+++ b/tools/attend-chat/src/text_layout.rs
@@ -1,0 +1,114 @@
+//! Char-boundary-aware text helpers for the compose box.
+//!
+//! These are the bits of `App` that are pure string math — no iocraft
+//! types, no state handles. Extracting them keeps `app.rs` focused on
+//! the component + event wiring, and makes the behaviour easy to test
+//! without spinning up a terminal.
+
+/// Count how many *rendered* rows `text` occupies inside a box of
+/// `interior` columns. Approximate: counts chars, ignores grapheme
+/// width — good enough for sizing a chat compose box where the exact
+/// last-column edge doesn't matter.
+pub fn visual_line_count(text: &str, interior: usize) -> usize {
+    if interior == 0 {
+        return 1;
+    }
+    let mut rows = 0usize;
+    for line in text.split('\n') {
+        let len = line.chars().count();
+        rows += if len == 0 { 1 } else { len.div_ceil(interior) };
+    }
+    rows.max(1)
+}
+
+/// Split a string at a *char* offset (not a byte offset). If the
+/// offset runs past the end of the string, the tail is empty.
+pub fn split_at_char(s: &str, n: usize) -> (&str, &str) {
+    match s.char_indices().nth(n) {
+        Some((byte, _)) => s.split_at(byte),
+        None => (s, ""),
+    }
+}
+
+/// Render the compose buffer with a block cursor at `pos`. The cursor
+/// sits *on* the char at `pos` (that char is replaced visually by the
+/// block) or past the end if `pos == len`. Matches how most terminal
+/// editors render a block cursor.
+pub fn render_cursor(text: &str, pos: usize) -> String {
+    let total = text.chars().count();
+    if pos >= total {
+        return format!("{}\u{2588}", text);
+    }
+    let (before, rest) = split_at_char(text, pos);
+    // Skip the char under the cursor so the block doesn't overlap it.
+    let after: String = rest.chars().skip(1).collect();
+    format!("{}\u{2588}{}", before, after)
+}
+
+#[cfg(test)]
+mod layout_tests {
+    use super::visual_line_count;
+
+    #[test]
+    fn short_line_is_one_row() {
+        assert_eq!(visual_line_count("hi", 20), 1);
+    }
+
+    #[test]
+    fn wrap_on_width() {
+        // 21 chars in a 10-wide box → 3 rows.
+        assert_eq!(visual_line_count("abcdefghijklmnopqrstu", 10), 3);
+    }
+
+    #[test]
+    fn explicit_newlines_count() {
+        assert_eq!(visual_line_count("a\nb\nc", 20), 3);
+    }
+
+    #[test]
+    fn combined_wrap_and_newline() {
+        // "abcdefghij" (10 chars) wraps once in 5-wide → 2 rows
+        // followed by "x" on its own line → 1 row = 3 total.
+        assert_eq!(visual_line_count("abcdefghij\nx", 5), 3);
+    }
+}
+
+#[cfg(test)]
+mod cursor_tests {
+    use super::{render_cursor, split_at_char};
+
+    #[test]
+    fn split_within_ascii() {
+        assert_eq!(split_at_char("hello", 2), ("he", "llo"));
+    }
+
+    #[test]
+    fn split_past_end() {
+        assert_eq!(split_at_char("hi", 10), ("hi", ""));
+    }
+
+    #[test]
+    fn split_respects_char_boundaries() {
+        // "héllo" — 'é' is 2 bytes. Splitting at char 2 should land
+        // between 'é' and 'l', not mid-byte.
+        let (before, after) = split_at_char("héllo", 2);
+        assert_eq!(before, "hé");
+        assert_eq!(after, "llo");
+    }
+
+    #[test]
+    fn cursor_at_end_appends_block() {
+        assert_eq!(render_cursor("hi", 2), "hi\u{2588}");
+    }
+
+    #[test]
+    fn cursor_mid_text_replaces_char_visually() {
+        // Cursor at position 1 over "abc" → 'a' + block + 'c'.
+        assert_eq!(render_cursor("abc", 1), "a\u{2588}c");
+    }
+
+    #[test]
+    fn cursor_on_empty_buffer() {
+        assert_eq!(render_cursor("", 0), "\u{2588}");
+    }
+}

--- a/tools/attend-chat/src/watcher.rs
+++ b/tools/attend-chat/src/watcher.rs
@@ -2,26 +2,29 @@
 //!
 //! `spawn_watcher` does three things, in order:
 //!
-//!   1. scans the directory for existing `.signal` files (sorted by
-//!      mtime ascending) so a freshly-started TUI catches up on recent
-//!      traffic instead of opening empty;
-//!   2. installs a `notify` recommended watcher; creates and writes
-//!      are forwarded as [`Signal`] values onto the caller's channel;
+//!   1. scans relevant directories for existing `.signal` files
+//!      (sorted by mtime ascending) so a freshly-started TUI catches
+//!      up on recent traffic instead of opening empty;
+//!   2. installs a `notify` recommended watcher on the signals base
+//!      *recursively*; creates and writes to files that pass
+//!      [`accept_path`] are forwarded as [`Signal`] values onto the
+//!      caller's channel;
 //!   3. parks the watcher on a dedicated thread so its lifetime is
 //!      tied to the process, not to any caller scope.
+//!
+//! The watcher is recursive because focus-group dirs (`@name/`) and
+//! the directed-send inbox for this host's own cwd both live as
+//! sibling directories under the base. A non-recursive watcher would
+//! miss both — and would also miss *new* groups created after the
+//! TUI started, which is the common case (another agent runs
+//! `attend focus on deploy` during the session).
 //!
 //! `notify`'s callback is synchronous, so we bridge to the async
 //! channel with [`async_channel::Sender::send_blocking`]. Keeping the
 //! watcher off smol means a slow renderer can't back-pressure the
 //! filesystem listener into dropping events.
-//!
-//! Initialisation failures (watcher construction, `.watch()`) are
-//! returned to the caller so it can decide whether to fall back or
-//! abort — post-init errors from inside the callback are best-effort
-//! and swallowed, because surfacing them into the TUI would require a
-//! status channel we don't need yet.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::Duration;
 
@@ -31,43 +34,99 @@ use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watche
 
 use crate::signal::{parse_file, Signal};
 
-pub fn spawn_watcher(dir: PathBuf, tx: Sender<Signal>) -> notify::Result<()> {
-    std::fs::create_dir_all(&dir).ok();
+/// Decide whether a filesystem path under the signals base is a
+/// signal we want to stream into the TUI.
+///
+/// Accepts three shapes:
+/// - `<base>/_broadcast/<name>.signal` — everyone
+/// - `<base>/@<group>/<name>.signal` — any focus group (we render
+///   them all; filtering by *subscribed* groups happens later in
+///   the component as the membership model lands)
+/// - `<base>/<own_encoded>/<name>.signal` — direct sends targeting
+///   this host's cwd (produced by PR 2's `@nickname` routing)
+///
+/// Rejects:
+/// - Directed sends to *other* cwds (noise — not addressed to us)
+/// - Non-`.signal` files (state files like `_groups.yaml`, tmp files)
+pub fn accept_path(base: &Path, own_encoded: &str, path: &Path) -> bool {
+    if path.extension().and_then(|s| s.to_str()) != Some("signal") {
+        return false;
+    }
+    let Ok(rel) = path.strip_prefix(base) else {
+        return false;
+    };
+    let mut comps = rel.components();
+    let Some(first) = comps.next() else {
+        return false;
+    };
+    let name = first.as_os_str().to_string_lossy();
+    if name == "_broadcast" {
+        return true;
+    }
+    if name.starts_with('@') {
+        return true;
+    }
+    if name == own_encoded {
+        return true;
+    }
+    false
+}
 
-    // Backfill existing signals so the stream isn't empty on launch.
-    // Ordered by mtime so replay matches wall-clock arrival order.
-    if let Ok(entries) = std::fs::read_dir(&dir) {
-        let mut items: Vec<(std::time::SystemTime, PathBuf)> = entries
-            .filter_map(|e| e.ok())
-            .filter_map(|e| {
-                let p = e.path();
-                e.metadata().and_then(|m| m.modified()).ok().map(|t| (t, p))
-            })
-            .collect();
-        items.sort_by_key(|(t, _)| *t);
-        for (_, path) in items {
-            if let Some(sig) = parse_file(&path) {
-                let _ = tx.send_blocking(sig);
+pub fn spawn_watcher(base: PathBuf, own_encoded: String, tx: Sender<Signal>) -> notify::Result<()> {
+    std::fs::create_dir_all(&base).ok();
+    // Pre-create the broadcast + own-cwd subdirs so notify's
+    // recursive watch installs sub-watchers on them before any
+    // signal is written. Without this, a write that races with
+    // create_dir inside `write_signal` can fire its filesystem
+    // event before the recursive watcher has observed the parent —
+    // the signal arrives on disk but the watcher callback never
+    // sees it. Group dirs don't need the same treatment: they're
+    // rare, and any missed "first signal in a new group" is
+    // indistinguishable from backlog a later signal will force the
+    // UI to re-scan for.
+    std::fs::create_dir_all(base.join("_broadcast")).ok();
+    if !own_encoded.is_empty() {
+        std::fs::create_dir_all(base.join(&own_encoded)).ok();
+    }
+
+    // Backfill existing signals from the three accepted shapes so
+    // the stream isn't empty on launch. Ordered by mtime across all
+    // source dirs so replay matches wall-clock arrival order.
+    let mut backfill: Vec<(std::time::SystemTime, PathBuf)> = Vec::new();
+    let dirs_to_scan = scan_targets(&base, &own_encoded);
+    for dir in &dirs_to_scan {
+        let Ok(entries) = std::fs::read_dir(dir) else { continue };
+        for entry in entries.filter_map(|e| e.ok()) {
+            let p = entry.path();
+            if p.extension().and_then(|s| s.to_str()) != Some("signal") {
+                continue;
             }
+            if let Ok(meta) = entry.metadata() {
+                if let Ok(ts) = meta.modified() {
+                    backfill.push((ts, p));
+                }
+            }
+        }
+    }
+    backfill.sort_by_key(|(t, _)| *t);
+    for (_, path) in backfill {
+        if let Some(sig) = parse_file(&path) {
+            let _ = tx.send_blocking(sig);
         }
     }
 
     let tx_cb = tx.clone();
+    let base_for_cb = base.clone();
+    let own_for_cb = own_encoded.clone();
     let mut watcher = RecommendedWatcher::new(
         move |res: notify::Result<Event>| {
             let Ok(event) = res else { return };
-            // An atomic rename fires two events — `Name(To)` and
+            // Atomic rename fires two events — `Name(To)` and
             // `Name(Both)` — both referencing the final filename. We
             // accept `Create(_)` (platforms that emit it, notably
             // kqueue) and `Modify(Name(To))` (the rename-destination
             // arrival on Linux), and explicitly drop `Name(Both)` and
             // `Name(From)` so we don't deliver each signal twice.
-            //
-            // TODO(bsd): kqueue reports bare `Modify(_)` rather than
-            // the RenameMode subvariants on some BSD builds of notify;
-            // if we start running on FreeBSD this matcher may miss
-            // events. Revisit with a platform-specific test when we
-            // add BSD CI.
             let accept = matches!(
                 event.kind,
                 EventKind::Create(_) | EventKind::Modify(ModifyKind::Name(RenameMode::To))
@@ -76,7 +135,7 @@ pub fn spawn_watcher(dir: PathBuf, tx: Sender<Signal>) -> notify::Result<()> {
                 return;
             }
             for path in event.paths {
-                if path.extension().and_then(|s| s.to_str()) != Some("signal") {
+                if !accept_path(&base_for_cb, &own_for_cb, &path) {
                     continue;
                 }
                 if let Some(sig) = parse_file(&path) {
@@ -86,7 +145,7 @@ pub fn spawn_watcher(dir: PathBuf, tx: Sender<Signal>) -> notify::Result<()> {
         },
         Config::default().with_poll_interval(Duration::from_millis(250)),
     )?;
-    watcher.watch(&dir, RecursiveMode::NonRecursive)?;
+    watcher.watch(&base, RecursiveMode::Recursive)?;
 
     // Park the watcher on a dedicated thread so its handle (and its
     // inotify descriptor on Linux) lives for the rest of the process.
@@ -99,4 +158,72 @@ pub fn spawn_watcher(dir: PathBuf, tx: Sender<Signal>) -> notify::Result<()> {
     });
 
     Ok(())
+}
+
+/// Enumerate the directories whose existing signals we should
+/// backfill on startup. Kept separate from the event filter because
+/// backfill walks the fs once up front — the filter runs per event.
+fn scan_targets(base: &Path, own_encoded: &str) -> Vec<PathBuf> {
+    let mut dirs = vec![base.join("_broadcast"), base.join(own_encoded)];
+    if let Ok(entries) = std::fs::read_dir(base) {
+        for entry in entries.filter_map(|e| e.ok()) {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.starts_with('@') {
+                dirs.push(entry.path());
+            }
+        }
+    }
+    dirs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> PathBuf {
+        PathBuf::from("/tmp/fake-base")
+    }
+
+    #[test]
+    fn accepts_broadcast_signal() {
+        let p = base().join("_broadcast").join("x.signal");
+        assert!(accept_path(&base(), "-home-me", &p));
+    }
+
+    #[test]
+    fn accepts_group_signal() {
+        let p = base().join("@deploy").join("x.signal");
+        assert!(accept_path(&base(), "-home-me", &p));
+    }
+
+    #[test]
+    fn accepts_own_cwd_signal() {
+        let p = base().join("-home-me").join("x.signal");
+        assert!(accept_path(&base(), "-home-me", &p));
+    }
+
+    #[test]
+    fn rejects_other_cwd_signal() {
+        // Directed to a different agent's cwd — not for us.
+        let p = base().join("-home-someone-else").join("x.signal");
+        assert!(!accept_path(&base(), "-home-me", &p));
+    }
+
+    #[test]
+    fn rejects_non_signal_file() {
+        let p = base().join("_broadcast").join("readme.txt");
+        assert!(!accept_path(&base(), "-home-me", &p));
+    }
+
+    #[test]
+    fn rejects_groups_yaml() {
+        let p = base().join("_groups.yaml");
+        assert!(!accept_path(&base(), "-home-me", &p));
+    }
+
+    #[test]
+    fn rejects_path_outside_base() {
+        let p = PathBuf::from("/etc/passwd");
+        assert!(!accept_path(&base(), "-home-me", &p));
+    }
 }

--- a/tools/attend-chat/src/watcher.rs
+++ b/tools/attend-chat/src/watcher.rs
@@ -164,7 +164,14 @@ pub fn spawn_watcher(base: PathBuf, own_encoded: String, tx: Sender<Signal>) -> 
 /// backfill on startup. Kept separate from the event filter because
 /// backfill walks the fs once up front — the filter runs per event.
 fn scan_targets(base: &Path, own_encoded: &str) -> Vec<PathBuf> {
-    let mut dirs = vec![base.join("_broadcast"), base.join(own_encoded)];
+    let mut dirs = vec![base.join("_broadcast")];
+    // Mirror the guard in `spawn_watcher`: when `env::current_dir()`
+    // fails, `own_encoded` is empty and `base.join("")` degenerates
+    // to `base` — we'd then walk the whole top level for no good
+    // reason. Skip that dir when there's nothing to watch.
+    if !own_encoded.is_empty() {
+        dirs.push(base.join(own_encoded));
+    }
     if let Ok(entries) = std::fs::read_dir(base) {
         for entry in entries.filter_map(|e| e.ok()) {
             let name = entry.file_name().to_string_lossy().to_string();
@@ -224,6 +231,18 @@ mod tests {
     #[test]
     fn rejects_path_outside_base() {
         let p = PathBuf::from("/etc/passwd");
+        assert!(!accept_path(&base(), "-home-me", &p));
+    }
+
+    #[test]
+    fn rejects_traversal_style_paths() {
+        // Defence-in-depth: the filter sees full paths from notify,
+        // but a `.signal`-suffixed traversal segment inside the base
+        // must not appear to be broadcast/group/own. We rely on
+        // `strip_prefix` + `Components` for safety, which normalizes
+        // `..` as a ParentDir component that can't equal `_broadcast`,
+        // `@<name>`, or our own_encoded.
+        let p = base().join("..").join("outside").join("x.signal");
         assert!(!accept_path(&base(), "-home-me", &p));
     }
 }

--- a/tools/attend-chat/tests/watcher_roundtrip.rs
+++ b/tools/attend-chat/tests/watcher_roundtrip.rs
@@ -52,7 +52,15 @@ fn write_broadcast_arrives_through_watcher() {
     std::env::set_var("HOME", &home);
 
     let (tx, rx) = async_channel::unbounded::<signal::Signal>();
-    watcher::spawn_watcher(signal::broadcast_dir(), tx)
+    // PR 3 made the watcher recursive over the whole signals base so
+    // it picks up focus-group dirs + the directed-send inbox. The
+    // integration path stays the same for broadcast, but we now pass
+    // the base plus our own cwd's encoded name.
+    let own_cwd = std::env::current_dir()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let own_encoded = signal::encode_cwd(&own_cwd);
+    watcher::spawn_watcher(signal::signals_base(), own_encoded, tx)
         .expect("watcher must initialise against a fresh temp dir");
 
     // Drain anything the backfill produced (should be nothing in a

--- a/tools/attend/src/groups.rs
+++ b/tools/attend/src/groups.rs
@@ -412,4 +412,42 @@ mod tests {
     fn test_encode_project() {
         assert_eq!(encode_project("/home/aaron/.claude"), "-home-aaron--claude");
     }
+
+    /// The exact byte sequence parsed by the drift-detection test.
+    /// Mirrored in `tools/attend-chat/src/groups.rs::tests::GROUPS_YAML_GOLDEN`.
+    /// If you change this string, update the mirror — and add whatever
+    /// new feature (new field, new nesting) to both parsers.
+    pub(super) const GROUPS_YAML_GOLDEN: &str = concat!(
+        "\n",
+        "# leading comment\n",
+        "deploy:\n",
+        "  pinned: true\n",
+        "  members:\n",
+        "    - sess-a\n",
+        "    - sess-b\n",
+        "\n",
+        "infra:\n",
+        "  pinned: false\n",
+        "  members: []\n",
+        "collab:\n",
+        "  pinned: false\n",
+        "  members:\n",
+        "    - sess-c\n",
+    );
+
+    #[test]
+    fn golden_matches_mirror_parser() {
+        // Wire-format drift guard. The attend-chat mirror parser has
+        // an identical test with the same golden string — if either
+        // parser stops producing this exact HashMap, one of the two
+        // has drifted and the mirror contract is broken.
+        let parsed = parse_groups_yaml(GROUPS_YAML_GOLDEN);
+        assert_eq!(parsed.len(), 3);
+        assert!(parsed["deploy"].pinned);
+        assert_eq!(parsed["deploy"].members, vec!["sess-a", "sess-b"]);
+        assert!(!parsed["infra"].pinned);
+        assert!(parsed["infra"].members.is_empty());
+        assert!(!parsed["collab"].pinned);
+        assert_eq!(parsed["collab"].members, vec!["sess-c"]);
+    }
 }


### PR DESCRIPTION
## Summary

PR 3 of the #23 sequence. Focus-group support in the TUI, read-only. Stacked on feat/agent-legend (#63). Merge order: #62 → #63 → this.

## What changed

**agent-identity gains `groups` module.** `Group::for_name` hashes a name through the same FNV-1a and picks (glyph, palette, style). Curated 20 Unicode glyphs with broad font coverage. Group/user namespaces disjoint so \`#aaron\` the group and \`@aaron\` the human never collide on a palette seat.

**Top legend strip** at the TUI top: `<glyph> #name` per discovered group in its hashed color. Tab-target candidates get underlined.

**Per-chip group glyphs.** Each agent chip now shows trailing glyphs for groups that agent's session UUID is in (cross-referenced against `_groups.yaml`). Humans don't have a membership key yet — their chips stay glyph-less until PR 4.

**`#group` routing.** `#Group body` → `signals_base/@Group/`. Unknown group fails loud, not silent broadcast. Grammar permits `-` in group names (matching attend's validator); nicknames stay alnum-only.

**Tab dispatch.** `find_trailing_mention` returns a `Sigil::{Agent, Group}`. Tab picks the right completion pool. Rightmost sigil wins when both appear trailing.

**Watcher went recursive over `signals_base`.** New `accept_path` filter decides which events we stream: accepts `_broadcast/`, `@group/`, own-cwd inbox; rejects other agents' cwd dirs, `_groups.yaml`, and non-`.signal` files. Pre-creates broadcast + own-cwd subdirs before `.watch()` so inotify has their sub-watchers installed — prevents a TOCTOU miss where the first write races with a subdir's own creation.

## Refactor

Extracted `text_layout` module (`visual_line_count`, `split_at_char`, `render_cursor` + 9 tests) out of `app.rs` to bring it back under the 500-line review threshold. `app.rs` is now 397 lines.

## Scope split

PR 3 is **read-only**. Group CRUD from the TUI (`/form`, `/dissolve`, `/join`, `/leave`, `/add`, `/remove`) is PR 4. That path needs a derivable membership key for humans — we agreed (user+cwd) hash, same shape as agents ("humans are slow agents with the same anchoring"), but it's worth a small design pass of its own.

## Tests

38 agent-identity tests (+7 group-module), 71 attend-chat unit (+24 new — group scan, yaml parse, sigil grammar, completion dispatch, #group parse edge cases, watcher accept filter), 1 integration (updated for new watcher signature). All green.

## Test plan

- [x] `cargo test -p agent-identity -p attend-chat` — all green
- [x] `make attend-chat-rebuild` — clean release build
- [x] Existing groups on disk (`@bosectl-demo`, `@open` in `~/.cache/attend/signals/`) will appear in the top legend with their hashed glyph + color on next TUI start
- [ ] Reviewer smoke: launch `./bin/attend-chat`, verify top legend shows both groups with distinct glyph+color; type `#bo` + Tab → completes to `#bosectl-demo `; type `#nonexistent hi` + Enter → status shows "send failed: #nonexistent: unknown group"

## Deferred

- Full-name ⇔ glyph-only toggle view (clutter reduction for many groups)
- PR 4: group CRUD commands
- PR 5: threading gutter
- PR 6: mouse scoping