### PR TITLE
docs(adr): ADR-135 content-aware write-time over-build gate

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -54,6 +54,8 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-131](./system/ADR-131-project-scope-way-toggles.md) | Project-scope way toggles | Draft |
 | [ADR-132](./system/ADR-132-collaboration-ways-domain.md) | Collaboration ways domain | Accepted |
 | [ADR-133](./system/ADR-133-plugin-way-discovery.md) | Plugin Way Discovery | Proposed |
+| [ADR-134](./system/ADR-134-empirical-auto-tuning-from-fire-and-near-miss-telemetry.md) | Empirical auto-tuning from fire and near-miss telemetry | Draft |
+| [ADR-135](./system/ADR-135-content-aware-write-time-over-build-gate-with-a-self-extending-pattern-corpus.md) | Content-aware write-time over-build gate with a self-extending pattern corpus | Draft |
 
 ## Documentation
 _Documentation structure, tooling, coherence_

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -55,7 +55,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-132](./system/ADR-132-collaboration-ways-domain.md) | Collaboration ways domain | Accepted |
 | [ADR-133](./system/ADR-133-plugin-way-discovery.md) | Plugin Way Discovery | Proposed |
 | [ADR-134](./system/ADR-134-empirical-auto-tuning-from-fire-and-near-miss-telemetry.md) | Empirical auto-tuning from fire and near-miss telemetry | Draft |
-| [ADR-135](./system/ADR-135-content-aware-write-time-over-build-gate-with-a-self-extending-pattern-corpus.md) | Content-aware write-time over-build gate with a self-extending pattern corpus | Draft |
+| [ADR-135](./system/ADR-135-content-aware-write-time-over-build-gate-with-a-self-extending-pattern-corpus.md) | Content-aware write-time over-build gate with a self-extending pattern corpus | Accepted |
 
 ## Documentation
 _Documentation structure, tooling, coherence_

