### PR TITLE
fix: half_life bump + ADR-127 reject full-body embedding

### DIFF
--- a/docs/architecture/system/ADR-127-reject-full-body-embedding-corpus.md
+++ b/docs/architecture/system/ADR-127-reject-full-body-embedding-corpus.md
@@ -1,0 +1,113 @@
+---
+status: Rejected
+date: 2026-04-22
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-105
+  - ADR-107
+  - ADR-108
+  - ADR-125
+---
+
+# ADR-127: Full-body embedding corpus for way matching
+
+## Context
+
+Way matching (ADR-108) embeds a keyword-curated string per way — the
+`description` field plus the `vocabulary` list — rather than the way's body
+prose. When specific parent/child promotions failed (e.g. `environment/deps`
+dominating `supplychain/depscan/node`), the instinct was that a denser text
+signal would sharpen discrimination. That instinct carried an implicit premise:
+**routing quality is limited by the text-matching dimension and can be improved
+by making the embedded representation smarter.**
+
+This ADR tests that premise by productizing full-body embedding in two shapes,
+and documents what the test revealed about where routing quality actually lives.
+
+## Considered
+
+Two variants against the existing `description + vocabulary` baseline, evaluated
+on a 90-way global corpus with 18 prompts (16 actionable across three firing
+bands, 2 negative):
+
+- **full-truncated** — embed the first ~256 tokens of each way's body
+- **full-chunked** — embed overlapping chunks of the full body, max-pool to a
+  single vector
+
+## Results
+
+| Variant | Rebuild | Cost × | Clear 8 | Cofire 5 | Bound 3 | Top-1 |
+|---|---|---|---|---|---|---|
+| baseline | 569 ms | 1.00× | 6/8 | 4/5 | 1/3 | 11/16 |
+| full-truncated | 3918 ms | 6.89× | 7/8 | 3/5 | 1/3 | 11/16 |
+| full-chunked | 5252 ms | 9.23× | 6/8 | 3/5 | 2/3 | 11/16 |
+
+All three variants tie at 11/16 top-1 hits. Full-body variants fix some
+parent-promotion failures and introduce new ones at the same rate:
+
+- **P1** `audit npm dependencies for known vulnerabilities` — baseline promotes
+  parent `environment/deps` over expected `supplychain/depscan/node`. Full-body
+  variants correctly return the child.
+- **P7** `decide between two approaches for the user schema` — baseline promotes
+  `meta/knowledge` over expected `architecture/design`. Full-body variants
+  correctly return design.
+- **P9** `catch me up on what happened in my inbox overnight` — baseline
+  correctly returns `ea/briefing` at 0.597; both full-body variants are pulled
+  to `ea/email` at 0.297–0.341.
+- **P10** `find a free 30-minute slot on my calendar` — all three correct, but
+  baseline confidence 0.671 vs full-body 0.414/0.420.
+
+Chunked vs truncated is a wash on recall. Chunking costs 34% more than
+truncation, confirming the content swap is doing any work, not the
+chunking+pooling mechanism.
+
+The softwaredev-only pilot's apparent win was sample homogeneity: technical
+prose is dense enough that full-body's broader signal dominates keyword
+curation. Once the corpus includes conversational (`ea/`), operational
+(`itops/`), and reflective (`meta/`) trees, full-body wins and losses cancel.
+
+## Decision
+
+**Rejected.** Do not productize full-body embedding — neither truncated nor
+chunked.
+
+The premise the experiment was testing — that text-matching density is the axis
+of improvement — is not supported by the data. Net-zero aggregate recall across
+a 7–9× rebuild-time penalty is the surface reading. The deeper reading is
+structural.
+
+Siblings in the authored graph share vocabulary *by design* — they are authored
+into the same subgraph. No text-only representation, keyword-curated or
+full-body, can reliably disambiguate them. P9 is the cleanest demonstration:
+`ea/briefing` and `ea/email` are graph neighbors with overlapping surface
+language, and baseline only picks correctly through keyword luck. Full-body's
+denser signal reveals the underlying ambiguity rather than resolving it, which
+is why confidence regresses on correct hits (P10: 0.671 → 0.414).
+
+The text-matching axis is exhausted.
+
+## Forward path
+
+The real value in way routing is the authored graph itself (ADR-125):
+parent/child structure, progressive disclosure (ADR-105), firing history, and
+neighborhood context. Embeddings are one coordinate on each node, not the
+routing algorithm.
+
+**Tactical (bridging):**
+- Targeted vocabulary adjustments when a specific sibling collision becomes
+  painful.
+- Per-way `embed_threshold` tuning under ADR-125.
+
+**Strategic:** graph-aware routing. Subsequent ADRs should explore how
+disclosure state, parent context, and recency break ties that text matching
+cannot. This ADR's contribution to that direction is negative evidence — the
+text-matching axis has been tested and yielded.
+
+## Provenance
+
+Full results, per-prompt top-5 for all 18 prompts, and timing distribution were
+produced by the harness at `experiments/chunked-embeddings/` on branch
+`experiment/full-body-embeddings`. Both were discarded with this ADR; the
+evidence above is the preserved record.

