### PR TITLE
fix(scan): cap bash embed query at 256 chars

### DIFF
--- a/hooks/ways/check-bash-pre.sh
+++ b/hooks/ways/check-bash-pre.sh
@@ -3,8 +3,26 @@
 #
 # The ways binary handles: command pattern matching, semantic scoring,
 # check curve scoring, session state, and content output.
+#
+# The command is truncated to its semantic prefix before being passed to
+# `ways scan command`. Heredoc bodies (`gh pr create --body "$(cat <<EOF…)"`),
+# JSON payloads (`curl -d '{…}'`), and other large argument bodies carry
+# no signal for "what kind of command is this" — the program name and
+# first few args do. The MiniLM embedding models cap at ~128 tokens of
+# position embeddings; queries past that abort the embedder (ggml
+# get_rows out-of-range). 256 chars ≈ 60 tokens, safely under the limit
+# with headroom for the description that gets appended downstream.
+#
+# This truncation feeds both the embed query *and* the regex matcher in
+# the ways binary. Every existing `commands:` pattern under hooks/ways/
+# matches on the program name + first arg (≤106 chars), so cropping at
+# 256 changes no current behavior. Future patterns that need to look
+# past char 256 of a bash command would be misusing this trigger
+# anyway — that signal belongs in `pattern:` against the description.
 
 source "$(dirname "$0")/require-ways.sh"
+
+readonly CMD_QUERY_MAX=256
 
 INPUT=$(cat)
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
@@ -14,9 +32,11 @@ AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // empty')
 [[ -n "$AGENT_ID" ]] && export CLAUDE_AGENT_ID="$AGENT_ID"
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(echo "$INPUT" | jq -r '.cwd // empty')}"
 
+CMD_QUERY="${CMD:0:$CMD_QUERY_MAX}"
+
 export CLAUDE_PROJECT_DIR="${PROJECT_DIR}"
 "${HOME}/.claude/bin/ways" scan command \
-  --command "$CMD" \
+  --command "$CMD_QUERY" \
   --description "$DESC" \
   --session "$SESSION_ID" \
   --project "$PROJECT_DIR"


### PR DESCRIPTION
## Summary

Bash tool inputs can carry kilobyte-scale heredoc bodies, JSON payloads, and multi-line PR descriptions — `gh pr create --body "$(cat <<EOF…)"`, `curl -d '{…}'`, `git commit -m "$(cat <<EOF…)"`. All of those overrun the MiniLM embedding model's position-embedding table and abort way-embed in `ggml_compute_forward_get_rows`. The Rust caller fails open so the crash was silent until KDE's reporter surfaced it.

The signal that distinguishes one bash command from another lives in the program name and first few args — `gh pr create`, `git commit`, `npm install`. Heredoc bodies carry no signal for "what kind of command is this." This caps the command at 256 chars (~60 tokens, safely under the 128-token model limit) before passing to `ways scan command`. Every existing `commands:` regex in `hooks/ways/` matches within 106 chars, so this changes no current matching behavior.

## Sister PR

This is the bash-hook companion to #94 (which discriminates by `subagent_type` for the Task/Agent hook). Same conceptual fix: the embed pipeline needs narrower input than the raw tool field. Custom agents → skip entirely. Bash commands → cap to the semantic prefix.

## Diagnosis

Crashes since 2026-05-06 (~600 cumulative, peaks at 136/day). Failure signature is consistent: `SIGABRT` in `ggml_compute_forward_get_rows`, query is always a long bash command body. The crashes were silent because `run_embed_match` catches non-zero exit and returns `None`. The April 30 fix (4756412 — UserPromptSubmit output routing) made the scan-path's *side effects* visible, but the underlying cost and crashes were already there.

## Test plan

- [x] `ls -la` (short cmd) → way-embed spawns, scan path runs as before
- [x] 4845-char heredoc command (mimics the just-now PID 177965 crash) → 0 crashes, scan path completes
- [x] `bash -n` clean
- [x] All existing `commands:` regex patterns ≤106 chars — no behavior change