### PR TITLE
fix(ways): pin list context lookup to session id

### DIFF
--- a/tools/ways-cli/src/cmd/context.rs
+++ b/tools/ways-cli/src/cmd/context.rs
@@ -20,18 +20,41 @@ pub struct ContextInfo {
 }
 
 /// Get context info for the current session. Used by `ways context` and `ways list`.
+///
+/// When `session_id` is provided, the transcript is located by scanning
+/// `~/.claude/projects/*/<session_id>.jsonl` — this is robust against
+/// cwd/project mismatches (e.g. a session rooted in `~/.claude` while the
+/// shell cwd is elsewhere). Falls back to `project_dir` + newest-transcript
+/// lookup when no session id is given.
 pub fn get_context(project_dir: Option<&str>) -> Result<ContextInfo> {
-    let project = project_dir
-        .map(|s| s.to_string())
-        .or_else(|| std::env::var("CLAUDE_PROJECT_DIR").ok())
-        .or_else(detect_project_dir)
-        .unwrap_or_else(|| ".".to_string());
+    get_context_inner(project_dir, None)
+}
 
-    let project_slug = project.replace(['/', '.'], "-");
-    let conv_dir = home_dir().join(format!(".claude/projects/{project_slug}"));
+/// Like `get_context`, but pinned to a known session id. Locates the
+/// transcript by session id across all project dirs rather than guessing
+/// the project from cwd.
+pub fn get_context_for_session(session_id: &str) -> Result<ContextInfo> {
+    get_context_inner(None, Some(session_id))
+}
 
-    let transcript = find_newest_transcript(&conv_dir)
-        .ok_or_else(|| anyhow::anyhow!("No active transcript found for project: {project}"))?;
+fn get_context_inner(project_dir: Option<&str>, session_id: Option<&str>) -> Result<ContextInfo> {
+    let transcript = if let Some(sid) = session_id {
+        find_transcript_by_session(sid).ok_or_else(|| {
+            anyhow::anyhow!("No transcript found for session: {sid}")
+        })?
+    } else {
+        let project = project_dir
+            .map(|s| s.to_string())
+            .or_else(|| std::env::var("CLAUDE_PROJECT_DIR").ok())
+            .or_else(detect_project_dir)
+            .unwrap_or_else(|| ".".to_string());
+
+        let project_slug = project.replace(['/', '.'], "-");
+        let conv_dir = home_dir().join(format!(".claude/projects/{project_slug}"));
+
+        find_newest_transcript(&conv_dir)
+            .ok_or_else(|| anyhow::anyhow!("No active transcript found for project: {project}"))?
+    };
 
     let session = transcript
         .file_stem()
@@ -220,6 +243,22 @@ fn read_token_usage(content: &str) -> (u64, String) {
     // Conservative: ~6.3 transcript JSON bytes per token
     let estimated = active_bytes * 10 / 63;
     (estimated, "bytes".to_string())
+}
+
+/// Find a transcript by session id, searching every project dir under
+/// `~/.claude/projects/`. Session ids are globally unique, so we don't
+/// need to know which project the session is rooted in.
+fn find_transcript_by_session(session_id: &str) -> Option<PathBuf> {
+    let projects_root = home_dir().join(".claude/projects");
+    let filename = format!("{session_id}.jsonl");
+    for entry in std::fs::read_dir(&projects_root).ok()? {
+        let entry = entry.ok()?;
+        let candidate = entry.path().join(&filename);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
 }
 
 fn find_newest_transcript(dir: &Path) -> Option<PathBuf> {

--- a/tools/ways-cli/src/cmd/list.rs
+++ b/tools/ways-cli/src/cmd/list.rs
@@ -56,8 +56,12 @@ pub fn run(session: Option<&str>, sort: &str, json_out: bool) -> Result<()> {
 
     let current_epoch = session::get_epoch(&session_id);
 
-    // Use accurate context data from transcript when available
-    let (current_tokens_k, context_window_k, context_window) = match context::get_context(None) {
+    // Use accurate context data from transcript when available.
+    // Pinning to session_id keeps detection correct when cwd is outside
+    // the session's project (e.g. a session rooted in ~/.claude while the
+    // shell has cd'd elsewhere) — otherwise the cwd-walk can land on
+    // ~/.claude (global config) and miss the real transcript.
+    let (current_tokens_k, context_window_k, context_window) = match context::get_context_for_session(&session_id) {
         Ok(ctx) => (ctx.tokens_used / 1000, ctx.tokens_total / 1000, ctx.tokens_total),
         Err(_) => {
             // Fallback to session markers


### PR DESCRIPTION
## Summary
- `ways list` was misreporting context as 200K on 1M-window sessions when the shell cwd was outside the active session's project.
- Root cause: `detect_project_dir` walks up from cwd looking for `.claude/settings.json`, and matches `~/.claude` (the global config) when no closer project marker exists. The transcript lookup then targets a non-existent project dir, errors out, and falls through to the 200K heuristic.
- Fix: resolve the transcript by session id directly (`~/.claude/projects/*/<sid>.jsonl`). The session id is already known to `ways list` and is globally unique, so no project guessing is needed.

## Test plan
- [x] `ways list` from `~/Projects/aaronsb/anthropic-basecamp/` (cwd outside session project) now reports `1000K ctx` instead of `200K ctx`
- [x] `ways list` from inside the session project still reports correctly
- [x] `cargo test -p ways --release` — 70 unit + 11 sim tests pass