### PR TITLE
docs(adr-134): accept — empirical tuning loop built (#13)

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -29,7 +29,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-106](./system/ADR-106-project-pulse-epoch-mapped-project-awareness.md) | Project Pulse — Epoch-Mapped Project Awareness | Accepted |
 | [ADR-107](./system/ADR-107-way-match-corpus-batch-mode-and-locale-support.md) | Corpus, Matching Pipeline, and Locale Support | Accepted |
 | [ADR-108](./system/ADR-108-embedding-based-way-matching-with-all-minilm-l6-v2.md) | Embedding-Based Way Matching with all-MiniLM-L6-v2 | Accepted |
-| [ADR-109](./system/ADR-109-project-scope-way-embedding-with-manifest-based-staleness-detection.md) | Project-Scope Way Embedding with Manifest-Based Staleness Detection | Draft |
+| [ADR-109](./system/ADR-109-project-scope-way-embedding-with-manifest-based-staleness-detection.md) | Project-Scope Way Embedding with Manifest-Based Staleness Detection | Accepted |
 | [ADR-110](./system/ADR-110-way-file-separation-and-graph-compatible-structure.md) | Way File Separation and Graph-Compatible Structure | Draft |
 | [ADR-111](./system/ADR-111-unified-ways-cli-single-binary-tool-consolidation.md) | Unified `ways` CLI — Single Binary Tool Consolidation | Accepted |
 | [ADR-112](./system/ADR-112-session-ledger-and-knowledge-graph-integration.md) | Session Ledger with Optional Knowledge Graph Enhancement | Draft |
@@ -54,7 +54,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-131](./system/ADR-131-project-scope-way-toggles.md) | Project-scope way toggles | Draft |
 | [ADR-132](./system/ADR-132-collaboration-ways-domain.md) | Collaboration ways domain | Accepted |
 | [ADR-133](./system/ADR-133-plugin-way-discovery.md) | Plugin Way Discovery | Proposed |
-| [ADR-134](./system/ADR-134-empirical-auto-tuning-from-fire-and-near-miss-telemetry.md) | Empirical auto-tuning from fire and near-miss telemetry | Draft |
+| [ADR-134](./system/ADR-134-empirical-auto-tuning-from-fire-and-near-miss-telemetry.md) | Empirical auto-tuning from fire and near-miss telemetry | Accepted |
 | [ADR-135](./system/ADR-135-content-aware-write-time-over-build-gate-with-a-self-extending-pattern-corpus.md) | Content-aware write-time over-build gate with a self-extending pattern corpus | Accepted |
 
 ## Documentation

--- a/docs/architecture/system/ADR-134-empirical-auto-tuning-from-fire-and-near-miss-telemetry.md
+++ b/docs/architecture/system/ADR-134-empirical-auto-tuning-from-fire-and-near-miss-telemetry.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-06-09
 deciders:
   - aaronsb
@@ -73,3 +73,15 @@ The reconciliation, decision by decision:
 - **Decision 4 (gated apply)** — **partly already shipped.** `tune-curves --apply` performs the `half_life` rewrite (on the `curve:` block) with sample-size reporting. Only `embed_threshold` apply — driven by the recall/precision signals — remains to build.
 
 Net: this ADR's open work is Decision 3 (precision) plus the `embed_threshold` slice of Decision 4. Decisions 1 and 2 and the `half_life` half of 4 are done. The ADR is retained whole — including the now-corrected Context — because the empirical-tuning frame and the precision signal it still authorizes remain valid; the value is in narrowing the build to what does not already exist.
+
+## Implementation status — 2026-06-12 (Accepted)
+
+The design is adopted; the empirical-tuning loop it authorizes is built and exercised against the real event log. Status of each piece:
+
+- **Decision 1 — near-miss logging** — shipped (PR #117). `way_nearmiss` events emit for below-threshold candidates within `near_miss_margin` (default 0.05); the matcher's `match_prompt` is a 3-state `Fired | NearMiss | NoMatch`. Verified live.
+- **Decision 2 — cadence calibration** — pre-existing as `ways tune-curves` (reconciled above, PR #118). No code.
+- **Decision 3 — relevance signal** — shipped (PR #119) as `ways tune-precision`: parent-family activity classes, off-class irrelevance rate, and a breadth-based cross-cutting guard that keeps the named false positive (`meta/tracking`) out of the vocab-narrowing remedy. Verified live (69 ok / 64 cross-cutting / 25 mis-targeted / 44 low-n of 202 ways).
+- **Decision 4 — gated apply** — split. `half_life` apply ships in `tune-curves --apply`. `embed_threshold` apply needs a derivation that the data did not support: `way_fired` carried no firing score. The **fire-score telemetry** that makes a principled raise possible shipped (PR #120) — `fire_score` is now logged on first-fires. The **suggestion + apply** itself is **deferred until that telemetry accumulates** (it cannot be validated over an empty population), sequenced exactly as `token_position`→`tune-curves` was. Tracked as the only remaining build.
+- **Negative (log growth)** — addressed (PR #121): `events.jsonl` is bounded by tail-compaction in `log_event`.
+
+This ADR is **Accepted** with the `embed_threshold`-apply slice of Decision 4 as tracked, data-gated future work — a sequencing constraint, not an open design question.


### PR DESCRIPTION
## What

Closes the ADR-134 initiative. Flips **ADR-134 Draft→Accepted** and records implementation status. The design is adopted and the empirical-tuning loop it authorizes is built and exercised against the real event log.

## Implementation status (added to the ADR)

| Decision | Status | PR |
|---|---|---|
| D1 — near-miss logging | shipped, verified live | #117 |
| D2 — cadence calibration | pre-existing (`tune-curves`), reconciled | #118 |
| D3 — relevance signal (`tune-precision`) | shipped, verified live (69 ok / 64 cross-cutting / 25 mis-targeted / 44 low-n of 202 ways) | #119 |
| D4 — `half_life` apply | pre-existing (`tune-curves --apply`) | — |
| D4 — fire-score telemetry | shipped (`fire_score` on first-fires) | #120 |
| D4 — `embed_threshold` apply | **deferred, data-gated** (see below) | — |
| Negative — log growth | bounded via tail-compaction | #121 |

**The one deferral:** `embed_threshold` apply needs a principled raise magnitude, which needs accumulated `fire_score` data. That telemetry shipped (#120) but is near-empty today, so the suggestion+apply can't be validated yet — sequenced exactly as `token_position`→`tune-curves` was. It's a sequencing constraint, not an open design question, so the ADR is Accepted with it as tracked future work (task #11b).

## Tests for A–E

Already landed inline with each PR: 8 near-miss tests (#117), `tune-curves` cadence tests (pre-existing), 8 precision tests incl. the cross-cutting-guard (#119), fire-score mapping test (#120), 4 compaction tests (#121). Full gate confirmed: `cargo test -p ways` **139+6+11 pass**, `cargo clippy -p ways --all-targets -D warnings` **clean**.

## Files
ADR-134 (status + new "Implementation status" section) and INDEX.md.

## Documented rider
`adr index -y` also corrected pre-existing INDEX drift — ADR-109's file is `Accepted` but the index listed it `Draft` (flagged when excluded from #118). Included here as a one-line truth fix rather than knowingly regenerating a stale line a third time.

Refs ADR-134, ADR-123 Phase E.