### PR TITLE
fix(hooks): remove interim truncation caps — reducer is the size gate

### DIFF
--- a/hooks/ways/check-bash-pre.sh
+++ b/hooks/ways/check-bash-pre.sh
@@ -4,25 +4,15 @@
 # The ways binary handles: command pattern matching, semantic scoring,
 # check curve scoring, session state, and content output.
 #
-# The command is truncated to its semantic prefix before being passed to
-# `ways scan command`. Heredoc bodies (`gh pr create --body "$(cat <<EOF…)"`),
-# JSON payloads (`curl -d '{…}'`), and other large argument bodies carry
-# no signal for "what kind of command is this" — the program name and
-# first few args do. The MiniLM embedding models cap at ~128 tokens of
-# position embeddings; queries past that abort the embedder (ggml
-# get_rows out-of-range). 256 chars ≈ 60 tokens, safely under the limit
-# with headroom for the description that gets appended downstream.
-#
-# This truncation feeds both the embed query *and* the regex matcher in
-# the ways binary. Every existing `commands:` pattern under hooks/ways/
-# matches on the program name + first arg (≤106 chars), so cropping at
-# 256 changes no current behavior. Future patterns that need to look
-# past char 256 of a bash command would be misusing this trigger
-# anyway — that signal belongs in `pattern:` against the description.
+# Size bounding for the embed query is the ways binary's responsibility
+# (ADR-130 sentence-salience reducer in scan/reduce.rs). This script
+# passes the full command through so the reducer can score the prose
+# distribution itself — pre-truncating here would starve the reducer
+# of the back half of any long input. The regex `commands:` matcher
+# also gets the full command, which is what ways with patterns like
+# `^(npm|cargo|gh) ` expect.
 
 source "$(dirname "$0")/require-ways.sh"
-
-readonly CMD_QUERY_MAX=256
 
 INPUT=$(cat)
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
@@ -32,11 +22,9 @@ AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // empty')
 [[ -n "$AGENT_ID" ]] && export CLAUDE_AGENT_ID="$AGENT_ID"
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(echo "$INPUT" | jq -r '.cwd // empty')}"
 
-CMD_QUERY="${CMD:0:$CMD_QUERY_MAX}"
-
 export CLAUDE_PROJECT_DIR="${PROJECT_DIR}"
 "${HOME}/.claude/bin/ways" scan command \
-  --command "$CMD_QUERY" \
+  --command "$CMD" \
   --description "$DESC" \
   --session "$SESSION_ID" \
   --project "$PROJECT_DIR"

--- a/hooks/ways/check-prompt.sh
+++ b/hooks/ways/check-prompt.sh
@@ -9,17 +9,12 @@
 # harness also injects structured content here: <task-notification>
 # blobs from completed background agents, <persisted-output> pointers
 # for tool results that exceed inline budget, and other system-reminder
-# envelopes. Any of those can run multiple KB, and embedding that
-# overruns the MiniLM model's position-embedding table (SIGABRT in
-# ggml_compute_forward_get_rows). Cap the embed query at 1024 chars
-# (~240 tokens — generous because real user prompts can legitimately
-# be paragraphs of context, unlike bash commands). Anything past 1024
-# in a prompt is system-injected envelope content that carries no
-# additional signal for matching the user's *intent* against ways.
+# envelopes. Size bounding for the embed query is the ways binary's
+# responsibility (ADR-130 sentence-salience reducer in scan/reduce.rs).
+# This script passes the full combined prompt+topics through so the
+# reducer can score sentence salience across the whole input.
 
 source "$(dirname "$0")/require-ways.sh"
-
-readonly PROMPT_QUERY_MAX=1024
 
 INPUT=$(cat)
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' | tr '[:upper:]' '[:lower:]')
@@ -37,11 +32,8 @@ if [[ -f "$RESPONSE_STATE" ]]; then
   RESPONSE_TOPICS=$(jq -r '.topics // empty' "$RESPONSE_STATE" 2>/dev/null)
 fi
 
-# Combined context: user prompt + Claude's recent topics, capped.
-# RESPONSE_TOPICS is bounded by check-response.sh's extraction (~50 chars
-# of keywords) so the cap is effectively a guard on PROMPT itself.
+# Combined context: user prompt + Claude's recent topics.
 COMBINED="${PROMPT} ${RESPONSE_TOPICS}"
-COMBINED="${COMBINED:0:$PROMPT_QUERY_MAX}"
 
 export CLAUDE_PROJECT_DIR="${PROJECT_DIR}"
 "${HOME}/.claude/bin/ways" scan prompt \


### PR DESCRIPTION
## Summary

Removes the character-based truncation blocks from `check-bash-pre.sh` (PR #95) and `check-prompt.sh` (PR #96). They were misframed in their own commit messages as "belt and suspenders" — in practice they ran strictly upstream of the ADR-130 reducer (PR #98), starving it by chopping the input before it could score sentence salience.

The custom-agent discriminator in `check-task-pre.sh` (PR #94) is **not** a cap — it stops `ways scan task` from running at all for dispatches to custom agents. Untouched.

## Why now, not after an observation window

The caps make every signal we'd want to observe *worse*:
- They pre-clamp inputs to a safe range, so a reducer-bounds bug would never surface in practice
- They pre-cut prose, so any match-quality regression after removal would be conflated with reducer behavior
- They add small shell-side overhead that masks reducer perf

Keeping them was actively delaying the observation we wanted to do.

## What's still guaranteed

ADR-130's `reduce_for_embed` enforces a per-hook token budget (110 for prompt/task, 75 for command, 30 for file) and bounds output regardless of input size. The CJK-aware approximate tokenizer (added in the PR #98 review fixes) prevents the Japanese/Chinese under-counting that would have been a regression here.

## Test plan

- [x] `bash -n` clean on both scripts
- [x] 6.4KB heredoc-bodied `gh pr create` through bash hook → 0 crashes
- [x] 6KB task-notification through prompt hook → 0 crashes
- [x] Hook context still emitted normally (no scan path regression)