--- a/hooks/ways/softwaredev/architecture/architecture.md
+++ b/hooks/ways/softwaredev/architecture/architecture.md
@@ -5,7 +5,7 @@ embed_threshold: 0.30
 scope: agent, subagent
 curve:
   type: Exponential
-  half_life: 30000
+  half_life: 200000
 ---
 <!-- epistemic: premise -->
 # Architecture

--- a/hooks/ways/softwaredev/code/code.md
+++ b/hooks/ways/softwaredev/code/code.md
@@ -5,7 +5,7 @@ embed_threshold: 0.30
 scope: agent, subagent
 curve:
   type: Exponential
-  half_life: 30000
+  half_life: 200000
 ---
 <!-- epistemic: premise -->
 # Code Craft

--- a/hooks/ways/softwaredev/code/errors/errors.md
+++ b/hooks/ways/softwaredev/code/errors/errors.md
@@ -5,7 +5,7 @@ pattern: error.?handl|exception|try.?catch|throw|catch
 scope: agent, subagent
 curve:
   type: Exponential
-  half_life: 30000
+  half_life: 200000
 ---
 <!-- epistemic: heuristic -->
 # Error Handling Way

--- a/hooks/ways/softwaredev/code/performance/performance.md
+++ b/hooks/ways/softwaredev/code/performance/performance.md
@@ -5,7 +5,7 @@ pattern: slow|optimi|latency|profile|performance|speed.?up|benchmark|bottleneck|
 scope: agent, subagent
 curve:
   type: Exponential
-  half_life: 30000
+  half_life: 200000
 ---
 <!-- epistemic: heuristic -->
 # Performance Way

--- a/hooks/ways/softwaredev/code/quality/quality.md
+++ b/hooks/ways/softwaredev/code/quality/quality.md
@@ -4,7 +4,7 @@ vocabulary: refactor quality solid principle decompose extract method responsibi
 pattern: solid.?principle|refactor|code.?review|code.?quality|clean.?up|simplify|decompos|extract.?method|tech.?debt
 curve:
   type: Exponential
-  half_life: 30000
+  half_life: 200000
 macro: append
 scan_exclude: \.md$|\.lock$|\.min\.(js|css)$|\.generated\.|\.bundle\.|vendor/|node_modules/|dist/|build/|__pycache__/
 scope: agent, subagent

--- a/hooks/ways/softwaredev/code/security/auth/auth.md
+++ b/hooks/ways/softwaredev/code/security/auth/auth.md
@@ -4,7 +4,7 @@ vocabulary: authentication authorization middleware guard permission role rbac a
 scope: agent, subagent
 curve:
   type: Exponential
-  half_life: 30000
+  half_life: 200000
 ---
 <!-- epistemic: constraint -->
 # Auth Way

--- a/hooks/ways/softwaredev/code/security/injection/injection.md
+++ b/hooks/ways/softwaredev/code/security/injection/injection.md
@@ -4,7 +4,7 @@ vocabulary: injection sql xss innerHTML parameterized sanitize escape shell comm
 scope: agent, subagent
 curve:
   type: Exponential
-  half_life: 30000
+  half_life: 200000
 ---
 <!-- epistemic: constraint -->
 # Injection Prevention Way

--- a/hooks/ways/softwaredev/code/security/secrets/secrets.md
+++ b/hooks/ways/softwaredev/code/security/secrets/secrets.md
@@ -4,7 +4,7 @@ vocabulary: secret credential password token key env api-key rotate expose expos
 scope: agent, subagent
 curve:
   type: Exponential
