### PR TITLE
fix(attend-chat): legend dedup + cold-start seed (#23)

### DIFF
--- a/tools/attend-chat/src/app.rs
+++ b/tools/attend-chat/src/app.rs
@@ -16,6 +16,7 @@ use async_channel::Receiver;
 use iocraft::prelude::*;
 
 use crate::chip::{chip_for, color_for, known_identities, resolve_nickname, CHIP_WIDTH};
+use crate::sessions::discover as discover_sessions;
 use crate::text_layout::{render_cursor, split_at_char, visual_line_count};
 use crate::groups::{resolve_group_dir, scan as scan_groups};
 use crate::legend::{
@@ -90,7 +91,8 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                     let msg = input.read().trim_end().to_string();
                     if !msg.is_empty() {
                         let caps = TermCaps::detect();
-                        let agents = known_identities(&signals.read(), caps);
+                        let seeds = discover_sessions();
+                        let agents = known_identities(&signals.read(), &seeds, caps);
                         let result = match parse_addressed(&msg) {
                             Some(Addressed::Agent(name)) => {
                                 match resolve_nickname(name, &agents) {
@@ -137,7 +139,8 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                     let Some(mention) = find_trailing_mention(&buf) else { return };
                     let completed: Option<(String, usize)> = match mention.sigil {
                         Sigil::Agent => {
-                            let agents = known_identities(&signals.read(), caps);
+                            let seeds = discover_sessions();
+                            let agents = known_identities(&signals.read(), &seeds, caps);
                             best_completion(mention.partial, &agents)
                                 .map(|hit| apply_completion(&buf, &mention, &hit.nickname))
                         }
@@ -248,7 +251,8 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
     //   The YAML is tiny (it has per-group membership, not message
     //   history), so the cost is negligible next to the render we'd
     //   do anyway. Simpler than caching with invalidation.
-    let known = known_identities(&signals.read(), caps);
+    let seed_sessions = discover_sessions();
+    let known = known_identities(&signals.read(), &seed_sessions, caps);
     let groups_known = scan_groups(caps);
     // Pre-index session-id → groups once per render so the chip
     // loop is O(signals) instead of O(signals · groups · members).

--- a/tools/attend-chat/src/chip.rs
+++ b/tools/attend-chat/src/chip.rs
@@ -413,6 +413,24 @@ mod tests {
     }
 
     #[test]
+    fn registry_signal_entries_precede_seed_only_entries() {
+        // Ordering invariant: signal-derived entries keep their
+        // newest-first position; seed-only entries fall in after.
+        // A loop-order refactor that swapped the two passes would
+        // flip this. `/X` is the signal, `/Y` is the seed — `/X`
+        // must appear first so active peers lead the legend.
+        let buf = vec![sig("claude:a", "/X")];
+        let seeds = vec![DiscoveredSession {
+            cwd: "/Y".to_string(),
+            session_id: "sy".into(),
+        }];
+        let reg = known_identities(&buf, &seeds, TermCaps::Rich);
+        assert_eq!(reg.len(), 2);
+        assert_eq!(reg[0].cwd, "/X", "signal-derived entry must lead");
+        assert_eq!(reg[1].cwd, "/Y", "seed-only entry falls in after");
+    }
+
+    #[test]
     fn registry_seed_doesnt_duplicate_signal_derived_entry() {
         // If the same cwd is in both the signal buffer and the seed,
         // we must not list it twice.

--- a/tools/attend-chat/src/chip.rs
+++ b/tools/attend-chat/src/chip.rs
@@ -14,6 +14,7 @@
 use agent_identity::{Identity, PaletteEntry, Style, TermCaps};
 use iocraft::prelude::Color;
 
+use crate::sessions::DiscoveredSession;
 use crate::signal::Signal;
 
 /// Width of the chip box in columns. Interior width for text =
@@ -129,13 +130,20 @@ pub struct KnownIdentity {
 }
 
 /// Build the registry of known identities from a slice of buffered
-/// signals. Pure function — no IO, no state. Called every render;
-/// the buffer cap keeps the work bounded.
+/// signals plus a seed of discovered claude sessions. Pure function —
+/// no IO, no state. Called every render; the buffer cap keeps the
+/// signal work bounded and the seed is already a materialized list.
 ///
-/// Ordering: most-recently-seen first, then stable by nickname. That
-/// way the legend strip tends to put active peers at the front
-/// without flickering if two peers have the same last-seen tick.
-pub fn known_identities(signals: &[Signal], caps: TermCaps) -> Vec<KnownIdentity> {
+/// The seed exists so `@Nickname` Tab-completion and routing work
+/// on a fresh TUI launch, *before* any peer has emitted a signal
+/// that lands in our buffer. Signal-derived entries take priority
+/// so ordering (newest-seen-first) still biases the legend toward
+/// active peers; seed-only entries fall in after.
+pub fn known_identities(
+    signals: &[Signal],
+    seeds: &[DiscoveredSession],
+    caps: TermCaps,
+) -> Vec<KnownIdentity> {
     // Walk from newest to oldest so the first time we see a cwd we
     // also capture its most-recent-seen position. A HashSet of cwd
     // strings keeps dedup O(n) without depending on a hasher.
@@ -154,16 +162,42 @@ pub fn known_identities(signals: &[Signal], caps: TermCaps) -> Vec<KnownIdentity
             continue; // unknown prefix — don't pollute the legend
         };
 
-        // Dedupe on (nickname, is_claude, cwd) — same claude can appear
-        // many times in the buffer; same username across different
-        // cwds should still surface once per cwd so legend can show
-        // them distinctly.
-        let key = format!("{}\x1f{}\x1f{}", primary_label, is_claude as u8, sig.cwd);
+        // Dedupe shape differs by kind:
+        // - Claudes are identified by cwd (the routing key). Two
+        //   claudes in different cwds are genuinely different
+        //   agents and should both appear in the legend.
+        // - Humans have no routing cwd, and the same human
+        //   sending from two terminals is still the same person.
+        //   Collapse them on `(nickname, is_claude)` so the
+        //   legend doesn't show `@aaron @aaron` when a user has
+        //   attend-chat running in more than one cwd.
+        let key = if is_claude {
+            format!("{}\x1f1\x1f{}", primary_label, sig.cwd)
+        } else {
+            format!("{}\x1f0", primary_label)
+        };
         if seen.insert(key) {
             out.push(KnownIdentity {
                 nickname: primary_label,
                 cwd: sig.cwd.clone(),
                 is_claude,
+                palette: id.palette,
+                style: id.style,
+            });
+        }
+    }
+
+    // Seed from discovered sessions — any claude cwd we haven't
+    // already registered from a signal. Keys match the signal-
+    // branch format so the same cwd doesn't double-register.
+    for seed in seeds {
+        let id = Identity::for_cwd(&seed.cwd, caps);
+        let key = format!("{}\x1f1\x1f{}", id.nickname, seed.cwd);
+        if seen.insert(key) {
+            out.push(KnownIdentity {
+                nickname: id.nickname.to_string(),
+                cwd: seed.cwd.clone(),
+                is_claude: true,
                 palette: id.palette,
                 style: id.style,
             });
@@ -305,7 +339,7 @@ mod tests {
             sig("claude:a", "/home/x"), // same cwd, should dedup
             sig("claude:b", "/home/y"),
         ];
-        let reg = known_identities(&buf, TermCaps::Rich);
+        let reg = known_identities(&buf, &[], TermCaps::Rich);
         assert_eq!(reg.len(), 2, "expected 2 unique identities, got {}", reg.len());
     }
 
@@ -315,7 +349,7 @@ mod tests {
             sig("claude:a", "/home/x"),
             sig("claude:b", "/home/y"),
         ];
-        let reg = known_identities(&buf, TermCaps::Rich);
+        let reg = known_identities(&buf, &[], TermCaps::Rich);
         // Buffer order is oldest→newest; registry should surface the
         // most-recent cwd first so active peers lead the legend.
         let y_id = Identity::for_cwd("/home/y", TermCaps::Rich);
@@ -325,17 +359,70 @@ mod tests {
     #[test]
     fn registry_includes_humans() {
         let buf = vec![sig("external:aaron@kitty", "/home/aaron/Projects")];
-        let reg = known_identities(&buf, TermCaps::Rich);
+        let reg = known_identities(&buf, &[], TermCaps::Rich);
         assert_eq!(reg.len(), 1);
         assert_eq!(reg[0].nickname, "aaron");
         assert!(!reg[0].is_claude);
     }
 
     #[test]
+    fn registry_collapses_same_human_across_cwds() {
+        // Same user sending from two different cwds (e.g. attend-chat
+        // running in ~/Projects and in ~/.claude) should surface once.
+        // Humans aren't routable to a cwd, so distinguishing them by
+        // cwd just pollutes the legend with `@aaron @aaron`.
+        let buf = vec![
+            sig("external:aaron@kitty", "/home/aaron/Projects"),
+            sig("external:aaron@kitty", "/home/aaron/.claude"),
+        ];
+        let reg = known_identities(&buf, &[], TermCaps::Rich);
+        let aarons: Vec<_> = reg.iter().filter(|k| k.nickname == "aaron").collect();
+        assert_eq!(aarons.len(), 1, "expected a single aaron entry, got {}", aarons.len());
+    }
+
+    #[test]
+    fn registry_still_distinguishes_claudes_per_cwd() {
+        // Two claudes in different cwds are different agents — they
+        // must both appear.
+        let buf = vec![
+            sig("claude:a", "/home/me/proj-a"),
+            sig("claude:b", "/home/me/proj-b"),
+        ];
+        let reg = known_identities(&buf, &[], TermCaps::Rich);
+        assert_eq!(reg.len(), 2);
+    }
+
+    #[test]
     fn registry_skips_unknown_prefix() {
         let buf = vec![sig("mystery:abc", "/tmp")];
-        let reg = known_identities(&buf, TermCaps::Rich);
+        let reg = known_identities(&buf, &[], TermCaps::Rich);
         assert!(reg.is_empty(), "unknown prefix should be ignored, got {reg:?}");
+    }
+
+    #[test]
+    fn registry_seeds_from_sessions_when_buffer_empty() {
+        // Cold-start case: no signals yet, but the sessions dir has
+        // claudes. `@Nickname` autocomplete + routing must still work.
+        let seeds = vec![
+            DiscoveredSession { cwd: "/home/x".to_string(), session_id: "sx".into() },
+            DiscoveredSession { cwd: "/home/y".to_string(), session_id: "sy".into() },
+        ];
+        let reg = known_identities(&[], &seeds, TermCaps::Rich);
+        assert_eq!(reg.len(), 2);
+        assert!(reg.iter().all(|k| k.is_claude));
+    }
+
+    #[test]
+    fn registry_seed_doesnt_duplicate_signal_derived_entry() {
+        // If the same cwd is in both the signal buffer and the seed,
+        // we must not list it twice.
+        let buf = vec![sig("claude:a", "/home/x")];
+        let seeds = vec![DiscoveredSession {
+            cwd: "/home/x".to_string(),
+            session_id: "sx".into(),
+        }];
+        let reg = known_identities(&buf, &seeds, TermCaps::Rich);
+        assert_eq!(reg.len(), 1);
     }
 
     #[test]
@@ -344,7 +431,7 @@ mod tests {
             sig("claude:a", "/home/repo"),
             sig("external:aaron@kitty", "/home/aaron/Projects"),
         ];
-        let reg = known_identities(&buf, TermCaps::Rich);
+        let reg = known_identities(&buf, &[], TermCaps::Rich);
         let claude_nick = &reg.iter().find(|k| k.is_claude).unwrap().nickname;
         // Case-insensitive match hits the claude cwd.
         let lowered = claude_nick.to_ascii_lowercase();

--- a/tools/attend-chat/src/lib.rs
+++ b/tools/attend-chat/src/lib.rs
@@ -9,6 +9,7 @@ pub mod app;
 pub mod chip;
 pub mod groups;
 pub mod legend;
+pub mod sessions;
 pub mod signal;
 pub mod text_layout;
 pub mod watcher;

--- a/tools/attend-chat/src/sessions.rs
+++ b/tools/attend-chat/src/sessions.rs
@@ -19,8 +19,13 @@ use std::path::PathBuf;
 
 /// Minimal view of a claude session file — only the fields the TUI
 /// needs to produce an `Identity`. We purposely don't carry `pid`
-/// (we're not checking liveness) or the full session_id (nothing in
-/// the attend-chat registry keys on it today).
+/// (we're not checking liveness in this PR).
+///
+/// `session_id` is carried even though `KnownIdentity` doesn't use it
+/// yet — ADR-124's group-membership glyph lookup wants to match a
+/// seeded peer's session UUID against `_groups.yaml` members. The
+/// field exists now so the seed path is forward-compatible; the
+/// consumer lands in a follow-up PR.
 #[derive(Debug, Clone)]
 pub struct DiscoveredSession {
     pub cwd: String,
@@ -63,9 +68,11 @@ pub fn discover_in(dir: &std::path::Path) -> Vec<DiscoveredSession> {
     out
 }
 
-/// Quick-and-dirty JSON string extractor mirroring sensor-peers.
-/// Good enough for Claude Code's stable session-file format.
-/// We avoid pulling in serde_json just for two fields.
+/// Quick-and-dirty JSON string extractor. Byte-identical to
+/// `sensor-peers/src/lib.rs::extract_json_string`; duplicated here
+/// so attend-chat doesn't depend on sensor-peers for two fields of
+/// a stable Claude Code file. If either copy changes (e.g., to
+/// handle escape sequences), update both.
 fn extract_json_string(json: &str, key: &str) -> Option<String> {
     let pattern = format!("\"{}\":\"", key);
     let start = json.find(&pattern)? + pattern.len();

--- a/tools/attend-chat/src/sessions.rs
+++ b/tools/attend-chat/src/sessions.rs
@@ -1,0 +1,153 @@
+//! Seed the identity registry from `~/.claude/sessions/*.json`.
+//!
+//! Without this, the TUI only knows about agents who have emitted a
+//! signal that's still in its buffer — so a fresh launch shows an
+//! empty `@` legend and `@Nickname` routing fails even for claudes
+//! that are visibly alive in `attend peers`. Walking the sessions
+//! directory gives us every claude cwd Claude Code has checked in
+//! for recently, which is the ground truth for "who exists".
+//!
+//! We deliberately don't filter by liveness (no `ps` call per entry).
+//! A stale session file is cheap legend clutter; a missing live
+//! agent is a broken Tab-completion and a silent send-failure. The
+//! tradeoff favors permissiveness.
+//!
+//! This is read-only. Session files are owned by Claude Code.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// Minimal view of a claude session file — only the fields the TUI
+/// needs to produce an `Identity`. We purposely don't carry `pid`
+/// (we're not checking liveness) or the full session_id (nothing in
+/// the attend-chat registry keys on it today).
+#[derive(Debug, Clone)]
+pub struct DiscoveredSession {
+    pub cwd: String,
+    pub session_id: String,
+}
+
+/// Enumerate sessions from the default location (`$HOME/.claude/sessions/`).
+pub fn discover() -> Vec<DiscoveredSession> {
+    let Ok(home) = std::env::var("HOME") else {
+        return Vec::new();
+    };
+    let dir = PathBuf::from(home).join(".claude").join("sessions");
+    discover_in(&dir)
+}
+
+/// Enumerate sessions from an arbitrary directory. Exists so tests
+/// can drive the walk against a scratch dir without touching
+/// `$HOME`.
+pub fn discover_in(dir: &std::path::Path) -> Vec<DiscoveredSession> {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Some(cwd) = extract_json_string(&content, "cwd") else {
+            continue;
+        };
+        let Some(session_id) = extract_json_string(&content, "sessionId") else {
+            continue;
+        };
+        out.push(DiscoveredSession { cwd, session_id });
+    }
+    out
+}
+
+/// Quick-and-dirty JSON string extractor mirroring sensor-peers.
+/// Good enough for Claude Code's stable session-file format.
+/// We avoid pulling in serde_json just for two fields.
+fn extract_json_string(json: &str, key: &str) -> Option<String> {
+    let pattern = format!("\"{}\":\"", key);
+    let start = json.find(&pattern)? + pattern.len();
+    let rest = &json[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn tempdir_like() -> PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "attend-chat-sessions-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    fn write_session(dir: &std::path::Path, id: &str, cwd: &str) {
+        let p = dir.join(format!("{}.json", id));
+        let body = format!(
+            r#"{{"sessionId":"{id}","cwd":"{cwd}","pid":12345,"model":"x"}}"#
+        );
+        let mut f = fs::File::create(&p).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn discover_reads_all_session_cwds() {
+        let dir = tempdir_like();
+        write_session(&dir, "sess-a", "/home/me/proj-a");
+        write_session(&dir, "sess-b", "/home/me/proj-b");
+        let mut found = discover_in(&dir);
+        found.sort_by(|a, b| a.cwd.cmp(&b.cwd));
+        assert_eq!(found.len(), 2);
+        assert_eq!(found[0].cwd, "/home/me/proj-a");
+        assert_eq!(found[1].cwd, "/home/me/proj-b");
+    }
+
+    #[test]
+    fn discover_empty_if_dir_missing() {
+        let dir = tempdir_like().join("nope"); // never created
+        assert!(discover_in(&dir).is_empty());
+    }
+
+    #[test]
+    fn discover_skips_non_json() {
+        let dir = tempdir_like();
+        write_session(&dir, "sess-a", "/home/me/proj");
+        let mut f = fs::File::create(dir.join("notes.txt")).unwrap();
+        f.write_all(b"nope").unwrap();
+        assert_eq!(discover_in(&dir).len(), 1);
+    }
+
+    #[test]
+    fn discover_skips_malformed_json() {
+        // A session file missing `cwd` is silently dropped — we're
+        // best-effort and don't want one bad file to mask the rest.
+        let dir = tempdir_like();
+        let p = dir.join("broken.json");
+        let mut f = fs::File::create(&p).unwrap();
+        f.write_all(br#"{"sessionId":"x","pid":1}"#).unwrap();
+        assert!(discover_in(&dir).is_empty());
+    }
+
+    #[test]
+    fn discover_carries_session_id() {
+        // Session IDs drive the per-chip group glyph lookup; the
+        // seed path must carry them through or discovery becomes
+        // legend-only (no membership render for pre-seeded peers).
+        let dir = tempdir_like();
+        write_session(&dir, "sess-xyz", "/home/me/proj");
+        let found = discover_in(&dir);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].session_id, "sess-xyz");
+    }
+}


### PR DESCRIPTION
## Summary

Two polish fixes on top of #64 from smoke-testing. Stacked on feat/agent-groups. Merge order: #62 → #63 → #64 → this.

## Fixes

**1. Double aaron in the legend.** Two attend-chat instances run by the same user in different cwds showed up as `@aaron @aaron`. Humans don't have a routing cwd, so per-cwd dedup just polluted the legend. Claudes still dedup per-cwd (each cwd = a distinct agent).

**2. `@Tamsin` fails on cold start.** On first launch the signal buffer is empty, so \`known_identities\` had no names to match — autocomplete was blank and \`@Tamsin body\` + Enter failed with "unknown nickname" until a Tamsin signal arrived. New \`sessions\` module walks \`~/.claude/sessions/*.json\` at render time and seeds the registry with every claude cwd Claude Code has recorded. Signal-derived entries keep priority (newest-first), seeded entries fall in after.

## Deliberately not fixing here

- **Restrict watcher to joined `@groups`.** Peer sensor already scopes to joined groups only (verified `sensor-peers::read_signals` line 203–209 — own cwd + broadcast + focus groups), so no cross-agent leak at the sensor layer. attend-chat seeing all groups is arguably a *feature* for spectators, and "only joined" needs PR 4's human-membership key to be well-defined.
- **`ps` liveness check on session files.** A stale session is cheap legend clutter; a missing live agent would break Tab-completion silently. Permissiveness wins.

## Test plan

- [x] \`cargo test -p attend-chat\` — 80 unit + 1 integration, all green
- [x] \`make attend-chat-rebuild\` — clean release build
- [ ] Reviewer smoke: rerun a two-instance attend-chat with the same user, confirm single `@aaron` in the legend; fresh launch should show all known claudes in the `@` legend before any signal flows.