### PR TITLE
fix(ways): add threshold field to state trigger schema

### DIFF
--- a/hooks/ways/frontmatter-schema.yaml
+++ b/hooks/ways/frontmatter-schema.yaml
@@ -112,6 +112,10 @@ way:
       values: [context-threshold, file-exists, session-start]
       required: optional
       role: State-based trigger type (instead of pattern/semantic)
+    threshold:
+      type: number
+      required: conditional  # required when trigger is context-threshold
+      role: Percentage (0-100) of context-window fill that fires the way. Only read for trigger, context-threshold.
     repeat:
       type: boolean
       required: optional


### PR DESCRIPTION
## Summary
- Post-ADR-125, the schema dropped BM25 but missed a small gap: ways using `trigger: context-threshold` (compaction-checkpoint, memory, todos) declare a way-level `threshold:` percentage that the scan code reads, but the schema only declared `threshold` under `check.trigger`. Linter flagged these three as UNKNOWN fields.
- Add `threshold` under `way.state` as a conditional field (required when `trigger: context-threshold`). Schema now matches what the code in `cmd/scan/candidates.rs:131` actually reads.

## Before / After
- Before: \`ways lint --global --check\` → 0 errors, 4 warnings (3 UNKNOWN threshold on meta ways)
- After: 0 errors, 1 warning (unrelated migration-macro requires: warning)

## Test plan
- [x] \`ways lint --global --check\` clean on the three previously-flagged meta ways
- [x] Project scope still respected (auto-detects \`CLAUDE_PROJECT_DIR/.claude/ways/\`)