### PR TITLE
chore(scan): warn on stderr when ways scan state defaults --hook-event

### DIFF
--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -368,9 +368,13 @@ enum ScanCommand {
         /// Hook event that invoked this scan (drives output envelope shape).
         /// `hookSpecificOutput` is canonical for all events; `SessionStart`
         /// and `PreToolUse` are the only events that take the legacy
-        /// top-level `additionalContext` shape. Defaults to SessionStart.
-        #[arg(long, default_value = "SessionStart")]
-        hook_event: String,
+        /// top-level `additionalContext` shape. When omitted, falls back to
+        /// `SessionStart` and emits a stderr trace — `check-state.sh` already
+        /// applies the same fallback via jq, so a missing value here means
+        /// neither layer received `hook_event_name` and the envelope shape
+        /// may be wrong for the actual invoking event.
+        #[arg(long)]
+        hook_event: Option<String>,
     },
 }
 
@@ -529,7 +533,15 @@ fn main() -> Result<()> {
                 cmd::scan::task(&query, &session, project.as_deref(), team.as_deref())
             }
             ScanCommand::State { session, project, transcript, hook_event } => {
-                cmd::scan::state(&session, project.as_deref(), transcript.as_deref(), &hook_event)
+                let event = hook_event.unwrap_or_else(|| {
+                    eprintln!(
+                        "[ways] scan state invoked without --hook-event; defaulting to SessionStart. \
+                         If the invoking hook is not SessionStart/PreToolUse, the output envelope \
+                         shape will be wrong and the agent will silently receive nothing."
+                    );
+                    "SessionStart".to_string()
+                });
+                cmd::scan::state(&session, project.as_deref(), transcript.as_deref(), &event)
             }
         },
         Commands::Show { what } => match what {

--- a/tools/ways-cli/tests/session_sim.rs
+++ b/tools/ways-cli/tests/session_sim.rs
@@ -158,18 +158,33 @@ impl Session {
     }
 
     fn scan_state(&self) -> String {
+        self.scan_state_full(None).0
+    }
+
+    /// Run `ways scan state`, optionally passing `--hook-event`, and return
+    /// `(stdout, stderr)`. Lets tests assert both content delivery and the
+    /// misroute warning channel.
+    fn scan_state_full(&self, hook_event: Option<&str>) -> (String, String) {
+        let mut args: Vec<&str> = vec![
+            "scan", "state",
+            "--session", &self.id,
+            "--project", "/tmp/nonexistent-project",
+        ];
+        if let Some(ev) = hook_event {
+            args.push("--hook-event");
+            args.push(ev);
+        }
         let output = Command::new(ways_bin())
-            .args([
-                "scan", "state",
-                "--session", &self.id,
-                "--project", "/tmp/nonexistent-project",
-            ])
+            .args(&args)
             .env("HOME", fixture_home())
             .env("XDG_CACHE_HOME", self.corpus.parent().unwrap().parent().unwrap().parent().unwrap())
             .output()
             .expect("Failed to run ways scan state");
 
-        String::from_utf8_lossy(&output.stdout).to_string()
+        (
+            String::from_utf8_lossy(&output.stdout).to_string(),
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        )
     }
 }
 
@@ -515,5 +530,30 @@ fn scenario_10_state_triggers() {
     assert!(
         !output2.contains("State Trigger Test Way"),
         "State trigger should not re-fire (marker exists)"
+    );
+}
+
+// ── Scenario 11: Hook-event misroute trace ─────────────────────
+
+#[test]
+fn scenario_11_hook_event_misroute_warning() {
+    // `ways scan state` invoked without `--hook-event` falls back to
+    // SessionStart, which is also the shell's jq fallback in
+    // `check-state.sh` — two layers of the same default mean a misrouted
+    // hook would silently emit the wrong envelope shape. The fallback
+    // itself is preserved (behavior unchanged) but a defensive stderr
+    // trace surfaces the misroute in hook-execution logs.
+    let s = Session::new("s11");
+
+    // Without --hook-event: stderr trace must surface, stdout must still
+    // carry content (the SessionStart fallback still runs).
+    let (stdout, stderr) = s.scan_state_full(None);
+    assert!(
+        stderr.contains("[ways]") && stderr.contains("--hook-event"),
+        "scan state without --hook-event must emit a [ways] stderr trace mentioning the missing flag; got stderr: {stderr:?}"
+    );
+    assert!(
+        stdout.contains("State Trigger Test Way"),
+        "scan state without --hook-event must still default-fire SessionStart; got stdout: {stdout:?}"
     );
 }


### PR DESCRIPTION
## Summary

Item 4 of #81 — defensive observability for the `--hook-event` fallback.

`ways scan state` had `default_value = "SessionStart"` on its `--hook-event` arg, layered on top of the shell's `jq -r '.hook_event_name // "SessionStart"'` fallback in `check-state.sh`. Two layers of the same default mean a misrouted hook (one whose JSON input has no `hook_event_name`) silently emits the wrong envelope shape — the exact failure PR #80 fixed for the UserPromptSubmit path.

This PR doesn't change behavior — the SessionStart fallback still runs. It just surfaces the misroute on stderr where hook-execution logs will catch it before silent damage accumulates.

## Changes

- `tools/ways-cli/src/main.rs`: `--hook-event` becomes `Option<String>` (no clap default). At the dispatch site, `unwrap_or_else` emits a `[ways]`-tagged stderr trace when `None` and substitutes `"SessionStart"`. Removing the clap default means the fallback is applied in exactly one place — easier to reason about than two layers.
- `tools/ways-cli/tests/session_sim.rs`: new `scan_state_full(hook_event: Option<&str>)` helper returns `(stdout, stderr)`. New scenario_11 asserts (a) the stderr trace surfaces when `--hook-event` is omitted and (b) content delivery is unchanged (SessionStart fallback still fires).

## Test plan

- [x] `make ways-rebuild` clean
- [x] `make test-unit` — 70/70 pass
- [x] `make test-sim` — 11/11 pass (scenario_11 added)
- [x] Smoke: `ways scan state --session smoke --project /tmp/nonexistent` emits the `[ways]` notice on stderr
- [x] Smoke: `ways scan state --hook-event SessionStart ...` emits nothing on stderr (no false positives)

Refs: #81 (item 4)