### PR TITLE
fix(scan): cap prompt-hook embed query at 1024 chars

### DIFF
--- a/hooks/ways/check-prompt.sh
+++ b/hooks/ways/check-prompt.sh
@@ -4,8 +4,22 @@
 # The ways binary handles: file walking, frontmatter extraction, pattern
 # + semantic matching, scope/precondition gating, parent threshold
 # lowering, session markers, macro dispatch, and content output.
+#
+# UserPromptSubmit doesn't just carry the user's typed message — the
+# harness also injects structured content here: <task-notification>
+# blobs from completed background agents, <persisted-output> pointers
+# for tool results that exceed inline budget, and other system-reminder
+# envelopes. Any of those can run multiple KB, and embedding that
+# overruns the MiniLM model's position-embedding table (SIGABRT in
+# ggml_compute_forward_get_rows). Cap the embed query at 1024 chars
+# (~240 tokens — generous because real user prompts can legitimately
+# be paragraphs of context, unlike bash commands). Anything past 1024
+# in a prompt is system-injected envelope content that carries no
+# additional signal for matching the user's *intent* against ways.
 
 source "$(dirname "$0")/require-ways.sh"
+
+readonly PROMPT_QUERY_MAX=1024
 
 INPUT=$(cat)
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' | tr '[:upper:]' '[:lower:]')
@@ -23,8 +37,11 @@ if [[ -f "$RESPONSE_STATE" ]]; then
   RESPONSE_TOPICS=$(jq -r '.topics // empty' "$RESPONSE_STATE" 2>/dev/null)
 fi
 
-# Combined context: user prompt + Claude's recent topics
+# Combined context: user prompt + Claude's recent topics, capped.
+# RESPONSE_TOPICS is bounded by check-response.sh's extraction (~50 chars
+# of keywords) so the cap is effectively a guard on PROMPT itself.
 COMBINED="${PROMPT} ${RESPONSE_TOPICS}"
+COMBINED="${COMBINED:0:$PROMPT_QUERY_MAX}"
 
 export CLAUDE_PROJECT_DIR="${PROJECT_DIR}"
 "${HOME}/.claude/bin/ways" scan prompt \


### PR DESCRIPTION
## Summary

Third crash vector in today's set. UserPromptSubmit doesn't just carry the user's typed message — the harness also injects structured content through this path: `<task-notification>` blobs from completed background agents, `<persisted-output>` pointers for tool results exceeding inline budget, system-reminder envelopes. Any of those can run multiple KB and overrun the MiniLM model's position-embedding table when embedded as a query.

Latest crash (PID 197729) was triggered by a 1.5KB task-completion notification flowing through this hook. Cap `COMBINED` (prompt + response-topics) at 1024 chars before passing to `ways scan prompt`.

## Sister PRs

- #94 — custom-agent discriminator (Task/Agent hook) — merged
- #95 — bash 256-char cap (Bash hook) — merged
- **#96 (this)** — prompt 1024-char cap (UserPromptSubmit hook)

Same conceptual fix as #95: narrow the embed input before it overruns the model. Why 1024 here vs 256 in #95: real user prompts can legitimately be paragraphs of context (unlike bash command *shapes* which fit in 256). 1024 ≈ 240 tokens — generous headroom while still well under the 128-position-embedding limit per chunk.

## Acknowledged trade-off

Plain truncation is the cheapest possible fix. It loses signal past char 1024 — a long system-injected envelope might contain a phrase relevant to a ways match that we'd miss. This is acceptable as immediate mitigation because the alternative was crashing (silent fail-open, but cost paid and KDE crash spam). A more sophisticated approach — BM25 / lexical pre-filtering before embedding to reduce large inputs to their highest-signal terms — is the right next step but belongs in an ADR, not this PR.

## Test plan

- [x] Short user prompt → way-embed spawns, scan path runs as before
- [x] 3464-char task-notification (mimics the PID 197729 crash) → 0 crashes, query trimmed to 1024 chars
- [x] `bash -n` clean