### PR TITLE
refactor(scan): make hookSpecificOutput the canonical envelope default

### DIFF
--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -42,10 +42,11 @@ pub(crate) struct WayCandidate {
 /// Match user prompt against ways and emit matched bodies for the agent.
 ///
 /// Wired only from the `UserPromptSubmit` hook (`check-prompt.sh`), so the
-/// envelope is hardcoded. If this is ever reused from another hook event,
-/// take a `hook_event` parameter and route through `emit_hook_context` —
-/// `SessionStart` and `PreToolUse` accept the simpler `additionalContext`
-/// shape, while `UserPromptSubmit` requires `hookSpecificOutput`.
+/// envelope event name is hardcoded. The call routes through the canonical
+/// `hookSpecificOutput` default branch of `emit_hook_context`. If this is
+/// ever reused from another hook event, just pass that event's name —
+/// `SessionStart` and `PreToolUse` are the only events that take the
+/// legacy top-level `additionalContext` envelope.
 pub fn prompt(query: &str, session_id: &str, project: Option<&str>) -> Result<()> {
     let project_dir = project
         .map(|s| s.to_string())
@@ -459,20 +460,24 @@ fn regex_matches(pattern: &str, text: &str) -> bool {
 }
 
 /// Emit accumulated context using the envelope shape required by the
-/// invoking hook event. UserPromptSubmit needs `hookSpecificOutput`
-/// per the Claude Code hook contract; SessionStart and PreToolUse use
-/// the simpler top-level `additionalContext` and continue to surface
-/// as visible attachments.
+/// invoking hook event. The Claude Code hook contract treats
+/// `hookSpecificOutput` as canonical for all events; the simpler top-level
+/// `additionalContext` is a legacy tolerance accepted only on
+/// `SessionStart` and `PreToolUse` (where it surfaces as a visible
+/// attachment). Defaulting to canonical means new event wirings
+/// (`Stop`, `PreCompact`, ...) get the right shape automatically rather
+/// than silently re-hitting the bug PR #80 fixed.
 fn emit_hook_context(hook_event: &str, context: &str) {
-    let payload = if hook_event == "UserPromptSubmit" {
-        serde_json::json!({
+    let payload = match hook_event {
+        "SessionStart" | "PreToolUse" => {
+            serde_json::json!({ "additionalContext": context })
+        }
+        _ => serde_json::json!({
             "hookSpecificOutput": {
-                "hookEventName": "UserPromptSubmit",
+                "hookEventName": hook_event,
                 "additionalContext": context,
             }
-        })
-    } else {
-        serde_json::json!({ "additionalContext": context })
+        }),
     };
     println!("{payload}");
 }

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -359,8 +359,9 @@ enum ScanCommand {
         #[arg(long)]
         transcript: Option<String>,
         /// Hook event that invoked this scan (drives output envelope shape).
-        /// UserPromptSubmit needs `hookSpecificOutput`; other events use the
-        /// simpler `additionalContext` shape. Defaults to SessionStart.
+        /// `hookSpecificOutput` is canonical for all events; `SessionStart`
+        /// and `PreToolUse` are the only events that take the legacy
+        /// top-level `additionalContext` shape. Defaults to SessionStart.
         #[arg(long, default_value = "SessionStart")]
         hook_event: String,
     },

--- a/tools/ways-cli/tests/session_sim.rs
+++ b/tools/ways-cli/tests/session_sim.rs
@@ -495,6 +495,20 @@ fn scenario_10_state_triggers() {
         output.contains("State Trigger Test Way"),
         "Expected state trigger content in output"
     );
+    // Envelope guard: SessionStart is the explicit legacy branch in
+    // emit_hook_context — it must emit `{"additionalContext": "..."}` at
+    // top level, not the canonical `hookSpecificOutput` wrapper. Locks in
+    // the legacy tolerance after the canonical-by-default discriminator
+    // flip; the inverse guard for the canonical default lives in
+    // scenario_1's scan_prompt assertion.
+    assert!(
+        output.contains("additionalContext"),
+        "scan_state on SessionStart must emit legacy additionalContext envelope; got: {output:?}"
+    );
+    assert!(
+        !output.contains("hookSpecificOutput"),
+        "scan_state on SessionStart must NOT use canonical hookSpecificOutput envelope; got: {output:?}"
+    );
 
     // Turn 2: second state scan — idempotent, marker prevents re-fire
     let output2 = s.scan_state();


### PR DESCRIPTION
## Summary

Item 1 of #81 — invert `emit_hook_context`'s discriminator so `hookSpecificOutput` is the default envelope and `SessionStart` / `PreToolUse` are the explicit legacy cases.

Per the [Claude Code hook contract](https://code.claude.com/docs/en/hooks.md), `hookSpecificOutput` is canonical for all hook events; the simpler top-level `additionalContext` is a legacy tolerance accepted only on `SessionStart` and `PreToolUse`. The previous `if hook_event == "UserPromptSubmit"` reversed rule and exception — when `Stop` or `PreCompact` get wired later, they would silently re-hit the same bug #80 fixed (output discarded by the consumer because the envelope shape is rejected on those events).

After this change, the canonical envelope is the default branch — `Stop`, `PreCompact`, `SubagentStop`, etc. all get the right shape automatically. Brings `scan::*` in line with `check-post.sh` and `inject-subagent.sh`, which already use `hookSpecificOutput`.

## Changes

- `tools/ways-cli/src/cmd/scan/mod.rs`: `emit_hook_context` now `match`es on the event name with `SessionStart | PreToolUse => legacy`, `_ => canonical`. Docstrings on `emit_hook_context` and `scan::prompt` rewritten to reflect inverted semantics.
- `tools/ways-cli/src/main.rs`: `--hook-event` clap doc-comment rewritten to match. Default value of `"SessionStart"` is intentionally retained — the silent-misroute concern is tracked separately as #81 item 4.
- `tools/ways-cli/tests/session_sim.rs`: scenario_10 gains positive + negative envelope assertions on the SessionStart path (`additionalContext` present at top level, `hookSpecificOutput` absent) to lock in the legacy tolerance after the flip. scenario_1's existing canonical-envelope assertion on `UserPromptSubmit` still passes via the new default branch.

## Out of scope

The `scan/mod.rs` file is at 685 lines (Code Quality Way Review tier). The split is item 3 of #81 and ships separately.

## Test plan

- [x] `make ways-rebuild` clean
- [x] `make test-unit` — 70/70 pass
- [x] `make test-sim` — 10/10 pass (scenario_1 covers canonical default; scenario_10 now covers explicit legacy branch)
- [x] Smoke test: `ways scan state --hook-event UserPromptSubmit ...` → `{"hookSpecificOutput":...}`
- [x] Smoke test: `ways scan state --hook-event SessionStart ...` → `{"additionalContext":...}`
- [x] Smoke test: `ways scan state --hook-event PreToolUse ...` → `{"additionalContext":...}` (other legacy event)
- [x] Smoke test: `ways scan state --hook-event Stop ...` would route to canonical (verified envelope branch reached; output empty in this env because no state-trigger ways match `Stop`)

Refs: #81 (item 1)