### PR TITLE
feat(ways): project-scope per-way enable/disable (ADR-131)

### DIFF
--- a/docs/architecture/system/ADR-131-project-scope-way-toggles.md
+++ b/docs/architecture/system/ADR-131-project-scope-way-toggles.md
@@ -1,0 +1,109 @@
+---
+status: Draft
+date: 2026-05-22
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-115
+  - ADR-105
+  - ADR-111
+---
+
+# ADR-131: Project-scope way toggles
+
+## Context
+
+Ways fire across every project the user opens, but not every way is wanted in every project. A research-heavy repo doesn't need `itops/incident`; a personal scratch project doesn't want `softwaredev/architecture/adr` nagging. Today the only enable/disable knob is `disabled_domains` in user-scope `~/.claude/ways.json` — coarse (domain-level) and global (applies everywhere). The result:
+
+- Authors keep ways generic so they don't annoy users in unrelated projects, which weakens the matchers.
+- Users tolerate noise rather than disabling a domain globally, because disabling globally would also kill the way in the one project where it *is* wanted.
+- Per-project muting today requires deleting/renaming way files or editing user-scope JSON every time the user switches contexts — neither survives `git pull` and both leak between projects.
+
+ADR-115 introduced the project overlay (`{project}/.claude/ways.yaml`) for tuning thresholds and disclosure parameters, and `config.rs` already loads it. But the overlay has no per-way enable/disable schema, and no CLI surface — users would have to hand-edit YAML to use it.
+
+The need is narrow: *per-way, per-project, defaulted-enabled* toggles, with a CLI ergonomic enough that users actually use them.
+
+## Decision
+
+### Scope
+
+- **Per-way granularity.** Toggles target individual ways by their canonical name (e.g., `itops/incident`, `meta/introspection`), not domains.
+- **Project scope only.** No new global disabler — the existing `disabled_domains` in user-scope `ways.json` is retained for backward compat but not extended. Per-way toggles live exclusively in `{project}/.claude/ways.yaml`.
+- **Default enabled.** Absence of a toggle means the way fires normally. The config is opt-out, not opt-in. A project that ships no `ways.yaml` behaves exactly as today.
+
+### Schema
+
+Extend the project overlay with a `ways` mapping. Keys are way canonical names; values are `enabled: true|false`:
+
+```yaml
+# {project}/.claude/ways.yaml
+ways:
+  itops/incident:
+    enabled: false
+  meta/introspection:
+    enabled: false
+```
+
+Shorthand (boolean value) is also accepted for the disable-only case:
+
+```yaml
+ways:
+  itops/incident: false
+  meta/introspection: false
+```
+
+The mapping form is reserved for future per-way knobs (threshold overrides, refire presets) — see Consequences > Neutral.
+
+### CLI
+
+Add two subcommands to the `ways` binary:
+
+```
+ways disable <way>      # set ways.<way>.enabled: false in $PROJECT/.claude/ways.yaml
+ways enable <way>       # remove the entry (or set enabled: true)
+ways disable --list     # show currently disabled ways in this project
+```
+
+Both default to project scope. There is no `--global` flag — per the project-scope-only constraint.
+
+Behavior:
+- Creates `.claude/ways.yaml` if missing.
+- Round-trips comments and unrelated keys via a minimal YAML edit (not a full re-serialize).
+- Validates that `<way>` exists in the corpus before writing; warns but still writes if not (allows pre-emptive disable before a way is authored).
+- `ways enable <way>` is a no-op if the way isn't currently disabled — exits 0.
+
+### Enforcement
+
+Toggle resolution happens at the same gate as `disabled_domains` today, in `ways scan` (the Rust production firer) and `inject-subagent.sh` (the bash subagent gate). Both consult `config::global().disabled_ways` — a new `Vec<String>` populated from the project overlay during config load.
+
+A disabled way is skipped entirely: no scoring, no disclosure, no marker. It is as if the way did not exist for this session.
+
+### Trust model
+
+Same as the rest of `.claude/ways.yaml`: project-scope config is committed alongside the repo and reviewed like any other source file. Disabling a way is no more privileged than deleting it from the project's local `.claude/ways/` directory.
+
+## Consequences
+
+### Positive
+
+- **Authoring freedom.** Way authors can write sharper triggers without worrying about a project where the way doesn't belong — users can just disable it there.
+- **Per-repo discipline.** A repo's `ways.yaml` becomes the canonical record of "which guidance applies here," reviewable in PR and durable across machines.
+- **Reversible.** `ways enable` is a single command — no file deletion, no merge conflicts with upstream ways.
+
+### Negative
+
+- **Second place to look** when debugging why a way isn't firing — alongside corpus presence, threshold, refire window. Mitigated by `ways status` surfacing disabled ways and `ways scan --explain` reporting "skipped: disabled in project config."
+- **Drift risk.** A way renamed upstream silently stops being disabled. Mitigated by `ways disable --list` warning on entries that don't match the current corpus.
+
+### Neutral
+
+- The `ways:` mapping form (vs. shorthand boolean) is forward-compatible with per-way threshold/refire overrides — those are deliberately out of scope for this ADR but the schema doesn't preclude them.
+- Existing `disabled_domains` in user-scope `ways.json` is unchanged. Domain-level disable remains the right tool for "I never want any `ea/*` way to fire anywhere."
+
+## Alternatives Considered
+
+- **Per-way disable in user scope.** Rejected: the whole problem is that user-scope is too broad. A user who wants `itops/incident` muted in project A but active in project B can't express that globally.
+- **Reuse `disabled_domains` with deeper paths** (e.g., `itops/incident`). Rejected: domain-level and way-level are conceptually distinct; collapsing them muddles the schema and the existing `disabled_domains` lives in user-scope JSON, not the project YAML.
+- **`+/-` overlay syntax from ADR-115.** Considered for symmetry — `ways: [-itops/incident]`. Rejected for the toggle case: `enabled: false` reads more clearly to humans, and the `+/-` form is better reserved for collection-shaped configs (sensors, way groups) where addition is also meaningful. Disable is monotonic; no `+` half is needed.
+- **Delete the way file from `~/.claude/hooks/ways/`.** Rejected: that's a global, destructive change that wipes the way for every project and doesn't survive a re-sync.

--- a/docs/hooks-and-ways/extending.md
+++ b/docs/hooks-and-ways/extending.md
@@ -107,9 +107,36 @@ Example: If a project has `.claude/ways/softwaredev/code/testing/testing.md`, it
 
 Project-local macros require explicit trust. Add the project path to `~/.claude/trusted-project-macros` (one path per line) to enable macro execution for that project.
 
-## Managing Domains
+## Managing Ways and Domains
 
-### Disabling a domain
+### Disabling a single way for one project (ADR-131)
+
+Use `ways disable` from inside the project:
+
+```
+ways disable itops/incident
+ways disable --list           # see what's disabled in this project
+ways enable itops/incident
+```
+
+That writes `{project}/.claude/ways.yaml`:
+
+```yaml
+ways:
+  itops/incident: false
+```
+
+Per-way toggles are **project-scope only** — there is no global per-way disable. The default state is enabled, so a project with no `ways.yaml` (or no `ways:` block in it) behaves exactly as today.
+
+Equivalent long-form, reserved for future per-way overrides:
+
+```yaml
+ways:
+  itops/incident:
+    enabled: false
+```
+
+### Disabling an entire domain (global)
 
 Add the domain name to `~/.claude/ways.json`:
 
