### PR TITLE
chore: bump ways to v0.7.0

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "ways"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "agent-fmt",
  "anyhow",

--- a/tools/ways-cli/Cargo.toml
+++ b/tools/ways-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ways"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 description = "Unified CLI for ways — knowledge guidance for Claude Code"
 license = "MIT"


### PR DESCRIPTION
## Summary

Minor version bump for the cumulative changes since v0.6.1.

## What's in this release

| PR | Change |
|---|---|
| #82 | `emit_hook_context` defaults to canonical `hookSpecificOutput`; `SessionStart` / `PreToolUse` are the explicit legacy `additionalContext` cases. Future Stop / PreCompact wirings get the right shape automatically. |
| #83 | `/tmp/claude-response-topics-{sid}` consolidated through `session::response_topics_path` and the new `ways response-topics-path <sid>` subcommand. Reset, the Stop-hook writer, and the UPS consumer share one source of truth. |
| #84 | `ways scan state` emits a `[ways]` stderr trace when `--hook-event` is missing. Surfaces hook misroutes in execution logs; behavior unchanged. |
| #85 | `scan::state` extracted into `scan/state.rs`. `scan/mod.rs` drops from 689 → 485 lines, below the Code Quality Way's Review tier. |

## Why minor (not patch)

Additive new subcommand (`ways response-topics-path`) and the canonical envelope architecture flip are more than a patch's worth of surface area. No breaking CLI changes — every prior invocation form still works.

## Test plan

- [x] `make ways-rebuild` clean (binary reports `ways 0.7.0`)
- [x] `Cargo.lock` updated to match (no other lockfile drift)
- [x] CI on each contributing PR was green at merge time

## After merge

Tag `ways-v0.7.0` on main → `build-ways.yml` workflow's `release` job builds 4-platform binaries and publishes the GitHub release.