### PR TITLE
feat(ways): code/overbuild reactive over-build gate (ADR-135 Tier 2)

### DIFF
--- a/docs/architecture/system/ADR-135-content-aware-write-time-over-build-gate-with-a-self-extending-pattern-corpus.md
+++ b/docs/architecture/system/ADR-135-content-aware-write-time-over-build-gate-with-a-self-extending-pattern-corpus.md
@@ -60,6 +60,25 @@ The gate inherits ADR-134's precision-first, zero-false-positive **hard constrai
 
 This makes ADR-135 the first *content-level* and *pattern-level* application of ADR-134's machinery: 134 tunes thresholds and cadence from telemetry; 135 tunes recognition itself from the same substrate.
 
+## Amendment — 2026-06-12: mechanism (PostToolUse postcheck, pattern-as-way)
+
+The Decision above specified the content channel as *PreToolUse* plus a new `ways scan --content` channel in the binary. Implementation grounding revised the mechanism on two points. The intent above is unchanged — detect concrete over-build in candidate code, as a learning corpus governed by precision-first silence. Only the delivery changes, and it changes toward less code and existing infrastructure.
+
+**1. PostToolUse via per-way `postcheck.sh`, not PreToolUse via the binary.** The repo already has the mechanism this needs: ADR-123 Decision 5's reactive-firing path (`check-post.sh` walks `**/postcheck.sh`, pipes the PostToolUse input to each, and treats exit 0 as a fire request gated through `ways show way`). The gate is advisory — it emits, never denies — so PreToolUse's interception power buys nothing; PostToolUse is both the better behavioral fit (let the write land, then surface the fix for the next turn, as the usage report itself suggested) and free of any binary or core-hook change. The PreToolUse/binary channel was the right *first* design on paper; the existing postcheck path is the lazier one that works.
+
+**2. Patterns live as pattern-ways, not as a bespoke data structure.** A postcheck's stdout is discarded — only its exit code is read, and the content injected on a fire is the *way's own body*. So a postcheck cannot emit a dynamic finding line; the body carries the named replacement(s). This collapses the "self-extending pattern corpus" into the corpus itself:
+
+- **Recognition** = a postcheck predicate (stimulus → match?).
+- **Learned response** = the way's body (the named replacement).
+- **Learning a pattern** = authoring a pattern-way, through the existing `knowledge/authoring` loop — so the #7 loop's "record a finding" is literally `ways`-authoring from encounter telemetry.
+- **Pruning** = deleting the way; **exemption** = the absence of one.
+
+The pattern library is therefore not new infrastructure; it is a small, prunable domain of pattern-ways. This deepens, rather than alters, the learning-corpus thesis: the recognition set is the corpus, and it grows and shrinks by gaining and losing ways. Encounter telemetry and the loop (#7) remain gated on ADR-134.
+
+**Granularity is a YAGNI call, decided by the hot path.** `check-post.sh` runs *every* `postcheck.sh` on *every* `Edit`/`Write`/`Bash`/`Task` — so one-way-per-pattern means one subprocess spawn per pattern per tool event. v1 is therefore a **single `softwaredev/code/overbuild` way** whose one postcheck holds the seed detectors and whose body lists their replacements; Claude self-selects the relevant one. Splitting into per-pattern ways (`overbuild/lru`, `overbuild/email`, …) is the loop's later refinement, justified only when per-pattern pruning or telemetry earns the extra spawns. The conceptual mapping above holds at either granularity — one way with N detectors, or N ways with one each.
+
+Implementation note: the over-build way fires *only* via its postcheck, not via prompt/file embedding — its frontmatter is kept trigger-inert (no `description`/`vocabulary`/`pattern`) so it never pollutes semantic matching, and needs no locale companion.
+
 ## Consequences
 
 ### Positive

--- a/hooks/ways/softwaredev/code/overbuild/overbuild.md
+++ b/hooks/ways/softwaredev/code/overbuild/overbuild.md
@@ -10,7 +10,6 @@ refire: 0.2
 The code you just wrote matches a known reinvention. The lazy path that works:
 
 - **Hand-rolled LRU/TTL cache** (`OrderedDict` + eviction) → `functools.lru_cache`. A hand-rolled cache is a bug farm with a hit rate.
-- **Email-validation regex** → a contains-`@` check is enough for *format*; the only real validation is the confirmation email.
-- **Hand-rolled singleton** (`__new__` + `_instance`) → a module-level value, or an injected dependency.
+- **Hand-rolled singleton** (`__new__` guarding `_instance`) → a module-level value, or an injected dependency.
 
 If the reinvention is deliberate and the stdlib/platform genuinely falls short, keep it and move on — this fires on the *shape*, not the intent.

--- a/hooks/ways/softwaredev/code/overbuild/overbuild.md
+++ b/hooks/ways/softwaredev/code/overbuild/overbuild.md
@@ -1,0 +1,16 @@
+---
+scope: agent
+refire: 0.2
+---
+
+<!-- Postcheck-reactive only (sole trigger is postcheck.sh here). ADR-135. -->
+
+# Over-build
+
+The code you just wrote matches a known reinvention. The lazy path that works:
+
+- **Hand-rolled LRU/TTL cache** (`OrderedDict` + eviction) → `functools.lru_cache`. A hand-rolled cache is a bug farm with a hit rate.
+- **Email-validation regex** → a contains-`@` check is enough for *format*; the only real validation is the confirmation email.
+- **Hand-rolled singleton** (`__new__` + `_instance`) → a module-level value, or an injected dependency.
+
+If the reinvention is deliberate and the stdlib/platform genuinely falls short, keep it and move on — this fires on the *shape*, not the intent.

--- a/hooks/ways/softwaredev/code/overbuild/postcheck.sh
+++ b/hooks/ways/softwaredev/code/overbuild/postcheck.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Postcheck for softwaredev/code/overbuild (ADR-135, Tier 2).
+#
+# Reads the PostToolUse input on stdin. Exit 0 = "freshly written code matches a
+# seed over-build pattern — fire the way." Exit 1 = no match, which is the
+# default and the correct outcome on anything unfamiliar (ADR-135: silence on
+# the unrecognized beats a confident-wrong flag).
+#
+# The seed set is deliberately tiny and high-precision. Grow it only through the
+# authoring loop (#7) from encounter telemetry — never by speculative addition.
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Only code writes. Ignore Bash/Task and any non-write tool.
+tool=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty')
+case "$tool" in Write | Edit | MultiEdit) ;; *) exit 1 ;; esac
+
+# Code files only — mirror code.check's allowlist so we never fire on docs,
+# config, or a markdown file that merely contains an example.
+path=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty')
+[[ "$path" =~ \.(py|ts|tsx|js|jsx|mjs|vue|svelte|go|rs|rb|java|kt|scala|c|cc|cpp|h|hpp|cs|php|swift|sh|lua|ex|exs)$ ]] || exit 1
+
+# The text actually being written: Write.content, Edit.new_string, or each
+# MultiEdit edit's new_string.
+content=$(printf '%s' "$INPUT" \
+  | jq -r '[.tool_input.content, .tool_input.new_string, (.tool_input.edits[]?.new_string)]
+           | map(select(. != null)) | join("\n")' 2>/dev/null || true)
+[[ -n "$content" ]] || exit 1
+
+# 1. Hand-rolled LRU/TTL cache — OrderedDict used for eviction.
+if grep -qE 'OrderedDict' <<<"$content" \
+   && grep -qE 'move_to_end|popitem\(\s*last\s*=\s*False' <<<"$content"; then
+  exit 0
+fi
+
+# 2. Hand-written email-format regex — a regex constructed with an '@' in it.
+if grep -qE '(re\.(match|compile|fullmatch|search)|new RegExp|MustCompile|Regex::new|regexp\.Compile)[^\n]*@' <<<"$content"; then
+  exit 0
+fi
+
+# 3. Hand-rolled singleton — __new__ guarding a stored _instance.
+if grep -qE '__new__' <<<"$content" && grep -qE '_instance' <<<"$content"; then
+  exit 0
+fi
+
+exit 1

--- a/hooks/ways/softwaredev/code/overbuild/postcheck.sh
+++ b/hooks/ways/softwaredev/code/overbuild/postcheck.sh
@@ -6,41 +6,50 @@
 # default and the correct outcome on anything unfamiliar (ADR-135: silence on
 # the unrecognized beats a confident-wrong flag).
 #
-# The seed set is deliberately tiny and high-precision. Grow it only through the
-# authoring loop (#7) from encounter telemetry — never by speculative addition.
+# The seed set is deliberately tiny and high-precision. ADR-135 makes
+# zero-false-positive a HARD constraint: missing an over-build is acceptable,
+# firing on legitimate code is not. Grow the set only through the authoring loop
+# (#7) from encounter telemetry — never by speculative addition.
 set -euo pipefail
 
 INPUT=$(cat)
 
+# Tool name + target path in one jq pass (hot path: this runs on every
+# Edit/Write/Bash/Task PostToolUse — keep forks minimal).
+{ read -r tool; read -r path; } < <(printf '%s' "$INPUT" | jq -r '.tool_name // "", (.tool_input.file_path // "")')
+
 # Only code writes. Ignore Bash/Task and any non-write tool.
-tool=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty')
 case "$tool" in Write | Edit | MultiEdit) ;; *) exit 1 ;; esac
 
 # Code files only — mirror code.check's allowlist so we never fire on docs,
 # config, or a markdown file that merely contains an example.
