### PR TITLE
fix(doclint): respect .gitignore in retired-range scan

### DIFF
--- a/hooks/ways/documentation/linting/doclint.py
+++ b/hooks/ways/documentation/linting/doclint.py
@@ -354,10 +354,33 @@ def check_duplicate_ids(doc_nodes: list):
                 n.issues.append(("error", f"duplicate catalog id {cid} (also on: {mates})"))
 
 
+def _retired_scan_files():
+    """Yield candidate files for the retired-range scan, respecting .gitignore.
+
+    Enumerate via `git ls-files` (tracked + untracked-but-not-ignored) so a
+    gitignored corpus, build tree, or scratch dir is never walked — without it,
+    the scan reads every ignored file in the repo (e.g. a 500MB private corpus).
+    Falls back to rglob for non-git checkouts, preserving portability.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(REPO), "ls-files", "--cached", "--others",
+             "--exclude-standard", "-z"],
+            capture_output=True, timeout=30)
+        if out.returncode == 0:
+            for raw in out.stdout.split(b"\x00"):
+                if raw:
+                    yield REPO / raw.decode("utf-8", "surrogateescape")
+            return
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    yield from REPO.rglob("*")   # non-git fallback
+
+
 def check_retired_refs(lo: int, hi: int):
     """Scan repo for references into a vacated pre-domain range (opt-in)."""
     hits = []
-    for f in REPO.rglob("*"):
+    for f in _retired_scan_files():
         if not f.is_file() or f.suffix not in RETIRED_SCAN_EXTS:
             continue
         if RETIRED_SKIP_PARTS & set(f.parts):


### PR DESCRIPTION
## Problem
`check_retired_refs` walked `REPO.rglob("*")` — every file in the repo, **including gitignored content**. Surfaced during KGS convergence: the knowledge-graph-system reference repo turned on `legacy.retired` and the scan flagged **3451 phantom refs** into the vacated 1–99 range — all inside a 574MB *gitignored* conversation corpus + scratch, **zero in authored docs/ADRs/source**.

## Fix
Enumerate scan candidates via `git ls-files --cached --others --exclude-standard` (tracked + untracked-but-not-ignored), so gitignored trees are never walked — while still catching new uncommitted authored docs. Falls back to `rglob` for non-git checkouts (preserves portability).

## Verified
- Behavioral test: a gitignored file is excluded; an untracked-but-not-ignored file is still scanned.
- Regression: normal `doclint` stays 0/0; module compiles.

Found by the KGS convergence (the repo doclint was generalized from). Owned upstream so consumers re-vendor rather than fork.