--- a/docs/architecture/system/ADR-134-empirical-auto-tuning-from-fire-and-near-miss-telemetry.md
+++ b/docs/architecture/system/ADR-134-empirical-auto-tuning-from-fire-and-near-miss-telemetry.md
@@ -1,0 +1,60 @@
+---
+status: Draft
+date: 2026-06-09
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-123
+  - ADR-125
+  - ADR-130
+  - ADR-135
+---
+
+# ADR-134: Empirical auto-tuning from fire and near-miss telemetry
+
+## Context
+
+The firing engine is tuned by hand. Every threshold, half-life, and vocabulary was set by authorial judgment, and the system collects no evidence that could revise them. Three gaps compound:
+
+1. **ADR-123 Phase E was never built.** The planned `ways tune` cadence calibration (derive per-way `half_life` from observed fire deltas in `~/.claude/stats/events.jsonl`) remains open; `ways tune` today audits locale alias fidelity only (per ADR-125).
+2. **Fires are logged; near-misses are discarded.** The matcher computes a score for every way on every prompt, then throws away everything below threshold. False silences — the way that *should* have fired — are structurally invisible, so the precision-first discipline (0 false positives as hard constraint) has no recall measurement to trade against.
+3. **Fire relevance is unmeasured.** A 2026-06-09 session readout showed ~17 of 47 fires landing in a session whose work never touched their domain (`itops/incident`, `delivery/migrations`, `testing/mocking` firing into a docs-only session). Each costs an injection; collectively they erode the trust the emission discipline exists to protect. Nothing currently distinguishes a fire that shaped an action from one that was scrolled past.
+
+Hand-tuning cannot close these gaps because the evidence doesn't exist to hand-tune *from*. A nervous system that cannot adjust its own sensitivities from experience is a reflex arc.
+
+## Decision
+
+Extend the telemetry surface and the `ways tune` subcommand into an empirical tuning loop with three measurements and a gated apply step.
+
+1. **Near-miss logging.** The matcher logs, per prompt, the top-scoring below-threshold candidates (score within a margin of their threshold, e.g. 0.05) to `events.jsonl` as `way_nearmiss` events. The scores are already computed; this is persistence, not new computation. Volume is bounded by the margin.
+2. **Cadence calibration (ADR-123 Phase E, as planned).** `ways tune --cadence` groups `way_fired` / `way_redisclosed` events by way, computes token-delta distributions between fires, and suggests `half_life` per the existing Phase E worksheet (rule of thumb: half_life ≈ median delta).
+3. **Relevance signal.** `ways tune --precision` correlates each way's fires with the session's subsequent activity class, derived from data already in the event log (trigger channel, tool mix, domains of other fires). A way whose fires repeatedly land in sessions that never touch its domain is flagged with its observed irrelevance rate and suggested remedies: threshold raise, vocabulary narrowing, or trigger-channel change. This is a heuristic flag, not a verdict — the same contract as `ways tune`'s fidelity audit.
+4. **Gated apply.** All three report by default; `--apply` rewrites frontmatter (`half_life`, `embed_threshold`) in place. Vocabulary changes are never auto-applied — they re-shape the embedding neighborhood and stay authorial. Applied changes are ordinary git diffs, reviewable and revertible.
+
+The recall counterpart falls out of (1): near-miss data plus the existing fixture workflow lets `ways tune` report likely false silences (ways that consistently score just under threshold on prompts whose sessions then did that way's kind of work), giving the 0-FP discipline its first recall estimate.
+
+## Consequences
+
+### Positive
+
+- Closes the open loop: telemetry that exists only as a record becomes input to calibration. Half-lives can be retuned per model generation (the maintenance posture ADR-301 documented).
+- False silences become measurable for the first time; precision-first stops being precision-only.
+- Per-session precision audits (`ways list` plus irrelevance rates) turn anecdotes like the 2026-06-09 readout into a tracked metric.
+
+### Negative
+
+- `events.jsonl` grows faster; near-miss margin needs a cap and the log needs rotation.
+- The relevance signal is a proxy — activity-class correlation can mislabel legitimately cross-cutting ways (e.g. `meta/tracking`). Flags must stay diagnostic, never auto-applied to vocabulary.
+- `--apply` writing frontmatter from observed behavior risks codifying one user's work distribution; suggested values should show the sample size they derive from.
+
+### Neutral
+
+- ADR-123 remains Accepted and unedited; this ADR absorbs and extends its open Phase E. Phase F (A/B validation) is unaffected.
+- Fine-tuning the embedding model (deferred in ADR-108) becomes more attractive once near-miss data accumulates as training signal — out of scope here.
+
+## Alternatives Considered
+
+- **Edit ADR-123 to widen Phase E** — rejected: ADR-123 is an Accepted historical record; widening its scope post-acceptance hides when the precision dimension entered the design.
+- **Model-graded relevance (LLM judges whether each fire influenced the session)** — rejected for now: highest-fidelity signal but adds inference cost to a system whose value is being cheap and ambient. Revisit if the activity-class proxy proves too coarse. Note that an *external* instance of this signal already arrives for free: the periodic Claude Code usage report is model-graded analysis of where a session actually went wrong, generated outside this loop at no inference cost to it. It does not measure way-fire relevance directly, but it measures the downstream thing ways exist to prevent — and a 2026-06 report (write-time friction: Buggy Code 40, Wrong Approach 37, Excessive Changes 7) is what empirically justified the content-level trigger in ADR-135, this design's first pattern-level consumer.
+- **Manual periodic audits of `ways list` output** — rejected as the only mechanism: it found today's signal, but it doesn't scale and never sees near-misses.

--- a/docs/architecture/system/ADR-135-content-aware-write-time-over-build-gate-with-a-self-extending-pattern-corpus.md
+++ b/docs/architecture/system/ADR-135-content-aware-write-time-over-build-gate-with-a-self-extending-pattern-corpus.md
@@ -1,0 +1,88 @@
+---
+status: Draft
+date: 2026-06-12
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-134
+  - ADR-123
+  - ADR-130
+---
+
+# ADR-135: Content-aware write-time over-build gate with a self-extending pattern corpus
+
+## Context
+
+A write-time check now exists: `softwaredev/code/code.check.md` fires at `PreToolUse(Edit|Write)` on source files and surfaces a short anchor plus verification questions — does this need to exist, is this the codepath that actually runs, is this the minimal change. It ships with no engine change because it needs none: the `ways scan file` path matches a check to a file by its `files:` regex and never inspects what is about to be written. That is its ceiling. A question can ask "did you reach for the stdlib first?"; it cannot *see* the hand-rolled LRU cache, the reinvented email-regex validator, or the new dependency in the diff and name them.
+
+Naming them requires the candidate content, which today never reaches the matcher. `check-file-pre.sh` forwards `tool_input.file_path` only, and `ways scan file` accepts `--path`, `--session`, `--project` — no content channel. Adding one is a genuine new capability, not a new file.
+
+Three forces make it worth building, and one makes it dangerous:
+
+1. **The friction is empirically at write-time.** An external, model-graded usage report (2026-05 to 2026-06, 92 sessions) shows the dominant friction buckets are Buggy Code (40), Wrong Approach (37), and Excessive Changes (7) — every one of them landing at the moment code is written, the exact moment this gate would fire.
+2. **The minimalism content is well-understood.** The "ponytail" plugin's ladder (YAGNI → stdlib → native → installed dep → one line) and its review tags (`stdlib:`, `native:`, `yagni:`, `shrink:`) are a serviceable taxonomy for what over-build *looks like* in concrete code.
+3. **The matcher already learns elsewhere.** ADR-134 established empirical tuning from fire and near-miss telemetry — but at the threshold and cadence level. Pattern *recognition* is the next level up and has no mechanism.
+
+The danger is the obvious implementation. The ponytail model bakes one experienced developer's opinion into a fixed catalog. A fixed catalog nags at its edges: code that falls outside it is misjudged, and legitimately novel approaches read as "you're doing it wrong." A matcher that suppresses innovation because it has not seen it before is a failure we will not ship. The catalog cannot be the deliverable.
+
+## Decision
+
+Build the content channel, but make the thing it feeds a **learning matcher, not a static catalog**. The pattern corpus self-extends from comprehended encounters, bounded by the precision discipline already in force, so it grows understanding without growing dogma.
+
+### 1. Content channel
+
+`check-file-pre.sh` forwards `tool_input.content` (Write) / `tool_input.new_string` (Edit). `ways scan file` gains a `--content` input — or a sibling `ways scan write` subcommand — that pattern-scans the candidate code. Content is budget-reduced before scanning, consistent with ADR-130's uniform hook budget.
+
+### 2. The gate, and what runs on the hot path
+
+The gate emits ponytail-style `stdlib:` / `native:` findings plus a new-file line-count signal, and is silent otherwise. The hot path is cheap and does no inference:
+
+- **Recognized pattern** → emit the finding (`stdlib: hand-rolled LRU — functools.lru_cache covers it`).
+- **Unrecognized code** → **silence**, plus an *encounter* entry to the `events.jsonl` near-miss stream (ADR-134). Silence is the correct output, not a fallback.
+
+There is no inline comprehension on the hot path. "Spend cycles to understand it" never means deep-analyze every keystroke — that would destroy the ambient, near-zero-cost value the firing engine exists to provide.
+
+### 3. The loop — corpus growth happens out of band, and runs both ways
+
+Comprehension and recording happen in a deliberate authoring/tuning pass modeled on `ways tune`, consuming the encounter telemetry the hot path emitted:
+
+1. Read the encounter stream — the unrecognized writes the gate stayed silent on.
+2. Comprehend the genuinely ambiguous cases (the cost is paid here, off the hot path, on a bounded sample).
+3. **Record a finding — or, usually, do not.** A finding is either a new **match** (a real, generalizable reinvention) or an **exemption** (a legitimate or novel shape that must never be flagged). Most encounters are neither and stay silent and unrecorded.
+4. **Prune** patterns whose telemetry shows them over-firing.
+
+The loop is **bidirectional by design**. A loop that only adds matches becomes ponytail-by-accretion — a catalog that has "seen everything" and therefore nags at everything. That is the named anti-pattern. Recognition is provisional and revisable; a pattern earns its place from observed behavior and loses it the same way.
+
+### 4. Precision discipline (inherited, not invented)
+
+The gate inherits ADR-134's precision-first, zero-false-positive **hard constraint**. The corpus gets less ignorant over time *only through comprehension*, never through speculative up-front enumeration. Comprehensiveness is explicitly a non-goal: a small, high-confidence corpus that is silent on the unfamiliar beats a large one that is confidently wrong. The bootstrap seed is deliberately tiny — on the order of three or four patterns (hand-rolled LRU/TTL cache, email-regex validation, manual retry around an idempotent call, new-file line count) — and the seed is a starting point for the loop, not a specification of coverage.
+
+This makes ADR-135 the first *content-level* and *pattern-level* application of ADR-134's machinery: 134 tunes thresholds and cadence from telemetry; 135 tunes recognition itself from the same substrate.
+
+## Consequences
+
+### Positive
+
+- The write-time over-build signal becomes concrete: it names the specific reinvention in the candidate code, not just a generic "did you consider…". This targets the usage report's measured #1 friction at the point it occurs.
+- The corpus is anti-fragile to novelty. The encounter ponytail would misjudge is exactly the encounter that, once comprehended, teaches the system — or is recorded as a permanent exemption. Unfamiliarity routes to silence-then-maybe-learn, never to a false flag.
+- ADR-134's near-miss substrate gets its first concrete consumer beyond threshold tuning, validating that design end to end.
+
+### Negative
+
+- A new input channel widens the hot-path surface: content must be forwarded, budget-reduced, and scanned within the PreToolUse latency envelope. Pattern scanning must stay cheap (literal/regex shape matching, no inference).
+- The loop requires human/agent attention on a cadence. Without the out-of-band pass, the corpus ossifies at its seed — functional, but not the learning system this ADR justifies.
+- `events.jsonl` gains an encounter stream on top of 134's near-miss volume; the encounter margin needs a cap and the log needs rotation (134's concern, compounded).
+
+### Neutral
+
+- Tier 1 (`code.check.md`) is unaffected and remains valuable on its own; this ADR is strictly additive. If 135 is never implemented, Tier 1 still ships the questions.
+- The ponytail review *tags* survive (`stdlib:`/`native:`); the ponytail *philosophy* (fixed, comprehensive, opinionated) is explicitly rejected. Only the finding shape is borrowed.
+- Pattern entries become ordinary versioned artifacts — reviewable, revertible git diffs — like the frontmatter 134's `--apply` rewrites.
+
+## Alternatives Considered
+
+- **Static curated catalog (the ponytail model).** Rejected as the deliverable: it nags at its edges and cannot grow from experience. Its taxonomy is borrowed; its fixedness is the thing this ADR exists to avoid.
+- **Model-graded per-write judgment (an LLM decides "is this over-built?" on every Write).** Highest fidelity, rejected for the hot path for the same reason ADR-134 rejected model-graded relevance: it adds inference cost to a system whose value is being cheap and ambient. It is admissible only in the out-of-band comprehension step, on a bounded sample.
+- **PostToolUse lint instead of PreToolUse gate** (the shape the usage report literally suggested: `PostToolUse(Edit|Write)` running a formatter/type-checker). Complementary, not a substitute — it catches mechanical defects *after* the code lands, whereas over-build is a *before-you-write* decision. Worth adopting separately; it does not address this signal.
+- **Append-only learning loop.** Rejected: monotonic growth reconstitutes the ponytail dogma by accretion. Pruning and exemptions are load-bearing, not optional.

