### PR TITLE
fix(attend): reject --focus to empty groups; drop misleading "(project)" label

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attend"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "agent-fmt",
  "agent-identity",

--- a/tools/attend/Cargo.toml
+++ b/tools/attend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "attend"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Active awareness module — adaptive sensing and disclosure for Claude Code sessions"
 license = "MIT"

--- a/tools/attend/src/cmd/peers.rs
+++ b/tools/attend/src/cmd/peers.rs
@@ -49,12 +49,17 @@ pub(crate) fn cmd_peers() {
     if !peers.is_empty() {
         t.add(vec!["", "", "", ""]);
         for (peer_cwd, _project, status, ctx) in &peers {
-            // Same-cwd peers used to render "(project)" in the Focus
-            // column; that string is misleading (it is not a focus
-            // group anyone joined) and the cwd basename is already
-            // visible in the Agent column's dim parens. Leave the
-            // Focus cell empty for project-only peers.
-            let focus_label = String::new();
+            // Same-cwd peers previously rendered "(project)" in the
+            // Focus column — a string that primed agents into running
+            // `attend send --focus project`, a group nobody had
+            // joined. "(here)" pairs with the self row's "(self)"
+            // marker, preserves the same-cwd visual scan, and uses
+            // parentheses to make clear it is not a focus group name.
+            let focus_label = if *peer_cwd == cwd {
+                "(here)".to_string()
+            } else {
+                String::new()
+            };
             let peer_id = Identity::for_cwd(peer_cwd, caps);
             let label = render_agent_label(&peer_id, caps);
             t.add_owned(vec![

--- a/tools/attend/src/cmd/peers.rs
+++ b/tools/attend/src/cmd/peers.rs
@@ -27,8 +27,12 @@ pub(crate) fn cmd_peers() {
         .unwrap_or_default();
     let self_id = Identity::for_cwd(&cwd, caps);
     let self_label = render_agent_label(&self_id, caps);
+    // Self-row Focus cell: "(self)" identifies which row IS the runner of
+    // `attend peers`, without using the literal string "project" — that
+    // priming caused agents to reach for `attend send --focus project`
+    // and silently land signals in an empty `@project/` room.
     t.add_owned(vec![
-        "(project)".to_string(),
+        "(self)".to_string(),
         self_label,
         "working".to_string(),
         String::new(),
@@ -45,11 +49,12 @@ pub(crate) fn cmd_peers() {
     if !peers.is_empty() {
         t.add(vec!["", "", "", ""]);
         for (peer_cwd, _project, status, ctx) in &peers {
-            let focus_label = if *peer_cwd == cwd {
-                "(project)".to_string()
-            } else {
-                String::new()
-            };
+            // Same-cwd peers used to render "(project)" in the Focus
+            // column; that string is misleading (it is not a focus
+            // group anyone joined) and the cwd basename is already
+            // visible in the Agent column's dim parens. Leave the
+            // Focus cell empty for project-only peers.
+            let focus_label = String::new();
             let peer_id = Identity::for_cwd(peer_cwd, caps);
             let label = render_agent_label(&peer_id, caps);
             t.add_owned(vec![
@@ -65,10 +70,14 @@ pub(crate) fn cmd_peers() {
 
     let focus_count = my_focus.len();
     let peer_count = peers.len();
+    // `focus_count` is now the literal number of explicit focus groups
+    // self has joined. The previous `+ 1` counted the implicit "(self)"
+    // row as if it were a focus group, which inflated the count and
+    // suggested a phantom "project" group existed.
     println!(
         "  {} agent(s), {} focus group(s)",
         peer_count + 1,
-        focus_count + 1
+        focus_count
     );
 }
 

--- a/tools/attend/src/cmd/send.rs
+++ b/tools/attend/src/cmd/send.rs
@@ -120,33 +120,52 @@ pub(crate) fn cmd_send(args: &[String]) {
 
     let r = get_groups();
 
-    // Validate --focus name against `_groups.yaml`. A signal written to a
-    // group nobody has joined sits unread in `@<name>/` until cleanup
-    // sweeps it; the sender only sees "signal written" and assumes
-    // delivery. Mirror the --to check: refuse the send and point at the
-    // broadcast default, which is the path that always routes.
+    // Validate --focus name against live `_groups.yaml` membership. A
+    // signal written to a group nobody is *currently* listening on sits
+    // unread in `@<name>/` until cleanup sweeps it; the sender only sees
+    // "signal written" and assumes delivery. Mirror --to's liveness
+    // discipline: `_groups.yaml` membership is intersected with
+    // `PeerSensor::live_session_ids` so a peer that joined-and-died
+    // does not let the validation pass on a phantom member.
     if let Some(ref name) = target_focus {
-        let groups = r.all_groups();
-        let entry = groups.iter().find(|(n, _, _)| n == name);
-        let self_in_group = r.joined_group_names().iter().any(|n| n == name);
-        let peer_count = match entry {
-            Some((_, count, _)) => {
-                if self_in_group { count.saturating_sub(1) } else { *count }
-            }
+        let members = r.members(name);
+        let self_id = own_session_id();
+        #[cfg(feature = "sensor-peers")]
+        let live_ids: std::collections::HashSet<String> = {
+            let sensor = crate::sensors::PeerSensor::new();
+            sensor.live_session_ids()
+        };
+        #[cfg(not(feature = "sensor-peers"))]
+        let live_ids: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        let live_peer_count: usize = match &members {
+            Some(ids) => ids
+                .iter()
+                .filter(|sid| {
+                    live_ids.contains(*sid)
+                        && self_id.as_ref().map(|s| s != *sid).unwrap_or(true)
+                })
+                .count(),
             None => 0,
         };
-        if peer_count == 0 {
-            if entry.is_none() {
+        if live_peer_count == 0 {
+            let self_in_group = members
+                .as_ref()
+                .zip(self_id.as_ref())
+                .map(|(ids, sid)| ids.iter().any(|m| m == sid))
+                .unwrap_or(false);
+            if members.is_none() {
                 eprintln!("error: no focus group named '{}'", name);
             } else if self_in_group {
-                eprintln!("error: you are the only member of focus group '{}'", name);
+                eprintln!("error: no live peers in focus group '{}' (you are the only listener)", name);
             } else {
-                eprintln!("error: focus group '{}' has no members", name);
+                eprintln!("error: no live peers in focus group '{}'", name);
             }
+            let groups = r.all_groups();
             if groups.is_empty() {
                 eprintln!("\nno active focus groups");
             } else {
-                eprintln!("\nactive focus groups:");
+                eprintln!("\nactive focus groups (yaml count, live peers may be fewer):");
                 for (gname, count, pinned) in &groups {
                     let pin = if *pinned { " (pinned)" } else { "" };
                     let suffix = if *count == 1 { "" } else { "s" };

--- a/tools/attend/src/cmd/send.rs
+++ b/tools/attend/src/cmd/send.rs
@@ -118,13 +118,53 @@ pub(crate) fn cmd_send(args: &[String]) {
         }
     }
 
+    let r = get_groups();
+
+    // Validate --focus name against `_groups.yaml`. A signal written to a
+    // group nobody has joined sits unread in `@<name>/` until cleanup
+    // sweeps it; the sender only sees "signal written" and assumes
+    // delivery. Mirror the --to check: refuse the send and point at the
+    // broadcast default, which is the path that always routes.
+    if let Some(ref name) = target_focus {
+        let groups = r.all_groups();
+        let entry = groups.iter().find(|(n, _, _)| n == name);
+        let self_in_group = r.joined_group_names().iter().any(|n| n == name);
+        let peer_count = match entry {
+            Some((_, count, _)) => {
+                if self_in_group { count.saturating_sub(1) } else { *count }
+            }
+            None => 0,
+        };
+        if peer_count == 0 {
+            if entry.is_none() {
+                eprintln!("error: no focus group named '{}'", name);
+            } else if self_in_group {
+                eprintln!("error: you are the only member of focus group '{}'", name);
+            } else {
+                eprintln!("error: focus group '{}' has no members", name);
+            }
+            if groups.is_empty() {
+                eprintln!("\nno active focus groups");
+            } else {
+                eprintln!("\nactive focus groups:");
+                for (gname, count, pinned) in &groups {
+                    let pin = if *pinned { " (pinned)" } else { "" };
+                    let suffix = if *count == 1 { "" } else { "s" };
+                    eprintln!("  {} — {} member{}{}", gname, count, suffix, pin);
+                }
+            }
+            eprintln!("\ndrop --focus to broadcast (reaches every peer):");
+            eprintln!("  attend send <message>");
+            std::process::exit(1);
+        }
+    }
+
     // Determine target directories.
     // Default is broadcast — simplest possible routing: every send reaches
     // every peer. Escape hatches remain for humans and scripts:
     //   --to <path>: specific project only
     //   --focus <name>: specific focus group only
     //   --broadcast: explicit (same as default)
-    let r = get_groups();
     let dest_dirs: Vec<std::path::PathBuf> = if let Some(ref focus_name) = target_focus {
         vec![r.group_dir(focus_name)]
     } else if let Some(ref path) = target_dir {

--- a/tools/attend/src/groups.rs
+++ b/tools/attend/src/groups.rs
@@ -148,6 +148,15 @@ impl Groups {
         self.load_state().contains_key(name)
     }
 
+    /// List session IDs in a named group, or None if the group does not exist.
+    /// Returns raw `_groups.yaml` membership — callers that need a
+    /// liveness-checked view should intersect with
+    /// `PeerSensor::live_session_ids` (see `cmd_send` for the routing-
+    /// validation shape).
+    pub fn members(&self, name: &str) -> Option<Vec<String>> {
+        self.load_state().get(name).map(|e| e.members.clone())
+    }
+
     /// List all active rooms with member counts and pin state.
     pub fn all_groups(&self) -> Vec<(String, usize, bool)> {
         let state = self.load_state();

--- a/tools/sensor-peers/src/lib.rs
+++ b/tools/sensor-peers/src/lib.rs
@@ -192,6 +192,16 @@ impl PeerSensor {
         result
     }
 
+    /// Return the set of live Claude session IDs currently visible to
+    /// the peer sensor. Callers cross-reference this against
+    /// `_groups.yaml` member lists when they need a liveness-checked
+    /// view (focus-group routing in `attend send --focus`, etc.) — the
+    /// yaml count alone trusts `Groups::session_alive`, which is a
+    /// best-effort placeholder that returns `true` for everyone.
+    pub fn live_session_ids(&self) -> std::collections::HashSet<String> {
+        self.discover_peers().into_keys().collect()
+    }
+
     /// Read signal files from peers. Scans own project dir, broadcast dir,
     /// focus list, and joined rooms. Returns observations for new signals.
     fn read_signals(&mut self, focus: &Focus) -> Vec<(f64, String)> {


### PR DESCRIPTION
## Summary
- `attend send --focus <name>` used to accept any string, deposit a signal in `@<name>/`, and print "signal written" — even when no peer was scanning that directory. The sender saw a successful send; the message vanished. This change validates `--focus` like `--to` already does: refuses the send and points at the broadcast default if the named group has no peer members.
- `attend peers` rendered "(project)" in the Focus column for self and same-cwd peers. That label never named a real focus group, but it primed an agent into running `attend send --focus project "..."` — the exact failure that triggered this PR. The label is now `(self)` for the self row, empty for same-cwd peers, and the footer count no longer treats the implicit row as a focus group.

## Failure mode this kills
Two peer Claude sessions running `attend`. Sender intent: ask the other agent a question. Sender ran:
```
attend send --focus project "Jovan — Aaron asking: ..."
[attend] signal written (focus, 1 dirs): 2f5153e5-...-1776896713.signal
```
But neither agent was a member of any explicit focus group. The signal sat unread in `@project/`. After this change, the same command returns:
```
error: no focus group named 'project'

active focus groups:
  bosectl-demo — 2 members

drop --focus to broadcast (reaches every peer):
  attend send <message>
```
…and exits 1. The default `attend send "msg"` was already correct; the trap was an optional flag failing silently.

## Test plan
- [x] `cargo test --manifest-path tools/Cargo.toml -p attend -p attend-chat -p sensor-peers` passes (39 + 30 + ... unit tests, no regressions)
- [x] Smoke: `attend send --focus nonexistent "hi"` → exits 1 with helpful error
- [x] Smoke: `attend send --focus self-only "hi"` (after `attend focus on self-only`) → exits 1 with "you are the only member"
- [x] Smoke: `attend send "hi"` (default broadcast) → still writes to `_broadcast/`
- [x] Smoke: `attend peers` → "(self)" on self row, footer reads "0 focus group(s)" when not joined to any