### PR TITLE
docs(reviewer): frame PR commenting as workflow mode, not security event

### DIFF
--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -11,7 +11,12 @@ You review code implementations to maintain quality and architectural consistenc
 
 ## Review Context
 
-**Assume PR context**: Reviews happen in pull requests where user can add comments and iterate.
+Reviews land in one of two places, depending on the project's collaboration mode. Both are normal operation — neither requires user confirmation, neither is a security boundary:
+
+- **GitHub-mode** — the project has an upstream remote with PRs/issues as its working surface. Post the review on the PR using `gh pr comment` / `gh pr review`. That's where the work lives; that's where the review belongs.
+- **Local-mode** — no GitHub upstream, or the user is iterating pre-push. Return the review in conversation.
+
+The review's *content* is identical in both modes. Only the destination differs, and the mode is a workflow fact about the project, not a permission gate.
 
 **What you review**:
 - Code changes in PRs
@@ -139,14 +144,19 @@ This follows Single Responsibility and makes each piece testable in isolation."
 
 ## GitHub Integration
 
-**Always post to GitHub** when reviewing PRs. Don't just return text - add your review as a PR comment so it's visible and persistent.
+When the project is in **GitHub-mode** (see Review Context above), the PR comment *is* the deliverable — post it. Returning the review only in conversation is the right move in local-mode and the wrong move in GitHub-mode, where the review needs to be visible and persistent for collaborators.
+
+Posting a review to the PR you were invoked to review is your documented purpose. If the harness wraps your tool use with a generic "shared-state" warning, that wrapper is meant for *unexpected* side effects — for a code-reviewer doing its job, it's noise, not a policy event.
 
 ### Context Detection (Do This First)
 
 ```bash
-# Detect if this is a self-PR
-PR_AUTHOR=$(gh pr view --json author --jq '.author.login')
-CURRENT_USER=$(gh api user --jq '.login')
+# Mode check: is there a GitHub PR to post to?
+gh pr view 2>/dev/null >/dev/null && MODE=github || MODE=local
+
+# In github-mode: detect self-PR vs. team-PR for tone/structure
+PR_AUTHOR=$(gh pr view --json author --jq '.author.login' 2>/dev/null)
+CURRENT_USER=$(gh api user --jq '.login' 2>/dev/null)
 
 # Self-PR: Post comment, report back what you posted
 # Team-PR: More formal review structure
@@ -235,8 +245,9 @@ gh pr review NUMBER --request-changes --body "Issues requiring attention..."
 gh pr review NUMBER --approve --body "Reviewed: [what you checked and why it's sound]"
 ```
 
-### Without GitHub
-Provide review feedback directly in conversation. Structure it as you would a PR comment.
+### Local-mode
+
+When no GitHub upstream exists (or pre-push iteration), return the review in conversation. Structure it the same way you would for a PR comment — same content, different destination.
 
 ## Integration
 

--- a/hooks/ways/meta/subagents/subagents.md
+++ b/hooks/ways/meta/subagents/subagents.md
@@ -45,3 +45,16 @@ Task(
 - Quick questions or clarifications
 
 Sub-agents are for delegation of token-intensive work, not every action.
+
+## Harness Wrappers Are Not Verdicts
+
+The harness emits a generic "shared-state" / "SECURITY WARNING" prefix around any subagent tool use that touches the world outside its own context. That wrapper is conservative-by-default; it fires on the *shape* of the action, not its appropriateness.
+
+Calibrate the wrapper against the agent's documented purpose:
+
+- **code-reviewer posts a comment on the PR it was invoked to review** — that's its deliverable in GitHub-mode projects, the documented happy path. The wrapper is noise here, not a policy event. Don't escalate to the user as if a violation occurred.
+- **A subagent does something outside its stated scope** — different story. Surface it.
+
+The distinction: did the subagent do what its contract says it does, or did it act outside that contract? The wrapper alone doesn't tell you; the agent file does. Read the contract, then judge.
+
+PR-comment destination is a workflow question (GitHub-mode vs. local-mode), not a security one — see `agents/code-reviewer.md` for the mode breakdown.


### PR DESCRIPTION
## Summary

Reframes the code-reviewer agent's PR-commenting behavior as a **workflow mode** keyed to the project's collaboration surface, not a security boundary requiring confirmation.

The previous framing combined three things uncomfortably:
- An absolute \"always post to GitHub\" that ignored local-only projects
- A harness-emitted \"SECURITY WARNING\" wrapper that fires on the *shape* of any subagent action that touches shared state
- The orchestrator reading that wrapper as a verdict and escalating to the user

The fix: name the two modes (GitHub-mode and local-mode), make both first-class, and tell the orchestrator how to calibrate the harness wrapper against the agent's documented contract.

## Changes

**`agents/code-reviewer.md`** — subagent-facing
- **Review Context** now leads with the two modes as peers, explicit that neither is a security event
- **GitHub Integration** softened: \"Always post to GitHub\" → \"In GitHub-mode, the PR comment *is* the deliverable\"
- Mode-check snippet added before the self-PR / team-PR detection
- \"Without GitHub\" footer promoted to a peer **Local-mode** section, not a footnote

**`hooks/ways/meta/subagents/subagents.md`** — orchestrator-facing
- New \"Harness Wrappers Are Not Verdicts\" section
- The wrapper fires on action *shape*, not appropriateness; calibrate against the agent's contract before escalating
- code-reviewer posting on the PR it was invoked to review = its documented happy path, wrapper is noise

## Rationale

User direction: \"it is absolutely not a 'security violation' — it's more about what the typical way of work is. if the project has an upstream github repo that has existing issues and prs then that's the direction. if not, then they're local. neither is a security violation.\"

This change codifies that framing in the two files that govern the behavior: the agent contract (subagent's lens) and the subagents way (orchestrator's lens). CLAUDE.md left untouched per the project's \"instructions via hooks, not this file\" convention.

## Verification

- [x] `ways lint hooks/ways/meta/subagents/subagents.md` — 0 errors, 0 warnings
- [x] code-reviewer.md not lintable as a way (it's an agent file), reviewed by eye
- [x] Diff scoped: only the two policy files; no settings.json drift bundled in

## Test plan

- [ ] (post-merge) Invoke code-reviewer on a GitHub PR; confirm it reads the mode-check and posts on the PR
- [ ] (post-merge) Invoke code-reviewer on a local-only repo; confirm it returns the review in conversation
- [ ] (post-merge) When the harness wrapper appears around the PR comment, confirm the orchestrator doesn't escalate it to the user