### PR TITLE
feat(scan): way_nearmiss telemetry (ADR-134 task A)

### DIFF
--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -77,6 +77,7 @@ pub fn prompt(query: &str, session_id: &str, project: Option<&str>) -> Result<()
 
     let scope = session::detect_scope(session_id);
     let candidates = collect_candidates(&project_dir);
+    let near_miss_margin = crate::config::global().near_miss_margin;
 
     // ADR-130: cap embed input to the model's working window via the
     // sentence-salience reducer. Pattern/keyword matching downstream
@@ -96,20 +97,25 @@ pub fn prompt(query: &str, session_id: &str, project: Option<&str>) -> Result<()
         }
 
         // Additive matching: pattern OR semantic
-        let channel = match_prompt(
+        match match_prompt(
             query,
             &way.pattern,
             &way.corpus_id,
             effective_thresholds(way, session_id),
             &embed_matches,
-        );
-
-        if let Some(trigger) = channel {
-            let out = capture_show_way(&way.id, session_id, &trigger);
-            if !out.is_empty() {
-                context.push_str(&out);
-                context.push_str("\n\n");
+            near_miss_margin,
+        ) {
+            PromptMatch::Fired(trigger) => {
+                let out = capture_show_way(&way.id, session_id, &trigger);
+                if !out.is_empty() {
+                    context.push_str(&out);
+                    context.push_str("\n\n");
+                }
             }
+            PromptMatch::NearMiss(nm) => {
+                log_near_miss(way, &nm, "prompt", &scope, &project_dir, session_id, query);
+            }
+            PromptMatch::NoMatch => {}
         }
     }
 
@@ -134,6 +140,10 @@ pub fn task(
 
     let is_teammate = team.is_some();
     let candidates = collect_candidates(&project_dir);
+    let near_miss_margin = crate::config::global().near_miss_margin;
+    // Session scope for telemetry: the task channel is subagent unless a team
+    // name marks it as a teammate dispatch.
+    let task_scope = if is_teammate { "teammate" } else { "subagent" };
 
     // ADR-130: agent delegation prompts are the largest input class in
     // practice. Reduce to the model's window before embedding.
@@ -162,16 +172,19 @@ pub fn task(
             continue;
         }
 
-        let channel = match_prompt(
+        match match_prompt(
             query,
             &way.pattern,
             &way.corpus_id,
             effective_thresholds(way, session_id),
             &embed_matches,
-        );
-
-        if let Some(trigger) = channel {
-            matched.push((way.id.clone(), trigger));
+            near_miss_margin,
+        ) {
+            PromptMatch::Fired(trigger) => matched.push((way.id.clone(), trigger)),
+            PromptMatch::NearMiss(nm) => {
+                log_near_miss(way, &nm, "task", task_scope, &project_dir, session_id, query);
+            }
+            PromptMatch::NoMatch => {}
         }
     }
 
@@ -393,17 +406,42 @@ pub fn file(filepath: &str, session_id: &str, project: Option<&str>) -> Result<(
 
 // ── Matching ────────────────────────────────────────────────────
 
+/// Outcome of matching a prompt against one way.
+enum PromptMatch {
+    /// The way fired; the payload is the trigger channel.
+    Fired(String),
+    /// The way did NOT fire, but at least one model scored within
+    /// `near_miss_margin` below its effective threshold (ADR-134). Carries the
+    /// already-computed scores for telemetry — no new embedding is done.
+    NearMiss(NearMiss),
+    /// No match, and not close enough to record.
+    NoMatch,
+}
+
+/// A below-threshold embedding result close enough to log (ADR-134 Decision 1).
+struct NearMiss {
+    score_en: Option<f64>,
+    score_multi: Option<f64>,
+    thr_en: f64,
+    thr_multi: f64,
+    /// Smallest `threshold - score` among the models within margin — how close
+    /// the way came to firing on its best path.
+    margin: f64,
+}
+
 fn match_prompt(
     query: &str,
     pattern: &Option<String>,
     corpus_id: &str,
     thresholds: EffectiveThresholds,
     scores: &EmbedScores,
-) -> Option<String> {
-    // Channel 1: Regex pattern — always checked first, always fires on match.
+    near_miss_margin: f64,
+) -> PromptMatch {
+    // Channel 1: Regex pattern — deterministic, scoreless. A pattern miss is
+    // never a near-miss (there is no margin to be near).
     if let Some(ref pat) = pattern {
         if regex_matches(pat, query) {
-            return Some("keyword".to_string());
+            return PromptMatch::Fired("keyword".to_string());
         }
     }
 
@@ -413,16 +451,79 @@ fn match_prompt(
     // each model's noise band sits below its gate:
     //   - EN model (0.40): sharp on English, noise below 0.35
     //   - multi model (0.55): cross-lingual but coarser, noise at 0.30-0.50
-    let en_fires = scores.best_en(corpus_id).is_some_and(|s| s >= thresholds.en);
-    let multi_fires = scores.best_multi(corpus_id).is_some_and(|s| s >= thresholds.multi);
+    let score_en = scores.best_en(corpus_id);
+    let score_multi = scores.best_multi(corpus_id);
 
-    if en_fires {
-        Some("semantic:embedding:en".to_string())
-    } else if multi_fires {
-        Some("semantic:embedding:multi".to_string())
-    } else {
-        None
+    if score_en.is_some_and(|s| s >= thresholds.en) {
+        return PromptMatch::Fired("semantic:embedding:en".to_string());
     }
+    if score_multi.is_some_and(|s| s >= thresholds.multi) {
+        return PromptMatch::Fired("semantic:embedding:multi".to_string());
+    }
+
+    // No fire. Record a near-miss when a model landed in the band just below
+    // its threshold: `thr - margin <= score < thr`. The reported margin is the
+    // smallest shortfall across qualifying models. Measured against the SAME
+    // effective thresholds the fire path uses, so parent-boost is honored.
+    let shortfall = |score: Option<f64>, thr: f64| -> Option<f64> {
+        score.and_then(|s| {
+            let gap = thr - s;
+            (gap > 0.0 && gap <= near_miss_margin).then_some(gap)
+        })
+    };
+    let margin = [
+        shortfall(score_en, thresholds.en),
+        shortfall(score_multi, thresholds.multi),
+    ]
+    .into_iter()
+    .flatten()
+    .fold(None, |acc: Option<f64>, g| Some(acc.map_or(g, |a| a.min(g))));
+
+    match margin {
+        Some(margin) => PromptMatch::NearMiss(NearMiss {
+            score_en,
+            score_multi,
+            thr_en: thresholds.en,
+            thr_multi: thresholds.multi,
+            margin,
+        }),
+        None => PromptMatch::NoMatch,
+    }
+}
+
+/// Emit a `way_nearmiss` telemetry event (ADR-134 Decision 1): a way that did
+/// not fire but scored within the near-miss margin of its threshold. This is
+/// persistence of already-computed scores, not new work — the tuning passes
+/// (`ways tune --cadence/--precision`) consume the stream. Field order mirrors
+/// `way_fired` (scan/state.rs) for reader symmetry.
+fn log_near_miss(
+    way: &WayCandidate,
+    nm: &NearMiss,
+    trigger: &str,
+    scope: &str,
+    project_dir: &str,
+    session_id: &str,
+    query: &str,
+) {
+    let fmt = |v: Option<f64>| v.map(|s| format!("{s:.4}")).unwrap_or_default();
+    let domain = way.id.split('/').next().unwrap_or(&way.id);
+    // ADR-134 task E: events.jsonl rotation/cap will bound this stream's growth.
+    session::log_event(&[
+        ("event", "way_nearmiss"),
+        ("way", &way.id),
+        ("corpus_id", &way.corpus_id),
+        ("domain", domain),
+        ("score_en", &fmt(nm.score_en)),
+        ("score_multi", &fmt(nm.score_multi)),
+        ("thr_en", &format!("{:.4}", nm.thr_en)),
+        ("thr_multi", &format!("{:.4}", nm.thr_multi)),
+        ("margin", &format!("{:.4}", nm.margin)),
+        ("trigger", trigger),
+        ("scope", scope),
+        ("project", project_dir),
+        ("session", session_id),
+        ("query_tokens", &reduce::approx_tokens(query).to_string()),
+    ]);
 }
 
 /// Per-model thresholds for a way at a given moment in a session.
@@ -515,4 +616,90 @@ pub(super) fn emit_hook_context(hook_event: &str, context: &str) {
         }),
     };
     println!("{payload}");
+}
+
+#[cfg(test)]
+mod near_miss_tests {
+    //! ADR-134 task A: the near-miss decision in `match_prompt`. These cover
+    //! the pure score/threshold arithmetic — no embedding subprocess, no I/O.
+    use super::*;
+
+    const THR: EffectiveThresholds = EffectiveThresholds { en: 0.40, multi: 0.55 };
+    const MARGIN: f64 = 0.05;
+
+    fn scores(en: Option<f64>, multi: Option<f64>) -> EmbedScores {
+        EmbedScores {
+            en: en.map(|s| vec![("w".to_string(), s)]),
+            multi: multi.map(|s| vec![("w".to_string(), s)]),
+        }
+    }
+
+    fn run(en: Option<f64>, multi: Option<f64>, pattern: Option<&str>) -> PromptMatch {
+        match_prompt(
+            "query text",
+            &pattern.map(|p| p.to_string()),
+            "w",
+            THR,
+            &scores(en, multi),
+            MARGIN,
+        )
+    }
+
+    #[test]
+    fn en_clears_fires_en() {
+        assert!(matches!(run(Some(0.41), None, None),
+            PromptMatch::Fired(c) if c == "semantic:embedding:en"));
+    }
+
+    #[test]
+    fn multi_clears_when_en_below_fires_multi() {
+        assert!(matches!(run(Some(0.20), Some(0.56), None),
+            PromptMatch::Fired(c) if c == "semantic:embedding:multi"));
+    }
+
+    #[test]
+    fn within_margin_is_near_miss_with_shortfall() {
+        match run(Some(0.37), None, None) {
+            PromptMatch::NearMiss(nm) => {
+                assert!((nm.margin - 0.03).abs() < 1e-9, "margin = thr - score");
+                assert_eq!(nm.score_en, Some(0.37));
+                assert_eq!(nm.score_multi, None);
+            }
+            other => panic!("expected NearMiss, got {:?}", discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn smallest_shortfall_wins_across_models() {
+        // en short by 0.03, multi short by 0.02 -> reported margin is 0.02.
+        match run(Some(0.37), Some(0.53), None) {
+            PromptMatch::NearMiss(nm) => assert!((nm.margin - 0.02).abs() < 1e-9),
+            other => panic!("expected NearMiss, got {:?}", discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn beyond_margin_is_no_match() {
+        assert!(matches!(run(Some(0.30), None, None), PromptMatch::NoMatch));
+    }
+
+    #[test]
+    fn pattern_match_preempts_near_miss() {
+        // Scores would be a near-miss, but a keyword hit is a deterministic fire.
+        assert!(matches!(run(Some(0.37), None, Some("query")),
+            PromptMatch::Fired(c) if c == "keyword"));
+    }
+
+    #[test]
+    fn absent_scores_are_no_match() {
+        assert!(matches!(run(None, None, None), PromptMatch::NoMatch));
+    }
+
+    fn discriminant(m: &PromptMatch) -> &'static str {
+        match m {
+            PromptMatch::Fired(_) => "Fired",
+            PromptMatch::NearMiss(_) => "NearMiss",
+            PromptMatch::NoMatch => "NoMatch",
+        }
+    }
 }

--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -494,8 +494,11 @@ fn match_prompt(
 /// Emit a `way_nearmiss` telemetry event (ADR-134 Decision 1): a way that did
 /// not fire but scored within the near-miss margin of its threshold. This is
 /// persistence of already-computed scores, not new work — the tuning passes
-/// (`ways tune --cadence/--precision`) consume the stream. Field order mirrors
-/// `way_fired` (scan/state.rs) for reader symmetry.
+/// (`ways tune --cadence/--precision`) consume the stream. The leading fields
+/// (`event`, `way`, `domain`, `trigger`, `scope`, `project`, `session`) follow
+/// the `way_fired` convention (scan/state.rs) for reader symmetry; the score
+/// fields are near-miss-specific. There is no `team` field — team attribution
+/// lives on fires (show/mod.rs), not on the below-threshold telemetry.
 fn log_near_miss(
     way: &WayCandidate,
     nm: &NearMiss,
@@ -693,6 +696,15 @@ mod near_miss_tests {
     #[test]
     fn absent_scores_are_no_match() {
         assert!(matches!(run(None, None, None), PromptMatch::NoMatch));
+    }
+
+    #[test]
+    fn score_exactly_at_threshold_fires_not_near_miss() {
+        // The boundary where the `>=` fire check and the `gap > 0.0` near-miss
+        // guard must agree: a score equal to the threshold fires, it is never
+        // a (zero-shortfall) near-miss.
+        assert!(matches!(run(Some(0.40), None, None),
+            PromptMatch::Fired(c) if c == "semantic:embedding:en"));
     }
 
     fn discriminant(m: &PromptMatch) -> &'static str {

--- a/tools/ways-cli/src/cmd/scan/reduce.rs
+++ b/tools/ways-cli/src/cmd/scan/reduce.rs
@@ -76,7 +76,7 @@ pub fn reduce_for_embed(input: &str, budget_tokens: usize) -> String {
     reduce_by_sentences(trimmed, &sentences, budget_tokens)
 }
 
-fn approx_tokens(s: &str) -> usize {
+pub(crate) fn approx_tokens(s: &str) -> usize {
     // Cheap upper bound. Three estimators, take the max so we never
     // under-budget:
     //

--- a/tools/ways-cli/src/config.rs
+++ b/tools/ways-cli/src/config.rs
@@ -65,6 +65,14 @@ pub struct Config {
     /// models produce scores in different distributions, so comparing
     /// them directly (max, average) is apples-to-oranges.
     pub default_multi_embed_threshold: f64,
+    /// Near-miss margin (ADR-134). A way that did NOT fire is logged as a
+    /// `way_nearmiss` telemetry event when at least one model's score landed
+    /// within this much *below* its effective threshold (`thr - margin <=
+    /// score < thr`). Purely a logging knob — it never changes firing. The
+    /// tuning passes (`ways tune --cadence/--precision`) consume the stream.
+    /// Default 0.05: a narrow band that captures genuine near-fires without
+    /// flooding the log with deep misses.
+    pub near_miss_margin: f64,
     /// Refire presets (ADR-126). Each value is a fraction of the session
     /// context window. At fire evaluation time, a way's `refire: <name>`
     /// resolves by looking up the preset here and multiplying by the
@@ -89,6 +97,7 @@ impl Default for Config {
             parent_boost_floor: 0.40,
             default_embed_threshold: 0.40,
             default_multi_embed_threshold: 0.55,
+            near_miss_margin: 0.05,
             refire_presets,
         }
     }
@@ -179,6 +188,9 @@ impl Config {
         }
         if let Some(v) = doc.get("default_multi_embed_threshold").and_then(|v| v.as_f64()) {
             self.default_multi_embed_threshold = v;
+        }
+        if let Some(v) = doc.get("near_miss_margin").and_then(|v| v.as_f64()) {
+            self.near_miss_margin = v;
         }
         if let Some(m) = doc.get("refire_presets").and_then(|v| v.as_mapping()) {
             for (k, v) in m {


### PR DESCRIPTION
## What

Implements **ADR-134 Decision 1** — near-miss telemetry. When a way scores close to its firing threshold but does **not** fire, persist that already-computed score as a `way_nearmiss` event in `~/.claude/stats/events.jsonl`. This is the evidence substrate the later tuning passes (`ways tune --cadence` #9, `--precision` #10) will consume. No new embedding is performed — purely persistence of scores the matcher already computed and was throwing away.

This is a **separate initiative from the over-build loop (#7)** — corpus-wide tuning, not the over-build gate. Per the decoupling decision, the over-build gate is a scoreless postcheck predicate and has nothing for the near-miss machinery to attach to; ADR-134 builds on its own merit (the measured 17/47 irrelevant-fire problem).

## How

- **`match_prompt`** now returns `Fired(channel) | NearMiss { scores, thresholds, margin } | NoMatch` instead of `Option<String>`. Firing is **byte-identical** — same channel strings, same order (EN before multi). The only new behavior is a silent telemetry line on the *non*-firing path.
- **Near-miss predicate:** at least one model landed in `thr - margin <= score < thr`. Reported `margin` is the smallest shortfall across qualifying models — how close the way came on its best path. Measured against the **same effective thresholds** the fire path uses, so parent-boost (ADR-125) is honored automatically.
- Pattern/keyword matches are deterministic and scoreless → never near-misses.
- **New config knob** `near_miss_margin` (default `0.05`), parsed alongside the other embed thresholds in `apply_yaml`. A pure logging knob; it cannot change firing.
- **Event shape** mirrors `way_fired`'s field order for reader symmetry: `way`, `corpus_id`, `domain`, `score_en`, `score_multi`, `thr_en`, `thr_multi`, `margin`, `trigger` (`prompt`|`task`), `scope`, `project`, `session`, `query_tokens`.
- Logged from **both** scan paths — `prompt()` and `task()` — distinguished by the `trigger` field.

## Scope boundary

Logging only. No `tune` consumer (#9/#10), no rotation/cap (#12). The events.jsonl growth this stream adds is bounded by task E (#12); a breadcrumb is left at the log site. ADR-134 stays **Draft** until task F (#13) flips it on the final merge.

## Tests

- New `near_miss_tests` module unit-covers the margin decision (fires EN / fires multi / in-band near-miss / smallest-shortfall-wins / beyond-margin no-match / pattern preempts / absent scores) — no embedding subprocess needed.
- Full suite green: `cargo test -p ways` (125 + 6 + 11 pass), `cargo clippy -p ways --all-targets` clean.
- Live release scan runs exit 0; embedding confirmed functional (a way fired semantically). A *deterministic* live near-miss depends on exact cosine values and isn't reliably reproducible from the CLI, so the decision logic is covered by unit tests instead.

## Note

`tools/ways-cli/src/cmd/scan/mod.rs` grew to ~705 lines (was 518; most of the growth is the `cfg(test)` module). It's in the >500 review band — splitting it is a separate refactor, deliberately out of scope here.

Refs ADR-134 Decision 1. Branch `adr-134-near-miss`.