### PR TITLE
fix(ways): UserPromptSubmit hook output now reaches agent context

### DIFF
--- a/hooks/ways/check-state.sh
+++ b/hooks/ways/check-state.sh
@@ -12,10 +12,11 @@ AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // empty')
 [[ -n "$AGENT_ID" ]] && export CLAUDE_AGENT_ID="$AGENT_ID"
 TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty')
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(echo "$INPUT" | jq -r '.cwd // empty')}"
+HOOK_EVENT=$(echo "$INPUT" | jq -r '.hook_event_name // "SessionStart"')
 
 export CLAUDE_PROJECT_DIR="${PROJECT_DIR}"
 
-ARGS=(--session "$SESSION_ID" --project "$PROJECT_DIR")
+ARGS=(--session "$SESSION_ID" --project "$PROJECT_DIR" --hook-event "$HOOK_EVENT")
 [[ -n "$TRANSCRIPT" ]] && ARGS+=(--transcript "$TRANSCRIPT")
 
 "${HOME}/.claude/bin/ways" scan state "${ARGS[@]}"

--- a/tools/ways-cli/src/cmd/reset.rs
+++ b/tools/ways-cli/src/cmd/reset.rs
@@ -1,10 +1,24 @@
 //! Reset session state — clear markers, epochs, and check fire counts.
 //!
 //! Unjams stale session state without restarting Claude Code.
+//!
+//! Clears both the per-session directory under `sessions_root()` and any
+//! known side files written by hooks to fixed `/tmp` paths (e.g. the
+//! response-topics file written by the Stop hook and consumed by
+//! `check-prompt.sh` to enrich prompt matching).
 
 use anyhow::Result;
+use std::path::PathBuf;
 
 use crate::session;
