### PR TITLE
feat(ways): add versioning (code) + pkghistory (workstation) ways

### DIFF
--- a/hooks/ways/softwaredev/code/quality/versioning/postcheck.sh
+++ b/hooks/ways/softwaredev/code/quality/versioning/postcheck.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Reactive firing for softwaredev/code/quality/versioning.
+#
+# Exits 0 (requesting fire) when the just-completed Edit/Write
+# introduced a version-numbered identifier or version-reference
+# docstring/comment in the *new* content — process_v2, _FOO_V0,
+# `"""v0 seed ..."""`, `# v1 of this`. These are the moment the
+# versioning way's guidance is load-bearing: a versioned twin is
+# about to become permanent.
+#
+# Scoped to tool_input.new_string / tool_input.content (the diff
+# being written), NOT the whole file — pre-existing version tokens
+# the agent didn't author must not re-fire on unrelated edits.
+#
+# Receives the full PostToolUse input JSON on stdin. Exit 0 = "please
+# fire"; non-zero = "no match, skip me." The engine's `ways show way`
+# gate still applies refractory, so this won't spam-fire.
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+case "$TOOL_NAME" in
+  Edit|Write) ;;
+  *) exit 1 ;;
+esac
+
+FP=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+[[ -z "$FP" ]] && exit 1
+
+# Code only. Docs/specs/locks legitimately carry version strings, and
+# the way files themselves quote the antipattern as examples.
+case "$FP" in
+  *.md|*.mdx|*.lock|*.jsonl|*.txt|*.csv) exit 1 ;;
+  */node_modules/*|*/dist/*|*/build/*|*/vendor/*|*/__pycache__/*) exit 1 ;;
+esac
+
+# The diff being written — Edit carries new_string, Write carries content.
+NEW=$(echo "$INPUT" | jq -r '.tool_input.new_string // .tool_input.content // empty')
+[[ -z "$NEW" ]] && exit 1
+
+# Discriminator: versioned identifiers the code OWNS, plus version-
+# reference comments/docstrings. Deliberately does NOT match external
+# version refs (/v1/ paths, apiVersion, __version__, schema_version)
+# because those lack the _V<n> identifier shape or the digit-after-_v.
+RE='(\b[A-Z][A-Z0-9]*_V[0-9]+\b|\b[a-zA-Z][a-zA-Z0-9]*_v[0-9]+\b|\b[A-Za-z]+V[0-9]+\b(?!ersion)|"""v[0-9]+ |# v[0-9]+ |\bv[0-9]+ (seed|impl|implementation|version of|rewrite|attempt)\b)'
+
+if printf '%s' "$NEW" | grep -qP "$RE" 2>/dev/null; then
+  exit 0
+fi
+exit 1

--- a/hooks/ways/softwaredev/code/quality/versioning/provenance.yaml
+++ b/hooks/ways/softwaredev/code/quality/versioning/provenance.yaml
@@ -1,0 +1,19 @@
+policy:
+  - uri: governance/policies/code-lifecycle.md
+    type: governance-doc
+controls:
+  - id: ISO/IEC 25010:2011 (Maintainability - Modifiability, Analyzability)
+    justifications:
+      - Version-numbered identifiers create parallel implementations that degrade modifiability — callers split across revisions nobody consolidates
+      - Names describing what a symbol is (not which revision) preserve analyzability; VCS carries the timeline
+  - id: NIST SP 800-53 SA-15 (Development Process, Standards, and Tools)
+    justifications:
+      - Anti-pattern detection on the authored diff catches versioned twins at the moment they would become permanent
+      - Distinguishes code-owned identifiers from legitimate external version references to avoid false enforcement
+verified: 2026-05-18
+rationale: >
+  Versioned identifiers (process_v2, _FOO_V0, "v0 seed") freeze authoring-time
+  snapshots into permanent names. The old revision rarely gets deleted, producing
+  parallel half-migrations — a direct ISO 25010 modifiability regression. Reactive
+  detection scoped to the written diff (not the whole file) operationalizes NIST
+  SA-15 anti-pattern enforcement without penalizing externally-versioned contracts.

--- a/hooks/ways/softwaredev/code/quality/versioning/versioning.md
+++ b/hooks/ways/softwaredev/code/quality/versioning/versioning.md
@@ -1,0 +1,53 @@
+---
+description: version-numbered identifiers, function/class/variable names, and docstrings/comments — process_v2, HandlerV2, _FOO_V0, 'v0 seed for the namespace'; the symbol name should describe what the thing is, not which revision it is
+vocabulary: identifier symbol naming rename suffix function class variable module docstring comment glueball twin revision snapshot versioned
+embed_threshold: 0.45
+refire: 0.15
+scope: agent,subagent
+---
+<!-- epistemic: convention -->
+# Versioning In Code
+
+## The Antipattern
+
+Putting a version number in something the codebase *owns* — a function, class, variable, module, or its docstring/comment:
+
+```python
+def process_v2(...)            # what happened to process? is v1 still called?
+_NAMESPACE_V0 = frozenset(...) # v0 of what? against which v1?
+"""v0 seed for the namespace.""" # "v0" describes nothing the reader can act on
+# v1 of this logic — revisit later
+```
+
+The version label is a snapshot of *when it was written*, frozen into a name that lives forever. The old version rarely gets deleted, so `process` and `process_v2` coexist, callers split between them, and every future reader has to reverse-engineer which is current. Repeat across a codebase and you get a glueball: parallel half-migrations nobody dares finish. **Git already holds the history.** The name should describe what the thing *is*, not which revision it is.
+
+## What To Do Instead
+
+- **Rename in place.** Changing `process`? Edit `process`. If the contract changed, the new name should say *how it differs* (`process_streaming`, `parse_strict`) — a behavioral distinction a reader can reason about — not `_v2`.
+- **Let VCS carry the timeline.** "Seed for the `crowd-dc` namespace" — not "v0 seed." The reader cares what it seeds, not that it's the zeroth cut.
+- **Migrating with a real overlap window?** Then the *old* name gets the deprecation marker and a removal condition (`# remove after all callers move off — tracked in #123`), not a `_v2` twin that silently becomes permanent.
+
+## Not This — Legitimate Version References
+
+This is about identifiers the codebase authors. Versions that name an *external, independently-versioned contract* are correct and expected:
+
+- API/URL paths and protocol versions: `/v1/users`, `apiVersion: apps/v1`
+- The package's own release identity: `__version__`, semver in manifests
+- A schema/wire-format version that is genuinely a data field: `schema_version`, `payload_version`
+- Migration filenames following the tool's convention
+
+The test: *does the version refer to something versioned outside this code?* If yes, keep it. If it's just "the revision I happened to write," strip it.
+
+## Common Rationalizations
+
+| Rationalization | Counter |
+|---|---|
+| "I'll keep `_v1` around until callers migrate" | Then mark `_v1` deprecated with a removal condition. An unmarked twin is permanent — that's the glueball. |
+| "v0 signals it's an early/partial seed" | "Early" is not actionable. Say what's partial: "anchor type only; full surface accrues with introspectors." |
+| "Renaming touches a lot of call sites" | The rename is the cheap part now and only gets more expensive. A versioned alias defers nothing — it adds a second thing to maintain. |
+| "The version makes intent clear" | A version number is the absence of intent. `parse_strict` carries intent; `parse_v2` carries a date stamp. |
+
+## See Also
+
+- code/quality(softwaredev) — parent: measurable quality thresholds
+- code/errors(softwaredev) — naming clarity at boundaries

--- a/hooks/ways/workstation/pkghistory/pkghistory.md
+++ b/hooks/ways/workstation/pkghistory/pkghistory.md
@@ -1,0 +1,64 @@
+---
+description: going over the stuff you have added to a machine over time and deciding what you no longer need — auditing a workstation for forgotten, unused, or leftover software you installed and stopped using, reviewing what accumulated, grouping it by subject, and trimming the cruft. The retrospective audit-and-cull side of installing software, distinct from project dependency management.
+vocabulary: stuff I added installation machine workstation unneeded dont need anymore no longer use forgotten unused leftover smelly leftovers cruft accumulated go over review audit clean up trim prune get rid of remove uninstall what did I add what have I installed group by subject still need AUR yay
+pattern: (?i)go over .*(stuff|things|packages|what).*(added|install)|stuff i.?ve added|what (did|have) i install|(unneeded|leftover|forgotten|unused) (things|stuff|packages|software)|(don.?t|do not) (need|want) (it|them|this|that|th[eo]se|any ?more)|no longer (use|need)|(clean up|get rid of|trim|prune|cull).*(cruft|leftover|smelly|packages)|smelly .*leftover
+scope: agent
+refire: 0.12
+---
+<!-- epistemic: heuristic -->
+# Package History as a Behavioral Journal
+
+The package manager's log is an *involuntary journal*. The user never sat down to write it, but every line is timestamped intent they couldn't fake in retrospect. When someone asks "what have I added that I don't need anymore?", don't just dump a package list — read the log as a time series. The shape is the answer.
+
+## Three signatures
+
+| Signature | What it looks like | What it means |
+|-----------|--------------------|---------------|
+| **Burst** | Several related packages on the *same day* | One focused sitting with a goal (set up remote desktop, rice the desktop, tune the CPU). Burst density ≈ how deep the flow state was. |
+| **Thread** | A theme recurring across months | Durable identity, not a whim. A persistent interest the log *proves*. Keep it. |
+| **Orphan** | A cluster that appeared once and never recruited a neighbor or got revisited | Abandoned. **This is the strong cull signal — not age.** Old ≠ unused; a stable tool used daily can be a year untouched. A theme that *stopped recruiting* is done. |
+
+The builder layer is the sharpest marker: packages the user *authored themselves* (their own AUR/local builds) mark a need no existing tool fit. They cluster around whatever the user was deep in at the time.
+
+## What the log cannot see
+
+- **Install ≠ use.** No telemetry on what actually runs. The log shows intent, not habit.
+- **Survivorship.** `pacman -Qm` / `brew leaves` show only what *survived*. For the true series — including removals and upgrade churn — read the transaction log, not the current state.
+
+## Extraction
+
+| Manager | Deliberate adds | Dated history (incl. removals) |
+|---------|-----------------|-------------------------------|
+| pacman/yay | `pacman -Qm` (foreign), `pacman -Qet` (explicit leaves) | `/var/log/pacman.log` (`installed`/`removed`/`upgraded`, all timestamped) |
+| apt | `apt-mark showmanual` | `/var/log/apt/history.log*` |
+| dnf | `dnf history userinstalled` | `dnf history` |
+| brew | `brew leaves` | `~/Library/Logs/Homebrew` / `brew info --json` install times |
+
+Dated AUR list (pacman): `expac --timefmt='%Y-%m-%d' '%l\t%n' $(pacman -Qmq) | sort`
+
+Focus pass 1 on **deliberate adds** (AUR/manual) — native repo leaves are mostly DE/base noise. Group by *subject*, then call out redundancy clusters *inside* each group (two remote-desktop stacks, three themes only one of which can be active, a build-tool cluster left over from one project). That's where the cull candidates hide.
+
+## Render the timeline
+
+Phases over time are sequential — show, don't narrate. Pipe a Mermaid `timeline` to `mmaid` for terminal art:
+
+```bash
+mmaid <<'EOF'
+timeline
+    title host — what the install log remembers
+    2025-04 Bootstrap : shell, grub, mounts (provisioning, not exploring)
+    2025-07 Infra sprint : whole remote-access stack in one sitting
+    2026-05 Re-provision : browser+editor+toolchain in one burst
+EOF
+```
+
+## Don't
+
+- Flag "unneeded" by install date. Age is a weak signal; recruitment is the strong one.
+- Persist a curated inventory before the cull — documenting cruft that's about to be culled wastes the write. Cull first, then offer to record the post-cull state.
+- Remove without a reverse-dependency check (`pactree -r` / `pacman -Rsp` dry run). Let the user drive every "kill it".
+
+## See Also
+
+- visualization/diagrams(softwaredev) — `mmaid` timeline/structural rendering
+- workstation/shell/tools(workstation) — the install side; this is the audit side


### PR DESCRIPTION
## Summary

Two new ways:

### `softwaredev/code/quality/versioning`
Anti-pattern guidance for version-numbered identifiers in code Claude owns — `process_v2`, `_FOO_V0`, `"""v0 seed for X"""`. These freeze authoring-time snapshots into permanent names; the old revision rarely gets deleted, producing parallel half-migrations callers split across.

Includes a reactive `postcheck.sh` that fires on Edit/Write when versioned identifiers or version-reference docstrings appear in the *new* diff (not the whole file — pre-existing tokens the agent didn't author must not re-fire). Scoped to code; skips docs/locks/JSONL where version strings are legitimate.

`provenance.yaml` maps to ISO/IEC 25010 (Maintainability — Modifiability/Analyzability) and NIST SP 800-53 SA-15 (Development Process Standards).

### `workstation/pkghistory`
Reads package-manager logs as a behavioral journal — Burst (focused sitting), Thread (durable interest, keep it), Orphan (cluster that stopped recruiting, strong cull signal). Counters the dump-a-list reflex when the user asks "what have I added that I don't need anymore?"

## Test plan
- [ ] `ways lint` passes for both new ways.
- [ ] `postcheck.sh` matches `process_v2`, `_FOO_V0`, `# v1 of this`; does NOT match `apiVersion`, `/v1/` paths, `__version__`.
- [ ] `pkghistory` triggers on prompts like "what software did I install I don't need anymore", "cull leftover packages".