### PR TITLE
feat(scan): log fire_score on semantic way_fired (ADR-134 D telemetry / #11a)

### DIFF
--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -105,8 +105,8 @@ pub fn prompt(query: &str, session_id: &str, project: Option<&str>) -> Result<()
             &embed_matches,
             near_miss_margin,
         ) {
-            PromptMatch::Fired(trigger) => {
-                let out = capture_show_way(&way.id, session_id, &trigger);
+            PromptMatch::Fired { channel, score } => {
+                let out = capture_show_way(&way.id, session_id, &channel, score);
                 if !out.is_empty() {
                     context.push_str(&out);
                     context.push_str("\n\n");
@@ -180,7 +180,7 @@ pub fn task(
             &embed_matches,
             near_miss_margin,
         ) {
-            PromptMatch::Fired(trigger) => matched.push((way.id.clone(), trigger)),
+            PromptMatch::Fired { channel, .. } => matched.push((way.id.clone(), channel)),
             PromptMatch::NearMiss(nm) => {
                 log_near_miss(way, &nm, "task", task_scope, &project_dir, session_id, query);
             }
@@ -263,7 +263,7 @@ pub fn command(
         }
 
         if matched {
-            let out = capture_show_way(&way.id, session_id, "bash");
+            let out = capture_show_way(&way.id, session_id, "bash", None);
             if !out.is_empty() {
                 context.push_str(&out);
             }
@@ -349,7 +349,7 @@ pub fn file(filepath: &str, session_id: &str, project: Option<&str>) -> Result<(
 
         if let Some(ref files_pattern) = way.files {
             if regex_matches(files_pattern, filepath) {
-                let out = capture_show_way(&way.id, session_id, "file");
+                let out = capture_show_way(&way.id, session_id, "file", None);
                 if !out.is_empty() {
                     context.push_str(&out);
                 }
@@ -408,8 +408,10 @@ pub fn file(filepath: &str, session_id: &str, project: Option<&str>) -> Result<(
 
 /// Outcome of matching a prompt against one way.
 enum PromptMatch {
-    /// The way fired; the payload is the trigger channel.
-    Fired(String),
+    /// The way fired. `channel` is the trigger channel; `score` is the
+    /// embedding score that cleared threshold (`None` for deterministic keyword
+    /// fires) — logged onto `way_fired` for embed_threshold tuning (ADR-134 D).
+    Fired { channel: String, score: Option<f64> },
     /// The way did NOT fire, but at least one model scored within
     /// `near_miss_margin` below its effective threshold (ADR-134). Carries the
     /// already-computed scores for telemetry — no new embedding is done.
@@ -441,7 +443,7 @@ fn match_prompt(
     // never a near-miss (there is no margin to be near).
     if let Some(ref pat) = pattern {
         if regex_matches(pat, query) {
-            return PromptMatch::Fired("keyword".to_string());
+            return PromptMatch::Fired { channel: "keyword".to_string(), score: None };
         }
     }
 
@@ -455,10 +457,10 @@ fn match_prompt(
     let score_multi = scores.best_multi(corpus_id);
 
     if score_en.is_some_and(|s| s >= thresholds.en) {
-        return PromptMatch::Fired("semantic:embedding:en".to_string());
+        return PromptMatch::Fired { channel: "semantic:embedding:en".to_string(), score: score_en };
     }
     if score_multi.is_some_and(|s| s >= thresholds.multi) {
-        return PromptMatch::Fired("semantic:embedding:multi".to_string());
+        return PromptMatch::Fired { channel: "semantic:embedding:multi".to_string(), score: score_multi };
     }
 
     // No fire. Record a near-miss when a model landed in the band just below
@@ -651,13 +653,30 @@ mod near_miss_tests {
     #[test]
     fn en_clears_fires_en() {
         assert!(matches!(run(Some(0.41), None, None),
-            PromptMatch::Fired(c) if c == "semantic:embedding:en"));
+            PromptMatch::Fired { channel: c, .. } if c == "semantic:embedding:en"));
+    }
+
+    #[test]
+    fn semantic_fire_carries_its_score_keyword_does_not() {
+        // ADR-134 D: the firing embedding score rides on Fired for telemetry;
+        // a deterministic keyword fire carries none.
+        match run(Some(0.41), None, None) {
+            PromptMatch::Fired { score, .. } => assert_eq!(score, Some(0.41)),
+            _ => panic!("expected Fired"),
+        }
+        match run(Some(0.41), None, Some("query")) {
+            PromptMatch::Fired { channel, score } => {
+                assert_eq!(channel, "keyword");
+                assert_eq!(score, None);
+            }
+            _ => panic!("expected keyword Fired"),
+        }
     }
 
     #[test]
     fn multi_clears_when_en_below_fires_multi() {
         assert!(matches!(run(Some(0.20), Some(0.56), None),
-            PromptMatch::Fired(c) if c == "semantic:embedding:multi"));
+            PromptMatch::Fired { channel: c, .. } if c == "semantic:embedding:multi"));
     }
 
     #[test]
@@ -690,7 +709,7 @@ mod near_miss_tests {
     fn pattern_match_preempts_near_miss() {
         // Scores would be a near-miss, but a keyword hit is a deterministic fire.
         assert!(matches!(run(Some(0.37), None, Some("query")),
-            PromptMatch::Fired(c) if c == "keyword"));
+            PromptMatch::Fired { channel: c, .. } if c == "keyword"));
     }
 
     #[test]
@@ -704,12 +723,12 @@ mod near_miss_tests {
         // guard must agree: a score equal to the threshold fires, it is never
         // a (zero-shortfall) near-miss.
         assert!(matches!(run(Some(0.40), None, None),
-            PromptMatch::Fired(c) if c == "semantic:embedding:en"));
+            PromptMatch::Fired { channel: c, .. } if c == "semantic:embedding:en"));
     }
 
     fn discriminant(m: &PromptMatch) -> &'static str {
         match m {
-            PromptMatch::Fired(_) => "Fired",
+            PromptMatch::Fired { .. } => "Fired",
             PromptMatch::NearMiss(_) => "NearMiss",
             PromptMatch::NoMatch => "NoMatch",
         }

--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -664,6 +664,14 @@ mod near_miss_tests {
             PromptMatch::Fired { score, .. } => assert_eq!(score, Some(0.41)),
             _ => panic!("expected Fired"),
         }
+        // multi fire (EN below) carries the multi score, not EN's.
+        match run(Some(0.20), Some(0.56), None) {
+            PromptMatch::Fired { channel, score } => {
+                assert_eq!(channel, "semantic:embedding:multi");
+                assert_eq!(score, Some(0.56));
+            }
+            _ => panic!("expected multi Fired"),
+        }
         match run(Some(0.41), None, Some("query")) {
             PromptMatch::Fired { channel, score } => {
                 assert_eq!(channel, "keyword");

--- a/tools/ways-cli/src/cmd/scan/scoring.rs
+++ b/tools/ways-cli/src/cmd/scan/scoring.rs
@@ -156,8 +156,13 @@ fn xdg_cache_dir() -> std::path::PathBuf {
 
 // ── In-process show capture ───────────────────────────────────
 
-pub(crate) fn capture_show_way(id: &str, session_id: &str, trigger: &str) -> String {
-    crate::cmd::show::way(id, session_id, trigger).unwrap_or_default()
+pub(crate) fn capture_show_way(
+    id: &str,
+    session_id: &str,
+    trigger: &str,
+    fire_score: Option<f64>,
+) -> String {
+    crate::cmd::show::way_scored(id, session_id, trigger, fire_score).unwrap_or_default()
 }
 
 pub(crate) fn capture_show_check(id: &str, session_id: &str, trigger: &str, score: f64) -> String {

--- a/tools/ways-cli/src/cmd/scan/state.rs
+++ b/tools/ways-cli/src/cmd/scan/state.rs
@@ -109,7 +109,7 @@ pub fn state(
             }
         } else {
             // Standard one-shot: marker-gated via show
-            let out = capture_show_way(&way.id, session_id, "state");
+            let out = capture_show_way(&way.id, session_id, "state", None);
             if !out.is_empty() {
                 context.push_str(&out);
                 context.push_str("\n\n");

--- a/tools/ways-cli/src/cmd/show/mod.rs
+++ b/tools/ways-cli/src/cmd/show/mod.rs
@@ -16,6 +16,20 @@ use metrics::{compute_tree_metrics, count_siblings, git_version, dirty_status_te
 // ── ways show way ───────────────────────────────────────────────
 
 pub fn way(id: &str, session_id: &str, trigger: &str) -> Result<String> {
+    way_scored(id, session_id, trigger, None)
+}
+
+/// Like [`way`], but records the embedding score that caused a semantic fire
+/// onto the `way_fired` event (ADR-134 task D telemetry). `fire_score` is
+/// `Some` only for embedding-channel fires from the in-process scan path;
+/// keyword/state/CLI fires pass `None` and log no score (they have none). The
+/// firing model is already implicit in `trigger` (`semantic:embedding:en|multi`).
+pub fn way_scored(
+    id: &str,
+    session_id: &str,
+    trigger: &str,
+    fire_score: Option<f64>,
+) -> Result<String> {
     let project_dir = std::env::var("CLAUDE_PROJECT_DIR")
         .unwrap_or_else(|_| std::env::var("PWD").unwrap_or_else(|_| ".".to_string()));
 
@@ -146,6 +160,11 @@ pub fn way(id: &str, session_id: &str, trigger: &str) -> Result<String> {
         ("session", session_id.to_string()),
         ("token_position", token_pos.to_string()),
     ];
+    // ADR-134 task D: the embedding score that fired this way, for deriving a
+    // principled embed_threshold from observed fires. Only on semantic fires.
+    if let Some(score) = fire_score {
+        log_fields.push(("fire_score", format!("{score:.4}")));
+    }
     if let Some(ref p) = parent_id {
         log_fields.push(("parent", p.clone()));
         log_fields.push(("tree_depth", tree_depth.to_string()));

--- a/tools/ways-cli/src/cmd/show/mod.rs
+++ b/tools/ways-cli/src/cmd/show/mod.rs
@@ -161,8 +161,14 @@ pub fn way_scored(
         ("token_position", token_pos.to_string()),
     ];
     // ADR-134 task D: the embedding score that fired this way, for deriving a
-    // principled embed_threshold from observed fires. Only on semantic fires.
-    if let Some(score) = fire_score {
+    // principled embed_threshold from observed fires. Recorded only on a
+    // first-fire (way_fired), never a redisclosure: threshold tuning is about
+    // what score gates a way's *entry* to a session, and a redisclosure's score
+    // reflects the re-triggering prompt — a different population that would bias
+    // the derivation. (Redisclosure dynamics are cadence signal: tune-curves.)
+    // This also aligns with how tune-precision reads placement (way_fired only)
+    // and makes the field self-documenting: its presence marks a placement event.
+    if let (false, Some(score)) = (is_redisclosure, fire_score) {
         log_fields.push(("fire_score", format!("{score:.4}")));
     }
     if let Some(ref p) = parent_id {


### PR DESCRIPTION
## What

Foundational telemetry for `embed_threshold` tuning (#11b). `way_fired` carried **no firing score**, so the precision audit's (#10) "raise threshold" remedy had no principled magnitude — confirmed at the log site (`show/mod.rs`) and in the live log. This PR logs the embedding score that cleared threshold onto the event, so a later pass can derive the smallest threshold that would have excluded a way's off-class fires while keeping its on-class ones.

Sequenced exactly like `token_position`→`tune-curves`: the telemetry lands and accumulates **now**; the suggestion+apply engine (#11b) consumes it once data exists (it can't be validated before then — acknowledged when choosing this path).

## How

- `match_prompt`'s `Fired` variant now carries the firing score: `Some(score)` for embedding fires (the EN or multi score that cleared), `None` for deterministic keyword fires. The firing model is already implicit in the existing `trigger` field (`semantic:embedding:en|multi`), so no second field.
- `capture_show_way` / `show::way` gain an `Option<f64> fire_score`; `show` logs a `fire_score` field only when present. New thin `show::way_scored` carries it; `show::way` stays a `None` wrapper — so the CLI/hook **subprocess** path (which has no semantic score) is unchanged.
- Keyword / state / bash / file fires and the task-stash path pass `None` (they have no score).

## No behavior change

Firing logic is untouched — this only adds an optional log field on the same proven `log_event` path as `token_position`. The score values flowing into `Fired` are the exact ones already compared against thresholds.

## Verification

- `cargo test -p ways`: 135 pass (incl. a new test asserting semantic fires carry their score and keyword fires don't, plus the existing #8 near-miss suite updated to the struct variant). `clippy --all-targets`: clean.
- **Live:** a semantic-fire scan now emits `trigger=semantic:embedding:multi … fire_score=0.5719` (above the 0.55 multi threshold); keyword/state fires emit no `fire_score`.

## Files
`scan/mod.rs`, `scan/scoring.rs`, `scan/state.rs`, `show/mod.rs`. No change to the CLI subprocess path or any non-semantic fire.

Refs ADR-134 Decision 4. Follow-up #11b builds the suggestion + gated apply on this data.