### PR TITLE
feat(docs): doc-authoring affordances — doc new, diataxis way, docs skill

### DIFF
--- a/hooks/ways/documentation/diataxis/diataxis.md
+++ b/hooks/ways/documentation/diataxis/diataxis.md
@@ -1,0 +1,58 @@
+---
+description: choosing a documentation mode — Diátaxis classification (tutorial / how-to / reference / explanation) for a catalog page
+vocabulary: diataxis tutorial how-to reference explanation mode classify learning working practical theoretical study newcomer goal information understanding catalog page
+pattern: di[aá]taxis|which (mode|kind of (doc|page))|tutorial vs|reference vs|explanation vs|classif.*(doc|page)|what mode
+scope: agent, subagent
+refire: 0.15
+---
+<!-- epistemic: convention -->
+# Diátaxis — picking a documentation mode
+
+Every catalog page is exactly **one** of four modes. The mode is the page's
+*pole* (the `P` in its `DD.NNN.P` id) and it is enforced — pick it deliberately,
+because a page that serves two modes serves neither.
+
+The tool computes the id and writes the frontmatter; **this is the one judgment
+it can't make for you.** Decide the mode, then scaffold:
+
+```bash
+docs/scripts/doc new <domain> <mode> "<title>"   # mode: tutorial|how-to|reference|explanation
+docs/scripts/doc lint                            # the page is lint-clean by construction
+```
+
+## The closed 2×2
+
+Two questions place every page:
+
+1. **Is the reader _studying_ or _working_?** Building understanding for later, or
+   solving a task right now?
+2. **Is the content _practical steps_ or _theoretical knowledge_?** Things to *do*,
+   or things that *are* / *why*?
+
+|                       | Practical steps (action) | Theoretical knowledge (cognition) |
+|-----------------------|--------------------------|-----------------------------------|
+| **Studying** (acquire) | **Tutorial** (`T`)       | **Explanation** (`E`)             |
+| **Working** (apply)    | **How-to** (`H`)         | **Reference** (`R`)               |
+
+- **Tutorial** — a guided lesson that takes a newcomer through doing something
+  successfully. Learning-oriented; you are the teacher, the reader trusts you.
+- **How-to** — a recipe to achieve a specific goal for someone who already knows
+  the basics. Task-oriented; assumes competence, omits the teaching.
+- **Reference** — a description of the machinery: APIs, flags, schemas, options.
+  Information-oriented; accurate, complete, consulted not read.
+- **Explanation** — illuminates a topic: why it works this way, the design
+  rationale, the trade-offs, the bigger picture. Understanding-oriented.
+
+## Rules
+
+- **There is no fifth mode.** If a page won't fit one quadrant, it is two pages.
+- **One mode per page.** The classic failure is a tutorial that keeps stopping to
+  explain, or a reference padded with how-to steps — each interrupts the other's
+  job. Split them and `related:`-link across.
+- **The mode is a promise to the reader** about what kind of help they're getting.
+  Keep the page faithful to its quadrant; if it drifts, reclassify or split.
+
+## See Also
+
+- documentation(documentation) — the typed-graph model these pages live in
+- standards(documentation) — house style for the prose itself

--- a/hooks/ways/documentation/linting/doc-tool
+++ b/hooks/ways/documentation/linting/doc-tool
@@ -40,6 +40,17 @@ except ImportError:
     sys.exit(1)
 
 
+# Diátaxis mode -> conventional directory under docs/ for `doc new`.
+# Catalog membership is by frontmatter, not path, so this is only a default
+# landing spot; --dir overrides (and may nest, e.g. explanation/attend-messaging).
+MODE_DIR = {
+    "tutorial": "tutorials",
+    "how-to": "how-to",
+    "reference": "reference",
+    "explanation": "explanation",
+}
+
+
 # ============================================================================
 # Loading
 # ============================================================================
@@ -231,6 +242,93 @@ def cmd_lint(args) -> int:
     return subprocess.run(cmd).returncode
 
 
