### PR TITLE
fix(scan): skip embed for custom-agent dispatches

### DIFF
--- a/hooks/ways/check-task-pre.sh
+++ b/hooks/ways/check-task-pre.sh
@@ -4,6 +4,13 @@
 # Phase 1 of two-phase subagent injection:
 # 1. This script: ways scan task (matches ways, writes stash)
 # 2. SubagentStart: inject-subagent.sh (reads stash, emits content)
+#
+# Skips dispatches to custom-defined agents (project, global, or plugin):
+# their .md file IS the agent's constitution, so ways injection would be
+# redundant — and their delegation prompts are large enough that embedding
+# them against the corpus crashes the embedder on its position-embedding
+# limit. The scan/embed exists for generic subagents that lack such a
+# constitution (general-purpose, Explore, Plan, etc.).
 
 source "$(dirname "$0")/require-ways.sh"
 
@@ -14,8 +21,25 @@ AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // empty')
 [[ -n "$AGENT_ID" ]] && export CLAUDE_AGENT_ID="$AGENT_ID"
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(echo "$INPUT" | jq -r '.cwd // empty')}"
 TEAM_NAME=$(echo "$INPUT" | jq -r '.tool_input.team_name // empty')
+SUBAGENT_TYPE=$(echo "$INPUT" | jq -r '.tool_input.subagent_type // empty')
 
 [[ -z "$TASK_PROMPT" || -z "$SESSION_ID" ]] && exit 0
+
+# Skip custom agents — they have their own .md constitution.
+if [[ -n "$SUBAGENT_TYPE" ]]; then
+  if [[ -f "${PROJECT_DIR}/.claude/agents/${SUBAGENT_TYPE}.md" ]] \
+     || [[ -f "${HOME}/.claude/agents/${SUBAGENT_TYPE}.md" ]]; then
+    exit 0
+  fi
+  # Plugin-provided agents live under .../plugins/<plugin>/agents/.
+  # Glob via bash so we don't pay for a find() walk on every dispatch.
+  shopt -s nullglob
+  plugin_hits=("${HOME}/.claude/plugins/marketplaces/"*"/plugins/"*"/agents/${SUBAGENT_TYPE}.md")
+  shopt -u nullglob
+  if (( ${#plugin_hits[@]} > 0 )); then
+    exit 0
+  fi
+fi
 
 ARGS=(--query "$TASK_PROMPT" --session "$SESSION_ID" --project "$PROJECT_DIR")
 [[ -n "$TEAM_NAME" ]] && ARGS+=(--team "$TEAM_NAME")

--- a/hooks/ways/check-task-pre.sh
+++ b/hooks/ways/check-task-pre.sh
@@ -26,17 +26,25 @@ SUBAGENT_TYPE=$(echo "$INPUT" | jq -r '.tool_input.subagent_type // empty')
 [[ -z "$TASK_PROMPT" || -z "$SESSION_ID" ]] && exit 0
 
 # Skip custom agents — they have their own .md constitution.
-if [[ -n "$SUBAGENT_TYPE" ]]; then
+#
+# SUBAGENT_TYPE is model-emitted tool input and is used below as a path
+# component. Validate the shape before letting it touch the filesystem
+# — Claude Code's own agent names match `[a-zA-Z0-9_-]+` (general-purpose,
+# vue-expert, code-reviewer, claude-code-guide). Without this guard,
+# `subagent_type="*"` would glob-expand and match every plugin agent
+# (spurious skip), and `"../foo"` would do shallow path traversal in
+# the `-f` checks. Blast radius is bounded (only effect is whether we
+# skip the scan, never an exec), but the input is untrusted so we keep
+# the path-component contract honest.
+if [[ "$SUBAGENT_TYPE" =~ ^[a-zA-Z0-9_-]+$ ]]; then
   if [[ -f "${PROJECT_DIR}/.claude/agents/${SUBAGENT_TYPE}.md" ]] \
      || [[ -f "${HOME}/.claude/agents/${SUBAGENT_TYPE}.md" ]]; then
     exit 0
   fi
   # Plugin-provided agents live under .../plugins/<plugin>/agents/.
-  # Glob via bash so we don't pay for a find() walk on every dispatch.
-  shopt -s nullglob
-  plugin_hits=("${HOME}/.claude/plugins/marketplaces/"*"/plugins/"*"/agents/${SUBAGENT_TYPE}.md")
-  shopt -u nullglob
-  if (( ${#plugin_hits[@]} > 0 )); then
+  # `compgen -G` returns rc=0 iff at least one path matches, without
+  # leaking shopt state back to a re-sourcing caller.
+  if compgen -G "${HOME}/.claude/plugins/marketplaces/*/plugins/*/agents/${SUBAGENT_TYPE}.md" > /dev/null; then
     exit 0
   fi
 fi


### PR DESCRIPTION
## Summary

The `PreToolUse:Task` hook (matcher `Task`) still fires for the renamed `Agent` tool in current Claude Code. When the dispatch is to a custom agent (project `.claude/agents/`, user `~/.claude/agents/`, or plugin-provided), Claude emits a long structured delegation prompt that overruns the embedding model's position-embedding table, causing way-embed to SIGABRT in `ggml_compute_forward_get_rows`. The Rust caller failed open so the crash was silent — KDE's crash reporter is what surfaced it.

Custom agents already carry their own constitution in their `.md` file, so injecting ways into them is redundant. Skip the scan entirely when `subagent_type` resolves to a known custom-agent definition; generic dispatches (`general-purpose`, `Explore`, `Plan`, etc.) keep getting the embed-based way matching they were designed for.

## Diagnosis

- Crash signature: `SIGABRT` in `ggml_compute_forward_get_rows` → `ggml_abort`. Position index overruns the model's position-embedding rows.
- Recent crashes (PIDs 88563, 128657, 156817) all had `--query` payloads that were full agent delegation prompts (vue-expert, code-reviewer) — multi-thousand chars.
- 600+ such crashes since 2026-05-06, peaking at 136 in a single day. Silent until KDE's crash reporter started popping.

## Why this is the right discriminator (not a kill-switch)

A kill-switch disables a feature. This fix preserves the feature for the agents that need it (no `.md` constitution) and skips it for the agents that don't (already have a constitution). The mismatch was conceptual: ways-injection was designed for context-less generic subagents, then custom agents arrived and the matcher caught them too.

## Test plan

- [x] Custom agent (`vue-expert`) with 4500-char prompt → 0 way-embed spawns, 0 crashes
- [x] Global custom agent (`code-reviewer`) → 0 way-embed spawns
- [x] Plugin agent (`code-simplifier`) → 0 way-embed spawns
- [x] `general-purpose` → way-embed still spawns as before (existing behavior preserved)
- [x] `bash -n` clean