### PR TITLE
feat(attend-chat): #open base channel + slash-command framework (ADR-124, #23)

### DIFF
--- a/docs/architecture/system/ADR-124-channel-bar-ordering-open-as-base.md
+++ b/docs/architecture/system/ADR-124-channel-bar-ordering-open-as-base.md
@@ -111,27 +111,24 @@ convention), but `@open/` goes away.
 Left-to-right order:
 
 1. **`#open` (base)** — always first, never moved, never hidden.
-2. **Pinned groups** — groups with `pinned: true` in `_groups.yaml`,
-   in the order they were pinned. Pinned = "this is a standing
-   concern I don't want to fall off the screen".
-3. **Unpinned groups with recent activity** — ordered by most-recent
-   signal timestamp (newest leftmost within this band).
-4. **Unpinned quiet groups** — alphabetical.
+2. **Everything else** — whatever order the underlying scan
+   returns (today that's alphabetical by group name).
 
-Rationale: pinning is the human's explicit "keep this close"
-affordance; after that, recency is the best predictor of relevance
-for active work; alphabetical is the fallback when nothing else
-differentiates.
+Originally this section prescribed bands for pinned / recent /
+quiet. That ordering rule deferred — pin-order would require a
+`_groups.yaml` schema change (pin timestamp), and recency requires
+a per-group mtime index the scan doesn't track. The base-channel
+leftmost is the one invariant this PR needs; richer ordering can
+land in a follow-up once there's pressure for it.
 
 ### 4. Visual treatment
 
 - Base channel `#open` renders with its hashed glyph + color same as
-  any group, but gets a subtle leading prefix (e.g. a left-margin dot
-  or a bold weight) so the eye registers its special role.
-- Pinned groups get a pin indicator (📌 or ⚑) next to their glyph.
-- Groups with unread signals get an unread dot to the left of the
-  glyph (ADR-XXX unread indicators — tracked separately, noted here
-  because the channel bar is where it'd surface).
+  any group, but with a bold weight so the eye registers its
+  special role as the commons.
+- Pin indicators and unread dots are deferred to a follow-up PR
+  alongside the ordering rule — no value in half-implementing them
+  without the band structure they're meant to cue.
 
 ### 5. Agent legend: three-state presence
 

--- a/docs/architecture/system/ADR-124-channel-bar-ordering-open-as-base.md
+++ b/docs/architecture/system/ADR-124-channel-bar-ordering-open-as-base.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-04-16
 deciders:
   - aaronsb
@@ -274,20 +274,25 @@ The work naturally splits into two PRs (post-slash-commands):
 
 ## Open questions
 
-- Does the `#open` naming trigger a rename of the `_broadcast/`
-  directory too, or is it display-only? (This ADR assumes
-  display-only.)
-- Is "pinned" mutually exclusive with "unread dot" visually, or do
-  we stack both indicators? (Probably stack.)
+Settled during PR A:
+
+- `#open` is display-only — `_broadcast/` stays as the on-disk name.
+- `open` is reserved in `validate_group_name` so nobody can
+  create an `@open/` group that would shadow the base.
+
+Still open (for PR B and beyond):
+
 - Do we need a `/unpin` slash command pair to `/pin`, or does
   `attend focus unpin <name>` suffice? (Slash commands PR will
   decide.)
 - Liveness cache TTL — is 2 seconds the right number? Too short and
   we burn syscalls on a busy signal stream; too long and a stopped
   agent lingers visibly. 2s is a guess based on "humans don't
-  notice", but we should measure and tune after the first PR lands.
+  notice", but we should measure and tune after PR B lands.
 - Should `attend peers` CLI output apply the same liveness filter as
   the TUI? If so, the detection logic wants to live in a shared
   crate (or in agent-identity), not duplicated. Leaving undecided
-  until the implementation PR — two duplicates is tolerable, three
-  is extract-pressure.
+  until the PR B implementation — two duplicates is tolerable,
+  three is extract-pressure.
+- Richer channel ordering (pinned band, recent-activity band) —
+  deferred per §3, revisit when there's concrete pressure.

--- a/docs/architecture/system/ADR-124-channel-bar-ordering-open-as-base.md
+++ b/docs/architecture/system/ADR-124-channel-bar-ordering-open-as-base.md
@@ -1,0 +1,296 @@
+---
+status: Draft
+date: 2026-04-16
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-118
+  - ADR-120
+---
+
+# ADR-124: TUI Legend Architecture — Base Channel, Liveness, and Ordering
+
+## Context
+
+The attend-chat TUI has two legend strips — a **channel bar** across
+the top (focus groups) and an **agent legend** above the status row
+(claudes and humans seen on the signal bus). Both are identity
+surfaces: they're how the human locates the set of peers and channels
+currently available to address.
+
+Three problems have surfaced in use:
+
+**1. `#open` is semantically special but visually equal.** ADR-118's
+scenes define `open` as the well-known "everyone who wants shared
+coordination" group. It's the canonical fallback that agents opt into
+when they're *not* in a specialized focus. A new user looking at the
+channel bar has no cue that `#open` is the place to drop a general
+message — it's just another group in an alphabetical row.
+
+**2. `_broadcast/` and `@open/` are distinct on disk but convey
+overlapping intent.** `_broadcast/` is "reach everyone regardless of
+group membership"; `@open/` is "the named group people gather in for
+shared coordination". In practice they're used the same way, and the
+dual affordance confuses both the TUI's mental model and the human
+writing a message ("do I `#open ...` or just plain text?").
+
+**3. No ordering rule beyond alphabetical.** As groups grow, the
+channel bar becomes a noisy alphabetical strip with no affordance for
+"active" vs. "idle" or "pinned" vs. "transient".
+
+**4. The agent legend never forgets.** Its seed source is
+`~/.claude/sessions/*.json` — a disk-persistent record that outlives
+any given claude process. When a claude exits, its session file
+lingers; the agent's nickname keeps appearing in the legend long
+after the agent is gone. Observed concretely: stopping the claude in
+`/home/aaron/temp` left `@Urban` in the legend indefinitely. The
+legend misrepresents system state.
+
+This ADR resolves all four. It's a single record because they share
+one substrate (the two legends) and one framing (what the TUI
+surfaces as the current coordination topology), so splitting them
+would scatter related consequences across multiple ADRs without
+making any of them clearer.
+
+## Decision
+
+### 1. `#open` is the base channel — always leftmost
+
+The channel bar renders with a fixed first position reserved for the
+base channel (`#open`). Every other discovered `@group` follows it,
+in a defined order (see §3).
+
+The base channel:
+
+- Always appears, even when its signal dir is empty
+- Never gets a removal affordance (can't `/dissolve #open`)
+- Is the implicit target of plain-text messages (no sigil required)
+- Is the implicit target of `attend send "msg"` with no flags
+
+`#open` isn't "just another group" — it's the commons.
+
+### 2. Resolve `_broadcast/` vs. `@open/`: `#open` becomes the canonical base
+
+Rename the display layer: what today lives at `~/.cache/attend/signals/_broadcast/`
+is rendered and addressed in the TUI as `#open`. This is a UX
+rename, not a wire-format change — the directory on disk stays
+`_broadcast/` so existing peers continue to receive messages there.
+`@open/` the named group is folded into the same logical channel.
+
+Two options for the folding:
+
+**Option A — `_broadcast/` is canonical; `@open/` is removed.** The
+scene named `open` updates to mean "subscribe to the base channel"
+(which is automatic for everyone anyway). Any existing `@open/` dir
+is migrated: messages move to `_broadcast/`, the dir is cleaned up
+on next peer-sensor poll, and the scene preset is simplified.
+
+- Pros: one dir, one concept. No ambiguity.
+- Cons: breaks any hand-crafted scenes/flows that rely on `@open/`
+  specifically. Migration script needed.
+
+**Option B — both dirs stay, rendered as the same `#open` channel.**
+The TUI merges signals from `_broadcast/` and `@open/` into a single
+`#open` channel view. Writes from `#open ...` land in `_broadcast/`
+(the canonical source of truth). `@open/` becomes deprecated but not
+removed — signals there are still read, just not written to by new
+senders.
+
+- Pros: no migration. Backwards-compatible.
+- Cons: two dirs, one channel — the ambiguity moves from the UX to
+  the implementation. Drift risk over time.
+
+**Recommendation: Option A.** Cleaner long-term, and the `@open`
+scene preset has been around long enough to carry a one-shot migration
+note in release notes. The `_broadcast/` directory name stays (on-disk
+convention), but `@open/` goes away.
+
+### 3. Channel ordering rule
+
+Left-to-right order:
+
+1. **`#open` (base)** — always first, never moved, never hidden.
+2. **Pinned groups** — groups with `pinned: true` in `_groups.yaml`,
+   in the order they were pinned. Pinned = "this is a standing
+   concern I don't want to fall off the screen".
+3. **Unpinned groups with recent activity** — ordered by most-recent
+   signal timestamp (newest leftmost within this band).
+4. **Unpinned quiet groups** — alphabetical.
+
+Rationale: pinning is the human's explicit "keep this close"
+affordance; after that, recency is the best predictor of relevance
+for active work; alphabetical is the fallback when nothing else
+differentiates.
+
+### 4. Visual treatment
+
+- Base channel `#open` renders with its hashed glyph + color same as
+  any group, but gets a subtle leading prefix (e.g. a left-margin dot
+  or a bold weight) so the eye registers its special role.
+- Pinned groups get a pin indicator (📌 or ⚑) next to their glyph.
+- Groups with unread signals get an unread dot to the left of the
+  glyph (ADR-XXX unread indicators — tracked separately, noted here
+  because the channel bar is where it'd surface).
+
+### 5. Agent legend: three-state presence
+
+The agent legend renders each claude in one of three states:
+
+| State | Condition | Rendering |
+|---|---|---|
+| **Live** | session file exists AND PID is alive AND PID is a claude process | full-weight, normal identity color |
+| **Declared (nobody home)** | session file exists BUT PID is dead | dimmed, same color/glyph, addressable |
+| **Absent** | no session file | not shown |
+
+**Declared agents stay addressable** — that's the point of dimming
+rather than dropping. The signal bus is filesystem-mediated: a
+message sent to a declared-but-dead claude writes to its cwd-encoded
+inbox dir and sits there. The next time a claude starts in that cwd,
+attend's backlog handling picks it up. Dimming signals "nobody's home
+right now, but your message won't be lost."
+
+This mirrors how a physical name card on an empty desk still tells
+you where to leave a note.
+
+Humans are **not** gated this way. Their presence in the legend is
+keyed on having emitted a signal that's still in the TUI's buffer
+(or, in a future PR, being derived from a human-membership key).
+Humans are "ephemeral by message" — a human who hasn't typed in a
+while fades via the buffer cap, not a liveness check.
+
+#### Detection mechanism
+
+Port the liveness idiom already used by `sensor-peers::pid_is_claude`
+into `attend-chat::sessions`. Each render-time `discover()` call
+filters session files by liveness before returning them to the
+identity registry.
+
+Concrete implementation:
+
+- `/proc/<pid>` existence check on Linux (single `stat`, sub-
+  microsecond).
+- Fall back to `ps -p <pid> -o comm` on non-Linux or when `/proc` is
+  unavailable.
+- Match the parent process name against `claude` to exclude PIDs that
+  happen to be reused by another program after the session file was
+  written.
+
+#### Refresh cadence
+
+Per-render liveness checks over 20+ session files are cheap on Linux
+but unnecessary. A 2-second TTL cache is plenty — the human won't
+notice a two-second lag between a claude exiting and its chip fading
+out, and the sub-second render work stays bounded.
+
+#### Why not rely on the peer sensor
+
+`sensor-peers` already does liveness. But it lives in the attend
+process, not attend-chat; and ADR-118's data flow is filesystem-
+mediated (everything goes through `~/.cache/attend/signals/`).
+There's no pre-computed "live peers" file attend-chat can read. We
+replicate the detection inline rather than introducing a new shared
+state file — the check is small enough that duplication is cheaper
+than a new coordination surface.
+
+### 6. Channel-bar: same three-state rule
+
+The channel bar applies the same presence logic as §5 at the group
+level:
+
+| State | Condition | Rendering |
+|---|---|---|
+| **Active** | at least one live member (per §5) | full-weight |
+| **Declared (nobody home)** | membership non-empty but zero live members | dimmed, addressable |
+| **Empty pinned** | zero members, `pinned: true` | full-weight (the pin overrides quiet) |
+
+Same reasoning as §5: a declared-but-inactive channel still has its
+directory on disk, and a message sent there sits until the next
+claude to join picks it up. Dimming, not hiding.
+
+`#open` (the base) is **never** dimmed or hidden — it's the commons
+whether or not anyone is listening. A message to `#open` always has
+someone eventually.
+
+## Consequences
+
+### Positive
+
+- New users see `#open` as the obvious commons without reading docs.
+- Ordering has a principled rule, not just alpha — the bar
+  self-organizes around what the human cares about.
+- The `_broadcast/@open` dual affordance disappears; there's one
+  default channel, not two overlapping ones.
+
+### Negative
+
+- Migration needed for any existing `@open/` dir (Option A). One-
+  shot at first run; script is trivial.
+- `attend` CLI output (`peers`, `focus all`) needs the same rename
+  to match the TUI — otherwise the CLI shows `open` as a group and
+  the TUI shows it as the base, which is worse than the current
+  state.
+- Release note: "`@open` is now the base channel; messages sent
+  plain-text reach it; the old `@open` group no longer exists."
+
+### Neutral
+
+- `_broadcast/` on disk stays. We're renaming the display layer, not
+  breaking the wire format.
+
+## Implementation notes
+
+The work naturally splits into two PRs (post-slash-commands):
+
+**PR A — Base channel.** §1 through §4.
+
+1. attend-chat: `#open` pinned leftmost in `group_legend_row`; sort
+   remaining by (pinned, recent, alpha).
+2. attend-chat: `_broadcast/` reads surface as `#open`; plain-text
+   writes route to `_broadcast/` (already do); `#open ...` writes
+   also route to `_broadcast/` (new — today they'd route to
+   `@open/`).
+3. attend: `groups.rs` removes special-case handling of "open" as a
+   scene name; scenes.yaml docs update; one-shot migration of any
+   lingering `@open/` dir on `attend run` startup.
+4. attend: `peers`, `focus all` output uses `#open` as the base
+   channel label; drop any display of `_broadcast/` as a thing the
+   user addresses directly.
+
+**PR B — Liveness.** §5 and §6.
+
+1. attend-chat: new `liveness` module with cached
+   `pid_is_claude(pid)` (2-second TTL). Port sensor-peers' detection
+   pattern.
+2. attend-chat: `sessions::discover` reads PID from each session
+   file and tags entries with a `Live | Declared` presence state
+   rather than filtering. The registry carries the state through to
+   render.
+3. `KnownIdentity` gains a `presence` field; renderers consult it to
+   pick full-weight vs. dimmed color.
+4. attend-chat: `groups::scan` cross-references each group's
+   membership list against the live-agent set; groups with zero
+   live members render dimmed (unless pinned or `#open`).
+5. Tests: synthesize a session file with a dead PID, assert legend
+   renders it as declared/dimmed (not dropped); assert routing to
+   `@DeclaredName body` still writes to disk successfully.
+
+## Open questions
+
+- Does the `#open` naming trigger a rename of the `_broadcast/`
+  directory too, or is it display-only? (This ADR assumes
+  display-only.)
+- Is "pinned" mutually exclusive with "unread dot" visually, or do
+  we stack both indicators? (Probably stack.)
+- Do we need a `/unpin` slash command pair to `/pin`, or does
+  `attend focus unpin <name>` suffice? (Slash commands PR will
+  decide.)
+- Liveness cache TTL — is 2 seconds the right number? Too short and
+  we burn syscalls on a busy signal stream; too long and a stopped
+  agent lingers visibly. 2s is a guess based on "humans don't
+  notice", but we should measure and tune after the first PR lands.
+- Should `attend peers` CLI output apply the same liveness filter as
+  the TUI? If so, the detection logic wants to live in a shared
+  crate (or in agent-identity), not duplicated. Leaving undecided
+  until the implementation PR — two duplicates is tolerable, three
+  is extract-pressure.

--- a/tools/attend-chat/src/app.rs
+++ b/tools/attend-chat/src/app.rs
@@ -19,6 +19,7 @@ use crate::chip::{chip_for, color_for, known_identities, resolve_nickname, CHIP_
 use crate::sessions::discover as discover_sessions;
 use crate::text_layout::{render_cursor, split_at_char, visual_line_count};
 use crate::groups::{channels, resolve_group_dir};
+use crate::helper::{self, HelperMode};
 use crate::legend::{
     apply_completion, best_completion, best_group_completion, find_trailing_mention,
     group_legend_row, legend_row, parse_addressed, Addressed, Sigil,
@@ -29,17 +30,6 @@ use crate::slash;
 #[derive(Default, Props)]
 pub struct AppProps {
     pub receiver: Option<Receiver<Signal>>,
-}
-
-/// Which registry the helper row (below the input box) is showing
-/// right now. Derived once per render from the input buffer and the
-/// trailing-mention context. The payload is the current partial —
-/// what the user has typed after the sigil — used to underline
-/// matching chips for Tab-target affordance.
-enum HelperMode {
-    Agents(Option<String>),
-    Groups(Option<String>),
-    Slash(Option<String>),
 }
 
 /// Upper bound on the in-memory message buffer. At typical chat rates
@@ -322,31 +312,21 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
     // binding so `find_trailing_mention`'s `&str` doesn't outlive
     // the temporary guard.
     let input_snapshot = input.read().clone();
+    // Trailing-mention context is still consumed by the top channel
+    // bar so it can underline a matching `#partial` when the user is
+    // picking a group; the agent-side partial now flows through
+    // `helper::derive` below and doesn't need its own binding here.
     let mention_ctx = find_trailing_mention(&input_snapshot);
-    let agent_partial: Option<String> = mention_ctx
-        .as_ref()
-        .filter(|m| m.sigil == Sigil::Agent)
-        .map(|m| m.partial.to_string());
     let group_partial: Option<String> = mention_ctx
         .as_ref()
         .filter(|m| m.sigil == Sigil::Group)
         .map(|m| m.partial.to_string());
-    // Helper-row mode: the row below the input switches its content
-    // based on what the user is typing. Slash wins if the buffer
-    // starts with `/` (slash grammar is start-of-input-only and
-    // unambiguous); otherwise the trailing mention's sigil decides
-    // between groups and agents; default is agents so the "who's
-    // around" glance stays available when no sigil is active.
-    let slash_partial: Option<String> = slash::find_slash_partial(&input_snapshot)
-        .map(|p| p.partial.to_string());
-    let helper_mode = if input_snapshot.starts_with('/') {
-        HelperMode::Slash(slash_partial.clone())
-    } else {
-        match mention_ctx.as_ref().map(|m| m.sigil) {
-            Some(Sigil::Group) => HelperMode::Groups(group_partial.clone()),
-            _ => HelperMode::Agents(agent_partial.clone()),
-        }
-    };
+    // Helper-row mode is a pure function of the input buffer. The
+    // state machine lives in `helper::derive` — see that module's
+    // docs + tests for the full rule table. Once a slash command
+    // is past its name, the registry's `ArgKind` routes the helper
+    // (`/whois ` → agents, `/join ` → channels).
+    let helper_mode = helper::derive(&input_snapshot);
     let rows: Vec<_> = signals
         .read()
         .iter()

--- a/tools/attend-chat/src/app.rs
+++ b/tools/attend-chat/src/app.rs
@@ -31,6 +31,17 @@ pub struct AppProps {
     pub receiver: Option<Receiver<Signal>>,
 }
 
+/// Which registry the helper row (below the input box) is showing
+/// right now. Derived once per render from the input buffer and the
+/// trailing-mention context. The payload is the current partial —
+/// what the user has typed after the sigil — used to underline
+/// matching chips for Tab-target affordance.
+enum HelperMode {
+    Agents(Option<String>),
+    Groups(Option<String>),
+    Slash(Option<String>),
+}
+
 /// Upper bound on the in-memory message buffer. At typical chat rates
 /// this is unreachable; the cap only matters for runaway conditions
 /// (overnight runs, a misbehaving peer, a loop). When we hit it, drop
@@ -320,6 +331,22 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
         .as_ref()
         .filter(|m| m.sigil == Sigil::Group)
         .map(|m| m.partial.to_string());
+    // Helper-row mode: the row below the input switches its content
+    // based on what the user is typing. Slash wins if the buffer
+    // starts with `/` (slash grammar is start-of-input-only and
+    // unambiguous); otherwise the trailing mention's sigil decides
+    // between groups and agents; default is agents so the "who's
+    // around" glance stays available when no sigil is active.
+    let slash_partial: Option<String> = slash::find_slash_partial(&input_snapshot)
+        .map(|p| p.partial.to_string());
+    let helper_mode = if input_snapshot.starts_with('/') {
+        HelperMode::Slash(slash_partial.clone())
+    } else {
+        match mention_ctx.as_ref().map(|m| m.sigil) {
+            Some(Sigil::Group) => HelperMode::Groups(group_partial.clone()),
+            _ => HelperMode::Agents(agent_partial.clone()),
+        }
+    };
     let rows: Vec<_> = signals
         .read()
         .iter()
@@ -447,7 +474,11 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                     )
                 }
             }
-            #(legend_row(&known, agent_partial.as_deref()))
+            #(match &helper_mode {
+                HelperMode::Agents(p) => legend_row(&known, p.as_deref()),
+                HelperMode::Groups(p) => group_legend_row(&groups_known, p.as_deref()),
+                HelperMode::Slash(p) => slash::slash_legend_row(p.as_deref()),
+            })
             View(height: 1, padding_left: 1) {
                 Text(color: Color::DarkGrey, content: status.to_string(), wrap: TextWrap::NoWrap)
             }

--- a/tools/attend-chat/src/app.rs
+++ b/tools/attend-chat/src/app.rs
@@ -24,6 +24,7 @@ use crate::legend::{
     group_legend_row, legend_row, parse_addressed, Addressed, Sigil,
 };
 use crate::signal::{cwd_dir, write_broadcast, write_signal, Signal};
+use crate::slash;
 
 #[derive(Default, Props)]
 pub struct AppProps {
@@ -90,6 +91,27 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                 KeyCode::Enter => {
                     let msg = input.read().trim_end().to_string();
                     if !msg.is_empty() {
+                        // Slash-command interceptor — stops `/help`,
+                        // `/whois`, etc. from leaking onto the signal
+                        // bus as plain messages. Runs before the
+                        // `@`/`#`/broadcast dispatch because slash
+                        // syntax is start-of-input only and unambiguous.
+                        if let Some((cmd, args)) = slash::parse(&msg) {
+                            match slash::dispatch(cmd, args) {
+                                slash::SlashOutcome::Ok(s) => {
+                                    status.set(s);
+                                    input.set(String::new());
+                                    cursor.set(0);
+                                }
+                                slash::SlashOutcome::Err(s) => {
+                                    // Leave the buffer intact so the
+                                    // user can edit + retry without
+                                    // retyping.
+                                    status.set(s);
+                                }
+                            }
+                            return;
+                        }
                         let caps = TermCaps::detect();
                         let seeds = discover_sessions();
                         let agents = known_identities(&signals.read(), &seeds, caps);
@@ -133,6 +155,19 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                     let buf = input.read().clone();
                     let pos = cursor.get();
                     if pos != buf.chars().count() {
+                        return;
+                    }
+                    // Slash completion runs first — its grammar is
+                    // start-of-input-only, so when it matches, the
+                    // `@`/`#` logic below never applies. Silent
+                    // fall-through on no match so a stale `/` with
+                    // no registry hit doesn't trap the user.
+                    if let Some(partial) = slash::find_slash_partial(&buf) {
+                        if let Some(hit) = slash::best_slash_completion(partial.partial) {
+                            let (next, new_cursor) = slash::apply_slash_completion(hit.name);
+                            input.set(next);
+                            cursor.set(new_cursor);
+                        }
                         return;
                     }
                     let caps = TermCaps::detect();

--- a/tools/attend-chat/src/app.rs
+++ b/tools/attend-chat/src/app.rs
@@ -18,7 +18,7 @@ use iocraft::prelude::*;
 use crate::chip::{chip_for, color_for, known_identities, resolve_nickname, CHIP_WIDTH};
 use crate::sessions::discover as discover_sessions;
 use crate::text_layout::{render_cursor, split_at_char, visual_line_count};
-use crate::groups::{resolve_group_dir, scan as scan_groups};
+use crate::groups::{channels, resolve_group_dir};
 use crate::legend::{
     apply_completion, best_completion, best_group_completion, find_trailing_mention,
     group_legend_row, legend_row, parse_addressed, Addressed, Sigil,
@@ -145,7 +145,7 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                                 .map(|hit| apply_completion(&buf, &mention, &hit.nickname))
                         }
                         Sigil::Group => {
-                            let groups = scan_groups(caps);
+                            let groups = channels(caps);
                             best_group_completion(mention.partial, &groups)
                                 .map(|hit| apply_completion(&buf, &mention, &hit.group.name))
                         }
@@ -253,7 +253,11 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
     //   do anyway. Simpler than caching with invalidation.
     let seed_sessions = discover_sessions();
     let known = known_identities(&signals.read(), &seed_sessions, caps);
-    let groups_known = scan_groups(caps);
+    // `channels` prepends the synthetic `#open` base and drops any
+    // lingering literal `open` group so the legend has a single
+    // commons chip (ADR-124 §1–§2). The base entry has empty
+    // membership, so it's a no-op for `session_to_groups` below.
+    let groups_known = channels(caps);
     // Pre-index session-id → groups once per render so the chip
     // loop is O(signals) instead of O(signals · groups · members).
     // At today's scale neither form matters, but the render path is

--- a/tools/attend-chat/src/groups.rs
+++ b/tools/attend-chat/src/groups.rs
@@ -39,11 +39,22 @@ pub struct GroupMembership {
 }
 
 /// One discovered group with its display identity baked in.
+///
+/// `is_base` marks the synthetic `#open` base channel — prepended by
+/// [`channels`] regardless of on-disk state. A base-channel entry has
+/// no membership and no underlying `@open/` directory; it's the TUI
+/// surface for `_broadcast/` (see [`BASE_CHANNEL_NAME`]).
 #[derive(Debug, Clone)]
 pub struct KnownGroup {
     pub group: Group,
     pub membership: GroupMembership,
+    pub is_base: bool,
 }
+
+/// Display name for the base channel rendered as `#open`. Also the
+/// disk name we filter out of the regular scan so a lingering
+/// `@open/` dir can't double-render as a second `#open` chip.
+pub const BASE_CHANNEL_NAME: &str = "open";
 
 /// Scan the signals base for groups.
 ///
@@ -77,6 +88,7 @@ pub fn scan_in(base: &Path, caps: TermCaps) -> Vec<KnownGroup> {
             Some(KnownGroup {
                 group: Group::for_name(&bare, caps),
                 membership,
+                is_base: false,
             })
         })
         .collect();
@@ -84,6 +96,37 @@ pub fn scan_in(base: &Path, caps: TermCaps) -> Vec<KnownGroup> {
     // Groups aren't temporally ordered the way agents are (no
     // "newest-seen" concept) — alpha is the least-surprising default.
     out.sort_by(|a, b| a.group.name.cmp(&b.group.name));
+    out
+}
+
+/// Channel-bar view: base `#open` followed by every discovered group.
+///
+/// The base channel is synthesised at the head of the list so it
+/// always renders leftmost and never depends on `@open/` existing on
+/// disk (per ADR-124 §1). Any literal `open` directory surfaced by
+/// [`scan`] is dropped — `#open` is the base's display name, and the
+/// real traffic rides `_broadcast/` under the hood (ADR-124 §2).
+///
+/// Groups after `#open` preserve the order [`scan`] returns them
+/// in — alphabetical today. Richer ordering (pinned, recent) is
+/// deferred per ADR-124 §3.
+pub fn channels(caps: TermCaps) -> Vec<KnownGroup> {
+    channels_in(&signals_base(), caps)
+}
+
+/// Test-seam counterpart to [`channels`] — same shape, arbitrary base.
+pub fn channels_in(base: &Path, caps: TermCaps) -> Vec<KnownGroup> {
+    let mut out = Vec::with_capacity(8);
+    out.push(KnownGroup {
+        group: Group::for_name(BASE_CHANNEL_NAME, caps),
+        membership: GroupMembership::default(),
+        is_base: true,
+    });
+    out.extend(
+        scan_in(base, caps)
+            .into_iter()
+            .filter(|g| g.group.name != BASE_CHANNEL_NAME),
+    );
     out
 }
 
@@ -165,9 +208,15 @@ fn parse_groups_yaml(content: &str) -> HashMap<String, GroupMembership> {
 }
 
 /// Resolve a `#name` addressed send to the group's signal directory.
+///
 /// Returns `None` if the named group has no on-disk dir (i.e. the
-/// user typed an unknown group name).
+/// user typed an unknown group name). The special name `"open"`
+/// resolves to `_broadcast/` — that's the base channel's
+/// on-disk home (ADR-124 §2); there is no `@open/` directory.
 pub fn resolve_group_dir(name: &str) -> Option<PathBuf> {
+    if name == BASE_CHANNEL_NAME {
+        return Some(crate::signal::broadcast_dir());
+    }
     let dir = signals_base().join(format!("{GROUP_PREFIX}{name}"));
     if dir.is_dir() {
         Some(dir)
@@ -197,6 +246,58 @@ mod tests {
     fn write_yaml(base: &Path, content: &str) {
         let mut f = fs::File::create(base.join("_groups.yaml")).unwrap();
         f.write_all(content.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn channels_prepends_base_with_empty_scan() {
+        // No groups on disk → the channel bar still shows `#open`.
+        // This is the ADR-124 §1 invariant: base never hides.
+        let base = tempdir_like();
+        let ch = channels_in(&base, TermCaps::Rich);
+        assert_eq!(ch.len(), 1);
+        assert!(ch[0].is_base);
+        assert_eq!(ch[0].group.name, BASE_CHANNEL_NAME);
+        assert!(ch[0].membership.members.is_empty());
+    }
+
+    #[test]
+    fn channels_base_leads_real_groups() {
+        let base = tempdir_like();
+        fs::create_dir_all(base.join("@deploy")).unwrap();
+        fs::create_dir_all(base.join("@infra")).unwrap();
+        let ch = channels_in(&base, TermCaps::Rich);
+        let names: Vec<_> = ch.iter().map(|c| c.group.name.as_str()).collect();
+        assert_eq!(names, vec!["open", "deploy", "infra"]);
+        assert!(ch[0].is_base);
+        assert!(!ch[1].is_base);
+        assert!(!ch[2].is_base);
+    }
+
+    #[test]
+    fn channels_drops_literal_open_dir() {
+        // A lingering `@open/` dir from before ADR-124 must not
+        // double-render. The synthetic base replaces it; real
+        // traffic rides `_broadcast/`.
+        let base = tempdir_like();
+        fs::create_dir_all(base.join("@open")).unwrap();
+        fs::create_dir_all(base.join("@deploy")).unwrap();
+        let ch = channels_in(&base, TermCaps::Rich);
+        let names: Vec<_> = ch.iter().map(|c| c.group.name.as_str()).collect();
+        // Exactly one `open` — the synthetic base — and `deploy`
+        // follows. The on-disk `@open/` is filtered out.
+        assert_eq!(names, vec!["open", "deploy"]);
+        assert!(ch[0].is_base);
+    }
+
+    #[test]
+    fn resolve_group_dir_open_routes_to_broadcast() {
+        // `#open` writes land in `_broadcast/` — ADR-124 §2.
+        // Point $HOME at a temp dir so the resolver doesn't touch
+        // the real cache.
+        let home = tempdir_like();
+        std::env::set_var("HOME", &home);
+        let dir = resolve_group_dir("open").expect("open must resolve");
+        assert_eq!(dir, crate::signal::broadcast_dir());
     }
 
     #[test]

--- a/tools/attend-chat/src/helper.rs
+++ b/tools/attend-chat/src/helper.rs
@@ -1,0 +1,216 @@
+//! Helper-row state machine.
+//!
+//! The row below the input box shows one of three registries — agents,
+//! groups, or slash commands — depending on what the user is typing.
+//! This module is the single source of truth for that decision.
+//!
+//! [`derive`] is a pure function of the input buffer. Given any
+//! string, it returns the [`HelperMode`] the render path should use.
+//! Deterministic, side-effect free, and covered by a table of unit
+//! tests that double as the state machine's visible specification
+//! — scroll to the bottom of this file to see every state and the
+//! input pattern that reaches it.
+//!
+//! ## States
+//!
+//! | State        | Entered when …                                | Partial underlined |
+//! |--------------|-----------------------------------------------|--------------------|
+//! | `Slash`      | buffer starts with `/`, still typing the name | yes, on command    |
+//! | `Agents`     | trailing `@partial`, OR default               | yes, on agent      |
+//! | `Groups`     | trailing `#partial`                           | yes, on group      |
+//! | `Agents/None`| past a slash command whose arg is [`ArgKind::Agent`] | no, until `@` typed |
+//! | `Groups/None`| past a slash command whose arg is [`ArgKind::Group`] | no, until `#` typed |
+//! | `Agents`     | past a slash command with [`ArgKind::None`]   | —                  |
+//!
+//! ## Extending
+//!
+//! Adding a new slash command that routes the helper: add a row to
+//! [`crate::slash::REGISTRY`] with the right [`ArgKind`]. No changes
+//! here — [`derive`] inspects the registry dynamically.
+
+use crate::legend::{find_trailing_mention, Sigil};
+use crate::slash::{self, ArgKind};
+
+/// Which registry the helper row should render right now. The
+/// `Option<String>` carries the current partial (what the user has
+/// typed after the sigil) so matching chips can underline for
+/// Tab-target affordance. `None` means "no active partial" — render
+/// the row without any underline.
+#[derive(Debug, PartialEq, Eq)]
+pub enum HelperMode {
+    Agents(Option<String>),
+    Groups(Option<String>),
+    Slash(Option<String>),
+}
+
+/// Derive the helper mode from the current input buffer.
+///
+/// Precedence:
+///
+/// 1. **Slash active.** Input starts with `/`:
+///    - still typing the name → [`HelperMode::Slash`] with partial.
+///    - past the name, argument phase → inspect the command's
+///      [`ArgKind`] and switch to the matching registry.
+///    - past the name, unknown command → stay on slash registry so
+///      the user can see valid options.
+/// 2. **Trailing mention.** A trailing `@partial` or `#partial`
+///    picks Agents or Groups respectively, with the partial under-
+///    lined.
+/// 3. **Default.** [`HelperMode::Agents`] with no partial — the
+///    "who's around" glance.
+pub fn derive(input: &str) -> HelperMode {
+    if let Some(mode) = derive_slash(input) {
+        return mode;
+    }
+    if let Some(mode) = derive_mention(input) {
+        return mode;
+    }
+    HelperMode::Agents(None)
+}
+
+fn derive_slash(input: &str) -> Option<HelperMode> {
+    if !input.starts_with('/') {
+        return None;
+    }
+    // Phase 1: still typing the command name.
+    if let Some(partial) = slash::find_slash_partial(input) {
+        return Some(HelperMode::Slash(Some(partial.partial.to_string())));
+    }
+    // Phase 2: past the name, in the argument(s). Inspect the
+    // command's ArgKind to pick the right registry.
+    let (name, args) = slash::parse(input)?;
+    let Some(cmd) = slash::lookup(name) else {
+        // Unknown command — keep the slash registry visible so the
+        // user can see what they might have meant.
+        return Some(HelperMode::Slash(None));
+    };
+    Some(match cmd.arg_kind {
+        ArgKind::None => HelperMode::Agents(None),
+        ArgKind::Agent => HelperMode::Agents(trailing_partial(args, Sigil::Agent)),
+        ArgKind::Group => HelperMode::Groups(trailing_partial(args, Sigil::Group)),
+    })
+}
+
+fn derive_mention(input: &str) -> Option<HelperMode> {
+    let ctx = find_trailing_mention(input)?;
+    Some(match ctx.sigil {
+        Sigil::Agent => HelperMode::Agents(Some(ctx.partial.to_string())),
+        Sigil::Group => HelperMode::Groups(Some(ctx.partial.to_string())),
+    })
+}
+
+/// Extract a trailing `@partial` or `#partial` from `input`, returning
+/// the partial text only if its sigil matches `expect`.
+fn trailing_partial(input: &str, expect: Sigil) -> Option<String> {
+    find_trailing_mention(input)
+        .filter(|m| m.sigil == expect)
+        .map(|m| m.partial.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    //! State machine's visible specification.
+    //!
+    //! Each test corresponds to one state-entry condition. Reading
+    //! the test names top-to-bottom is reading the rule table.
+
+    use super::*;
+
+    // ── Default + mention states ───────────────────────────────
+
+    #[test]
+    fn empty_input_defaults_to_agents() {
+        assert_eq!(derive(""), HelperMode::Agents(None));
+    }
+
+    #[test]
+    fn plain_text_defaults_to_agents() {
+        assert_eq!(derive("hello world"), HelperMode::Agents(None));
+    }
+
+    #[test]
+    fn trailing_at_partial_selects_agents() {
+        assert_eq!(derive("hi @Tam"), HelperMode::Agents(Some("Tam".into())));
+    }
+
+    #[test]
+    fn trailing_hash_partial_selects_groups() {
+        assert_eq!(derive("hi #dep"), HelperMode::Groups(Some("dep".into())));
+    }
+
+    // ── Slash: typing the command name ─────────────────────────
+
+    #[test]
+    fn bare_slash_shows_slash_with_empty_partial() {
+        assert_eq!(derive("/"), HelperMode::Slash(Some("".into())));
+    }
+
+    #[test]
+    fn slash_partial_name_shows_slash() {
+        assert_eq!(derive("/he"), HelperMode::Slash(Some("he".into())));
+    }
+
+    // ── Slash: past the name, ArgKind routing ──────────────────
+
+    #[test]
+    fn slash_help_space_stays_on_agents_as_default() {
+        // ArgKind::None → default registry (agents), no partial.
+        assert_eq!(derive("/help "), HelperMode::Agents(None));
+    }
+
+    #[test]
+    fn slash_whois_space_switches_to_agents_waiting_for_at() {
+        // ArgKind::Agent, no @ typed yet — Agents with no partial.
+        assert_eq!(derive("/whois "), HelperMode::Agents(None));
+    }
+
+    #[test]
+    fn slash_whois_with_at_partial_underlines_agent() {
+        // ArgKind::Agent, user is now typing @Ur — underline "Ur".
+        assert_eq!(
+            derive("/whois @Ur"),
+            HelperMode::Agents(Some("Ur".into()))
+        );
+    }
+
+    #[test]
+    fn slash_join_space_switches_to_groups() {
+        // ArgKind::Group, no # typed yet — Groups with no partial.
+        assert_eq!(derive("/join "), HelperMode::Groups(None));
+    }
+
+    #[test]
+    fn slash_join_with_hash_partial_underlines_group() {
+        assert_eq!(
+            derive("/join #dep"),
+            HelperMode::Groups(Some("dep".into()))
+        );
+    }
+
+    #[test]
+    fn slash_leave_space_switches_to_groups() {
+        // Second Group-arg command — confirms ArgKind routing isn't
+        // tied to a single command name.
+        assert_eq!(derive("/leave "), HelperMode::Groups(None));
+    }
+
+    // ── Slash: unknown / malformed ─────────────────────────────
+
+    #[test]
+    fn slash_unknown_command_keeps_slash_registry() {
+        // So the user can see what they might have meant.
+        assert_eq!(derive("/bogus "), HelperMode::Slash(None));
+        assert_eq!(derive("/bogus arg"), HelperMode::Slash(None));
+    }
+
+    // ── Precedence: slash wins over any other sigil ────────────
+
+    #[test]
+    fn slash_precedes_trailing_mention() {
+        // `/help @Tam` — even though there's a trailing @, the
+        // buffer starts with `/` and we're past the command name.
+        // ArgKind::None returns Agents(None), which tests the
+        // state machine's "slash wins" invariant.
+        assert_eq!(derive("/help @Tam"), HelperMode::Agents(None));
+    }
+}

--- a/tools/attend-chat/src/helper.rs
+++ b/tools/attend-chat/src/helper.rs
@@ -69,7 +69,10 @@ pub fn derive(input: &str) -> HelperMode {
 }
 
 fn derive_slash(input: &str) -> Option<HelperMode> {
-    if !input.starts_with('/') {
+    // Leading-whitespace tolerant, matching `slash::parse` and
+    // `slash::find_slash_partial`. " /help" is the same state as
+    // "/help" for routing purposes — see PR #66 review item S2.
+    if !input.trim_start().starts_with('/') {
         return None;
     }
     // Phase 1: still typing the command name.
@@ -212,5 +215,56 @@ mod tests {
         // ArgKind::None returns Agents(None), which tests the
         // state machine's "slash wins" invariant.
         assert_eq!(derive("/help @Tam"), HelperMode::Agents(None));
+    }
+
+    // ── Leading whitespace tolerance (PR #66 review S2) ────────
+
+    #[test]
+    fn slash_with_leading_space_enters_slash_state() {
+        // Stray leading space must not drop the buffer into mention
+        // or default mode — otherwise the Enter interceptor and the
+        // helper-row mode disagree on what the user is doing.
+        assert_eq!(derive(" /he"), HelperMode::Slash(Some("he".into())));
+        assert_eq!(derive("\t/"), HelperMode::Slash(Some("".into())));
+    }
+
+    #[test]
+    fn slash_with_leading_space_routes_arg_kind() {
+        // Past-the-name routing must also tolerate leading
+        // whitespace — otherwise `" /whois "` silently shows agents
+        // (the default) instead of agents-because-ArgKind.
+        // The observable state is the same, but the reasoning path
+        // differs; we want the state machine to take the Slash
+        // branch for consistency with Enter / Tab.
+        assert_eq!(derive(" /whois "), HelperMode::Agents(None));
+        assert_eq!(derive(" /join #dep"), HelperMode::Groups(Some("dep".into())));
+    }
+
+    // ── Extra states suggested in PR #66 review ────────────────
+
+    #[test]
+    fn agent_cmd_with_wrong_sigil_falls_back_to_default_agents() {
+        // `/whois #dep` — ArgKind::Agent but user typed `#`. The
+        // trailing-# doesn't satisfy the Agent filter, so the state
+        // is "agents waiting for @" (no partial) rather than
+        // hijacking to groups.
+        assert_eq!(derive("/whois #dep"), HelperMode::Agents(None));
+    }
+
+    #[test]
+    fn slash_agent_cmd_bare_at_yields_empty_partial() {
+        // The user committed to addressing but hasn't typed letters
+        // yet. Agents(Some("")) is the correct "everything matches
+        // trivially" state — no chip gets underlined because the
+        // underline rule requires a non-empty partial.
+        assert_eq!(derive("/whois @"), HelperMode::Agents(Some("".into())));
+    }
+
+    #[test]
+    fn leading_whitespace_no_slash_stays_on_default() {
+        // Plain leading whitespace without a slash is still default
+        // mode — the tolerance is surgical, not blanket.
+        assert_eq!(derive(" hello"), HelperMode::Agents(None));
+        assert_eq!(derive("   "), HelperMode::Agents(None));
     }
 }

--- a/tools/attend-chat/src/legend.rs
+++ b/tools/attend-chat/src/legend.rs
@@ -250,7 +250,14 @@ pub fn group_legend_row(
                 .map(|p| !p.is_empty() && k.group.name.to_ascii_lowercase().starts_with(p))
                 .unwrap_or(false);
             let color = color_for(k.group.palette, caps);
-            let weight = if k.group.style.bold || matches { Weight::Bold } else { Weight::Normal };
+            // Base channel (`#open`) always renders bold as the
+            // visual affordance for "this is the commons" —
+            // ADR-124 §4. Partial-match underline still overlays.
+            let weight = if k.is_base || k.group.style.bold || matches {
+                Weight::Bold
+            } else {
+                Weight::Normal
+            };
             let italic = k.group.style.italic;
             let decoration = if matches { TextDecoration::Underline } else { TextDecoration::None };
             let content = format!("{} #{} ", k.group.glyph, k.group.name);

--- a/tools/attend-chat/src/lib.rs
+++ b/tools/attend-chat/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod app;
 pub mod chip;
 pub mod groups;
+pub mod helper;
 pub mod legend;
 pub mod sessions;
 pub mod signal;

--- a/tools/attend-chat/src/lib.rs
+++ b/tools/attend-chat/src/lib.rs
@@ -11,5 +11,6 @@ pub mod groups;
 pub mod legend;
 pub mod sessions;
 pub mod signal;
+pub mod slash;
 pub mod text_layout;
 pub mod watcher;

--- a/tools/attend-chat/src/slash.rs
+++ b/tools/attend-chat/src/slash.rs
@@ -23,6 +23,8 @@
 //! command lands, flip its [`Status`] to [`Status::Implemented`] and
 //! add a handler arm in [`dispatch`].
 
+use iocraft::prelude::*;
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Status {
     /// Wired into [`dispatch`]. Runs when invoked.
@@ -160,6 +162,57 @@ pub fn dispatch(name: &str, _args: &str) -> SlashOutcome {
             cmd.name, cmd.description
         )),
     }
+}
+
+/// Render the slash-command legend row — one chip per registered
+/// command. Implemented entries render in a full-weight foreground
+/// color; planned entries dim so the roadmap is visible without
+/// looking equally available. Matching names underline when the
+/// caller passes the current partial (Tab-target affordance, same
+/// idiom as the agent / group legends).
+pub fn slash_legend_row(current_partial: Option<&str>) -> Vec<AnyElement<'static>> {
+    let lc_partial = current_partial.map(|p| p.to_ascii_lowercase());
+    let chips: Vec<AnyElement<'static>> = REGISTRY
+        .iter()
+        .map(|cmd| {
+            let matches = lc_partial
+                .as_ref()
+                .map(|p| !p.is_empty() && cmd.name.to_ascii_lowercase().starts_with(p))
+                .unwrap_or(false);
+            // Slash commands aren't identities, so they don't carry
+            // palette hashing — a uniform Cyan for ready, DarkGrey
+            // for planned keeps the bar readable without adding new
+            // visual dimensions the user has to learn.
+            let color = match cmd.status {
+                Status::Implemented => Color::Cyan,
+                Status::Planned => Color::DarkGrey,
+            };
+            let weight = if matches { Weight::Bold } else { Weight::Normal };
+            let decoration = if matches {
+                TextDecoration::Underline
+            } else {
+                TextDecoration::None
+            };
+            let content = format!("/{} ", cmd.name);
+            element! {
+                Text(color, weight, decoration, content, wrap: TextWrap::NoWrap)
+            }
+            .into_any()
+        })
+        .collect();
+    vec![element! {
+        View(
+            flex_direction: FlexDirection::Row,
+            padding_left: 1,
+            padding_right: 1,
+            height: 1u32,
+            flex_shrink: 0.0,
+            overflow: Overflow::Hidden,
+        ) {
+            #(chips)
+        }
+    }
+    .into_any()]
 }
 
 fn help_message() -> String {

--- a/tools/attend-chat/src/slash.rs
+++ b/tools/attend-chat/src/slash.rs
@@ -1,0 +1,306 @@
+//! Slash-command parser, registry, and autocomplete.
+//!
+//! Slash commands are a TUI-local grammar: they never touch the
+//! signal bus. A message beginning with `/` is intercepted in the
+//! Enter handler and dispatched here; everything else falls through
+//! to the `@`/`#`/plain-text send paths in `app.rs`.
+//!
+//! The grammar differs from `@Name` and `#group`:
+//! - mentions can appear anywhere in a message body
+//! - slash commands are start-of-input only — a `/` mid-sentence is a
+//!   literal slash, not a command sigil
+//!
+//! Because of that asymmetry, parse + completion live in their own
+//! module instead of being retrofitted into [`crate::legend`]. Agent
+//! / group legends and slash completion share only the spirit of
+//! "Tab completes the partial you're typing" — the plumbing is
+//! distinct.
+//!
+//! **Scope.** Today `/help` is the only dispatched command. Other
+//! names in [`REGISTRY`] are advertised as planned so autocomplete
+//! can surface them and `/help` can print the roadmap; dispatching
+//! them returns a "not implemented yet" status. When a planned
+//! command lands, flip its [`Status`] to [`Status::Implemented`] and
+//! add a handler arm in [`dispatch`].
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Status {
+    /// Wired into [`dispatch`]. Runs when invoked.
+    Implemented,
+    /// Listed for autocomplete + `/help` visibility, but dispatch
+    /// short-circuits to a "coming soon" status message.
+    Planned,
+}
+
+/// One row of the slash-command registry.
+#[derive(Copy, Clone, Debug)]
+pub struct SlashCommand {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub status: Status,
+}
+
+/// Every slash command the TUI knows about. Implemented ones
+/// dispatch; planned ones autocomplete and show up in `/help` so
+/// agents can see the roadmap without reading code.
+pub const REGISTRY: &[SlashCommand] = &[
+    SlashCommand {
+        name: "help",
+        description: "List available commands",
+        status: Status::Implemented,
+    },
+    SlashCommand {
+        name: "whois",
+        description: "Show a peer's identity + cwd",
+        status: Status::Planned,
+    },
+    SlashCommand {
+        name: "peers",
+        description: "List active claudes + humans",
+        status: Status::Planned,
+    },
+    SlashCommand {
+        name: "join",
+        description: "Join a focus group",
+        status: Status::Planned,
+    },
+    SlashCommand {
+        name: "leave",
+        description: "Leave a focus group",
+        status: Status::Planned,
+    },
+    SlashCommand {
+        name: "clear",
+        description: "Clear the message buffer",
+        status: Status::Planned,
+    },
+];
+
+/// Parse a slash command from the input buffer.
+///
+/// Returns `Some((name, args))` if `input` begins with `/` followed
+/// by a non-empty name; args is whatever follows the first whitespace
+/// run, trimmed of its leading spaces. Returns `None` for plain text,
+/// a bare `/`, or a `/ ` followed by whitespace.
+pub fn parse(input: &str) -> Option<(&str, &str)> {
+    let rest = input.strip_prefix('/')?;
+    let end = rest
+        .char_indices()
+        .find(|(_, c)| c.is_whitespace())
+        .map(|(i, _)| i)
+        .unwrap_or(rest.len());
+    if end == 0 {
+        return None;
+    }
+    let name = &rest[..end];
+    let args = rest[end..].trim_start();
+    Some((name, args))
+}
+
+/// Partial slash command at the head of the input — the autocomplete
+/// gate. Returns `Some` only while the user is still typing the
+/// *name*: a space after the name means completion is done and args
+/// are being typed.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SlashPartial<'a> {
+    pub partial: &'a str,
+}
+
+pub fn find_slash_partial(input: &str) -> Option<SlashPartial<'_>> {
+    let rest = input.strip_prefix('/')?;
+    if rest.contains(char::is_whitespace) {
+        return None;
+    }
+    Some(SlashPartial { partial: rest })
+}
+
+/// Find the best match for `partial` in the registry. Case-
+/// insensitive prefix match; first hit in registry order wins (so
+/// the order in [`REGISTRY`] doubles as completion priority).
+pub fn best_slash_completion(partial: &str) -> Option<&'static SlashCommand> {
+    let lc = partial.to_ascii_lowercase();
+    REGISTRY
+        .iter()
+        .find(|c| c.name.to_ascii_lowercase().starts_with(&lc))
+}
+
+/// Apply a completion: replace the whole buffer with `/<name> ` and
+/// place the cursor after the trailing space, ready for args.
+pub fn apply_slash_completion(full_name: &str) -> (String, usize) {
+    let out = format!("/{full_name} ");
+    let cursor = out.chars().count();
+    (out, cursor)
+}
+
+/// Outcome of dispatching a parsed slash command.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SlashOutcome {
+    /// Status message to show; clear the input buffer.
+    Ok(String),
+    /// Status message to show; *keep* the input so the user can
+    /// edit + retry (typical for unknown / malformed commands).
+    Err(String),
+}
+
+/// Dispatch a parsed slash command.
+pub fn dispatch(name: &str, _args: &str) -> SlashOutcome {
+    let Some(cmd) = REGISTRY.iter().find(|c| c.name == name) else {
+        return SlashOutcome::Err(format!("unknown: /{name} (try /help)"));
+    };
+    match cmd.status {
+        Status::Implemented => match cmd.name {
+            "help" => SlashOutcome::Ok(help_message()),
+            // Keeps the match exhaustive — if a registry entry flips
+            // to Implemented without a handler arm, this fires at
+            // runtime rather than silently treating it as planned.
+            other => SlashOutcome::Err(format!("/{other}: registered but unhandled")),
+        },
+        Status::Planned => SlashOutcome::Err(format!(
+            "/{}: {} — not implemented yet",
+            cmd.name, cmd.description
+        )),
+    }
+}
+
+fn help_message() -> String {
+    let mut ready: Vec<String> = Vec::new();
+    let mut planned: Vec<String> = Vec::new();
+    for c in REGISTRY {
+        let label = format!("/{}", c.name);
+        match c.status {
+            Status::Implemented => ready.push(label),
+            Status::Planned => planned.push(label),
+        }
+    }
+    format!(
+        "available: {} · planned: {}",
+        ready.join(" "),
+        planned.join(" ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_bare_command() {
+        assert_eq!(parse("/help"), Some(("help", "")));
+    }
+
+    #[test]
+    fn parse_command_with_args() {
+        assert_eq!(parse("/whois @Urban"), Some(("whois", "@Urban")));
+    }
+
+    #[test]
+    fn parse_collapses_leading_arg_whitespace() {
+        assert_eq!(parse("/whois    @Urban"), Some(("whois", "@Urban")));
+    }
+
+    #[test]
+    fn parse_rejects_bare_slash() {
+        assert_eq!(parse("/"), None);
+    }
+
+    #[test]
+    fn parse_rejects_slash_space() {
+        // `/ foo` — no command name, just a stray slash.
+        assert_eq!(parse("/ foo"), None);
+    }
+
+    #[test]
+    fn parse_rejects_plain_text() {
+        assert_eq!(parse("hello /help"), None);
+        assert_eq!(parse("hello"), None);
+        assert_eq!(parse(""), None);
+    }
+
+    #[test]
+    fn slash_partial_while_typing_name() {
+        let p = find_slash_partial("/hel").unwrap();
+        assert_eq!(p.partial, "hel");
+    }
+
+    #[test]
+    fn slash_partial_bare_slash_is_empty() {
+        let p = find_slash_partial("/").unwrap();
+        assert_eq!(p.partial, "");
+    }
+
+    #[test]
+    fn slash_partial_stops_after_space() {
+        // Past the command name — completion no longer applies.
+        assert!(find_slash_partial("/help ").is_none());
+        assert!(find_slash_partial("/whois @Ur").is_none());
+    }
+
+    #[test]
+    fn slash_partial_rejects_non_slash_input() {
+        assert!(find_slash_partial("hello").is_none());
+        assert!(find_slash_partial("").is_none());
+    }
+
+    #[test]
+    fn best_completion_matches_prefix_case_insensitive() {
+        let c = best_slash_completion("he").unwrap();
+        assert_eq!(c.name, "help");
+        let c = best_slash_completion("HE").unwrap();
+        assert_eq!(c.name, "help");
+    }
+
+    #[test]
+    fn best_completion_empty_partial_picks_first() {
+        // A bare `/` + Tab should complete to the first registry
+        // entry — the most visible command gets the zero-friction
+        // path.
+        let c = best_slash_completion("").unwrap();
+        assert_eq!(c.name, REGISTRY[0].name);
+    }
+
+    #[test]
+    fn best_completion_none_on_miss() {
+        assert!(best_slash_completion("zzzzz").is_none());
+    }
+
+    #[test]
+    fn apply_completion_adds_trailing_space() {
+        let (out, cursor) = apply_slash_completion("help");
+        assert_eq!(out, "/help ");
+        assert_eq!(cursor, "/help ".chars().count());
+    }
+
+    #[test]
+    fn dispatch_help_lists_commands() {
+        let SlashOutcome::Ok(s) = dispatch("help", "") else {
+            panic!("help should dispatch Ok")
+        };
+        assert!(s.contains("/help"));
+        // At least one planned command surfaces — roadmap visibility.
+        assert!(s.contains("planned"));
+    }
+
+    #[test]
+    fn dispatch_unknown_returns_err() {
+        let SlashOutcome::Err(s) = dispatch("bogus", "") else {
+            panic!("unknown should dispatch Err")
+        };
+        assert!(s.contains("unknown"));
+        assert!(s.contains("/bogus"));
+    }
+
+    #[test]
+    fn dispatch_planned_returns_err_with_not_implemented() {
+        // Pick any Planned command from the registry — keeps the
+        // test valid as planned/implemented sets shift.
+        let planned = REGISTRY
+            .iter()
+            .find(|c| c.status == Status::Planned)
+            .expect("registry must contain at least one planned command while slash infra is new");
+        let SlashOutcome::Err(s) = dispatch(planned.name, "") else {
+            panic!("planned should dispatch Err")
+        };
+        assert!(s.contains("not implemented"));
+        assert!(s.contains(planned.name));
+    }
+}

--- a/tools/attend-chat/src/slash.rs
+++ b/tools/attend-chat/src/slash.rs
@@ -112,12 +112,17 @@ pub fn lookup(name: &str) -> Option<&'static SlashCommand> {
 
 /// Parse a slash command from the input buffer.
 ///
-/// Returns `Some((name, args))` if `input` begins with `/` followed
-/// by a non-empty name; args is whatever follows the first whitespace
-/// run, trimmed of its leading spaces. Returns `None` for plain text,
-/// a bare `/`, or a `/ ` followed by whitespace.
+/// Returns `Some((name, args))` if `input` begins (optionally after
+/// leading whitespace) with `/` followed by a non-empty name; args
+/// is whatever follows the first whitespace run, trimmed of its
+/// leading spaces. Returns `None` for plain text, a bare `/`, or a
+/// `/ ` followed by whitespace.
+///
+/// Leading-whitespace tolerance means `" /help"` parses identically
+/// to `"/help"` — the user who stray-spaces their command shouldn't
+/// get silently routed onto the signal bus as a peer message.
 pub fn parse(input: &str) -> Option<(&str, &str)> {
-    let rest = input.strip_prefix('/')?;
+    let rest = input.trim_start().strip_prefix('/')?;
     let end = rest
         .char_indices()
         .find(|(_, c)| c.is_whitespace())
@@ -141,7 +146,10 @@ pub struct SlashPartial<'a> {
 }
 
 pub fn find_slash_partial(input: &str) -> Option<SlashPartial<'_>> {
-    let rest = input.strip_prefix('/')?;
+    // Mirror [`parse`]'s leading-whitespace tolerance so every caller
+    // (Enter interceptor, Tab completion, helper-row state machine)
+    // sees the same "starts with `/`" predicate.
+    let rest = input.trim_start().strip_prefix('/')?;
     if rest.contains(char::is_whitespace) {
         return None;
     }
@@ -302,6 +310,15 @@ mod tests {
     }
 
     #[test]
+    fn parse_tolerates_leading_whitespace() {
+        // A stray space in front of `/help` should not leak onto
+        // the signal bus as a peer message — the interceptor
+        // relies on this predicate.
+        assert_eq!(parse(" /help"), Some(("help", "")));
+        assert_eq!(parse("\t/whois @Urban"), Some(("whois", "@Urban")));
+    }
+
+    #[test]
     fn slash_partial_while_typing_name() {
         let p = find_slash_partial("/hel").unwrap();
         assert_eq!(p.partial, "hel");
@@ -324,6 +341,17 @@ mod tests {
     fn slash_partial_rejects_non_slash_input() {
         assert!(find_slash_partial("hello").is_none());
         assert!(find_slash_partial("").is_none());
+    }
+
+    #[test]
+    fn slash_partial_tolerates_leading_whitespace() {
+        // Mirror of `parse_tolerates_leading_whitespace` for the
+        // completion-gate path — the helper row and Tab handler
+        // both depend on this agreeing with `parse`.
+        let p = find_slash_partial(" /he").unwrap();
+        assert_eq!(p.partial, "he");
+        let p = find_slash_partial("  /").unwrap();
+        assert_eq!(p.partial, "");
     }
 
     #[test]

--- a/tools/attend-chat/src/slash.rs
+++ b/tools/attend-chat/src/slash.rs
@@ -34,12 +34,30 @@ pub enum Status {
     Planned,
 }
 
+/// What registry the helper row should switch to once the user is
+/// past a command's name and typing its argument. The app-side
+/// state machine in `crate::helper` reads this to pick the right
+/// chip source — keeping the "which commands expect which kind of
+/// argument" data next to the command definition itself, so adding
+/// a command means adding one row here and nothing elsewhere.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ArgKind {
+    /// Command takes no argument. Helper stays on the default
+    /// (agents) once the name is complete.
+    None,
+    /// Expects an `@Agent`. Helper switches to the agent legend.
+    Agent,
+    /// Expects a `#group`. Helper switches to the channel legend.
+    Group,
+}
+
 /// One row of the slash-command registry.
 #[derive(Copy, Clone, Debug)]
 pub struct SlashCommand {
     pub name: &'static str,
     pub description: &'static str,
     pub status: Status,
+    pub arg_kind: ArgKind,
 }
 
 /// Every slash command the TUI knows about. Implemented ones
@@ -50,33 +68,47 @@ pub const REGISTRY: &[SlashCommand] = &[
         name: "help",
         description: "List available commands",
         status: Status::Implemented,
+        arg_kind: ArgKind::None,
     },
     SlashCommand {
         name: "whois",
         description: "Show a peer's identity + cwd",
         status: Status::Planned,
+        arg_kind: ArgKind::Agent,
     },
     SlashCommand {
         name: "peers",
         description: "List active claudes + humans",
         status: Status::Planned,
+        arg_kind: ArgKind::None,
     },
     SlashCommand {
         name: "join",
         description: "Join a focus group",
         status: Status::Planned,
+        arg_kind: ArgKind::Group,
     },
     SlashCommand {
         name: "leave",
         description: "Leave a focus group",
         status: Status::Planned,
+        arg_kind: ArgKind::Group,
     },
     SlashCommand {
         name: "clear",
         description: "Clear the message buffer",
         status: Status::Planned,
+        arg_kind: ArgKind::None,
     },
 ];
+
+/// Look up a registered command by name (exact match, case-sensitive).
+/// The helper state machine uses this to inspect `arg_kind` once the
+/// user is past the name; callers that need prefix matching use
+/// [`best_slash_completion`] instead.
+pub fn lookup(name: &str) -> Option<&'static SlashCommand> {
+    REGISTRY.iter().find(|c| c.name == name)
+}
 
 /// Parse a slash command from the input buffer.
 ///

--- a/tools/attend/src/cmd/focus.rs
+++ b/tools/attend/src/cmd/focus.rs
@@ -83,12 +83,12 @@ pub(crate) fn cmd_focus_new(args: &[String]) {
         Some("all") => {
             r.cleanup_stale();
             let all = r.all_groups();
-            if all.is_empty() {
-                println!("no active focus groups");
-                return;
-            }
             let mut t = agent_fmt::Table::new(&["Focus", "Members", "Pinned"]);
             t.align(1, agent_fmt::Align::Right);
+            // ADR-124 §I.4: base channel leads the list, mirrors the
+            // TUI's leftmost rule. `(all)` captures the fact that
+            // every peer is implicitly subscribed.
+            t.add(vec!["#open", "(all)", "(base)"]);
             for (name, count, pinned) in &all {
                 t.add(vec![
                     name.as_str(),

--- a/tools/attend/src/cmd/inbox.rs
+++ b/tools/attend/src/cmd/inbox.rs
@@ -165,7 +165,7 @@ pub(crate) fn cmd_inbox() {
             .unwrap_or("?")
             .to_string();
         let scope = if dir_name == "_broadcast" {
-            "broadcast"
+            "#open"
         } else if dir_name == own_encoded {
             "project"
         } else {

--- a/tools/attend/src/cmd/run.rs
+++ b/tools/attend/src/cmd/run.rs
@@ -122,6 +122,16 @@ pub(crate) fn cmd_run_with_catchup(catchup: bool) {
     let session_id = own_session_id().unwrap_or_else(|| format!("pid-{}", std::process::id()));
     let group_mgr = groups::Groups::new(&signals_base(), &session_id);
 
+    // ADR-124 one-shot: fold any lingering `@open/` group into the
+    // `_broadcast/` base. Idempotent — a no-op once there's nothing
+    // left to move, which is the common case after the first
+    // post-upgrade startup.
+    if let Some(moved) = groups::migrate_legacy_open_group(&signals_base(), &group_mgr) {
+        emit::log(&format!(
+            "migrated legacy @open/ → _broadcast/ ({moved} signal(s) moved)"
+        ));
+    }
+
     // Self-documenting startup
     let my_groups = group_mgr.my_groups();
     let focus_desc = if my_groups.is_empty() {
@@ -240,7 +250,7 @@ pub(crate) fn cmd_run_with_catchup(catchup: bool) {
         println!("[attend] restarted (unchanged)");
     } else {
         println!(
-            "[attend] v{} ({}) — sensors: {} | focus: {} | send: attend send <msg> (broadcast)",
+            "[attend] v{} ({}) — sensors: {} | focus: {} | send: attend send <msg> (#open)",
             env!("CARGO_PKG_VERSION"),
             env!("ATTEND_COMMIT"),
             sensor_list,

--- a/tools/attend/src/cmd/send.rs
+++ b/tools/attend/src/cmd/send.rs
@@ -165,7 +165,7 @@ pub(crate) fn cmd_send(args: &[String]) {
     } else if target_dir.is_some() {
         "directed"
     } else {
-        "broadcast"
+        "#open"
     };
 
     for dest_dir in &dest_dirs {

--- a/tools/attend/src/cmd/status.rs
+++ b/tools/attend/src/cmd/status.rs
@@ -63,7 +63,7 @@ pub(crate) fn cmd_status() {
 
     // ── Signals section
     t.add(vec!["signals", "project", &format!("{own_count} pending")]);
-    t.add(vec!["", "broadcast", &format!("{broadcast_count} pending")]);
+    t.add(vec!["", "#open", &format!("{broadcast_count} pending")]);
 
     // ── Separator
     t.add(vec!["", "", ""]);

--- a/tools/attend/src/groups.rs
+++ b/tools/attend/src/groups.rs
@@ -251,10 +251,61 @@ fn validate_group_name(name: &str) -> Result<(), String> {
     if name.contains('/') || name.contains(' ') {
         return Err("group name cannot contain / or spaces".to_string());
     }
-    if name == "broadcast" {
-        return Err("'broadcast' is reserved".to_string());
+    // `broadcast` backs `_broadcast/`; `open` is the display name of
+    // the base channel (ADR-124) — both would alias the commons if
+    // we let a user create an explicit group with either name.
+    if name == "broadcast" || name == "open" {
+        return Err(format!("'{name}' is reserved"));
     }
     Ok(())
+}
+
+/// One-shot migration for the legacy `@open/` focus group.
+///
+/// Pre-ADR-124 the `open` scene would create an `@open/` dir alongside
+/// `_broadcast/`; post-ADR the base channel is `_broadcast/` and the
+/// display name is `#open` (no `@open/` on disk). This helper makes
+/// `attend run` idempotently clean up lingering state on the next
+/// startup after an upgrade:
+///
+/// - move any `*.signal` files from `@open/` to `_broadcast/`
+/// - delete `@open/` and strip the `open:` entry from `_groups.yaml`
+///
+/// Returns the number of signal files moved, or `None` if there was
+/// nothing to migrate (the common case after the first post-upgrade
+/// run). A returned `Some(0)` means `@open/` existed but was empty —
+/// still worth logging since we removed an empty dir.
+pub fn migrate_legacy_open_group(signals_base: &Path, groups: &Groups) -> Option<usize> {
+    let open_dir = signals_base.join("@open");
+    if !open_dir.is_dir() {
+        return None;
+    }
+    let broadcast_dir = signals_base.join("_broadcast");
+    fs::create_dir_all(&broadcast_dir).ok();
+
+    let mut moved = 0;
+    if let Ok(entries) = fs::read_dir(&open_dir) {
+        for entry in entries.filter_map(|e| e.ok()) {
+            let src = entry.path();
+            if src.extension().and_then(|s| s.to_str()) != Some("signal") {
+                continue;
+            }
+            let Some(name) = src.file_name() else { continue };
+            let dst = broadcast_dir.join(name);
+            // Prefer rename (atomic, intra-fs); fall back to copy+remove
+            // when rename fails (e.g. cross-device — unlikely here but
+            // defensive). Ignore errors per-file: best-effort migration.
+            if fs::rename(&src, &dst).is_ok() {
+                moved += 1;
+            } else if fs::copy(&src, &dst).is_ok() {
+                fs::remove_file(&src).ok();
+                moved += 1;
+            }
+        }
+    }
+    // `dissolve` handles the _groups.yaml edit + removes the dir.
+    groups.dissolve("open");
+    Some(moved)
 }
 
 /// Check if a Claude Code session is still alive by looking for its lock dir.
@@ -378,6 +429,67 @@ mod tests {
         assert!(validate_group_name("has/slash").is_err());
         assert!(validate_group_name("has space").is_err());
         assert!(validate_group_name("broadcast").is_err());
+        // ADR-124: `open` is the base channel display name — reserved
+        // so nobody can shadow it with a real focus group.
+        assert!(validate_group_name("open").is_err());
+    }
+
+    #[test]
+    fn migrate_legacy_open_noop_when_absent() {
+        // No `@open/` → returns None. Idempotent fast path on
+        // subsequent startups.
+        let base = std::env::temp_dir().join(format!(
+            "attend-migrate-noop-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        fs::create_dir_all(&base).unwrap();
+        let mgr = Groups::new(&base, "sess-test");
+        assert!(migrate_legacy_open_group(&base, &mgr).is_none());
+    }
+
+    #[test]
+    fn migrate_legacy_open_moves_signals_and_drops_dir() {
+        let base = std::env::temp_dir().join(format!(
+            "attend-migrate-move-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        let open_dir = base.join("@open");
+        fs::create_dir_all(&open_dir).unwrap();
+        fs::write(open_dir.join("a.signal"), "from|proj|/x|hi\n").unwrap();
+        fs::write(open_dir.join("b.signal"), "from|proj|/x|bye\n").unwrap();
+        // A non-signal file — must be left alone (still in
+        // @open/, until dissolve drops the dir).
+        fs::write(open_dir.join("notes.txt"), "scratch").unwrap();
+
+        // Pre-seed the `open` group in _groups.yaml so dissolve has
+        // something to remove. Written directly because `join` now
+        // rejects `"open"` as reserved — this simulates state left
+        // by a pre-ADR-124 binary.
+        fs::write(
+            base.join("_groups.yaml"),
+            "open:\n  pinned: false\n  members:\n    - sess-test\n",
+        )
+        .unwrap();
+        let mgr = Groups::new(&base, "sess-test");
+
+        let moved = migrate_legacy_open_group(&base, &mgr).unwrap();
+        assert_eq!(moved, 2);
+
+        let broadcast_dir = base.join("_broadcast");
+        assert!(broadcast_dir.join("a.signal").exists());
+        assert!(broadcast_dir.join("b.signal").exists());
+        assert!(!open_dir.exists(), "@open/ should be gone after dissolve");
+        // _groups.yaml should no longer mention `open`.
+        let yaml = fs::read_to_string(base.join("_groups.yaml")).unwrap_or_default();
+        assert!(!yaml.contains("open:"));
     }
 
     #[test]

--- a/tools/attend/src/groups.rs
+++ b/tools/attend/src/groups.rs
@@ -139,6 +139,15 @@ impl Groups {
             .collect()
     }
 
+    /// Whether `_groups.yaml` currently has an entry for `name`.
+    /// Exists so callers (notably the ADR-124 migration) can avoid
+    /// triggering a full `save_state` rewrite when the work is
+    /// already done — narrows the read-modify-write window against
+    /// peer sessions editing the same file.
+    pub fn has_group(&self, name: &str) -> bool {
+        self.load_state().contains_key(name)
+    }
+
     /// List all active rooms with member counts and pin state.
     pub fn all_groups(&self) -> Vec<(String, usize, bool)> {
         let state = self.load_state();
@@ -268,13 +277,22 @@ fn validate_group_name(name: &str) -> Result<(), String> {
 /// `attend run` idempotently clean up lingering state on the next
 /// startup after an upgrade:
 ///
-/// - move any `*.signal` files from `@open/` to `_broadcast/`
-/// - delete `@open/` and strip the `open:` entry from `_groups.yaml`
+/// - move any `*.signal` files from `@open/` into `_broadcast/`
+/// - remove the `@open/` dir and — if present — strip the `open:`
+///   entry from `_groups.yaml`
+///
+/// **Non-signal files are destroyed.** The directory is removed
+/// wholesale after the signal files are migrated; any `.tmp`, stray
+/// lockfiles, or hand-placed notes under `@open/` go with it.
+/// That's acceptable under attend's "only attend writes to its own
+/// signal base" contract — no legitimate caller should have put
+/// anything else there — but noted explicitly so nobody is surprised
+/// later.
 ///
 /// Returns the number of signal files moved, or `None` if there was
 /// nothing to migrate (the common case after the first post-upgrade
-/// run). A returned `Some(0)` means `@open/` existed but was empty —
-/// still worth logging since we removed an empty dir.
+/// run). `Some(0)` means `@open/` existed but had no signal files
+/// to move — we still removed the dir, which is worth logging.
 pub fn migrate_legacy_open_group(signals_base: &Path, groups: &Groups) -> Option<usize> {
     let open_dir = signals_base.join("@open");
     if !open_dir.is_dir() {
@@ -303,8 +321,16 @@ pub fn migrate_legacy_open_group(signals_base: &Path, groups: &Groups) -> Option
             }
         }
     }
-    // `dissolve` handles the _groups.yaml edit + removes the dir.
-    groups.dissolve("open");
+    // Only drive `dissolve` (full `_groups.yaml` rewrite) when the
+    // yaml actually has an `open:` entry to remove — otherwise the
+    // migration pays a read-modify-write on every startup for no
+    // reason, widening a race window against peer-session edits on
+    // shared signal bases.
+    if groups.has_group("open") {
+        groups.dissolve("open");
+    } else {
+        fs::remove_dir_all(&open_dir).ok();
+    }
     Some(moved)
 }
 
@@ -449,6 +475,54 @@ mod tests {
         fs::create_dir_all(&base).unwrap();
         let mgr = Groups::new(&base, "sess-test");
         assert!(migrate_legacy_open_group(&base, &mgr).is_none());
+    }
+
+    #[test]
+    fn migrate_legacy_open_skips_yaml_rewrite_when_no_entry() {
+        // PR #66 review S3: the migration must not rewrite
+        // _groups.yaml when `open:` isn't present. A user who
+        // hand-made `@open/` without an attend scene shouldn't
+        // trigger a yaml churn that races peer sessions.
+        let base = std::env::temp_dir().join(format!(
+            "attend-migrate-noyaml-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        fs::create_dir_all(base.join("@open")).unwrap();
+        fs::write(
+            base.join("@open").join("a.signal"),
+            "from|proj|/x|hi\n",
+        )
+        .unwrap();
+        // Seed _groups.yaml with a *different* group so we can
+        // observe whether the migration rewrites it. If it rewrites
+        // without real work, the mtime will bump.
+        let yaml_path = base.join("_groups.yaml");
+        fs::write(
+            &yaml_path,
+            "infra:\n  pinned: false\n  members:\n    - sess-x\n",
+        )
+        .unwrap();
+        let before = fs::metadata(&yaml_path).unwrap().modified().unwrap();
+
+        let mgr = Groups::new(&base, "sess-test");
+        let moved = migrate_legacy_open_group(&base, &mgr).unwrap();
+        assert_eq!(moved, 1);
+        assert!(base.join("_broadcast").join("a.signal").exists());
+        assert!(!base.join("@open").exists());
+
+        // The canary yaml was not rewritten — the mtime is
+        // unchanged. (On fast filesystems the resolution may match,
+        // but the actual file-content invariant is the reliable
+        // signal, so check both.)
+        let after = fs::metadata(&yaml_path).unwrap().modified().unwrap();
+        let contents = fs::read_to_string(&yaml_path).unwrap();
+        assert_eq!(before, after, "yaml must not be rewritten");
+        assert!(contents.contains("infra:"));
+        assert!(!contents.contains("open:"));
     }
 
     #[test]

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -136,7 +136,7 @@ fn main() {
                 ],
             );
             println!();
-            println!("  send defaults to broadcast (reaches every peer and Aaron).");
+            println!("  send defaults to #open, the base channel (reaches every peer and Aaron).");
             agent_fmt::print_commands(
                 "send flags (rarely needed)",
                 &[

--- a/tools/attend/src/scenes.rs
+++ b/tools/attend/src/scenes.rs
@@ -5,7 +5,10 @@
 //!
 //! Built-in defaults:
 //!   private — leave all focus groups (project scope only)
-//!   open    — join the well-known "open" group
+//!
+//! `open` used to be a scene preset that joined an `@open/` group;
+//! ADR-124 folded it into the `#open` base channel (which everyone
+//! is always in implicitly), so the preset was removed.
 
 use std::collections::HashMap;
 use std::fs;
@@ -23,9 +26,9 @@ pub struct Scene {
 pub fn load_scenes() -> HashMap<String, Scene> {
     let mut scenes = HashMap::new();
 
-    // Built-in defaults
+    // Built-in defaults. `open` used to live here; it's now the
+    // `#open` base channel (ADR-124) — implicit for every peer.
     scenes.insert("private".to_string(), Scene { rooms: Vec::new() });
-    scenes.insert("open".to_string(), Scene { rooms: vec!["open".to_string()] });
 
     // User config overlay
     let path = scenes_config_path();
@@ -168,8 +171,9 @@ custom:
     fn test_builtins() {
         let scenes = load_scenes();
         assert!(scenes.contains_key("private"));
-        assert!(scenes.contains_key("open"));
         assert!(scenes["private"].rooms.is_empty());
-        assert_eq!(scenes["open"].rooms, vec!["open"]);
+        // `open` is no longer a built-in scene (ADR-124 §2). The
+        // equivalent — everyone in #open — is now the implicit base.
+        assert!(!scenes.contains_key("open"));
     }
 }

--- a/tools/sensor-disclosure/src/disclosures/messaging.md
+++ b/tools/sensor-disclosure/src/disclosures/messaging.md
@@ -1,6 +1,6 @@
 **New topic:** `attend send "text"` — one-shot Bash call, never Monitor and never via the running `attend run` process.
 **Reply to a peer:** `attend reply "text"` — auto-threads to the most recent peer message your sensor surfaced. No id lookup, no flags.
-**Scope (send only):** default is broadcast (every peer + every Aaron session). Override with `--focus {group}` or `--to {path}`.
+**Scope (send only):** default is `#open` — the base channel (every peer + every Aaron session). Override with `--focus {group}` or `--to {path}`.
 **Quoting:** always double-quote the message — `?`, `*`, `!`, and backticks get eaten by your shell otherwise.
 **Length:** notifications carry ~400 characters; anything longer is chunked into multiple lines, and the full signal file stays on disk.
 **Silence is a valid reply.** Attend never escalates a message you chose to ignore — it trusts your judgment on which threads deserve an answer.

--- a/tools/sensor-disclosure/src/lib.rs
+++ b/tools/sensor-disclosure/src/lib.rs
@@ -195,7 +195,11 @@ mod tests {
     fn component_registry_has_messaging_body() {
         let body = Component::Messaging.body();
         assert!(body.contains("attend send"));
-        assert!(body.contains("--broadcast"));
+        // Post-ADR-124: default scope is `#open` (the base channel),
+        // previously labelled `broadcast`. The assertion follows the
+        // display-layer rename so any future regression in the
+        // disclosure copy gets caught.
+        assert!(body.contains("#open"));
         assert!(!body.is_empty());
     }
 


### PR DESCRIPTION
## Summary

Two stacked pieces of work on the attend-chat TUI.

### ADR-124 PR A — `#open` as the base channel

- Synthetic `#open` channel always leftmost in the channel bar, renders bold, filters any lingering `@open/` disk entry.
- `#open ...` writes route to `_broadcast/` (display-layer rename; wire format unchanged).
- `open` reserved in `validate_group_name`; `open` scene preset dropped.
- One-shot `@open/ → _broadcast/` migration on `attend run` startup — idempotent no-op after the first post-upgrade run.
- CLI labels unified on `#open` across banner, status, inbox, send, focus all, messaging disclosure (fixes a pre-existing broken `--broadcast` assertion along the way).
- ADR-124 flipped Draft → Accepted; §3 ordering and §4 pin/unread indicators explicitly deferred per scope call with Aaron.

### Slash-command framework (tightens ADR-124's scope one notch)

- Aaron typed `/help` mid-session and it leaked onto the signal bus as a peer message. Built the interceptor + autocomplete to stop that.
- `slash::REGISTRY` with `Implemented` vs `Planned` status — `/help` dispatched; `/whois`, `/peers`, `/join`, `/leave`, `/clear` surface in autocomplete + `/help` output but short-circuit to "not implemented yet" so the roadmap is visible.
- Enter handler intercepts any `/<cmd>` before it can reach the send paths. Ok outcomes clear the buffer; Err outcomes keep it so the user can edit + retry.
- Tab completes `/<partial>` before falling through to `@`/`#` mention completion.

### Sigil-aware helper row + semantic routing

- Row below the input box is now contextual: `/` shows slash commands, `#` shows channels, `@` (or nothing) shows agents.
- Each slash command carries an `ArgKind` (`None | Agent | Group`). After the name is typed, the helper row switches to whatever the command expects — `/whois ` opens agents, `/join ` opens channels. Adding a routing-aware command is one registry row.
- `helper::derive(input) -> HelperMode` is a pure function: rule table at the top of `helper.rs`, enumerated unit tests at the bottom. The state machine is inspectable by reading one file.

## Test plan

- [x] `cargo test --workspace` — 118 tests in attend-chat (+31 new: slash, helper, channels), 38 in attend
- [x] `make attend-rebuild attend-chat-rebuild` — release binaries built, symlinks live
- [x] Live hot-swap of `attend run` succeeded (`d018db0 → f825907`); migration log confirmed no lingering `@open/` on this machine
- [x] Disclosure reheat of messaging.md observed with updated `#open` copy
- [ ] Reviewer: relaunch `attend-chat`, confirm: `#open` leftmost and bold; top channel bar stays; type `/`, `#`, `@` and watch the helper row switch; type `/whois ` and confirm the helper row opens agents; `/join ` opens channels
- [ ] Reviewer: confirm `attend focus all` shows `#open (base)` as the leading row
- [ ] Reviewer: confirm `attend status` scope column reads `#open`, not `broadcast`

## Related

- ADR-124 — `docs/architecture/system/ADR-124-channel-bar-ordering-open-as-base.md`
- Issue #23 — attend TUI thread

## Follow-ups (explicitly deferred)

- ADR-124 PR B — three-state liveness (agents + channels)
- Slash-command disclosure component (`tools/sensor-disclosure/`) so agents learn slash commands exist — memory note filed at `projects/-home-aaron--claude/memory/pr4-slash-command-disclosure.md`
- Richer channel ordering (pinned band, recent-activity band) — needs a `_groups.yaml` schema change, deferred per ADR §3