+def _next_serial(domain: str, digits: dict) -> int:
+    """Next free 3-digit serial within a domain's band, scanning the catalog.
+
+    Mirrors `adr new`'s next-number logic, but over catalog ids (DD.NNN.P)
+    rather than ADR numbers — so authors never compute an id by hand.
+    """
+    band = digits[domain]
+    used = set()
+    for p in doclint.iter_catalog_pages():
+        node = doclint.build_doc_node(p, digits)
+        if node is None or node.domain != domain:
+            continue
+        m = doclint.ID_RE.match(node.key or "")
+        if m and int(m.group(1)) == band:
+            used.add(int(m.group(2)))
+    n = 1
+    while n in used:
+        n += 1
+    return n
+
+
+def cmd_new(args) -> int:
+    """Scaffold a catalog page with a correct, lint-clean id — no hand-edited
+    frontmatter. `doc new <domain> <mode> "<title>"`."""
+    digits = _digits()
+    domain = args.domain.lower()
+    mode = args.mode.lower()
+
+    if domain not in digits:
+        print(f"Error: unknown domain '{domain}'. Valid: {', '.join(digits)} "
+              "(see `doc domains`).", file=sys.stderr)
+        return 1
+    if mode not in doclint.MODE_LETTER:
+        print(f"Error: unknown mode '{mode}'. Valid: "
+              f"{', '.join(doclint.MODE_LETTER)}.", file=sys.stderr)
+        return 1
+
+    band, pole = digits[domain], doclint.MODE_LETTER[mode]
+    serial = _next_serial(domain, digits)
+    cid = f"{band:02d}.{serial:03d}.{pole}"
+
+    slug_source = args.slug if args.slug else args.title
+    slug = re.sub(r"[^a-z0-9]+", "-", slug_source.lower()).strip("-")
+    if not slug:
+        print(f"Error: could not derive a slug from '{slug_source}' "
+              "(no alphanumerics); pass --slug explicitly.", file=sys.stderr)
+        return 1
+
+    subdir = args.dir if args.dir else MODE_DIR[mode]
+    parts = Path(subdir).parts
+    if parts and parts[0] in doclint.SKIP_DIR_PARTS:
+        print(f"Error: '{subdir}' is under a non-catalog subtree "
+              f"('{parts[0]}' is excluded from the catalog); choose another --dir.",
+              file=sys.stderr)
+        return 1
+
+    dest_dir = doclint.DOCS / subdir
+    path = dest_dir / f"{slug}.md"
+    if path.exists():
+        print(f"Error: file already exists: {path}", file=sys.stderr)
+        return 1
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    related = "".join(f'\n  - "[[{r}]]"' for r in (args.related or []))
+    related_block = related if related else " []"
+    path.write_text(
+        f"---\n"
+        f"id: {cid}\n"
+        f"domain: {domain}\n"
+        f"mode: {mode}\n"
+        f"related:{related_block}\n"
+        f"aliases: []\n"
+        f"---\n\n"
+        f"# {args.title}\n\n"
+    )
+
+    try:
+        shown = path.relative_to(doclint.REPO)
+    except ValueError:
+        shown = path
+    print(f"Created: {shown}")
+    print(f"  id:     {cid}  (domain '{domain}' band {band:02d} · "
+          f"mode '{mode}' pole {pole})")
+    print(f"  Lint:   docs/scripts/doc lint")
+    return 0
+
+
 # ============================================================================
 # Main
 # ============================================================================
@@ -255,6 +353,17 @@ def main() -> int:
     p_lint.add_argument("--strict", action="store_true",
                         help="enforce ADR issues too (--enforce-adrs)")
 
