### PR TITLE
chore: bump attend to v0.7.1

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attend"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "agent-fmt",
  "agent-identity",

--- a/tools/attend/Cargo.toml
+++ b/tools/attend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "attend"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Active awareness module — adaptive sensing and disclosure for Claude Code sessions"
 license = "MIT"


### PR DESCRIPTION
## Summary

Patch release for #89 (`fix(attend): resolve session UUID in background sessions`). No other changes since v0.7.0.

After merge, push the `attend-v0.7.1` tag and CI takes over from there.

## Test plan
- [x] `cargo build --release -p attend` succeeds with new version
- [x] `Cargo.lock` updated