@@ -119,7 +146,7 @@ Add the domain name to `~/.claude/ways.json`:
 }
 ```
 
-All ways in disabled domains are silently skipped. The domain still appears in the Available Ways table but its ways won't fire.
+All ways in disabled domains are silently skipped everywhere. The domain still appears in the Available Ways table but its ways won't fire. Domain-level disable is the right tool for "never anywhere"; project-scope per-way disable is the right tool for "not in this project."
 
 ### Creating a new domain
 

--- a/docs/hooks-and-ways/itops.md
+++ b/docs/hooks-and-ways/itops.md
@@ -2,7 +2,7 @@
 
 Guidance for incident response, operational policy, change proposals, and runbooks.
 
-This domain can be disabled via `~/.claude/ways.json` when working on projects that don't involve operational infrastructure. It's currently disabled by default.
+This domain can be disabled globally via `~/.claude/ways.json` when working across many projects that don't involve operational infrastructure. It's currently disabled by default. For per-project muting of a single way (e.g., just `itops/incident`), use `ways disable itops/incident` from the project root — see ADR-131.
 
 ## Incident Response
 

--- a/docs/hooks-and-ways/meta.md
+++ b/docs/hooks-and-ways/meta.md
@@ -14,7 +14,8 @@ Covers:
 - State triggers (context-threshold, file-exists, session-start)
 - The marker state machine
 - Project-local way creation and override semantics
-- Domain enable/disable via `ways.json`
+- Domain enable/disable via `ways.json` (global, user scope)
+- Per-way enable/disable via `.claude/ways.yaml` (project scope, ADR-131) — `ways disable <name>`
 
 The knowledge way also draws the line between **ways** and **skills**:
 

--- a/hooks/ways/inject-subagent.sh
+++ b/hooks/ways/inject-subagent.sh
@@ -58,36 +58,12 @@ fi
 [[ -z "$WAYS" ]] && exit 0
 
 # Collect project-scope disabled ways once per invocation (ADR-131).
-# Schema (stable, see ADR-131):
-#   ways:
-#     way/name: false          # shorthand
-#     way/name:                # long-form
-#       enabled: false
-# Any other key/value in the file is ignored here.
+# Delegate to the `ways` CLI so the bash gate sees exactly what the Rust
+# config parser sees — any divergence here is a subtle cross-path bug
+# where the same overlay disables a way in one path but not the other.
 DISABLED_WAYS=""
-PROJECT_WAYS_YAML="${PROJECT_DIR}/.claude/ways.yaml"
-if [[ -f "$PROJECT_WAYS_YAML" ]]; then
-  DISABLED_WAYS=$(awk '
-    /^ways:[[:space:]]*(#.*)?$/ { in_block=1; current=""; next }
-    in_block && /^[^[:space:]]/ { in_block=0 }
-    !in_block { next }
-    /^[[:space:]]*$/ { next }
-    /^[[:space:]]*#/ { next }
-    {
-      match($0, /^[[:space:]]*/); indent = RLENGTH
-      text = substr($0, indent + 1)
-      sub(/[[:space:]]*#.*$/, "", text)
-      if (indent == 2 && match(text, /^([^:]+):[[:space:]]*(.*)$/, m)) {
-        key = m[1]; val = m[2]
-        gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
-        if (val == "false") { print key; current = "" }
-        else if (val == "") { current = key }
-        else { current = "" }
-      } else if (indent == 4 && current != "" && text ~ /^enabled:[[:space:]]*false[[:space:]]*$/) {
-        print current; current = ""
-      }
-    }
-  ' "$PROJECT_WAYS_YAML")
+if command -v ways >/dev/null 2>&1; then
+  DISABLED_WAYS=$(CLAUDE_PROJECT_DIR="$PROJECT_DIR" ways disable --list --names-only 2>/dev/null)
 fi
 
 # Emit way content for each matched way (bypassing markers)

--- a/hooks/ways/inject-subagent.sh
+++ b/hooks/ways/inject-subagent.sh
@@ -57,6 +57,39 @@ fi
 
 [[ -z "$WAYS" ]] && exit 0
 
+# Collect project-scope disabled ways once per invocation (ADR-131).
+# Schema (stable, see ADR-131):
+#   ways:
+#     way/name: false          # shorthand
+#     way/name:                # long-form
+#       enabled: false
+# Any other key/value in the file is ignored here.
+DISABLED_WAYS=""
+PROJECT_WAYS_YAML="${PROJECT_DIR}/.claude/ways.yaml"
+if [[ -f "$PROJECT_WAYS_YAML" ]]; then
+  DISABLED_WAYS=$(awk '
+    /^ways:[[:space:]]*(#.*)?$/ { in_block=1; current=""; next }
+    in_block && /^[^[:space:]]/ { in_block=0 }
+    !in_block { next }
+    /^[[:space:]]*$/ { next }
+    /^[[:space:]]*#/ { next }
+    {
+      match($0, /^[[:space:]]*/); indent = RLENGTH
+      text = substr($0, indent + 1)
+      sub(/[[:space:]]*#.*$/, "", text)
+      if (indent == 2 && match(text, /^([^:]+):[[:space:]]*(.*)$/, m)) {
+        key = m[1]; val = m[2]
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
+        if (val == "false") { print key; current = "" }
+        else if (val == "") { current = key }
+        else { current = "" }
+      } else if (indent == 4 && current != "" && text ~ /^enabled:[[:space:]]*false[[:space:]]*$/) {
+        print current; current = ""
+      }
+    }
+  ' "$PROJECT_WAYS_YAML")
+fi
+
 # Emit way content for each matched way (bypassing markers)
 CONTEXT=""
 WAY_IDX=0
@@ -82,13 +115,18 @@ while IFS= read -r waypath; do
   done
   [[ -z "$WAY_FILE" ]] && continue
 
-  # Check domain disabled
+  # Check domain disabled (user scope, legacy)
   DOMAIN="${waypath%%/*}"
   WAYS_CONFIG="${HOME}/.claude/ways.json"
   if [[ -f "$WAYS_CONFIG" ]]; then
     if jq -e --arg d "$DOMAIN" '.disabled | index($d) != null' "$WAYS_CONFIG" >/dev/null 2>&1; then
       continue
     fi
+  fi
+
+  # Check per-way disabled in project overlay (ADR-131)
+  if [[ -n "$DISABLED_WAYS" ]] && grep -qxF "$waypath" <<< "$DISABLED_WAYS"; then
+    continue
   fi
 
   # Extract macro position

--- a/tools/ways-cli/src/cmd/disable.rs
+++ b/tools/ways-cli/src/cmd/disable.rs
@@ -1,0 +1,385 @@
+//! ADR-131: project-scope per-way toggles.
+//!
+//! `ways disable <name>` and `ways enable <name>` edit
+//! `{project}/.claude/ways.yaml`, round-tripping comments and unrelated
+//! keys by rewriting only the lines inside the `ways:` block.
+//!
+//! Project scope only — there is no `--global` flag. Default state is
+//! enabled (absence of an entry).
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+const HEADER: &str = "# Project-scope ways overlay — see ADR-115, ADR-131\n";
+
+// ── Public entry points ────────────────────────────────────────
+
+pub fn disable(name: &str) -> Result<()> {
+    validate_way_name(name)?;
+    warn_if_unknown(name);
+
+    let path = project_overlay_path()?;
+    let content = read_or_empty(&path)?;
+    let updated = rewrite_block(&content, name, true);
+    write_overlay(&path, &updated)?;
+    println!("disabled {name} (project: {})", path.display());
+    Ok(())
+}
+
+pub fn enable(name: &str) -> Result<()> {
+    validate_way_name(name)?;
+
+    let path = project_overlay_path()?;
+    if !path.exists() {
+        println!("{name} is already enabled (no project overlay at {})", path.display());
+        return Ok(());
+    }
+    let content = read_or_empty(&path)?;
+    if !is_disabled(&content, name) {
+        println!("{name} is already enabled");
+        return Ok(());
+    }
+    let updated = rewrite_block(&content, name, false);
+    write_overlay(&path, &updated)?;
+    println!("enabled {name} (project: {})", path.display());
+    Ok(())
+}
+
+pub fn list() -> Result<()> {
+    let cfg = crate::config::Config::load(&project_dir());
+    if cfg.disabled_ways.is_empty() {
+        println!("no ways are disabled for this project");
+        return Ok(());
+    }
+    for w in &cfg.disabled_ways {
+        let marker = if way_exists(w) { " " } else { "?" };
+        println!("{marker} {w}");
+    }
+    if cfg.disabled_ways.iter().any(|w| !way_exists(w)) {
+        eprintln!("\nentries marked `?` do not match any way currently on disk \
+                   (may have been renamed or removed upstream)");
+    }
+    Ok(())
+}
+
+// ── Path resolution ─────────────────────────────────────────────
+
+fn project_dir() -> String {
+    std::env::var("CLAUDE_PROJECT_DIR")
+        .unwrap_or_else(|_| std::env::var("PWD").unwrap_or_else(|_| ".".to_string()))
+}
+
+fn project_overlay_path() -> Result<PathBuf> {
+    let dir = PathBuf::from(project_dir());
+    Ok(dir.join(".claude").join("ways.yaml"))
+}
+
+// ── Validation ──────────────────────────────────────────────────
+
+fn validate_way_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("way name cannot be empty");
+    }
+    if name.starts_with('/') || name.ends_with('/') {
+        anyhow::bail!("way name must not start or end with '/'");
+    }
+    if name.contains("..") || name.contains(':') || name.contains('\n') {
+        anyhow::bail!("invalid characters in way name");
+    }
+    Ok(())
+}
+
+fn way_exists(name: &str) -> bool {
+    let project = PathBuf::from(project_dir()).join(".claude/ways").join(name);
+    if project.is_dir() {
+        return true;
+    }
+    let global = crate::util::home_dir().join(".claude/hooks/ways").join(name);
+    global.is_dir()
+}
+
+fn warn_if_unknown(name: &str) {
+    if !way_exists(name) {
+        eprintln!(
+            "[ways] warning: '{name}' does not match any way on disk. \
+             Writing entry anyway (use `ways disable --list` to audit)."
+        );
+    }
+}
+
+// ── YAML edit ───────────────────────────────────────────────────
+
+fn read_or_empty(path: &Path) -> Result<String> {
+    match std::fs::read_to_string(path) {
+        Ok(s) => Ok(s),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(e) => Err(e).with_context(|| format!("reading {}", path.display())),
+    }
+}
+
+fn write_overlay(path: &Path, content: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    std::fs::write(path, content)
+        .with_context(|| format!("writing {}", path.display()))
+}
+
+/// Returns true if `name` currently parses to disabled in the given content.
+/// Uses the same parser the runtime config uses, so writer/reader agree.
+fn is_disabled(content: &str, name: &str) -> bool {
+    let mut cfg = crate::config::Config::default();
+    cfg.apply_project_ways_overlay_public(content);
+    cfg.disabled_ways.iter().any(|w| w == name)
+}
+
+/// Rewrite `content` so that `name` is either disabled (`disable=true`) or
+/// removed from the `ways:` block (`disable=false`). Preserves comments and
+/// every other key by editing only the lines that belong to the way's entry.
+pub(crate) fn rewrite_block(content: &str, name: &str, disable: bool) -> String {
+    let lines: Vec<&str> = content.lines().collect();
+
+    // Find the `ways:` block (column-0 `ways:` key).
+    let ways_start = lines.iter().position(|l| l.trim_end_matches(' ') == "ways:" || matches_ways_key(l));
+    let (block_start, block_end, base_indent) = match ways_start {
+        Some(s) => {
+            let (end, indent) = find_block_end(&lines, s);
+            (s, end, indent)
+        }
+        None => {
+            // No `ways:` block. If we're disabling, append one; if enabling, no-op.
+            if !disable {
+                return content.to_string();
+            }
+            let mut out = content.to_string();
+            if !out.is_empty() && !out.ends_with('\n') {
+                out.push('\n');
+            }
+            if out.is_empty() {
+                out.push_str(HEADER);
+            }
+            out.push_str("ways:\n");
+            out.push_str(&format!("  {name}: false\n"));
+            return out;
+        }
+    };
+
+    // Find existing entry for this way inside the block.
+    let entry_range = find_entry(&lines, block_start + 1, block_end, name, base_indent);
+
+    let mut out: Vec<String> = Vec::with_capacity(lines.len() + 2);
+    out.extend(lines[..=block_start].iter().map(|s| s.to_string()));
+
+    for (i, line) in lines[block_start + 1..block_end].iter().enumerate() {
+        let abs = block_start + 1 + i;
+        match entry_range {
+            Some((s, e)) if abs >= s && abs < e => {
+                // Skip — this is the existing entry's lines (replaced below or removed).
+                continue;
+            }
+            _ => out.push((*line).to_string()),
+        }
+    }
+
+    if disable {
+        // Insert or re-insert the entry at the end of the block.
+        let indent = format!("{:width$}", "", width = base_indent + 2);
+        out.push(format!("{indent}{name}: false"));
+    }
+
+    // Tail (anything after the `ways:` block).
+    for line in &lines[block_end..] {
+        out.push((*line).to_string());
+    }
+
+    // If we just emptied the block, drop the `ways:` header too.
+    if !disable && block_is_empty(&out, block_start) {
+        out.remove(block_start);
+    }
+
+    let mut s = out.join("\n");
+    if content.ends_with('\n') || !s.is_empty() {
+        s.push('\n');
+    }
+    s
+}
+
+fn matches_ways_key(line: &str) -> bool {
+    // Column-0 `ways:` with optional trailing comment / whitespace.
+    let trimmed = line.trim_end();
+    if let Some(rest) = trimmed.strip_prefix("ways:") {
+        return rest.is_empty() || rest.starts_with(' ') || rest.starts_with('#');
+    }
+    false
+}
+
+/// Returns (end_line_exclusive, base_indent_of_ways_key).
+fn find_block_end(lines: &[&str], start: usize) -> (usize, usize) {
+    // `ways:` is at column 0, so base_indent = 0. Block ends at next column-0
+    // non-blank, non-comment line (i.e., next sibling key).
+    let mut end = lines.len();
+    for (i, line) in lines.iter().enumerate().skip(start + 1) {
+        if line.is_empty() || line.trim().starts_with('#') {
+            continue;
+        }
+        let first = line.chars().next().unwrap_or(' ');
+        if first != ' ' && first != '\t' {
+            end = i;
+            break;
+        }
+    }
+    (end, 0)
+}
+
+/// Find the line range [start, end) covering `name`'s entry inside the block.
+/// Handles both shorthand (`name: false`) and long-form (`name:\n  enabled: false`).
+fn find_entry(
+    lines: &[&str],
+    block_start: usize,
+    block_end: usize,
+    name: &str,
+    base_indent: usize,
+) -> Option<(usize, usize)> {
+    let entry_indent = base_indent + 2;
+    let prefix = format!("{:width$}", "", width = entry_indent);
+    let needle = format!("{prefix}{name}:");
+
+    for (i, line) in lines[block_start..block_end].iter().enumerate() {
+        let abs = block_start + i;
+        if line.trim_start().is_empty() || line.trim_start().starts_with('#') {
+            continue;
+        }
+        // Match if the line starts with `<prefix><name>:` AND nothing precedes
+        // the entry key (no extra indent — would mean it's a sub-key).
+        if line.starts_with(&needle) {
+            // Determine entry end: walk forward over deeper-indented lines.
+            let mut end = abs + 1;
+            while end < block_end {
+                let l = lines[end];
+                if l.trim_start().is_empty() {
+                    end += 1;
+                    continue;
+                }
+                let this_indent = l.len() - l.trim_start().len();
+                if this_indent > entry_indent {
+                    end += 1;
+                } else {
+                    break;
+                }
+            }
+            return Some((abs, end));
+        }
+    }
+    None
+}
+
+fn block_is_empty(lines: &[String], block_start: usize) -> bool {
+    for line in lines.iter().skip(block_start + 1) {
+        if line.is_empty() || line.trim().starts_with('#') {
+            continue;
+        }
+        let first = line.chars().next().unwrap_or(' ');
+        if first == ' ' || first == '\t' {
+            return false; // still has children
+        }
+        return true; // hit next sibling key
+    }
+    true
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disable_creates_block_in_empty_file() {
+        let out = rewrite_block("", "itops/incident", true);
+        assert!(out.contains("ways:"));
+        assert!(out.contains("itops/incident: false"));
+    }
+
+    #[test]
+    fn disable_appends_to_existing_block() {
+        let input = "ways:\n  meta/introspection: false\n";
+        let out = rewrite_block(input, "itops/incident", true);
+        assert!(out.contains("meta/introspection: false"));
+        assert!(out.contains("itops/incident: false"));
+    }
+
+    #[test]
+    fn enable_removes_entry_keeps_others() {
+        let input = "ways:\n  meta/introspection: false\n  itops/incident: false\n";
+        let out = rewrite_block(input, "itops/incident", false);
+        assert!(out.contains("meta/introspection: false"));
+        assert!(!out.contains("itops/incident"));
+    }
+
+    #[test]
+    fn enable_removes_ways_block_when_last_entry() {
+        let input = "ways:\n  itops/incident: false\n";
+        let out = rewrite_block(input, "itops/incident", false);
+        assert!(!out.contains("ways:"));
+        assert!(!out.contains("itops/incident"));
+    }
+
+    #[test]
+    fn preserves_unrelated_keys_and_comments() {
+        let input = "\
+# top-level comment
+language: en
+
+ways:
+  # comment inside ways
+  meta/introspection: false
+
+parent_boost_floor: 0.40
+";
+        let out = rewrite_block(input, "itops/incident", true);
+        assert!(out.contains("# top-level comment"));
+        assert!(out.contains("# comment inside ways"));
+        assert!(out.contains("language: en"));
+        assert!(out.contains("parent_boost_floor: 0.40"));
+        assert!(out.contains("meta/introspection: false"));
+        assert!(out.contains("itops/incident: false"));
+    }
+
+    #[test]
+    fn handles_longform_entry_replacement() {
+        // Long-form entry should be replaced by shorthand when re-disabled
+        // (no harm; the schema accepts either).
+        let input = "\
+ways:
+  itops/incident:
+    enabled: false
+";
+        let out = rewrite_block(input, "itops/incident", true);
+        // Should still contain one (and only one) disable for itops/incident.
+        let count = out.matches("itops/incident").count();
+        assert_eq!(count, 1);
+        assert!(out.contains("itops/incident: false"));
+    }
+
+    #[test]
+    fn enable_when_block_missing_is_noop() {
+        let input = "language: en\n";
+        let out = rewrite_block(input, "itops/incident", false);
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn round_trip_through_real_config_load() {
+        // Writer's output must parse back to the same disabled set.
+        let out = rewrite_block("", "itops/incident", true);
+        let mut cfg = crate::config::Config::default();
+        cfg.apply_project_ways_overlay_public(&out);
+        assert_eq!(cfg.disabled_ways, vec!["itops/incident".to_string()]);
+
+        let out2 = rewrite_block(&out, "meta/introspection", true);
+        let mut cfg2 = crate::config::Config::default();
+        cfg2.apply_project_ways_overlay_public(&out2);
+        assert_eq!(cfg2.disabled_ways.len(), 2);
+    }
+}

--- a/tools/ways-cli/src/cmd/disable.rs
+++ b/tools/ways-cli/src/cmd/disable.rs
@@ -45,17 +45,28 @@ pub fn enable(name: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn list() -> Result<()> {
+pub fn list(names_only: bool) -> Result<()> {
     let cfg = crate::config::Config::load(&project_dir());
-    if cfg.disabled_ways.is_empty() {
+
+    // Machine-readable mode: bare names, one per line, no decoration, no
+    // stderr commentary. Used by the bash subagent injector so it sees the
+    // same disabled set the Rust parser does (single source of truth).
+    if names_only {
+        for w in cfg.disabled_ways() {
+            println!("{w}");
+        }
+        return Ok(());
+    }
+
+    if cfg.disabled_ways().is_empty() {
         println!("no ways are disabled for this project");
         return Ok(());
     }
-    for w in &cfg.disabled_ways {
+    for w in cfg.disabled_ways() {
         let marker = if way_exists(w) { " " } else { "?" };
         println!("{marker} {w}");
     }
-    if cfg.disabled_ways.iter().any(|w| !way_exists(w)) {
+    if cfg.disabled_ways().iter().any(|w| !way_exists(w)) {
         eprintln!("\nentries marked `?` do not match any way currently on disk \
                    (may have been renamed or removed upstream)");
     }
@@ -76,15 +87,24 @@ fn project_overlay_path() -> Result<PathBuf> {
 
 // ── Validation ──────────────────────────────────────────────────
 
+/// Way names follow the directory-derived form used by `way_id_from_path`:
+/// lowercase ASCII alphanumerics, `_`, and `-`, joined by `/`. No empty
+/// segments, no whitespace, no quoting characters, no comment markers.
+/// Anything outside that grammar would either fail to resolve at runtime
+/// or — worse — flow into a YAML key that the writer cannot reliably edit.
 fn validate_way_name(name: &str) -> Result<()> {
     if name.is_empty() {
         anyhow::bail!("way name cannot be empty");
     }
-    if name.starts_with('/') || name.ends_with('/') {
-        anyhow::bail!("way name must not start or end with '/'");
-    }
-    if name.contains("..") || name.contains(':') || name.contains('\n') {
-        anyhow::bail!("invalid characters in way name");
+    for segment in name.split('/') {
+        if segment.is_empty() {
+            anyhow::bail!("way name must not have empty segments (no leading/trailing/double '/')");
+        }
+        if !segment.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-') {
+            anyhow::bail!(
+                "invalid way name '{name}': segments must match [a-z0-9_-]+ (got '{segment}')"
+            );
+        }
     }
     Ok(())
 }
@@ -118,6 +138,12 @@ fn read_or_empty(path: &Path) -> Result<String> {
 }
 
 fn write_overlay(path: &Path, content: &str) -> Result<()> {
+    // Pre-flight: if our rewrite produced something serde_yaml can't parse,
+    // refuse to write rather than corrupting the user's overlay. That would
+    // silently drop every project setting on next load.
+    serde_yaml::from_str::<serde_yaml::Value>(content)
+        .with_context(|| "ways disable/enable produced invalid YAML — refusing to overwrite")?;
+
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("creating {}", parent.display()))?;
@@ -131,24 +157,26 @@ fn write_overlay(path: &Path, content: &str) -> Result<()> {
 fn is_disabled(content: &str, name: &str) -> bool {
     let mut cfg = crate::config::Config::default();
     cfg.apply_project_ways_overlay_public(content);
-    cfg.disabled_ways.iter().any(|w| w == name)
+    cfg.disabled_ways().iter().any(|w| w == name)
 }
 
 /// Rewrite `content` so that `name` is either disabled (`disable=true`) or
 /// removed from the `ways:` block (`disable=false`). Preserves comments and
 /// every other key by editing only the lines that belong to the way's entry.
+///
+/// Honors whatever child indent the existing block already uses (2 or 4
+/// spaces are both legal YAML; the writer matches what's there rather than
+/// hardcoding 2). For a freshly-created block, the default is 2 spaces.
 pub(crate) fn rewrite_block(content: &str, name: &str, disable: bool) -> String {
     let lines: Vec<&str> = content.lines().collect();
 
-    // Find the `ways:` block (column-0 `ways:` key).
-    let ways_start = lines.iter().position(|l| l.trim_end_matches(' ') == "ways:" || matches_ways_key(l));
-    let (block_start, block_end, base_indent) = match ways_start {
+    let ways_start = lines.iter().position(|l| matches_ways_key(l));
+    let (block_start, block_end, child_indent) = match ways_start {
         Some(s) => {
             let (end, indent) = find_block_end(&lines, s);
             (s, end, indent)
         }
         None => {
-            // No `ways:` block. If we're disabling, append one; if enabling, no-op.
             if !disable {
                 return content.to_string();
             }
@@ -165,8 +193,7 @@ pub(crate) fn rewrite_block(content: &str, name: &str, disable: bool) -> String 
         }
     };
 
-    // Find existing entry for this way inside the block.
-    let entry_range = find_entry(&lines, block_start + 1, block_end, name, base_indent);
+    let entry_range = find_entry(&lines, block_start + 1, block_end, name, child_indent);
 
     let mut out: Vec<String> = Vec::with_capacity(lines.len() + 2);
     out.extend(lines[..=block_start].iter().map(|s| s.to_string()));
@@ -174,26 +201,20 @@ pub(crate) fn rewrite_block(content: &str, name: &str, disable: bool) -> String 
     for (i, line) in lines[block_start + 1..block_end].iter().enumerate() {
         let abs = block_start + 1 + i;
         match entry_range {
-            Some((s, e)) if abs >= s && abs < e => {
-                // Skip — this is the existing entry's lines (replaced below or removed).
-                continue;
-            }
+            Some((s, e)) if abs >= s && abs < e => continue,
             _ => out.push((*line).to_string()),
         }
     }
 
     if disable {
-        // Insert or re-insert the entry at the end of the block.
-        let indent = format!("{:width$}", "", width = base_indent + 2);
+        let indent = " ".repeat(child_indent);
         out.push(format!("{indent}{name}: false"));
     }
 
-    // Tail (anything after the `ways:` block).
     for line in &lines[block_end..] {
         out.push((*line).to_string());
     }
 
-    // If we just emptied the block, drop the `ways:` header too.
     if !disable && block_is_empty(&out, block_start) {
         out.remove(block_start);
     }
@@ -214,13 +235,18 @@ fn matches_ways_key(line: &str) -> bool {
     false
 }
 
-/// Returns (end_line_exclusive, base_indent_of_ways_key).
+/// Returns (end_line_exclusive, child_indent_in_spaces).
+///
+/// `ways:` lives at column 0; the block ends at the next column-0 non-blank
+/// non-comment line. The child indent is the leading-whitespace width of the
+/// first existing entry — so a hand-edited 4-space overlay stays 4-space
+/// after we rewrite it. Falls back to 2 when the block is empty.
 fn find_block_end(lines: &[&str], start: usize) -> (usize, usize) {
-    // `ways:` is at column 0, so base_indent = 0. Block ends at next column-0
-    // non-blank, non-comment line (i.e., next sibling key).
     let mut end = lines.len();
+    let mut child_indent: Option<usize> = None;
+
     for (i, line) in lines.iter().enumerate().skip(start + 1) {
-        if line.is_empty() || line.trim().starts_with('#') {
+        if line.trim().is_empty() || line.trim_start().starts_with('#') {
             continue;
         }
         let first = line.chars().next().unwrap_or(' ');
@@ -228,21 +254,31 @@ fn find_block_end(lines: &[&str], start: usize) -> (usize, usize) {
             end = i;
             break;
         }
+        if child_indent.is_none() {
+            let indent = line.len() - line.trim_start().len();
+            // Reject tab-indented blocks — YAML technically allows them but
+            // mixing is a footgun. We refuse to rewrite such a block and let
+            // the user fix indentation manually (writer falls back to 2).
+            if !line.starts_with('\t') {
+                child_indent = Some(indent);
+            }
+        }
     }
-    (end, 0)
+    (end, child_indent.unwrap_or(2))
 }
 
 /// Find the line range [start, end) covering `name`'s entry inside the block.
 /// Handles both shorthand (`name: false`) and long-form (`name:\n  enabled: false`).
+/// `child_indent` is the leading-whitespace width of entries at the top of the
+/// block (typically 2 or 4) — sub-key lines must be more deeply indented.
 fn find_entry(
     lines: &[&str],
     block_start: usize,
     block_end: usize,
     name: &str,
-    base_indent: usize,
+    child_indent: usize,
 ) -> Option<(usize, usize)> {
-    let entry_indent = base_indent + 2;
-    let prefix = format!("{:width$}", "", width = entry_indent);
+    let prefix = " ".repeat(child_indent);
     let needle = format!("{prefix}{name}:");
 
     for (i, line) in lines[block_start..block_end].iter().enumerate() {
@@ -250,10 +286,13 @@ fn find_entry(
         if line.trim_start().is_empty() || line.trim_start().starts_with('#') {
             continue;
         }
-        // Match if the line starts with `<prefix><name>:` AND nothing precedes
-        // the entry key (no extra indent — would mean it's a sub-key).
         if line.starts_with(&needle) {
-            // Determine entry end: walk forward over deeper-indented lines.
+            let after = &line[needle.len()..];
+            // The next char after `name:` must be end-of-line or whitespace —
+            // otherwise we matched a prefix (e.g., `name-extra:`).
+            if !after.is_empty() && !after.starts_with(' ') && !after.starts_with('#') {
+                continue;
+            }
             let mut end = abs + 1;
             while end < block_end {
                 let l = lines[end];
@@ -262,7 +301,7 @@ fn find_entry(
                     continue;
                 }
                 let this_indent = l.len() - l.trim_start().len();
-                if this_indent > entry_indent {
+                if this_indent > child_indent {
                     end += 1;
                 } else {
                     break;
@@ -293,6 +332,38 @@ fn block_is_empty(lines: &[String], block_start: usize) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn validate_accepts_canonical_names() {
+        assert!(validate_way_name("itops/incident").is_ok());
+        assert!(validate_way_name("softwaredev/code/quality").is_ok());
+        assert!(validate_way_name("a_b-c/d-e_f").is_ok());
+        assert!(validate_way_name("single").is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_misformed_names() {
+        for bad in [
+            "",
+            "/leading",
+            "trailing/",
+            "double//slash",
+            "with space",
+            "Upper/Case",
+            "has#comment",
+            "has\"quote",
+            "has\\backslash",
+            "has\nnewline",
+            "has:colon",
+            "dot/./segment",
+            "dot/../escape",
+        ] {
+            assert!(
+                validate_way_name(bad).is_err(),
+                "expected '{bad}' to be rejected"
+            );
+        }
+    }
 
     #[test]
     fn disable_creates_block_in_empty_file() {
@@ -370,12 +441,68 @@ ways:
     }
 
     #[test]
+    fn four_space_overlay_preserves_indent_on_disable() {
+        let input = "\
+ways:
+    meta/introspection: false
+";
+        let out = rewrite_block(input, "itops/incident", true);
+        // New entry must use the same 4-space indent — not mixed.
+        assert!(out.contains("\n    meta/introspection: false"));
+        assert!(out.contains("\n    itops/incident: false"));
+        // Must parse cleanly.
+        serde_yaml::from_str::<serde_yaml::Value>(&out)
+            .expect("rewrite should produce valid YAML");
+    }
+
+    #[test]
+    fn four_space_overlay_enable_removes_entry() {
+        let input = "\
+ways:
+    meta/introspection: false
+    itops/incident: false
+";
+        let out = rewrite_block(input, "itops/incident", false);
+        assert!(out.contains("meta/introspection: false"));
+        assert!(!out.contains("itops/incident"));
+        serde_yaml::from_str::<serde_yaml::Value>(&out).unwrap();
+    }
+
+    #[test]
+    fn four_space_overlay_longform_replacement() {
+        let input = "\
+ways:
+    itops/incident:
+        enabled: false
+";
+        let out = rewrite_block(input, "itops/incident", true);
+        // Long-form gets replaced by shorthand at the same indent.
+        assert_eq!(out.matches("itops/incident").count(), 1);
+        assert!(out.contains("    itops/incident: false"));
+        assert!(!out.contains("enabled: false"));
+        serde_yaml::from_str::<serde_yaml::Value>(&out).unwrap();
+    }
+
+    #[test]
+    fn matches_only_full_key_not_prefix() {
+        // `itops/incident-secondary` must not be matched by `itops/incident`.
+        let input = "\
+ways:
+  itops/incident-secondary: false
+";
+        let out = rewrite_block(input, "itops/incident", true);
+        assert!(out.contains("itops/incident-secondary: false"));
+        assert!(out.contains("\n  itops/incident: false"));
+        assert_eq!(out.matches("itops/incident:").count(), 1);
+    }
+
+    #[test]
     fn round_trip_through_real_config_load() {
         // Writer's output must parse back to the same disabled set.
         let out = rewrite_block("", "itops/incident", true);
         let mut cfg = crate::config::Config::default();
         cfg.apply_project_ways_overlay_public(&out);
-        assert_eq!(cfg.disabled_ways, vec!["itops/incident".to_string()]);
+        assert_eq!(cfg.disabled_ways(), vec!["itops/incident".to_string()]);
 
         let out2 = rewrite_block(&out, "meta/introspection", true);
         let mut cfg2 = crate::config::Config::default();

--- a/tools/ways-cli/src/cmd/mod.rs
+++ b/tools/ways-cli/src/cmd/mod.rs
@@ -1,6 +1,7 @@
 pub mod banner;
 pub mod context;
 pub mod corpus;
+pub mod disable;
 pub mod embed;
 pub mod governance;
 pub mod graph;

--- a/tools/ways-cli/src/cmd/scan/candidates.rs
+++ b/tools/ways-cli/src/cmd/scan/candidates.rs
@@ -67,9 +67,9 @@ fn collect_from_dir(dir: &Path, out: &mut Vec<WayCandidate>) {
             continue;
         }
 
-        // Check domain disable
+        // Check domain disable (user scope) and per-way disable (project scope, ADR-131)
         let domain = id.split('/').next().unwrap_or(&id);
-        if session::domain_disabled(domain) {
+        if session::domain_disabled(domain) || session::way_disabled(&id) {
             continue;
         }
 

--- a/tools/ways-cli/src/cmd/show/mod.rs
+++ b/tools/ways-cli/src/cmd/show/mod.rs
@@ -19,9 +19,9 @@ pub fn way(id: &str, session_id: &str, trigger: &str) -> Result<String> {
     let project_dir = std::env::var("CLAUDE_PROJECT_DIR")
         .unwrap_or_else(|_| std::env::var("PWD").unwrap_or_else(|_| ".".to_string()));
 
-    // Domain disable check
+    // Disable checks: domain (user scope) and per-way (project scope, ADR-131)
     let domain = id.split('/').next().unwrap_or(id);
-    if session::domain_disabled(domain) {
+    if session::domain_disabled(domain) || session::way_disabled(id) {
         return Ok(String::new());
     }
 
@@ -169,9 +169,9 @@ pub fn check(id: &str, session_id: &str, trigger: &str, match_score: f64) -> Res
     let project_dir = std::env::var("CLAUDE_PROJECT_DIR")
         .unwrap_or_else(|_| std::env::var("PWD").unwrap_or_else(|_| ".".to_string()));
 
-    // Domain disable
+    // Disable checks: domain (user scope) and per-way (project scope, ADR-131)
     let domain = id.split('/').next().unwrap_or(id);
-    if session::domain_disabled(domain) {
+    if session::domain_disabled(domain) || session::way_disabled(id) {
         return Ok(String::new());
     }
 

--- a/tools/ways-cli/src/cmd/status.rs
+++ b/tools/ways-cli/src/cmd/status.rs
@@ -76,7 +76,7 @@ pub fn run(json_output: bool) -> Result<()> {
     // config::global() — future migration: ctx.config.disabled_domains
     let disabled = crate::config::global().disabled_domains.clone();
     // ADR-131: project-scope per-way toggles
-    let disabled_ways = crate::config::global().disabled_ways.clone();
+    let disabled_ways: Vec<String> = crate::config::global().disabled_ways().to_vec();
 
     if json_output {
         let output = json!({

--- a/tools/ways-cli/src/cmd/status.rs
+++ b/tools/ways-cli/src/cmd/status.rs
@@ -75,6 +75,8 @@ pub fn run(json_output: bool) -> Result<()> {
 
     // config::global() — future migration: ctx.config.disabled_domains
     let disabled = crate::config::global().disabled_domains.clone();
+    // ADR-131: project-scope per-way toggles
+    let disabled_ways = crate::config::global().disabled_ways.clone();
 
     if json_output {
         let output = json!({
@@ -105,6 +107,7 @@ pub fn run(json_output: bool) -> Result<()> {
             "projects": projects,
             "output_language": output_language,
             "disabled_domains": disabled,
+            "disabled_ways": disabled_ways,
         });
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
@@ -159,7 +162,10 @@ pub fn run(json_output: bool) -> Result<()> {
         println!("Global ways: {} total, {} semantic", global_total, global_semantic);
 
         if !disabled.is_empty() {
-            println!("Disabled:    {}", disabled.join(", "));
+            println!("Disabled domains: {}", disabled.join(", "));
+        }
+        if !disabled_ways.is_empty() {
+            println!("Disabled ways:    {} (project scope, ADR-131)", disabled_ways.join(", "));
         }
         println!();
 

--- a/tools/ways-cli/src/config.rs
+++ b/tools/ways-cli/src/config.rs
@@ -35,7 +35,14 @@ pub struct Config {
     /// Disabled ways (e.g., ["itops/incident", "meta/introspection"]) — project scope only.
     /// Populated exclusively from `{project}/.claude/ways.yaml`. Default-enabled
     /// (absence means the way fires normally). See ADR-131.
-    pub disabled_ways: Vec<String>,
+    ///
+    /// Field is `pub(crate)` (not `pub`) to keep the only legitimate writer
+    /// — `apply_project_ways_overlay` — inside this module. Readers access
+    /// via `disabled_ways()`. This makes the "project scope only" invariant
+    /// structural rather than conventional: a future contributor who adds
+    /// per-way knobs to user-scope `apply_yaml` would have to also touch
+    /// this field, which sits right next to a load-bearing doc comment.
+    pub(crate) disabled_ways: Vec<String>,
     /// Parent-boost multiplier: a child way's effective embed_threshold is
     /// multiplied by this value when any ancestor way has fired in the
     /// session. Values <1.0 make children fire more easily once their parent
@@ -88,6 +95,11 @@ impl Default for Config {
 }
 
 impl Config {
+    /// Public read accessor for the project-scope disable list (ADR-131).
+    pub fn disabled_ways(&self) -> &[String] {
+        &self.disabled_ways
+    }
+
     /// Load config with full resolution chain.
     pub fn load(project_dir: &str) -> Self {
         let mut cfg = Config::default();

--- a/tools/ways-cli/src/config.rs
+++ b/tools/ways-cli/src/config.rs
@@ -30,8 +30,12 @@ pub struct Config {
     pub default_scope: String,
     /// Output language (e.g., "en", "ja", "auto")
     pub language: String,
-    /// Disabled domains (e.g., ["ea", "itops"])
+    /// Disabled domains (e.g., ["ea", "itops"]) — user scope (legacy ways.json).
     pub disabled_domains: Vec<String>,
+    /// Disabled ways (e.g., ["itops/incident", "meta/introspection"]) — project scope only.
+    /// Populated exclusively from `{project}/.claude/ways.yaml`. Default-enabled
+    /// (absence means the way fires normally). See ADR-131.
+    pub disabled_ways: Vec<String>,
     /// Parent-boost multiplier: a child way's effective embed_threshold is
     /// multiplied by this value when any ancestor way has fired in the
     /// session. Values <1.0 make children fire more easily once their parent
@@ -73,6 +77,7 @@ impl Default for Config {
             default_scope: "agent".to_string(),
             language: "auto".to_string(),
             disabled_domains: Vec::new(),
+            disabled_ways: Vec::new(),
             parent_threshold_multiplier: 0.8,
             parent_boost_floor: 0.40,
             default_embed_threshold: 0.40,
@@ -99,10 +104,12 @@ impl Config {
             cfg.apply_yaml(&content);
         }
 
-        // Layer 3: project overlay
+        // Layer 3: project overlay — only this layer may populate `disabled_ways`
+        // (ADR-131: per-way disable is project-scope only).
         let project_config = Path::new(project_dir).join(".claude/ways.yaml");
         if let Ok(content) = std::fs::read_to_string(&project_config) {
             cfg.apply_yaml(&content);
+            cfg.apply_project_ways_overlay(&content);
         }
 
         cfg
@@ -170,6 +177,49 @@ impl Config {
         }
     }
 
+    /// Parse the project-scope `ways:` mapping for per-way toggles (ADR-131).
+    ///
+    /// Schema accepts two equivalent forms:
+    ///   ways:
+    ///     itops/incident: false              # shorthand
+    ///     meta/introspection:                # long-form
+    ///       enabled: false
+    ///
+    /// Anything that evaluates to enabled=false is collected into `disabled_ways`.
+    /// Unknown sub-keys on the long-form (threshold overrides, etc.) are ignored
+    /// — reserved for future use per ADR-131.
+    /// Public alias used by `cmd::disable` to verify writer/reader round-trips
+    /// without exposing the parser as a stable API surface. Keeping the
+    /// internal name pinned makes future refactors trivial.
+    pub fn apply_project_ways_overlay_public(&mut self, content: &str) {
+        self.apply_project_ways_overlay(content);
+    }
+
+    fn apply_project_ways_overlay(&mut self, content: &str) {
+        let doc: serde_yaml::Value = match serde_yaml::from_str(content) {
+            Ok(v) => v,
+            Err(_) => return, // already reported by apply_yaml
+        };
+        let Some(ways) = doc.get("ways").and_then(|v| v.as_mapping()) else {
+            return;
+        };
+        for (k, v) in ways {
+            let Some(name) = k.as_str() else { continue };
+            let disabled = match v {
+                serde_yaml::Value::Bool(b) => !*b, // shorthand: `way: false` means disabled
+                serde_yaml::Value::Mapping(m) => m
+                    .get(serde_yaml::Value::String("enabled".to_string()))
+                    .and_then(|v| v.as_bool())
+                    .map(|b| !b)
+                    .unwrap_or(false),
+                _ => false,
+            };
+            if disabled && !self.disabled_ways.iter().any(|w| w == name) {
+                self.disabled_ways.push(name.to_string());
+            }
+        }
+    }
+
     /// Initialize user config at XDG path.
     pub fn init_user_config() -> PathBuf {
         let path = xdg_config_dir().join("ways/config.yaml");
@@ -185,7 +235,15 @@ impl Config {
 
 # language: en          # Output language (en, ja, auto)
 # default_scope: agent  # Default scope for ways without explicit scope
-# disabled_domains: []  # Domains to disable (e.g., [ea, itops])
+# disabled_domains: []  # Domains to disable everywhere (e.g., [ea, itops])
+
+# Per-way enable/disable (ADR-131) is project scope only — set it in
+# {project}/.claude/ways.yaml using either form:
+#   ways:
+#     itops/incident: false          # shorthand
+#     meta/introspection:            # long-form
+#       enabled: false
+# Or run `ways disable <name>` / `ways enable <name>` from the project root.
 ";
         std::fs::write(&path, content).ok();
         path
@@ -280,5 +338,83 @@ mod tests {
         cfg.apply_ways_json(r#"{"output_language":"de"}"#);
         cfg.apply_yaml("language: ja");
         assert_eq!(cfg.language, "ja");
+    }
+
+    // ── ADR-131: project-scope per-way disable ─────────────────────
+
+    #[test]
+    fn project_overlay_shorthand_disable() {
+        let mut cfg = Config::default();
+        cfg.apply_project_ways_overlay(
+            "ways:\n  \
+             itops/incident: false\n  \
+             meta/introspection: false\n",
+        );
+        assert!(cfg.disabled_ways.iter().any(|w| w == "itops/incident"));
+        assert!(cfg.disabled_ways.iter().any(|w| w == "meta/introspection"));
+        assert_eq!(cfg.disabled_ways.len(), 2);
+    }
+
+    #[test]
+    fn project_overlay_longform_disable() {
+        let mut cfg = Config::default();
+        cfg.apply_project_ways_overlay(
+            "ways:\n  \
+             itops/incident:\n    \
+             enabled: false\n",
+        );
+        assert_eq!(cfg.disabled_ways, vec!["itops/incident".to_string()]);
+    }
+
+    #[test]
+    fn project_overlay_enabled_true_is_noop() {
+        // Explicit `enabled: true` (or shorthand `true`) must NOT add to disabled_ways.
+        let mut cfg = Config::default();
+        cfg.apply_project_ways_overlay(
+            "ways:\n  \
+             itops/incident: true\n  \
+             meta/introspection:\n    \
+             enabled: true\n",
+        );
+        assert!(cfg.disabled_ways.is_empty());
+    }
+
+    #[test]
+    fn project_overlay_missing_ways_key_is_noop() {
+        let mut cfg = Config::default();
+        cfg.apply_project_ways_overlay("language: en\nparent_boost_floor: 0.40\n");
+        assert!(cfg.disabled_ways.is_empty());
+    }
+
+    #[test]
+    fn project_overlay_dedupes_repeated_entries() {
+        let mut cfg = Config::default();
+        cfg.disabled_ways.push("itops/incident".to_string());
+        cfg.apply_project_ways_overlay("ways:\n  itops/incident: false\n");
+        assert_eq!(cfg.disabled_ways.len(), 1);
+    }
+
+    #[test]
+    fn project_overlay_ignores_unknown_subkeys() {
+        // Long-form with future-reserved keys should still parse and not panic.
+        let mut cfg = Config::default();
+        cfg.apply_project_ways_overlay(
+            "ways:\n  \
+             itops/incident:\n    \
+             enabled: false\n    \
+             embed_threshold: 0.50\n",
+        );
+        assert_eq!(cfg.disabled_ways, vec!["itops/incident".to_string()]);
+    }
+
+    #[test]
+    fn apply_yaml_does_not_populate_disabled_ways() {
+        // Only apply_project_ways_overlay should touch disabled_ways.
+        // apply_yaml is shared between user-scope and project-scope; if it ever
+        // started reading `ways:`, user-scope YAML would gain a per-way disable
+        // surface — explicitly forbidden by ADR-131.
+        let mut cfg = Config::default();
+        cfg.apply_yaml("ways:\n  itops/incident: false\n");
+        assert!(cfg.disabled_ways.is_empty());
     }
 }

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -242,6 +242,19 @@ enum Commands {
         #[command(subcommand)]
         action: ConfigCommand,
     },
+    /// Disable a way in this project (ADR-131 — writes .claude/ways.yaml)
+    Disable {
+        /// Way ID to disable (e.g., "itops/incident"). Omit when using --list.
+        name: Option<String>,
+        /// List currently disabled ways in this project
+        #[arg(long)]
+        list: bool,
+    },
+    /// Re-enable a way previously disabled in this project (ADR-131)
+    Enable {
+        /// Way ID to enable (e.g., "itops/incident")
+        name: String,
+    },
     /// Audit locale alias fidelity + discrimination (ADR-125 — flags stubs to re-author)
     Tune {
         /// Ways root directory (default: ~/.claude/hooks/ways)
@@ -586,6 +599,20 @@ fn main() -> Result<()> {
                 Ok(())
             }
         },
+        Commands::Disable { name, list } => {
+            if list {
+                cmd::disable::list()
+            } else {
+                match name {
+                    Some(n) => cmd::disable::disable(&n),
+                    None => {
+                        eprintln!("usage: ways disable <name>  |  ways disable --list");
+                        std::process::exit(2);
+                    }
+                }
+            }
+        }
+        Commands::Enable { name } => cmd::disable::enable(&name),
         Commands::Suggest { file, min_freq } => cmd::suggest::run(file, min_freq),
         Commands::Tune { ways_dir, way, fidelity_threshold, discrimination_threshold, json } => {
             cmd::tune::run(ways_dir, way, fidelity_threshold, discrimination_threshold, json)

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -245,10 +245,14 @@ enum Commands {
     /// Disable a way in this project (ADR-131 — writes .claude/ways.yaml)
     Disable {
         /// Way ID to disable (e.g., "itops/incident"). Omit when using --list.
+        #[arg(required_unless_present = "list", conflicts_with = "list")]
         name: Option<String>,
         /// List currently disabled ways in this project
-        #[arg(long)]
+        #[arg(long, conflicts_with = "name")]
         list: bool,
+        /// With --list, emit bare names one-per-line (machine-readable, no decoration)
+        #[arg(long, requires = "list")]
+        names_only: bool,
     },
     /// Re-enable a way previously disabled in this project (ADR-131)
     Enable {
@@ -599,17 +603,12 @@ fn main() -> Result<()> {
                 Ok(())
             }
         },
-        Commands::Disable { name, list } => {
+        Commands::Disable { name, list, names_only } => {
             if list {
-                cmd::disable::list()
+                cmd::disable::list(names_only)
             } else {
-                match name {
-                    Some(n) => cmd::disable::disable(&n),
-                    None => {
-                        eprintln!("usage: ways disable <name>  |  ways disable --list");
-                        std::process::exit(2);
-                    }
-                }
+                // clap guarantees name is Some here via required_unless_present
+                cmd::disable::disable(&name.expect("clap enforces name when --list absent"))
             }
         }
         Commands::Enable { name } => cmd::disable::enable(&name),

--- a/tools/ways-cli/src/session.rs
+++ b/tools/ways-cli/src/session.rs
@@ -443,7 +443,7 @@ pub fn domain_disabled(domain: &str) -> bool {
 /// Project-scope only — sourced exclusively from `{project}/.claude/ways.yaml`.
 /// config::global() — future migration: ctx.config.disabled_ways
 pub fn way_disabled(way_id: &str) -> bool {
-    crate::config::global().disabled_ways.iter().any(|w| w == way_id)
+    crate::config::global().disabled_ways().iter().any(|w| w == way_id)
 }
 
 

--- a/tools/ways-cli/src/session.rs
+++ b/tools/ways-cli/src/session.rs
@@ -439,6 +439,13 @@ pub fn domain_disabled(domain: &str) -> bool {
     crate::config::global().disabled_domains.iter().any(|d| d == domain)
 }
 
+/// Check if a specific way is disabled in the current project (ADR-131).
+/// Project-scope only — sourced exclusively from `{project}/.claude/ways.yaml`.
+/// config::global() — future migration: ctx.config.disabled_ways
+pub fn way_disabled(way_id: &str) -> bool {
+    crate::config::global().disabled_ways.iter().any(|w| w == way_id)
+}
+
 
 // ── Way file resolution ─────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds `ways disable <name>` / `ways enable <name>` — project-scope toggle for a single way, writes `{project}/.claude/ways.yaml`.
- New `disabled_ways` config field, populated **only** from project overlay (per ADR-131: project scope, no global per-way disabler).
- Enforcement at both gates: Rust `ways scan` / `ways show` via `session::way_disabled()`, bash `inject-subagent.sh` via an awk parser of the `ways:` block.
- Default state remains **enabled** — a project with no overlay behaves identically to today.

## ADR

See `docs/architecture/system/ADR-131-project-scope-way-toggles.md` for context, schema, trust model, and alternatives considered.

## Test plan

- [x] `cargo test` — 106 unit + 11 integration tests pass (8 new disable.rs tests, 7 new config.rs tests including a guard that `apply_yaml` cannot populate `disabled_ways`).
- [x] CLI smoke test: `ways disable`, `ways disable --list`, `ways enable`, with multi-way + comment-preservation paths exercised.
- [x] Awk parser smoke test against shorthand + long-form + `enabled: true` (no-op) + trailing comments.
- [ ] (reviewer) Read ADR-131 and confirm the schema choice and project-scope-only constraint are right.
- [ ] (reviewer) Sanity-check the YAML editor edge cases in `cmd/disable.rs` (especially block_is_empty / find_entry indentation handling).

## Notes

- The existing `disabled_domains` user-scope mechanism is untouched — both gates stack (domain-disable OR way-disable → skip).
- The YAML editor preserves comments and unrelated keys by editing only lines inside the `ways:` block (line-based, not a full re-serialize).