### PR TITLE
refactor(ways): declare fire-bearing fields once for lint

### DIFF
--- a/tools/ways-cli/src/cmd/lint/per_file.rs
+++ b/tools/ways-cli/src/cmd/lint/per_file.rs
@@ -137,24 +137,16 @@ pub(super) fn lint_file(
         }
     }
 
-    // ADR-126: fire-bearing ways should carry a `refire:` field. A way is
-    // fire-bearing if any of its trigger channels are wired: semantic
-    // (description + vocabulary), regex (pattern/files/commands), or state
-    // (trigger:). Check files and attend signal handlers are exempt —
-    // checks ride on their parent way's firing, and attend handlers are
-    // triggered by signal name rather than the refire engine.
+    // ADR-126: fire-bearing ways should carry a `refire:` field. Fire
+    // eligibility (which frontmatter fields count as firing channels) is
+    // declared in `frontmatter::FIRE_BEARING_FIELDS` so adding a new channel
+    // flows through automatically. Check files and attend signal handlers
+    // are exempt — checks ride on their parent way's firing, and attend
+    // handlers are triggered by signal name rather than the refire engine.
     let has_refire = has_field(&fm_str, "refire");
     let has_curve = has_field(&fm_str, "curve");
-    let has_pattern = has_field(&fm_str, "pattern");
-    let has_files = has_field(&fm_str, "files");
-    let has_commands = has_field(&fm_str, "commands");
-    let has_trigger = has_field(&fm_str, "trigger");
-    let fires_on_something = (has_desc && has_vocab)
-        || has_pattern
-        || has_files
-        || has_commands
-        || has_trigger;
-    let is_fire_bearing = !is_check && !is_attend && fires_on_something;
+    let is_fire_bearing =
+        !is_check && !is_attend && crate::frontmatter::fires_on_something(&fm_str);
     if is_fire_bearing && !has_refire {
         eprintln!(
             "  WARNING: {rel} — no `refire:` field (ADR-126). \

--- a/tools/ways-cli/src/frontmatter.rs
+++ b/tools/ways-cli/src/frontmatter.rs
@@ -149,6 +149,34 @@ impl Frontmatter {
     }
 }
 
+/// Frontmatter fields that wire a way into a runtime dispatch channel.
+/// A way carrying any of these participates in firing and therefore needs
+/// a `refire:` field (ADR-126). The semantic channel (description +
+/// vocabulary) is checked separately by [`fires_on_something`] because it
+/// requires both fields together.
+///
+/// **Adding a channel:** extending this list picks the new field up in
+/// `ways lint`'s fire-eligibility check automatically. The corresponding
+/// dispatch entry point in `cmd/scan/` still needs wiring separately — this
+/// const is the advisory declaration, not the dispatcher.
+pub const FIRE_BEARING_FIELDS: &[&str] = &["pattern", "files", "commands", "trigger"];
+
+/// Does this frontmatter wire the way into any firing channel?
+/// Used by `ways lint` to flag fire-bearing ways that lack a `refire:` field.
+///
+/// Operates on the raw YAML string rather than the parsed [`Frontmatter`]
+/// struct because several channel fields (`pattern`, `files`, `commands`,
+/// `trigger`) aren't modeled on the serde type. Keeping the predicate
+/// string-based lets it run against partially-valid frontmatter during lint.
+pub fn fires_on_something(fm_str: &str) -> bool {
+    fn has(fm: &str, name: &str) -> bool {
+        let prefix = format!("{name}:");
+        fm.lines().any(|l| l.starts_with(&prefix))
+    }
+    let has_desc_vocab = has(fm_str, "description") && has(fm_str, "vocabulary");
+    has_desc_vocab || FIRE_BEARING_FIELDS.iter().any(|f| has(fm_str, f))
+}
+
 /// Extract YAML frontmatter from a way file.
 pub fn parse(path: &Path) -> Result<Frontmatter> {
     let content = std::fs::read_to_string(path)
@@ -570,6 +598,54 @@ curve:
   half_life: 50000
 "#;
         detect_legacy_redisclose(yaml).expect("clean yaml should pass");
+    }
+
+    #[test]
+    fn fires_on_semantic_channel() {
+        assert!(fires_on_something("description: x\nvocabulary: y\n"));
+    }
+
+    #[test]
+    fn does_not_fire_on_description_alone() {
+        // Semantic channel needs both — description without vocabulary is
+        // flagged by a separate lint rule, not by fire-eligibility.
+        assert!(!fires_on_something("description: x\n"));
+    }
+
+    #[test]
+    fn does_not_fire_on_vocabulary_alone() {
+        assert!(!fires_on_something("vocabulary: x\n"));
+    }
+
+    #[test]
+    fn fires_on_each_declared_channel() {
+        // Every field in FIRE_BEARING_FIELDS must flip the predicate on its
+        // own — this test catches a new channel being added to the const but
+        // the iteration logic drifting away from it.
+        for field in FIRE_BEARING_FIELDS {
+            let fm = format!("{field}: something\n");
+            assert!(
+                fires_on_something(&fm),
+                "expected fire on {field}-only frontmatter"
+            );
+        }
+    }
+
+    #[test]
+    fn does_not_fire_on_empty_or_non_channel_fields() {
+        assert!(!fires_on_something(""));
+        assert!(!fires_on_something("scope: user\n"));
+        assert!(!fires_on_something("embed_threshold: 0.5\n"));
+        // curve: and refire: are cadence fields, not firing channels
+        assert!(!fires_on_something("curve:\n  type: Flat\n"));
+        assert!(!fires_on_something("refire: 0.2\n"));
+    }
+
+    #[test]
+    fn fires_on_combined_channels() {
+        // A typical way with semantic + pattern — both channels wired.
+        let fm = "description: x\nvocabulary: y\npattern: '^foo'\n";
+        assert!(fires_on_something(fm));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Moves the fire-eligibility field list (`pattern`, `files`, `commands`, `trigger`) into `frontmatter::FIRE_BEARING_FIELDS` and exposes `fires_on_something(fm_str)` alongside it.
- Lint's five-disjunct predicate in `per_file.rs` becomes a single call; adding a new trigger channel is now a one-line edit to the const.
- No runtime change — there's no runtime-side fire-eligibility predicate to unify with. Each scan entry point dispatches on only the fields it handles. The const's doc comment makes this explicit (advisory declaration, not a dispatcher).

## Context

From the post-ADR-126 simplification plan (`docs/design-notes/post-adr-126-simplification.md`, Opportunity 3). Initial scoping suggested unifying runtime dispatch with lint; investigation found the runtime has no such predicate, so the refactor is scoped to eliminating lint's drift risk when new channels get added. Opp 1 (delete dead `Curve` variants) will follow in a separate PR; Opp 2 is dropped.

## Test plan

- [x] `cargo test -p ways --bins` — 64 tests pass (6 new on `fires_on_something`, covering semantic channel, iteration over the const, and non-channel fields).
- [x] `ways lint --global` on the full tree — same output as before (0 errors, 1 pre-existing unrelated warning for `macro: without requires:`).
- [x] No runtime changes; existing dispatch paths unchanged.