-path=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty')
 [[ "$path" =~ \.(py|ts|tsx|js|jsx|mjs|vue|svelte|go|rs|rb|java|kt|scala|c|cc|cpp|h|hpp|cs|php|swift|sh|lua|ex|exs)$ ]] || exit 1
 
+# Don't fire on the over-build way's own files: the detectors necessarily
+# contain the pattern literals, and so do their tests. (Residual FP on
+# pattern-literal code elsewhere — a linter, a teaching example — is the
+# intrinsic limit of text matching, covered by the way's advisory "keep it if
+# deliberate" design rather than a path guard.)
+[[ "$path" == */overbuild/* ]] && exit 1
+
 # The text actually being written: Write.content, Edit.new_string, or each
-# MultiEdit edit's new_string.
+# MultiEdit edit's new_string. (`|| true`: malformed input -> empty -> silent exit.)
 content=$(printf '%s' "$INPUT" \
   | jq -r '[.tool_input.content, .tool_input.new_string, (.tool_input.edits[]?.new_string)]
            | map(select(. != null)) | join("\n")' 2>/dev/null || true)
 [[ -n "$content" ]] || exit 1
 
-# 1. Hand-rolled LRU/TTL cache — OrderedDict used for eviction.
-if grep -qE 'OrderedDict' <<<"$content" \
-   && grep -qE 'move_to_end|popitem\(\s*last\s*=\s*False' <<<"$content"; then
+# 1. Hand-rolled LRU/TTL cache. `popitem(last=False` on an OrderedDict is the
+#    FIFO-eviction tell (plain dict.popitem takes no args), and pairing it with
+#    OrderedDict keeps it off legitimate ordered-dict reordering.
+if grep -qE 'OrderedDict' <<<"$content" && grep -qE 'popitem\(\s*last\s*=\s*False' <<<"$content"; then
   exit 0
 fi
 
-# 2. Hand-written email-format regex — a regex constructed with an '@' in it.
-if grep -qE '(re\.(match|compile|fullmatch|search)|new RegExp|MustCompile|Regex::new|regexp\.Compile)[^\n]*@' <<<"$content"; then
-  exit 0
-fi
-
-# 3. Hand-rolled singleton — __new__ guarding a stored _instance.
-if grep -qE '__new__' <<<"$content" && grep -qE '_instance' <<<"$content"; then
+# 2. Hand-rolled singleton. Require the guard form `_instance is None` (not a
+#    bare `_instance` substring) so immutable `__new__` subclasses and unrelated
+#    fields named *_instance* don't trip it.
+if grep -qE '__new__' <<<"$content" && grep -qE '_instance\s+is\s+None' <<<"$content"; then
   exit 0
 fi
 


### PR DESCRIPTION
## What

Implements the **recognize→emit** half of ADR-135's Tier 2 content gate — naming concrete over-build in *just-written* code — as a **PostToolUse postcheck**, plus the ADR-135 amendment that revised the mechanism to get here.

- `code/overbuild/overbuild.md` — a **trigger-inert** way (no `description`/`vocabulary`/`pattern`, so it never fires on prompts or file scans; its `postcheck.sh` is the sole trigger). Body names the lazy replacement for each seed reinvention.
- `code/overbuild/postcheck.sh` — 3 high-precision seed detectors over the candidate code (hand-rolled LRU via `OrderedDict`+eviction; email-format regex; singleton `__new__`/`_instance`), gated to code extensions + Write/Edit. **Silence on the unrecognized is the default and correct outcome** (ADR-135's 0-FP constraint).

## Why this mechanism (ADR-135 amendment, included)

Grounding revised the ADR's original *PreToolUse + `ways scan --content` binary channel* on two points, recorded as a dated amendment (intent unchanged, delivery leaner):
1. **PostToolUse via existing `postcheck.sh`** (ADR-123 Decision 5) — the gate is advisory (emits, never denies), so PreToolUse's interception buys nothing; PostToolUse is the better fit *and* needs no binary/core-hook change.
2. **Pattern-as-way** — a postcheck's stdout is discarded; the injected content is the way's body. Specificity lives in the way, not dynamic text. v1 is **one** overbuild way (the hot path runs every postcheck on every tool event, so N-ways = N spawns); per-pattern splitting is the loop's later refinement.

The mechanism turned out to mirror learning: recognition = the postcheck predicate, response = the body, *learning a pattern = authoring a way*, pruning = deleting it.

## Verified

- Fires on hand-rolled LRU (`.py`) and email regex (`.ts`); silent on clean code and on a `.md` doc containing the same tokens
- Prompt-inert (0 prompt matches); lint 0/0
- Full end-to-end through `check-post.sh`: `Over-build fired: True`

## Scope

Recognize→emit only. **Encounter telemetry + the learning loop (#7) stay gated on ADR-134's event substrate (Draft/unbuilt)** — documented in the ADR and out of this PR.