### PR TITLE
docs: refresh hooks-and-ways for ADR-134 tuning & telemetry

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -289,6 +289,50 @@ flowchart TB
 
 The embedding model is a hard dependency of `ways`. See ADR-125 for the authored disclosure graph model and the single-tier decision.
 
+## Telemetry & Tuning
+
+The matcher computes a score for every way on every prompt. Fires are recorded; so are the *near-misses* — ways that scored just under threshold and stayed silent. Both feed back into how the engine is tuned. This closes the loop ADR-134 opened: hand-set thresholds and half-lives become things the system can revise from its own experience.
+
+```mermaid
+flowchart LR
+    classDef match fill:#6A1B9A,stroke:#4A148C,color:#fff
+    classDef log fill:#1565C0,stroke:#0D47A1,color:#fff
+    classDef tune fill:#00695C,stroke:#004D40,color:#fff
+    classDef apply fill:#E65100,stroke:#BF360C,color:#fff
+
+    Scan["match_prompt<br/>Fired · NearMiss · NoMatch"]:::match
+
+    Scan -->|fired| WF["way_fired<br/>(+ fire_score on first-fires)"]:::log
+    Scan -->|"within near_miss_margin"| NM["way_nearmiss<br/>(recall signal)"]:::log
+
+    WF --> EV[("~/.claude/stats/events.jsonl<br/>bounded ~24–32 MiB")]:::log
+    NM --> EV
+
+    EV --> TC["ways tune-curves<br/>half_life ≈ median fire delta"]:::tune
+    EV --> TP["ways tune-precision<br/>off-class irrelevance audit"]:::tune
+
+    TC -->|--apply| Curve["rewrite curve: block"]:::apply
+    TP -->|report-only| Remedy["flag: mis-targeted / cross-cutting"]:::apply
+```
+
+### Telemetry events
+
+Two events in `~/.claude/stats/events.jsonl` carry the tuning signal:
+
+- `way_fired` now records `fire_score` — the embedding score that cleared threshold — on **first-fires only** (not on `way_redisclosed`). It feeds future `embed_threshold` tuning.
+- `way_nearmiss` is emitted when a way scores within `near_miss_margin` *below* its effective threshold but does not fire. The scores already exist; this is persistence, not new computation. Fields: `score_en`, `score_multi`, `thr_en`, `thr_multi`, `margin`, `trigger`, `query_tokens`. It is a recall signal — the first measure of likely *false silences*, the ways that should have fired and didn't.
+
+`near_miss_margin` (default `0.05`) is parsed from the ways config YAML alongside `default_embed_threshold` and `default_multi_embed_threshold`. It caps near-miss volume: only the band just under threshold logs.
+
+The log grows faster with near-misses, so its growth is bounded. `log_event` tail-compacts `events.jsonl` once it crosses ~32 MiB, keeping the most recent ~24 MiB (cut at a line boundary, written to a temp file and atomically renamed). The oldest events are lost; readers are unaffected — a reader holding the pre-compaction file keeps reading it intact.
+
+### Tuning commands
+
+- **`ways tune-curves`** (ADR-123 Phase E) — cadence calibration. Groups `way_fired` / `way_redisclosed` by `(way, session)`, computes token-position deltas between fires, and suggests `half_life ≈ median delta`. `--apply` rewrites the way's `curve:` block in place.
+- **`ways tune-precision`** (ADR-134 Decision 3) — a heuristic relevance audit of fire telemetry, report-only. For each way it estimates how often its fires landed *off-class*: in sessions whose activity — judged by the parent-family of the ways that co-fired — never touched the way's own domain. It reports an irrelevance rate and a flag: **mis-targeted** (a narrow way repeatedly firing into the same wrong kind of session; remedy: raise `embed_threshold`, narrow vocabulary, or change trigger channel) vs **cross-cutting** (a way that fires broadly by design, e.g. `meta/tracking`; remedy: scope by trigger — vocabulary is *never* auto-narrowed). Flags: `--min-sessions` (default 5), `--flag-threshold` (default 0.5), `--project`, `--way`, `--json`.
+
+ADR-134 is **Accepted**. One slice — the `embed_threshold`-gated `--apply`, driven by accumulated `fire_score` data — is deferred and data-gated (GitHub issue #123).
+
 ## Macro Injection
 
 Ways with `macro: prepend|append` run dynamic scripts that query live state:

--- a/docs/cognitive-loop.md
+++ b/docs/cognitive-loop.md
@@ -125,6 +125,22 @@ This is *habituation* in the biological sense. The first mention of something is
 
 The mental model: **ways are a rate-limited stream of premises**. Claude does not read them all at once; Claude reads them as the situation calls for them, with the understanding that anything already disclosed is still in context unless compaction has happened.
 
+## Empirical tuning: letting telemetry revise the thresholds
+
+The thresholds, half-lives, and vocabularies above were all set by authorial judgment. **Empirical auto-tuning** ([ADR-134](architecture/system/ADR-134-empirical-auto-tuning-from-fire-and-near-miss-telemetry.md)) closes the loop by feeding the matcher's own firing record back into those settings. This is optional operational tooling, not part of the per-turn loop — but it is what keeps the precision-first discipline honest over time.
+
+Two signals accumulate in `~/.claude/stats/events.jsonl`, both written by the cheap substrate at fire time:
+
+- **`way_nearmiss` events** — a *recall* signal. When a way scores within `near_miss_margin` (default 0.05) of its effective threshold but does not fire, the matcher records the would-be miss (`score_en`, `score_multi`, `thr_en`, `thr_multi`, `margin`, `trigger`, `query_tokens`). The scores are already computed; this is persistence, not new work. False silences — the way that *should* have fired — were structurally invisible before this; now they are measurable.
+- **`fire_score` on `way_fired` events** — the embedding score that cleared threshold, recorded on first-fires only (never on re-disclosures, whose score reflects the re-triggering prompt). This is the population a future `embed_threshold` raise would tune against.
+
+Two report-only subcommands read this record:
+
+- **`ways tune-curves`** (ADR-123 Phase E) groups `way_fired` / `way_redisclosed` by `(way, session)`, computes token-position deltas between fires, and suggests `half_life ≈ median delta`. `--apply` rewrites the way's `curve:` block in place as an ordinary, reviewable git diff.
+- **`ways tune-precision`** is a heuristic relevance audit. For each way it estimates how often its fires landed off-class — in sessions whose activity (judged by the parent-family of the ways that co-fired) never touched the way's own domain — and reports an irrelevance rate. A narrow way repeatedly firing into the same wrong kind of session is flagged **mis-targeted** (remedy: raise `embed_threshold`, narrow vocabulary, or change trigger channel); a way that fires broadly by design (e.g. `meta/tracking`) is flagged **cross-cutting** and the vocabulary-narrowing remedy is suppressed — those are scoped by trigger, never auto-narrowed. Flags: `--min-sessions` (default 5), `--flag-threshold` (default 0.5), `--project`, `--way`, `--json`.
+
+Both report by default. Vocabulary is never auto-applied — it re-shapes the embedding neighborhood and stays authorial. The `embed_threshold` apply slice is deferred until the `fire_score` population accumulates (tracked as issue #123); the threshold is read alongside `default_embed_threshold` and `default_multi_embed_threshold` in the ways config, which is also where `near_miss_margin` lives.
+
 ## Memory across sessions: ledger and optional projections
 
 Ways handle the *current* session. Memory handles what persists across sessions.
@@ -138,6 +154,8 @@ The ledger is **what was understood**, not **what was observed**. Entries are sm
 Memory projections are **configurable and never required**. The KG is one example; a user could attach a different memory tool with the same general shape, or none at all. The system is memory-tool-agnostic: it works with whatever projection (or none) is configured, and the ledger is the stable foundation underneath.
 
 The **forgetting principle** is the critical counterpart. Most of what passes through a session is not worth keeping. Reflection captures what was reasoned about; everything else evaporates when the session ends. This keeps the ledger a journal rather than a log. The gate is: *did Claude actually reason about this?* If yes, eligible for ledger. If no, it dies with the session.
+
+The same principle bounds the raw telemetry. The fire/near-miss log (`~/.claude/stats/events.jsonl`, the input to the tuning loop above) is append-only, so it needs a ceiling: when it exceeds ~32 MiB, `log_event` tail-compacts it to the most recent ~24 MiB at a line boundary via an atomic temp-and-rename. The rewrite is rare, lossy on the oldest events only, and invisible to readers — tuning works from recent behavior, so the old tail is the part safe to forget.
 
 ## Active perception: the awareness layer
 
@@ -245,7 +263,7 @@ Stage by stage:
 - **Attention.** The disclosure gate ([ADR-104](architecture/system/ADR-104-token-gated-way-re-disclosure-for-long-context-windows.md)) applies habituation rules. Recently-disclosed ways are suppressed or re-surfaced tersely. Fresh signals get full weight. The cheap substrate decides what reaches Claude's reasoning in what form.
 - **Reasoning.** Claude integrates observations and guidance into its working model and decides what to do.
 - **Action.** Claude acts — edits files, runs tools, responds to the user.
-- **Capture.** At context-threshold boundaries, the reflection way fires. Claude writes a short prose reflection. The Stop hook captures it and appends to the ledger. If a memory projection is configured, the entry is also handed off to it.
+- **Capture.** At context-threshold boundaries, the reflection way fires. Claude writes a short prose reflection. The Stop hook captures it and appends to the ledger. If a memory projection is configured, the entry is also handed off to it. Separately, every fire and near-miss this turn is logged as cheap telemetry; offline, that record drives the empirical tuning of thresholds and half-lives (ADR-134) without touching the loop.
 - **Consolidation.** When context fills, compaction distills the working window. The ledger, memory projections, and `attend`'s state survive the pass. The next turn begins with a compressed but coherent working context.
 - **Back to Wake.** At the next session, the loop restarts with the updated state as its foundation.
 
@@ -279,6 +297,7 @@ Ordered roughly by how specific the topic is to your interest:
 - [ADR-112](architecture/system/ADR-112-session-ledger-and-knowledge-graph-integration.md) — session ledger and optional KG integration
 - [ADR-113](architecture/system/ADR-113-attend-active-awareness-module.md) — the `attend` binary
 - [ADR-114](architecture/system/ADR-114-attend-as-insistent-way-trigger-type.md) — the way trigger schema for `attend` signals
+- [ADR-134](architecture/system/ADR-134-empirical-auto-tuning-from-fire-and-near-miss-telemetry.md) — empirical auto-tuning from fire and near-miss telemetry
 
 **If you want to build ways or operate the system:**
 - [hooks-and-ways/README.md](hooks-and-ways/README.md) — start here for way authoring

--- a/docs/hooks-and-ways.md
+++ b/docs/hooks-and-ways.md
@@ -204,6 +204,22 @@ Corpus: `${XDG_CACHE_HOME:-~/.cache}/claude-ways/user/ways-corpus.jsonl`
 
 Both user-scope (`~/.claude/hooks/ways/`) and project-scope (`.claude/ways/`) corpora are scanned. They share the same model file.
 
+#### Calibrating from telemetry
+
+Once a corpus has been firing for a while, two commands audit and calibrate the embedding match against observed behavior rather than guesswork (ADR-134).
+
+```bash
+# Audit fire relevance — flag ways landing in off-domain sessions
+ways tune-precision
+
+# Calibrate firing-dynamics curves from observed cadence
+ways tune-curves
+```
+
+`ways tune-precision` is a report-only relevance audit. For each way it estimates how often its fires landed *off-class* — in sessions whose activity (judged by the parent-family of the ways that co-fired) never touched the way's own domain — and reports an irrelevance rate plus a flag. **mis-targeted** is a narrow way repeatedly firing into the same wrong kind of session (remedy: raise `embed_threshold`, narrow vocabulary, or change the trigger channel); **cross-cutting** is a way that fires broadly by design, e.g. meta/tracking ways (remedy: scope by trigger — never auto-narrow vocabulary). Flags: `--min-sessions` (default 5), `--flag-threshold` (default 0.5), `--project`, `--way`, `--json`.
+
+`ways tune-curves` (ADR-123 Phase E) groups `way_fired`/`way_redisclosed` events by (way, session), computes token-position deltas between consecutive fires, and suggests a `half_life` ≈ the median delta. Dry-run by default; `--apply` rewrites the `curve:` block in place via line surgery. (Vocabulary and `embed_threshold` are never auto-applied — they stay authorial.)
+
 ## State Triggers
 
 Evaluated by `check-state.sh` on every UserPromptSubmit. Unlike pattern-based ways, these fire based on session conditions.
@@ -377,6 +393,19 @@ sequenceDiagram
         Note right of CR: Topics feed into next check-prompt.sh
     end
 ```
+
+## Telemetry
+
+Firing activity is logged to `~/.claude/stats/events.jsonl` — one JSON object per line. Beyond the `way_fired`/`way_redisclosed` cadence events that `tune-curves` reads, two signals feed the precision and recall tuning above (ADR-134):
+
+- **`fire_score`** — recorded on `way_fired` events for **first-fires only** (not redisclosures): the embedding score that cleared threshold. It is the raw material for future `embed_threshold` tuning.
+- **`way_nearmiss`** — emitted when a way scored within `near_miss_margin` *below* its effective threshold but did **not** fire. Fields: `score_en`, `score_multi`, `thr_en`, `thr_multi`, `margin`, `trigger`, `query_tokens`. This is a recall signal — it measures the likely false silences a threshold drop would recover.
+
+`near_miss_margin` (default `0.05`) is a config knob, parsed from the ways config YAML alongside `default_embed_threshold` and `default_multi_embed_threshold`.
+
+The near-miss and fire-score streams grow the log faster than fires alone, so its size is **bounded**: `log_event` tail-compacts `events.jsonl` once it exceeds ~32 MiB, keeping the most recent ~24 MiB (cut at a line boundary, written atomically via temp + rename). Compaction is lossy only on the oldest events; readers are unaffected.
+
+ADR-134 ("Empirical auto-tuning from fire and near-miss telemetry") is Accepted. One slice — the gated `embed_threshold` `--apply` — is deferred until the `fire_score` population accumulates enough to validate against, tracked as GitHub issue #123.
 
 ## Macros
 

--- a/docs/hooks-and-ways/matching.md
+++ b/docs/hooks-and-ways/matching.md
@@ -119,7 +119,9 @@ sequenceDiagram
 Configure via `~/.config/ways/config.yaml`:
 ```yaml
 parent_threshold_multiplier: 0.8   # 1.0 disables the boost
-default_embed_threshold: 0.35      # base for nodes without explicit override
+default_embed_threshold: 0.35      # English base for nodes without explicit override
+default_multi_embed_threshold: 0.55 # multilingual-model base (per-way override via embed_threshold)
+near_miss_margin: 0.05             # how far below threshold a non-fire is logged as a near-miss (ADR-134)
 ```
 
 A way's **effective threshold** therefore depends on session state, not just frontmatter. This is what makes disclosure feel progressive: the same query "rename this variable" may not fire the refactoring way in a fresh session but will fire it once the code/quality parent has been active.

--- a/docs/hooks-and-ways/scoring-and-testing.md
+++ b/docs/hooks-and-ways/scoring-and-testing.md
@@ -222,6 +222,19 @@ The `/ways-tests crowding` command distinguishes these cases. When it reports tw
 | `/ways-tests lint --all` | Validate all way frontmatter |
 | `ways tune` | Audit locale alias fidelity + discrimination (per-way, across all languages) |
 | `ways tune --way <path>` | Filter the audit to a single way or subtree |
+| `ways tune-curves` | Calibrate firing cadence: suggest `half_life` from observed fire deltas (`--apply` rewrites the `curve:` block) — ADR-123 Phase E |
+| `ways tune-precision` | Heuristic relevance audit: flag ways firing into off-domain sessions (`--min-sessions`, `--flag-threshold`, `--project`, `--way`, `--json`) — ADR-134 Decision 3 |
 | `ways siblings <path>` | Compute vocabulary overlap (Jaccard) between sibling ways |
 
 See the [ways-tests skill](/skills/ways-tests/SKILL.md) for the testing skill and [Locale Alias Audit](../../hooks/ways/meta/knowledge/optimization/tuning/tuning.md) (the `knowledge/optimization/tuning` way) for the `ways tune` workflow in depth.
+
+## Empirical Signals: Tuning From What Actually Fired
+
+The worked example above tunes a way against prompts you write by hand. But once a way ships, the firing engine itself becomes the evidence. [ADR-134](../architecture/system/ADR-134-empirical-auto-tuning-from-fire-and-near-miss-telemetry.md) extends the telemetry in `~/.claude/stats/events.jsonl` so that hand-tuning gets a record to revise from — two new signals, both report-first:
+
+- **Near-misses.** When a way scores within `near_miss_margin` (default 0.05) *below* its effective threshold but doesn't fire, the matcher logs a `way_nearmiss` event (`score_en`, `score_multi`, `thr_en`, `thr_multi`, `margin`, `trigger`, `query_tokens`). These are the false silences the precision-first discipline can't otherwise see — a way that consistently lands just under threshold on prompts whose sessions then do that way's kind of work is a candidate to lower, the recall counterpart to the 0-FP constraint. `near_miss_margin` is parsed from ways config alongside `default_embed_threshold` / `default_multi_embed_threshold`.
+- **Fire scores.** A `way_fired` event now carries `fire_score`: the embedding score that cleared threshold, recorded on first-fires only (not redisclosures). This is the population a future `embed_threshold` tuning draws on.
+
+`ways tune-precision` reads the fire stream and reports, per way, an off-class irrelevance rate — how often its fires landed in sessions whose activity (judged by the parent-family of the ways that co-fired) never touched the way's own domain. It distinguishes **mis-targeted** (a narrow way repeatedly firing into the same wrong kind of session — remedy: raise `embed_threshold`, narrow vocabulary, or change trigger channel) from **cross-cutting** (a way that fires broadly by design, e.g. `meta/tracking` — remedy: scope by trigger, *never* auto-narrow vocabulary). Like `ways tune`'s fidelity audit, these are diagnostic flags, not verdicts.
+
+A practitioner note: `events.jsonl` growth is bounded. `log_event` tail-compacts the file when it exceeds ~32 MiB, retaining the most recent ~24 MiB at a line boundary via atomic temp+rename — lossy on the oldest events, but readers always see a complete file.

--- a/docs/hooks-and-ways/stats.md
+++ b/docs/hooks-and-ways/stats.md
@@ -7,8 +7,10 @@ You can't manage what you can't see. The ways system logs every firing event and
 Every time a way fires, `log-event.sh` appends a line to `~/.claude/stats/events.jsonl`:
 
 ```json
-{"ts":"2026-02-05T19:00:34Z","event":"way_fired","way":"softwaredev/delivery/commits","domain":"softwaredev","trigger":"bash","scope":"agent","project":"/home/you/myproject","session":"abc-123"}
+{"ts":"2026-02-05T19:00:34Z","event":"way_fired","way":"softwaredev/delivery/commits","domain":"softwaredev","trigger":"semantic:embedding:en","scope":"agent","project":"/home/you/myproject","session":"abc-123","fire_score":"0.4812"}
 ```
+
+The `fire_score` field is the embedding score that cleared threshold. It's recorded on first-fires only (not redisclosures), so the auto-tuning passes (ADR-134) can later learn where `embed_threshold` should sit.
 
 Session start events are also logged. For teammates, the team name is included:
 
@@ -16,7 +18,15 @@ Session start events are also logged. For teammates, the team name is included:
 {"ts":"2026-02-05T19:01:12Z","event":"way_fired","way":"collaboration/teams","domain":"collaboration","trigger":"state","scope":"teammate","project":"/home/you/myproject","session":"def-456","team":"my-refactor-team"}
 ```
 
-The log is append-only JSONL. Each line is self-contained. Nothing reads this file during normal operation — it's purely for after-the-fact analysis.
+A way that *almost* fired is logged too. When a way's score lands within `near_miss_margin` below its effective threshold but doesn't clear it, a `way_nearmiss` event records the silence:
+
+```json
+{"ts":"2026-02-05T19:02:08Z","event":"way_nearmiss","way":"softwaredev/architecture/design","corpus_id":"...","domain":"softwaredev","score_en":"0.3791","score_multi":"","thr_en":"0.4000","thr_multi":"0.5500","margin":"0.0209","trigger":"prompt","scope":"agent","project":"/home/you/myproject","session":"abc-123","query_tokens":"42"}
+```
+
+These are a recall signal — they measure the likely false silences (ADR-134 Decision 1). `score_en`/`score_multi` are the per-model scores, `thr_en`/`thr_multi` the per-model thresholds, `margin` how far under the bar the best model landed, and `query_tokens` the size of the prompt that nearly matched. An empty score field means that model didn't score.
+
+The log is JSONL — each line is self-contained, and nothing reads the file during normal operation; it's purely for after-the-fact analysis. Growth is bounded: when `events.jsonl` exceeds ~32 MiB, `log_event` tail-compacts it down to the most recent ~24 MiB (cut at a line boundary, written to a temp file and atomically renamed). This is lossy on the oldest events but leaves readers untouched.
 
 ## Reading the Stats
 
@@ -115,15 +125,33 @@ The `--json` flag returns structured data for tooling:
 
 ## What the Stats Don't Tell You
 
-The stats show *what fired*, not *whether it helped*. A way that fires 96 times isn't necessarily 96 times useful — it might be triggering too broadly. A way that never fires isn't necessarily broken — it might be waiting for a workflow you haven't hit yet.
+The stats show *what fired*, not *whether it helped*. A way that fires 96 times isn't necessarily 96 times useful — it might be triggering too broadly. A way that never fires isn't necessarily broken — it might be waiting for a workflow you haven't hit yet. `stats.sh` reports the counts; the `fire_score` and `way_nearmiss` telemetry it doesn't summarize feeds the audit commands below, which is where the precision and recall questions get answered.
 
 Use the stats to spot patterns: ways that fire too often (noisy triggers), ways that never fire (dead patterns or disabled domains), scopes that are unexpectedly empty (scope gating too aggressive), and teams that generate unusual activity (worth investigating what they were doing).
+
+## Auditing the Telemetry
+
+Two report-only commands read the event log and turn it back on the ways that produced it (ADR-134). Both write nothing — they surface a heuristic flag, not a verdict.
+
+`ways tune-precision` is a relevance audit. For each way it estimates how often its fires landed *off-class* — in sessions whose actual activity (judged by the parent-family of the ways that co-fired) never touched the way's own domain — and reports an irrelevance rate. It separates two failure modes that look identical to a naive counter: **mis-targeted** (a narrow way repeatedly firing into the same wrong kind of session — remedy: raise `embed_threshold`, narrow vocabulary, or change the trigger channel) versus **cross-cutting** (a way that fires broadly by design, like `meta/tracking` — remedy: scope by trigger, and *never* auto-narrow its vocabulary). Flags: `--min-sessions` (default 5), `--flag-threshold` (default 0.5), `--project`, `--way`, `--json`.
+
+```bash
+ways tune-precision
+```
+
+`ways tune-curves` is the cadence companion (ADR-123 Phase E). It groups `way_fired`/`way_redisclosed` by `(way, session)`, computes the token-position deltas between firings, and suggests a `half_life` near the median delta. With `--apply` it rewrites each way's `curve:` block in place; without it, the run is a dry report. Flags: `--apply`, `--min-fires` (default 3), `--project`, `--way`.
+
+```bash
+ways tune-curves
+```
+
+The width of the near-miss band these tools consume is set by the `near_miss_margin` config knob (default 0.05), parsed from the ways config YAML alongside `default_embed_threshold` and `default_multi_embed_threshold`. It's purely a logging knob — it never changes which ways fire, only how far below threshold a silence has to land before it's worth recording.
 
 ## Where the Data Lives
 
 | File | Purpose |
 |------|---------|
-| `~/.claude/stats/events.jsonl` | Append-only event log |
+| `~/.claude/stats/events.jsonl` | Event log (tail-compacted at ~32 MiB to ~24 MiB) |
 | `/tmp/.claude-config-update-state-{uid}` | Update check cache (hourly) |
 | `{SESSIONS_ROOT}/{session}/ways/{way_path}/.marker` | Way firing markers (per-session) |
 | `{SESSIONS_ROOT}/{session}/teammate` | Teammate scope marker (contains team name) |


### PR DESCRIPTION
## What

The ADR-134 work this session (PRs #117–122) landed in code and ADRs, but the **narrative docs** in `docs/hooks-and-ways/` were never updated — they omitted the new `tune-precision` command, the `way_nearmiss`/`fire_score` telemetry, the `near_miss_margin` config, and the events.jsonl capping. This refreshes them.

Produced by a survey→update fanout over 7 candidate docs (`observed-behavior.md` correctly needed nothing), then **reviewed against source** — not merged on trust.

## Files
- `stats.md` — `fire_score` on `way_fired` (first-fires), `way_nearmiss` event + full field list, events.jsonl tail-compaction (~32→24 MiB), an "Auditing the Telemetry" section for `tune-precision`/`tune-curves` + `near_miss_margin`.
- `scoring-and-testing.md` — `tune-curves`/`tune-precision` in the tools table + an "Empirical Signals" subsection.
- `matching.md` — `near_miss_margin` + `default_multi_embed_threshold` added to the config block.
- `hooks-and-ways.md` — "Calibrating from telemetry" + "Telemetry" sections.
- `architecture.md` — "Telemetry & Tuning" section + a feedback-loop flowchart.
- `cognitive-loop.md` — "Empirical tuning" subsection; compaction noted in the forgetting principle.

## Verification (review caught one error)
- All flags/field-names/defaults checked against `tools/ways-cli/` and ADR-134. Documented `tune-precision` flags match the live CLI exactly (`--min-sessions --flag-threshold --project --way --json`).
- **Fixed in review:** a `way_fired` example had `fire_score` on a `bash` trigger — but `fire_score` is only logged on *semantic* fires, so the example is now `semantic:embedding:en`.
- The new mermaid block is a `flowchart` (the `<br/>` labels are valid there — not the sequence-message angle-bracket gotcha from 9421e7e).
- Prose matches the situated-socialization register (ADR-301).

Precedes the `ways-v0.8.0` release tag so the release ships current docs.