+
+/// Return paths to off-root, per-session state files that hooks write
+/// outside `sessions_root()`. Reset must clear these alongside the main
+/// session directory or matching can be biased by stale topic context
+/// after a reset.
+fn session_side_files(sid: &str) -> Vec<PathBuf> {
+    vec![PathBuf::from(format!("/tmp/claude-response-topics-{sid}"))]
+}
 
 
 pub fn run(session: Option<&str>, all: bool, confirm: bool) -> Result<()> {
@@ -44,26 +58,42 @@ pub fn run(session: Option<&str>, all: bool, confirm: bool) -> Result<()> {
     for sid in &sessions {
         let dir = format!("{}/{sid}", session::sessions_root());
         let path = std::path::Path::new(&dir);
-        if !path.is_dir() {
+        let side_files: Vec<PathBuf> = session_side_files(sid)
+            .into_iter()
+            .filter(|p| p.exists())
+            .collect();
+
+        let has_main = path.is_dir();
+        if !has_main && side_files.is_empty() {
             continue;
         }
 
-        let count = count_files(path);
+        let main_count = if has_main { count_files(path) } else { 0 };
+        let count = main_count + side_files.len();
         let short_id = &sid[..sid.len().min(12)];
 
         if dry_run {
             println!("Session {short_id}... ({count} state files)");
-            // Show summary of what's in the directory
-            let ways = session::list_fired_ways(sid);
-            if !ways.is_empty() {
-                println!("  ways: {}", ways.len());
+            if has_main {
+                let ways = session::list_fired_ways(sid);
+                if !ways.is_empty() {
+                    println!("  ways: {}", ways.len());
+                }
+                let epoch = session::get_epoch(sid);
+                if epoch > 0 {
+                    println!("  epoch: {epoch}");
+                }
             }
-            let epoch = session::get_epoch(sid);
-            if epoch > 0 {
-                println!("  epoch: {epoch}");
+            if !side_files.is_empty() {
+                println!("  side files: {}", side_files.len());
             }
         } else {
-            let _ = std::fs::remove_dir_all(path);
+            if has_main {
+                let _ = std::fs::remove_dir_all(path);
+            }
+            for f in &side_files {
+                let _ = std::fs::remove_file(f);
+            }
             println!("Session {short_id}...: cleared ({count} state files)");
             total += count;
         }

--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -52,6 +52,8 @@ pub fn prompt(query: &str, session_id: &str, project: Option<&str>) -> Result<()
 
     let embed_matches = batch_embed_score(query);
 
+    let mut context = String::new();
+
     for way in &candidates {
         if !session::scope_matches(&way.scope, &scope) {
             continue;
@@ -70,8 +72,16 @@ pub fn prompt(query: &str, session_id: &str, project: Option<&str>) -> Result<()
         );
 
         if let Some(trigger) = channel {
-            let _ = crate::cmd::show::way(&way.id, session_id, &trigger);
+            let out = capture_show_way(&way.id, session_id, &trigger);
+            if !out.is_empty() {
+                context.push_str(&out);
+                context.push_str("\n\n");
+            }
         }
+    }
+
+    if !context.is_empty() {
+        emit_hook_context("UserPromptSubmit", context.trim_end());
     }
 
     Ok(())
@@ -441,12 +451,32 @@ fn regex_matches(pattern: &str, text: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Emit accumulated context using the envelope shape required by the
+/// invoking hook event. UserPromptSubmit needs `hookSpecificOutput`
+/// per the Claude Code hook contract; SessionStart and PreToolUse use
+/// the simpler top-level `additionalContext` and continue to surface
+/// as visible attachments.
+fn emit_hook_context(hook_event: &str, context: &str) {
+    let payload = if hook_event == "UserPromptSubmit" {
+        serde_json::json!({
+            "hookSpecificOutput": {
+                "hookEventName": "UserPromptSubmit",
+                "additionalContext": context,
+            }
+        })
+    } else {
+        serde_json::json!({ "additionalContext": context })
+    };
+    println!("{payload}");
+}
+
 // ── State scan ──────────────────────────────────────────────────
 
 pub fn state(
     session_id: &str,
     project: Option<&str>,
     transcript: Option<&str>,
+    hook_event: &str,
 ) -> Result<()> {
     let project_dir = project
         .map(|s| s.to_string())
@@ -547,12 +577,7 @@ pub fn state(
     }
 
     if !context.is_empty() {
-        // Trim trailing newlines
-        let trimmed = context.trim_end();
-        println!(
-            "{}",
-            serde_json::json!({ "additionalContext": trimmed })
-        );
+        emit_hook_context(hook_event, context.trim_end());
     }
 
     Ok(())

--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -39,6 +39,13 @@ pub(crate) struct WayCandidate {
 
 // ── Prompt scan ─────────────────────────────────────────────────
 
+/// Match user prompt against ways and emit matched bodies for the agent.
+///
+/// Wired only from the `UserPromptSubmit` hook (`check-prompt.sh`), so the
+/// envelope is hardcoded. If this is ever reused from another hook event,
+/// take a `hook_event` parameter and route through `emit_hook_context` —
+/// `SessionStart` and `PreToolUse` accept the simpler `additionalContext`
+/// shape, while `UserPromptSubmit` requires `hookSpecificOutput`.
 pub fn prompt(query: &str, session_id: &str, project: Option<&str>) -> Result<()> {
     let project_dir = project
         .map(|s| s.to_string())

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -358,6 +358,11 @@ enum ScanCommand {
         /// Transcript path (for context-threshold)
         #[arg(long)]
         transcript: Option<String>,
+        /// Hook event that invoked this scan (drives output envelope shape).
+        /// UserPromptSubmit needs `hookSpecificOutput`; other events use the
+        /// simpler `additionalContext` shape. Defaults to SessionStart.
+        #[arg(long, default_value = "SessionStart")]
+        hook_event: String,
     },
 }
 
@@ -515,8 +520,8 @@ fn main() -> Result<()> {
             ScanCommand::Task { query, session, project, team } => {
                 cmd::scan::task(&query, &session, project.as_deref(), team.as_deref())
             }
-            ScanCommand::State { session, project, transcript } => {
-                cmd::scan::state(&session, project.as_deref(), transcript.as_deref())
+            ScanCommand::State { session, project, transcript, hook_event } => {
+                cmd::scan::state(&session, project.as_deref(), transcript.as_deref(), &hook_event)
             }
         },
         Commands::Show { what } => match what {

--- a/tools/ways-cli/tests/session_sim.rs
+++ b/tools/ways-cli/tests/session_sim.rs
@@ -245,17 +245,30 @@ fn scenario_1_basic_prompt_matching() {
     let s = Session::new("s1");
 
     // Turn 1: query with "test" vocabulary → should match child (testing)
-    s.scan_prompt("how do I write a unit test for this module");
+    let output = s.scan_prompt("how do I write a unit test for this module");
     assert_epoch(&s.id, 1);
     assert_marker_exists("testdomain/parent/child", &s.id);
+    // Regression guard: scan::prompt must emit the UserPromptSubmit envelope
+    // when a way matches. Before this guard, the function silently discarded
+    // show::way output (`let _ = ...`), and after the first envelope fix it
+    // briefly emitted the wrong shape (`additionalContext` at top-level
+    // instead of `hookSpecificOutput`). Both regressions pass marker-only
+    // assertions because show::way still stamps state for its side effects.
+    assert!(
+        output.contains("hookSpecificOutput"),
+        "scan_prompt must emit hookSpecificOutput envelope when a way matches; got: {output:?}"
+    );
 
     // Turn 2: same query again → should NOT re-fire (idempotency)
-    let _output = s.scan_prompt("how do I write a unit test for this module");
+    let output_repeat = s.scan_prompt("how do I write a unit test for this module");
     assert_epoch(&s.id, 2);
-    // Marker still exists from turn 1 — no new content expected
-    // (we can't easily assert "no new output" beyond marker check,
-    //  but the marker being present means show::way returned early)
     assert_marker_exists("testdomain/parent/child", &s.id);
+    // Idempotency: marker stops show::way before body is emitted, so output
+    // should be empty on the repeat.
+    assert!(
+        output_repeat.is_empty(),
+        "scan_prompt must be idempotent within a session; got: {output_repeat:?}"
+    );
 
     // Turn 3: different vocabulary → should match child2 (refactoring)
     s.scan_prompt("refactor extract method decompose this function");


### PR DESCRIPTION
## Summary

The UserPromptSubmit hook pipeline has been silently dropping all output for the entire history of the system. `ways list` showed prompt-matched ways as "fired," but their bodies never reached the agent's context — markers stamped, content discarded. Only SessionStart and PreToolUse paths actually injected anything.

Two distinct bugs in the same flow:

1. **`scan::prompt` discarded its output entirely.** The match loop called `let _ = crate::cmd::show::way(...)` and never `println!`-ed anything. The marker side effects in `show::way` (engagement state, `way-markers/`, `way-epochs/`) ran successfully, which is why `ways list` reported firings — but stdout was empty.
2. **`scan::state` used the wrong envelope on UserPromptSubmit.** It emitted `{"additionalContext": "..."}` which works on SessionStart and PreToolUse (surfaces as `attachment` entries in the JSONL) but is silently rejected on UserPromptSubmit. The Claude Code hook contract requires `{"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "..."}}` for UPS — that shape is wrapped in a discrete system reminder, no separate attachment.

Caught by fingerprint testing: distinctive phrases from `itops/policy.md` (`WRITE_HIGH`, `Multi-party approval`, `Blast Radius`) appeared in the JSONL only at lines from explicit `Read` tool calls, never from any UserPromptSubmit firing.

Reference: https://code.claude.com/docs/en/hooks.md

## Changes

- `scan::prompt` (`tools/ways-cli/src/cmd/scan/mod.rs`) accumulates `show::way` output into a context buffer and emits via `emit_hook_context` using the `hookSpecificOutput` envelope.
- `scan::state` takes a `--hook-event` arg and dispatches between the two envelope shapes — SessionStart firings keep the legacy attachment delivery, UserPromptSubmit firings get the discrete system-reminder delivery.
- `emit_hook_context` helper centralizes the per-event envelope decision so future scan modes only have one place to reach.
- `check-state.sh` extracts `hook_event_name` from hook input JSON and passes `--hook-event` through.
- `ways reset` also clears `/tmp/claude-response-topics-${session_id}` alongside the per-session dir under `sessions_root()`. Previously this side file (written by the Stop hook, read by `check-prompt.sh`) survived reset and biased post-reset matching with stale topics. New `session_side_files()` helper makes it easy to add other off-root state paths if needed.

## Test plan

- [x] `make ways-rebuild` clean
- [x] `make test-unit` — 70/70 pass
- [x] `make test-sim` — 10/10 pass (existing scenarios assert markers, not stdout shape)
- [x] Smoke test: `ways scan prompt --query "operation classification destructive..."` emits `{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"# Policy Way\n## Operation Classification\n..."}}`
- [x] Smoke test: `ways scan state --hook-event UserPromptSubmit ...` emits the new envelope; `--hook-event SessionStart` (default) keeps the legacy envelope
- [x] Live test in this session after `ways reset --confirm`: way bodies (STRIDE, supply chain tier names, Policy class scheme) demonstrably reach agent context — answers cite config-specific fingerprints that were unreachable before the fix
- [x] `ways reset --session ... --confirm` cleared 210 files (was 209 — the side file is now included)

## Known follow-ups (out of scope for this PR)

- `tools/ways-cli/src/cmd/scan/mod.rs` is at 677 lines, in the Code Quality Way's Review tier (>500). Natural split: extract `state` and its private helpers (`evaluate_context_threshold`, `detect_window_chars`, `transcript_size_since_summary`, `evaluate_file_exists`, `strip_frontmatter`, `capture_show_core`) into `scan/state.rs` (~250 lines moved → mod.rs to ~430).
- Existing session simulator scenarios assert `marker_exists` after `scan_prompt` but never verify non-empty stdout. That's the testing gap that allowed this bug to ship — worth a regression test in a follow-up.
- `make lint` fails in `attend-instances` on a pre-existing doc-comment indentation error (reproduces on `main`). Unrelated; separate cleanup.