### PR TITLE
refactor(session): canonicalize response-topics path through one helper

### DIFF
--- a/hooks/ways/check-prompt.sh
+++ b/hooks/ways/check-prompt.sh
@@ -14,8 +14,10 @@ PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(echo "$INPUT" | jq -r '.cwd // empty')}"
 AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // empty')
 [[ -n "$AGENT_ID" ]] && export CLAUDE_AGENT_ID="$AGENT_ID"
 
-# Read response topics from Stop hook (if available)
-RESPONSE_STATE="/tmp/claude-response-topics-${SESSION_ID}"
+# Read response topics from Stop hook (if available).
+# Path resolves through the binary so the writer (check-response.sh),
+# the consumer (here), and `ways reset` cannot drift.
+RESPONSE_STATE=$("${HOME}/.claude/bin/ways" response-topics-path "$SESSION_ID")
 RESPONSE_TOPICS=""
 if [[ -f "$RESPONSE_STATE" ]]; then
   RESPONSE_TOPICS=$(jq -r '.topics // empty' "$RESPONSE_STATE" 2>/dev/null)

--- a/hooks/ways/check-response.sh
+++ b/hooks/ways/check-response.sh
@@ -20,7 +20,9 @@ STOP_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
 # Need transcript
 [[ ! -f "$TRANSCRIPT" ]] && exit 0
 
-STATE_FILE="/tmp/claude-response-topics-${SESSION_ID}"
+# Path resolves through the binary so this writer, the consumer
+# (check-prompt.sh), and `ways reset` cannot drift.
+STATE_FILE=$("${HOME}/.claude/bin/ways" response-topics-path "$SESSION_ID")
 
 # Extract last assistant message from transcript (JSONL format)
 # Use tail instead of tac to avoid reading entire file

--- a/tools/ways-cli/src/cmd/reset.rs
+++ b/tools/ways-cli/src/cmd/reset.rs
@@ -15,9 +15,10 @@ use crate::session;
 /// Return paths to off-root, per-session state files that hooks write
 /// outside `sessions_root()`. Reset must clear these alongside the main
 /// session directory or matching can be biased by stale topic context
-/// after a reset.
+/// after a reset. Each path resolves through its canonical helper so
+/// reset and the writing/reading hooks can never drift.
 fn session_side_files(sid: &str) -> Vec<PathBuf> {
-    vec![PathBuf::from(format!("/tmp/claude-response-topics-{sid}"))]
+    vec![session::response_topics_path(sid)]
 }
 
 

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -230,6 +230,13 @@ enum Commands {
         #[arg(long)]
         confirm: bool,
     },
+    /// Print the per-session response-topics state file path (single source
+    /// of truth for the Stop hook writer, the UserPromptSubmit consumer, and
+    /// `ways reset`'s side-file cleanup).
+    ResponseTopicsPath {
+        /// Session ID
+        session: String,
+    },
     /// Manage configuration (init/show/path)
     Config {
         #[command(subcommand)]
@@ -576,6 +583,10 @@ fn main() -> Result<()> {
         }
         Commands::Reset { session, all, confirm } => {
             cmd::reset::run(session.as_deref(), all, confirm)
+        }
+        Commands::ResponseTopicsPath { session } => {
+            println!("{}", session::response_topics_path(&session).display());
+            Ok(())
         }
         Commands::Permissions { action, global } => {
             match action {

--- a/tools/ways-cli/src/session.rs
+++ b/tools/ways-cli/src/session.rs
@@ -47,6 +47,16 @@ fn session_dir(session_id: &str) -> PathBuf {
     PathBuf::from(format!("{}/{session_id}", sessions_root()))
 }
 
+/// Path to the per-session response-topics state file written by the Stop
+/// hook (`check-response.sh`) and consumed on the next turn by
+/// `check-prompt.sh` to enrich prompt matching with topics from Claude's
+/// last reply. Lives outside `sessions_root()` because it predates that
+/// hierarchy and the path is hardcoded in shell hooks; canonicalized here
+/// so reset, the writer, and the consumer cannot drift.
+pub fn response_topics_path(session_id: &str) -> PathBuf {
+    PathBuf::from(format!("/tmp/claude-response-topics-{session_id}"))
+}
+
 /// Ensure a path's parent directories exist.
 fn ensure_parent(path: &Path) {
     if let Some(parent) = path.parent() {

--- a/tools/ways-cli/src/session.rs
+++ b/tools/ways-cli/src/session.rs
@@ -51,8 +51,8 @@ fn session_dir(session_id: &str) -> PathBuf {
 /// hook (`check-response.sh`) and consumed on the next turn by
 /// `check-prompt.sh` to enrich prompt matching with topics from Claude's
 /// last reply. Lives outside `sessions_root()` because it predates that
-/// hierarchy and the path is hardcoded in shell hooks; canonicalized here
-/// so reset, the writer, and the consumer cannot drift.
+/// hierarchy. Canonical here so reset, the writer, and the consumer all
+/// resolve through one source of truth and cannot drift.
 pub fn response_topics_path(session_id: &str) -> PathBuf {
     PathBuf::from(format!("/tmp/claude-response-topics-{session_id}"))
 }


### PR DESCRIPTION
## Summary

Item 2 of #81 — DRY the `/tmp/claude-response-topics-{sid}` path that was hardcoded in three places.

The path was inlined in:
- `tools/ways-cli/src/cmd/reset.rs:20` — the side-files cleanup helper
- `hooks/ways/check-response.sh:23` — the Stop-hook writer
- `hooks/ways/check-prompt.sh:18` — the UserPromptSubmit consumer

A divergence between any two would silently break the reset/inject loop — reset would leave stale topics behind, or the writer and reader would disagree on where to look.

## Changes

- `tools/ways-cli/src/session.rs`: new `pub fn response_topics_path(session_id: &str) -> PathBuf` — single source of truth, lives next to `sessions_root()` since that's the same module that owns session-state path conventions.
- `tools/ways-cli/src/main.rs`: new `ways response-topics-path <sid>` subcommand exposes the helper for shell hooks. One-line dispatch — `println!` the path and exit.
- `tools/ways-cli/src/cmd/reset.rs`: `session_side_files` now calls `session::response_topics_path` directly.
- `hooks/ways/check-prompt.sh`, `hooks/ways/check-response.sh`: resolve the path via `$("${HOME}/.claude/bin/ways" response-topics-path "$SESSION_ID")`.

The shell scripts already invoke `ways` as their core operation; one extra binary call for the path lookup is negligible compared to the matching/scanning that follows.

## Test plan

- [x] `make ways-rebuild` clean
- [x] `make test-unit` — 70/70 pass
- [x] `make test-sim` — 10/10 pass
- [x] Smoke test: `ways response-topics-path test-sid-123` → `/tmp/claude-response-topics-test-sid-123` (matches old hardcoded shape exactly, so existing topics files written before this change remain readable)
- [x] Shell command substitution form `STATE=$(... response-topics-path "$SESSION_ID")` returns the same string that was previously inlined

Refs: #81 (item 2)