+    p_new = sub.add_parser("new", help="scaffold a new catalog page (correct id)")
+    p_new.add_argument("domain", help="domain key (see `doc domains`)")
+    p_new.add_argument("mode", help="Diátaxis mode: "
+                       + " / ".join(doclint.MODE_LETTER))
+    p_new.add_argument("title", help="page title (becomes the H1 and slug)")
+    p_new.add_argument("--dir", help="subdir under docs/ (default: by mode; "
+                       "may nest, e.g. explanation/attend-messaging)")
+    p_new.add_argument("--slug", help="override the filename slug")
+    p_new.add_argument("--related", action="append", metavar="REF",
+                       help="add a related edge (ADR-NNN or DD.NNN.P); repeatable")
+
     args = parser.parse_args()
     return {
         None: cmd_coverage,
@@ -263,6 +372,7 @@ def main() -> int:
         "gaps": cmd_gaps,
         "domains": cmd_domains,
         "lint": cmd_lint,
+        "new": cmd_new,
     }[args.command](args)
 
 

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: docs
+description: Author and manage documentation-catalog pages using the project's doc CLI tool. Use when the user wants to write, scaffold, list, or lint catalog docs (tutorials, how-to guides, reference, explanation), or asks "write docs for X", "new doc page", "what docs exist", "document this". Pairs with the adr skill — docs and ADRs share domain bands.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# Documentation Catalog Authoring
+
+Operate catalog pages through the `docs/scripts/doc` CLI tool. **Never hand-write
+catalog frontmatter** — the tool computes the `DD.NNN.P` id, picks the next
+in-domain serial, and emits a lint-clean page. Reverse-engineering the id scheme
+from the linter is the smell this skill exists to remove.
+
+Docs and ADRs are **one typed graph** sharing domain bands (see the project's
+documentation-catalog ADR). This skill is the docs half; the `adr` skill is the
+decisions half.
+
+## Commands
+
+```bash
+# Discover
+docs/scripts/doc domains                       # domain bands (shared with ADRs)
+docs/scripts/doc coverage                       # domain × mode matrix — where the gaps are
+docs/scripts/doc list [--domain D] [--mode M]   # list catalog pages
+docs/scripts/doc gaps                           # empty cells + doc/ADR imbalance
+
+# Create
+docs/scripts/doc new <domain> <mode> "Title"    # scaffold (correct id, frontmatter, H1)
+#   mode ∈ tutorial | how-to | reference | explanation
+#   --dir <subdir>   land it somewhere specific (may nest, e.g. explanation/attend-messaging)
+#   --related ADR-NNN / --related DD.NNN.P   add edges up front (repeatable)
+
+# Maintain
+docs/scripts/doc lint [--strict]                # lint the catalog graph (the test)
+```
+
+## Workflow
+
+1. **Classify the mode first.** Decide Tutorial / How-to / Reference / Explanation
+   *before* scaffolding — it's the one judgment the tool can't make. The
+   **diataxis** way carries the 2×2; the short form: *studying vs working* ×
+   *practical steps vs theoretical knowledge*. One mode per page.
+2. **Check domains**: `docs/scripts/doc domains` — domains and bands vary per project.
+3. **Scaffold**: `docs/scripts/doc new <domain> <mode> "Title"`. The tool assigns
+   the next id and writes the frontmatter; you never type an id by hand.
+4. **Write the body** faithful to its mode (a tutorial teaches; a reference
+   describes; don't blend).
+5. **Link edges**: add `related:`/`supersedes:` as Obsidian wikilinks
+   (`[[ADR-136]]`, `[[01.003.E]]`) — these are the graph edges the linter checks.
+6. **Lint**: `docs/scripts/doc lint` before committing (dangling edges, malformed
+   ids, mode/pole mismatches all surface here).
+
+## Page format
+
+The tool generates catalog frontmatter — identity is the `id`, not the path:
+
+```markdown
+---
+id: 01.003.E          # DD.NNN.P — domain band . serial . mode pole
+domain: system
+mode: explanation     # tutorial=T  how-to=H  reference=R  explanation=E
+related: []           # wikilink edges: [[ADR-136]], [[01.001.E]]
+aliases: []
+---
+
+# Title
+```
+
+## Key rules
+
+- **Always use the CLI** — never hand-author `id`/`domain`/`mode` frontmatter.
+- **One mode per page** — if it won't fit one Diátaxis quadrant, it's two pages.
+- **Identity is the id, the path is a view** — the filesystem is a serialization;
+  move/rename freely, the `id` is what the graph keys on.
+- **Lint before commit** — `docs/scripts/doc lint` is the catalog's test.
+
+## See also
+
+- the **diataxis** way — picking the mode (the 2×2)
+- the **documentation** way — the typed-graph model
+- the **adr** skill — the decisions half of the same catalog


### PR DESCRIPTION
## Why

Authoring a documentation-catalog page meant reverse-engineering the `DD.NNN.P` id scheme out of `doclint.py` — the "guessed wrong frontmatter schemas" friction. The `adr` side has a full authoring kit (tool `new` + way + skill); the `doc` side had none. This closes the asymmetry.

## What

- **`doc new <domain> <mode> "Title"`** (`hooks/ways/documentation/linting/doc-tool`) — scaffolds a lint-clean catalog page: computes the id (next in-domain serial, domain→band, mode→pole), writes the frontmatter and H1, places it by mode (`--dir` to nest, e.g. `explanation/attend-messaging`; `--related` for edges up front). Mirrors `adr new`. **Nobody computes an id by hand again.**
- **`documentation/diataxis` way** — the one judgment a tool can't make: picking Tutorial / How-to / Reference / Explanation via the closed 2×2 (*studying vs working* × *practical steps vs theoretical knowledge*). Has a `pattern:` so it fires on keyword (not the dead semantic-only path that silently killed the think way).
- **`skills/docs`** — semantic entry point ("write docs for X") orchestrating classify → `doc new` → write → lint → link. Symmetric with `skills/adr`.

## Verification

- `doc new` produces 0-error pages; serial auto-increments (001 → 002); shows in `doc list`
- `ways lint`: 0 errors; diataxis way matches classification intent, ignores unrelated prompts
- New files not swallowed by the whitelist `.gitignore`

## Follow-up

A separate task tracks adding a **"dead way" lint check** — the gap that let the think way ship un-fireable (no pattern, semantic score below threshold, `ways lint` green).