-  half_life: 30000
+  half_life: 200000
 ---
 <!-- epistemic: constraint -->
 # Secrets Way

--- a/hooks/ways/softwaredev/code/security/security.md
+++ b/hooks/ways/softwaredev/code/security/security.md
@@ -4,7 +4,7 @@ vocabulary: security vulnerability protect defense secure harden owasp
 scope: agent, subagent
 curve:
   type: Exponential
-  half_life: 30000
+  half_life: 200000
 ---
 <!-- epistemic: convention -->
 # Security Way

--- a/hooks/ways/softwaredev/code/supplychain/supplychain.md
+++ b/hooks/ways/softwaredev/code/supplychain/supplychain.md
@@ -5,7 +5,7 @@ commands: git\ clone
 scope: agent, subagent
 curve:
   type: Exponential
-  half_life: 30000
+  half_life: 200000
 ---
 <!-- epistemic: premise -->
 # Supply Chain Trust Assessment

--- a/hooks/ways/softwaredev/code/testing/mocking/mocking.md
+++ b/hooks/ways/softwaredev/code/testing/mocking/mocking.md
@@ -4,7 +4,7 @@ vocabulary: mock fake stub spy double dependency inject external isolate test do
 scope: agent, subagent
 curve:
   type: Exponential
-  half_life: 30000
+  half_life: 200000
 ---
 <!-- epistemic: heuristic -->
 # Mocking Way

--- a/hooks/ways/softwaredev/code/testing/tdd/tdd.md
+++ b/hooks/ways/softwaredev/code/testing/tdd/tdd.md
@@ -4,7 +4,7 @@ vocabulary: tdd red green refactor test first implementation failing
 scope: agent, subagent
 curve:
   type: Exponential
-  half_life: 30000
+  half_life: 200000
 ---
 <!-- epistemic: heuristic -->
 # TDD Way

--- a/hooks/ways/softwaredev/code/testing/testing.md
+++ b/hooks/ways/softwaredev/code/testing/testing.md
@@ -5,7 +5,7 @@ commands: npm\ test|yarn\ test|jest|pytest|cargo\ test|go\ test|rspec
 scope: agent, subagent
 curve:
   type: Exponential
-  half_life: 30000
+  half_life: 200000
 ---
 <!-- epistemic: convention -->
 # Testing Way

--- a/hooks/ways/softwaredev/docs/standards/standards.md
+++ b/hooks/ways/softwaredev/docs/standards/standards.md
@@ -4,7 +4,7 @@ vocabulary: convention norm guideline accessibility style guide linting rule agr
 scope: agent, subagent
 curve:
   type: Exponential
-  half_life: 30000
+  half_life: 200000
 ---
 <!-- epistemic: convention -->
 # Standards Way


### PR DESCRIPTION
## Summary

Two related pieces of closing out the `experiment/full-body-embeddings` branch.

**1. `chore(ways)`: bump `half_life` 30k → 200k on 14 softwaredev ways.**
A localized hack against the refire-cadence staleness described in ADR-126. Raw token counts calibrated for a 200k window fire too often in 1M-token sessions; bumping to 200k restores roughly the original 3-fires-per-session cadence on Opus. Not the real fix — ADR-126 proposes banded ratios that survive future window expansions. This commit is a bridge.

**2. `docs(adr)`: ADR-127 reject full-body embedding corpus.**
Negative-evidence ADR. We tested full-body embedding (truncated and chunked) against the baseline `description + vocabulary` corpus on 90 ways × 18 prompts. All three variants tied at 11/16 top-1 hits despite a 7–9× rebuild-time penalty.

The deeper read is structural: siblings in the authored graph share vocabulary *by design*, so no text-only representation can reliably disambiguate them. P9 (`ea/briefing` vs `ea/email`) shows this cleanly. The text-matching axis is exhausted; the strategic direction is graph-aware routing under ADR-125.

Experiment code at `experiments/chunked-embeddings/` and the `experiment/full-body-embeddings` branch were discarded with this ADR. The summary table and illustrative prompts in the Results section are the preserved record.

## Test plan

- [ ] ADR-127 renders correctly (headings, tables, links)
- [ ] `ways match` still works after half_life bump (no schema breakage)
- [ ] After merge: delete `experiment/full-body-embeddings` branch locally and on GitHub