--- a/docs/architecture/system/ADR-135-content-aware-write-time-over-build-gate-with-a-self-extending-pattern-corpus.md
+++ b/docs/architecture/system/ADR-135-content-aware-write-time-over-build-gate-with-a-self-extending-pattern-corpus.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-06-12
 deciders:
   - aaronsb


### PR DESCRIPTION
## Decision (Draft)

Records **Tier 2** of the over-build work whose **Tier 1** (the `code.check.md` write-time check) is in #114.

**ADR-135** decides *how* to build a content-aware over-build gate without inheriting the failure mode of the obvious design. The naive build — a fixed, opinionated pattern catalog (the "ponytail" model) — nags at its edges: code outside the catalog is misjudged and legitimate novelty reads as wrong. So the deliverable is **a learning matcher, not a catalog**:

- **Hot path stays cheap** — recognized pattern → emit a `stdlib:`/`native:` finding; **unrecognized code → silence + an encounter-telemetry entry**. No inline inference.
- **The loop runs out of band** (modeled on `ways tune`) — comprehend the ambiguous encounters, then record a **match**, an **exemption**, or **nothing**; **prune** over-firers. Bidirectional by design.
- **Precision discipline inherited from ADR-134** — zero-false-positive hard constraint; the corpus grows only through comprehension, never speculative enumeration. Comprehensiveness is the named anti-pattern.

This makes ADR-135 the first *content-level / pattern-level* consumer of ADR-134's empirical-tuning substrate.

## Why both ADRs are here

This branch also carries **ADR-134** (empirical auto-tuning) — previously an untracked draft — because 135 extends it, they cross-reference, and INDEX covers both. ADR-134 gains one note: the external Claude Code **usage report** is a free, model-graded instance of the relevance signal 134 deferred, and is what empirically justified 135's trigger (write-time friction: Buggy Code 40 / Wrong Approach 37 / Excessive Changes 7).

## Status

**Draft.** Implementation (#6 hook content forwarding + `ways scan --content` + the gate; #7 the learning loop) is **gated on acceptance of this ADR** — not started, per the debate→ADR→implement workflow.

## Lint

`adr lint --check` → 0 errors (the single warning is pre-existing ADR-127).