### PR TITLE
fix(ci): clear clippy, shebang, and settings.json portability failures

### DIFF
--- a/hooks/ways/softwaredev/code/quality/versioning/postcheck.sh
+++ b/hooks/ways/softwaredev/code/quality/versioning/postcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Reactive firing for softwaredev/code/quality/versioning.
 #
 # Exits 0 (requesting fire) when the just-completed Edit/Write

--- a/settings.json
+++ b/settings.json
@@ -99,17 +99,13 @@
       "Bash(./dotfiles deploy:*)",
       "Bash(./dotfiles capture:*)",
       "Bash(~/.dotfiles/dotfiles status *)",
-      "Bash(~/.dotfiles/dotfiles diff *)",
       "Bash(~/.dotfiles/dotfiles list *)",
       "Bash(~/.dotfiles/dotfiles deploy *)",
       "Bash(~/.dotfiles/dotfiles help *)",
       "Bash(~/.dotfiles/dotfiles capture *)",
-      "Bash(/home/aaron/.dotfiles/dotfiles help *)",
-      "Bash(/home/aaron/.dotfiles/dotfiles status *)",
       "Read(//usr/share/oh-my-posh/themes/**)",
-      "Read(//home/aaron/**)",
-      "Bash(/home/aaron/.dotfiles/dotfiles add *)",
-      "Bash(/home/aaron/.dotfiles/dotfiles deploy *)",
+      "Read(~/**)",
+      "Bash(~/.dotfiles/dotfiles add *)",
       "Bash(posh-theme help *)",
       "Bash(posh-theme list *)",
       "Bash(posh-theme current *)",
@@ -121,8 +117,6 @@
       "Bash(oh-my-posh debug *)",
       "Bash(oh-my-posh config *)",
       "Bash(posh-theme fetch *)",
-      "Bash(/home/aaron/.dotfiles/dotfiles diff *)",
-      "Bash(/home/aaron/.dotfiles/dotfiles push *)",
       "Bash(posh-theme preview-all *)",
       "Bash(zsh *)",
       "Bash(oh-my-posh init *)",
@@ -130,8 +124,7 @@
       "Bash(/bin/cat -A)",
       "Bash(ssh *)",
       "Bash(sshpass -V)",
-      "Bash(glow --version)",
-      "Bash(/home/aaron/.dotfiles/dotfiles)"
+      "Bash(glow --version)"
     ],
     "deny": [],
     "defaultMode": "auto"
@@ -322,6 +315,7 @@
       }
     }
   },
+  "skipWorkflowUsageWarning": true,
   "autoCompactEnabled": false,
   "teammateMode": "auto"
 }

--- a/tools/attend-chat/src/app/keys.rs
+++ b/tools/attend-chat/src/app/keys.rs
@@ -95,8 +95,7 @@ pub fn handle_enter(input_value: &str, signals: &[Signal]) -> EnterAction {
             Some(dir) if live_peer_count(name) > 0 => {
                 write_signal(&dir, &msg).map(|n| format!("sent → #{name}: {n}"))
             }
-            Some(_) => Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            Some(_) => Err(std::io::Error::other(
                 format!(
                     "#{name}: no live peers — message would not be read. \
                      Try #open to broadcast."

--- a/tools/attend-heartbeat/src/lib.rs
+++ b/tools/attend-heartbeat/src/lib.rs
@@ -116,6 +116,7 @@ pub fn clear(session_id: &str) -> io::Result<()> {
 ///   file's fd.
 /// - Windows: exclusive `share_mode(0)` on a sibling `<id>.lock` file,
 ///   so the heartbeat file itself remains freely openable by `touch`.
+///
 /// In both cases we keep the `File` open for the lock's lifetime, and
 /// even a panicking attend releases on process exit.
 pub struct SessionLock {

--- a/tools/attend-instances/src/lib.rs
+++ b/tools/attend-instances/src/lib.rs
@@ -289,7 +289,7 @@ impl Default for Registry {
 ///
 /// PR #77 review: the previous render path called
 /// `Registry::new().lookup(cwd, sid)` once per chip — N file reads
-/// + N parses every render even when most chips share a cwd. This
+/// plus N parses every render even when most chips share a cwd. This
 /// cache collapses that to one read per distinct cwd per render.
 ///
 /// **Lifetime is exactly one render.** Construct fresh; do not

--- a/tools/sensor-peers/src/lib.rs
+++ b/tools/sensor-peers/src/lib.rs
@@ -441,7 +441,7 @@ impl PeerSensor {
             }
 
             let project_name = sf.cwd
-                .rsplit(|c| c == '/' || c == '\\')
+                .rsplit(['/', '\\'])
                 .next()
                 .unwrap_or("?")
                 .to_string();


### PR DESCRIPTION
Turns `main`'s CI green. All failures here were **pre-existing on main** (not from #130/#131) — `make test` runs `make lint` (clippy) and the portability lint, both of which were already red.

## Clippy (`-D warnings`) — 5 errors, all behavior-preserving
- `doc_lazy_continuation` in `attend-heartbeat`, `attend-instances` (doc-comment formatting)
- `manual_pattern_char_comparison` in `sensor-peers` → `['/', '\\']`
- `io_other_error` in `attend-chat` → `std::io::Error::other(_)`

## Portability lint
- `versioning/postcheck.sh`: `#!/bin/bash` → `#!/usr/bin/env bash`
- `settings.json`: 8 hardcoded `/home/aaron/...` permission paths → `~/...` (the matcher already supports `~`, proven by existing `~/.dotfiles` entries) + dedup. Redundant full-path `diff`/`push` grants drop out (bare `Bash(dotfiles:*)` still covers normal invocation). Also commits `skipWorkflowUsageWarning`.

Verified locally: `make lint`, portability check, and `make test-smoke` all pass.