### PR TITLE
chore: bump ways to v0.8.0

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "ways"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agent-fmt",
  "anyhow",

--- a/tools/ways-cli/Cargo.toml
+++ b/tools/ways-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ways"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Unified CLI for ways — knowledge guidance for Claude Code"
 license = "MIT"


### PR DESCRIPTION
Version bump for the **ways-v0.8.0** release — the ADR-134 empirical-tuning work plus supporting changes since v0.7.0 (86 commits).

## Since v0.7.0
- `ways tune-precision` — heuristic relevance audit of fire telemetry (ADR-134 Decision 3, #119)
- `way_nearmiss` telemetry + `near_miss_margin` config (ADR-134 Decision 1, #117)
- `fire_score` on `way_fired` first-fires (ADR-134 Decision 4 foundation, #120)
- `events.jsonl` tail-compaction / bounded growth (ADR-134 Negative, #121)
- ADR-134 Accepted (#122); docs refreshed (#125)
- (earlier in the series) ADR-135 over-build gate + Tier-1 `code.check`

Bumps `tools/ways-cli/Cargo.toml` 0.7.0 → 0.8.0 and updates `Cargo.lock`. The annotated `ways-v0.8.0` tag (pushed after merge) triggers the `build-ways` CI workflow. Minor bump: new user-facing command + telemetry/config, no breaking changes.