### PR TITLE
fix(attend): resolve session UUID in background sessions

### DIFF
--- a/tools/sensor-peers/src/lib.rs
+++ b/tools/sensor-peers/src/lib.rs
@@ -743,17 +743,23 @@ fn parse_session_file(content: &str) -> Option<SessionFile> {
 }
 
 /// Check if a PID is alive and running a claude process.
+///
+/// Inspects the full command line rather than `comm`. The `comm` field is
+/// the executable basename, which for background sessions is the version
+/// number (e.g. `2.1.139`) because they exec the versioned binary at
+/// `~/.local/share/claude/versions/<ver>` directly. The full argv keeps
+/// the binary's path, which contains `claude` for both foreground and
+/// background sessions.
 fn pid_is_claude(pid: u32) -> bool {
     let output = Command::new("ps")
-        .args(["--no-headers", "-p", &pid.to_string(), "-o", "comm"])
+        .args(["--no-headers", "-p", &pid.to_string(), "-o", "args"])
         .output()
         .ok();
 
     match output {
         Some(out) if out.status.success() => {
-            let comm = String::from_utf8_lossy(&out.stdout);
-            let comm = comm.trim();
-            comm == "claude" || comm.contains("claude")
+            let args = String::from_utf8_lossy(&out.stdout);
+            args.contains("claude")
         }
         _ => false,
     }
@@ -799,37 +805,57 @@ fn extract_json_string(json: &str, key: &str) -> Option<String> {
     Some(rest[..end].to_string())
 }
 
-/// Find our own session ID by walking up the process tree to the claude parent,
-/// then matching against ~/.claude/sessions/*.json.
-/// Find the Claude session ID for the current process by walking up the
-/// process tree to find the claude parent, then matching against session files.
+/// Find the Claude session ID for the current process.
+///
+/// Walks up the process tree and matches each ancestor pid against the pids
+/// recorded in `~/.claude/sessions/*.json`. The first ancestor that matches a
+/// session file wins, and its `sessionId` is returned.
+///
+/// We deliberately do not rely on the process `comm` string. Foreground
+/// sessions show `comm=claude` because they run the user-launched
+/// `~/.local/bin/claude` wrapper, but background sessions are forked directly
+/// from the versioned binary at `~/.local/share/claude/versions/<ver>` and
+/// show `comm=<ver>` (e.g. `2.1.139`). Filtering on the comm string skips
+/// past bg-session inner pids and lands on the daemon, which is not in
+/// `sessions/*.json`, so resolution silently falls back to `pid-<self>` for
+/// every subcommand invocation. Probing the pid index directly avoids that
+/// trap and works for both kinds of session.
 pub fn find_own_session_id(own_pid: u32) -> Option<String> {
+    let sessions_dir = home_dir().join(".claude").join("sessions");
+    let mut pid_to_session: std::collections::HashMap<u32, String> =
+        std::collections::HashMap::new();
+    if let Ok(entries) = fs::read_dir(&sessions_dir) {
+        for entry in entries.flatten() {
+            if let Ok(content) = fs::read_to_string(entry.path()) {
+                if let (Some(pid), Some(sid)) = (
+                    extract_json_u64(&content, "pid"),
+                    extract_json_string(&content, "sessionId"),
+                ) {
+                    pid_to_session.insert(pid as u32, sid);
+                }
+            }
+        }
+    }
+    if pid_to_session.is_empty() {
+        return None;
+    }
+
     let mut pid = own_pid;
-    let mut claude_pid = None;
-    for _ in 0..10 {
-        if pid <= 1 { break; }
+    for _ in 0..15 {
+        if let Some(sid) = pid_to_session.get(&pid) {
+            return Some(sid.clone());
+        }
+        if pid <= 1 {
+            break;
+        }
         let output = Command::new("ps")
-            .args(["--no-headers", "-p", &pid.to_string(), "-o", "ppid,comm"])
+            .args(["--no-headers", "-p", &pid.to_string(), "-o", "ppid"])
             .output()
             .ok()?;
         let line = String::from_utf8_lossy(&output.stdout);
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.len() >= 2 && parts[1].contains("claude") {
-            claude_pid = Some(pid);
-            break;
-        }
-        pid = parts.first()?.parse().ok()?;
-    }
-
-    let claude_pid = claude_pid?;
-    let home = home_dir();
-    let sessions_dir = home.join(".claude").join("sessions");
-    for entry in fs::read_dir(&sessions_dir).ok()?.flatten() {
-        if let Ok(content) = fs::read_to_string(entry.path()) {
-            let pid_pattern = format!("\"pid\":{}", claude_pid);
-            if content.contains(&pid_pattern) {
-                return extract_json_string(&content, "sessionId");
-            }
+        match line.trim().parse::<u32>() {
+            Ok(ppid) if ppid > 0 && ppid != pid => pid = ppid,
+            _ => break,
         }
     }
     None


### PR DESCRIPTION
## Summary

Background sessions launched via `claude --bg` or `/bg` (Claude Code v2.1.139's new agent view) couldn't be peers in attend: their attend Monitor would run, heartbeat would tick, signal files would write — but discovery and liveness checks treated them as dead. Tested empirically by spawning a backgrounded session and observing that:

- group membership and heartbeat keyed off different pid-fallback identities
- `attend send --focus` reported "no live peers" even with a fresh heartbeat
- broadcast wrote to a single peer dir (the sender's), never reaching the bg session

Two places in `sensor-peers` relied on the process `comm` field equalling `claude`. Foreground sessions invoke the user-launched wrapper at `~/.local/bin/claude`, so their `comm` is `claude`. Background sessions are forked directly from the versioned binary at `~/.local/share/claude/versions/<ver>`, so `comm` is the version string (e.g. `2.1.139`). Both code paths walked past bg pids and lost the trail.

### Fixes

- **`find_own_session_id`** — drop the comm filter. Read `~/.claude/sessions/*.json` (the pid → session UUID index, written for both kinds of session) into a HashMap, then walk own process ancestry probing each pid against the map. First match wins.
- **`pid_is_claude`** — switch from `ps -o comm` to `ps -o args`. The full command line keeps the binary path, which contains `claude` for both foreground and bg processes regardless of which entry-point they exec'd.

## Verification

Reproduction script: spawn a fresh bg session running attend in a named focus group, observe identity in `_groups.yaml` and `heartbeat/`.

Pre-fix:
- `_groups.yaml` member: `pid-150303` (the agent's bash subprocess pid)
- `heartbeat/`: `pid-151279` (the Monitor's own pid)
- `attend send --focus`: `error: no live peers in focus group`

Post-fix:
- `_groups.yaml` member: `44d42b6f-576b-4a44-9c05-2918778b2522` (real session UUID)
- `heartbeat/`: same UUID — both subcommands agree
- `attend send --focus`: `signal written (focus, 1 dirs)`
- `attend peers` from a foreground session lists the bg session as a live peer

Several long-running peer sessions on the box that had been invisible (Severin, Horatio, Primrose — all background) showed up in `attend peers` immediately after the rebuild, confirming the fix lifts a class-wide blindness, not just the test case.

## Test plan

- [x] `cargo test -p sensor-peers --release` — 30 tests pass, no regressions
- [x] Foreground session regression check — `attend status` from this PR's session still resolves to its real UUID, not a pid fallback
- [x] Bg session round-trip — message sent from foreground, delivered to bg session's focus group dir
- [ ] Manual smoke test by a reviewer with a bg session of their own (optional)