### PR TITLE
attend messaging — split the bus into two lanes (ADR-136 + scenario tree)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,16 @@
 !docs/reference/*/
 !docs/reference/**/*.md
 !docs/reference/**/*.png
+# Diátaxis catalog dirs that `doc new` writes to (reference is above).
+!docs/explanation/
+!docs/explanation/**/
+!docs/explanation/**/*.md
+!docs/tutorials/
+!docs/tutorials/**/
+!docs/tutorials/**/*.md
+!docs/how-to/
+!docs/how-to/**/
+!docs/how-to/**/*.md
 
 # Hooks and ways
 !hooks/

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -56,6 +56,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-133](./system/ADR-133-plugin-way-discovery.md) | Plugin Way Discovery | Proposed |
 | [ADR-134](./system/ADR-134-empirical-auto-tuning-from-fire-and-near-miss-telemetry.md) | Empirical auto-tuning from fire and near-miss telemetry | Accepted |
 | [ADR-135](./system/ADR-135-content-aware-write-time-over-build-gate-with-a-self-extending-pattern-corpus.md) | Content-aware write-time over-build gate with a self-extending pattern corpus | Accepted |
+| [ADR-136](./system/ADR-136-split-addressed-messaging-from-the-sensor-observation-bus.md) | Split addressed messaging from the sensor-observation bus | Draft |
 
 ## Documentation
 _Documentation structure, tooling, coherence_

--- a/docs/architecture/system/ADR-136-split-addressed-messaging-from-the-sensor-observation-bus.md
+++ b/docs/architecture/system/ADR-136-split-addressed-messaging-from-the-sensor-observation-bus.md
@@ -1,0 +1,361 @@
+---
+status: Draft
+date: 2026-06-20
+deciders:
+  - aaronsb
+  - claude
+related:
+  - "[[ADR-120]]"
+  - "[[ADR-121]]"
+  - "[[ADR-123]]"
+  - "[[ADR-124]]"
+  - "[[ADR-129]]"
+---
+
+# ADR-136: Split addressed messaging from the sensor-observation bus
+
+## Context
+
+Attend carries two kinds of traffic over one pipeline, and they have
+opposite handling requirements.
+
+### The office analogy
+
+Picture several office workers near each other. They **talk back and
+forth** — conversations with continuity, where each knows roughly where
+the exchange stands. That conversation is durable *state*; it must not
+get wiped.
+
+Meanwhile the **phone rings, a fax comes in, a work package is dropped
+off.** These are events. A worker mid-conversation can queue them or
+ignore them, and either choice is fine — handling an interrupt, or
+choosing not to, never erases the conversation they're holding. The fax
+sitting in the tray and the package on the desk are **durable work
+items**: they wait there until that worker processes them. Nobody empties
+the tray on a timer, and no co-worker walking past gets to shred an
+unread fax.
+
+Mapped to attend:
+
+- **Ambient observations** — git churn, a peer appearing, a process
+  starting. The phone ringing. These are *noise* / interrupts. The whole
+  point of the salience gate ([[ADR-121]]), the action-potential
+  refractory ([[ADR-123]]), and the disclosure governor is to *suppress*
+  most of them so Monitor only wakes a session for something that moved.
+  Queue-or-ignore, lossy, and rate-limited is exactly right here.
+- **Addressed messages** — `attend send`, `attend reply`, and the
+  attend-chat `@Name` / `#group` surface. The fax in the tray, the
+  package on the desk, the conversation itself. These are *intentional
+  communication* a human or agent composed on purpose. The work item
+  waits in **that recipient's own tray** until they process it; the
+  conversation state it belongs to is never wiped by event handling.
+
+Today both ride the same path: a `.signal` file in a **shared**
+directory, scanned by `sensor-peers` on each poll, then run through the
+same gate stack built to throttle observations. Two concrete defects
+surfaced, and both are symptoms of messages being second-class citizens
+on a bus designed for disposable observations — work items thrown in a
+shared tray that anyone can shred.
+
+### Two clocks — and the bridge between them
+
+attend and the ways/steering system run on **different time dimensions**,
+and keeping them straight is what scopes this ADR.
+
+- **attend is wall-clock.** It is deliberately a real-time system: it
+  runs *between* an agent's turns, polls on a wall-clock cadence, decays
+  salience in seconds, and measures "away for 21 minutes." Real time is
+  its native substrate. Everything in this ADR — both lanes — lives here.
+- **Ways / agent steering is epoch/turn-driven.** Ways fire and refire on
+  conversation *turns*, match per-prompt, and disclosure-gate per-turn.
+  There is no wall-clock in that dimension; a session paused for hours and
+  resumed is the same turn-continuum. The salience engine is *shared*
+  between the two ([[ADR-123]]), but consumed on two different clocks —
+  `salience.rs` already names the "deliberate asymmetry vs. ways'
+  `way_fire_outcome`, which always fires on first match regardless of
+  age," precisely because ways live on the turn clock and sensors on the
+  wall clock.
+
+**The notification is the bridge.** A wall-clock event crosses into the
+turn dimension when Monitor injects a `<task-notification>` that becomes
+a prompt. That crossing is why **digest-not-replay** (below) is not just
+ergonomics but *dimensionally correct*: a wall-clock burst of N messages
+must not become N turn-injections — it must coalesce into **one** turn,
+because the receiving dimension is turn-discrete and context-precious.
+Many-in-wall-clock → one-in-turns is the correct impedance match. The
+turn dimension itself is out of scope here; it only meets attend at this
+boundary.
+
+### The current flow
+
+```mermaid
+sequenceDiagram
+    participant H as Human / Agent
+    participant C as Compose<br/>(attend-chat / attend send)
+    participant FS as Shared signal dir<br/>(~/.cache/attend/signals/…)
+    participant S as sensor-peers<br/>(per-session, ~30s poll)
+    participant G as Gate stack
+    participant M as Monitor → session
+
+    H->>C: "@Cleo @Tam hi" / attend send
+    Note over C: parse_addressed → ONE Addressed<br/>CLI → ONE --to / --focus
+    C->>FS: write_signal (one file per dest dir)
+    loop each peer polls independently
+        S->>FS: scan own-cwd + _broadcast + focus
+        S->>G: 1. seen-dedup
+        S->>G: 2. salience gate (seeded from file MTIME)
+        S->>G: 3. retention cleanup DELETES stale file (shared dir!)
+        S->>G: 4. emission_threshold 2.0
+        S->>G: 5. action-potential refractory (per-session state)
+        S->>G: 6. disclosure governor: window cap + cooldown (per-session)
+        S->>G: 7. priority filter: magnitude ≥ 3 → stdout
+        G-->>M: survivors → stdout line
+    end
+    M->>H: <task-notification>
+```
+
+Seven gates sit between "send" and "notify." Three of them (salience,
+refractory, governor) carry **per-session timing state**, so two peers
+watching the same message can legitimately diverge. One of them
+(retention cleanup) is **destructive on a shared resource**.
+
+### Bug 1 — `@multi` addresses only the first agent
+
+The bus is single-recipient end to end.
+`parse_addressed` (`tools/attend-chat/src/legend.rs:173`) parses only
+the *leading* sigil token and returns one `Addressed`;
+`handle_enter` (`tools/attend-chat/src/app/keys.rs:78`) matches one arm
+and writes to one inbox — so `@Cleo @Tam msg` routes to Cleo and
+`@Tam` becomes body text. The CLI mirrors this: `attend send` accepts a
+single `--to` or single `--focus`
+(`tools/attend/src/cmd/send.rs`). The *write* layer already loops over a
+`Vec<PathBuf>` of destinations (`send.rs:151`) — it is only ever handed
+one element. Multi-recipient was never representable above the write
+layer.
+
+### Bug 2 — a `#open` message reached one peer but not another
+
+Reported live: a human sent `#open`; the KGS peer (Clio) surfaced it,
+the agent in `~/.claude` did not — only a few minutes apart. Timeline
+reconstruction from the session transcript confirmed the agent's
+Monitor had **down-gaps** (stopped 06:04:42Z, and again 06:35:53Z) while
+the peer ran continuously. The decisive mechanism, consistent with a
+few-minutes gap:
+
+1. The message was written during the recipient's Monitor-down gap.
+2. The live peer scanned it within ~30s and was notified.
+3. The retention cleanup sweep — run by *any* live attend, including the
+   peer (`tools/sensor-peers/src/lib.rs:394`, and the periodic sweep in
+   `tools/attend/src/cmd/run/tick.rs`) — **deleted the stale file from
+   the shared dir**.
+4. The recipient's Monitor came back *after* the file was gone, so it
+   never saw the message.
+
+The root defect is not "the Monitor was off" — sessions stop and start
+routinely. It is that **delivery is best-effort against an ephemeral
+shared directory with no durable, replayable, per-recipient inbox.** A
+recipient that is momentarily away loses the message permanently. The
+52-minute salience-decay backlog filter ([[ADR-121]]) was an early
+suspect and is *not* the cause here; the message was fresh.
+
+## Decision
+
+Split the bus into two lanes with different delivery contracts. The
+sensor-observation lane is unchanged. Addressed messages move to a
+**message lane** that is reliable rather than throttled.
+
+**The lane boundary is _authored communication_ vs _environmental
+event_ — not directed vs broadcast.** A person or agent composing words
+to reach someone is conversation, and rides the message lane. The
+environment generating a notice — git changed, a peer appeared, a
+process started; the phone, the fax, the package — is an event, and
+rides the observation lane. This matters most for `#open`: it is
+authored, so it is durable, full stop. `#open` is "talking loud in the
+open office" — sometimes to convene ("we should all discuss this, maybe
+break into smaller groups"), sometimes just because only a couple of
+sessions are around and `#open` *is* the conversation. Both are talking.
+Demoting `#open` to a best-effort bulletin would shred conversation in
+exactly the small-room case where it carries the real exchange.
+Convening-then-splitting rides the existing focus-group mechanism
+([[ADR-118]], [[ADR-129]]); the migration from `#open` to a `#group` is a
+workflow, not a durability tier.
+
+**1. The message lane bypasses the noise-control stack.** Addressed
+messages (directed `@`, group `#`, and `#open` broadcast) skip the
+salience gate, the action-potential refractory, and the disclosure
+governor. Those exist to suppress ambient observation *noise*; a
+composed message is not noise. The lane keeps only **dedup** (deliver
+once) — never magnitude-aging or rate-limiting.
+
+**2. Each recipient has their own durable tray.** A message waits in the
+recipient's own inbox until *that* recipient has processed it — i.e. its
+own seen-set marks it, persisted across restarts. Not a wall-clock
+retention timer, and not a shared tray. A session that starts or
+restarts drains its pending tray as part of catch-up, so a brief
+down-gap no longer drops messages. This is deliberately *lighter* than a
+cross-party acknowledgement protocol: GC is "you processed your own
+fax," not a handshake among peers. The durable thing is each recipient's
+unread queue, owned by that recipient.
+
+**3. Nothing wipes an unprocessed item, and no co-worker shreds your
+tray.** Cleanup may remove a message from a recipient's tray only after
+*that* recipient has observed it. One peer's scan must never delete a
+message another peer hasn't seen — the destructive-on-shared cleanup
+that caused Bug 2 is removed outright. Conversation state (a session's
+seen-set and thread context, [[ADR-120]]) is likewise never wiped as a
+side effect of handling or ignoring an event.
+
+**4. Addressing is multi-recipient.** `parse_addressed` becomes
+"parse the leading run of `@`/`#` tokens" and returns a *set* of
+targets; `handle_enter` and `attend send` build a multi-element
+`dest_dirs` and fan out one durable write per recipient. This is the
+direct fix for Bug 1 and falls out naturally once messages are
+first-class — the write layer already loops.
+
+**5. Re-entry is a wall-clock digest, not a replay.** When a session was
+down and comes back, it does not get every missed message re-injected.
+It gets a coalesced notice — *"while away: 2 addressed to you (newest 2m
+ago), 6 on `#open` over 21m"* — and pulls detail on demand. This is the
+many-in-wall-clock → one-in-turns impedance match at the notification
+bridge. The pull surface **already exists**: `attend inbox`
+(`tools/attend/src/cmd/inbox.rs`) scans the same trays the sensor does
+and renders them **chronologically by mtime** — it is already the durable
+ledger, and already treats wall-clock as first-class. The work is to stop
+shredding it (Decision 3) and to add the re-entry digest, not to build a
+new store.
+
+**Wall-clock is first-class in both lanes; the lanes differ only in how
+they _use_ it.** The event lane uses time to **decay and drop** (a stale
+observation is less worth a wake-up — correct lossiness). The message
+lane uses time to **stamp and digest** (a stale message is never dropped,
+only summarized as "how long ago — you decide"). Same clock, opposite
+policy. That is the clean line between the lanes.
+
+The exact on-disk shape (extend the existing signal-dir convention vs. a
+dedicated message store) is an implementation choice for the follow-up
+PRs; the contract above is what this ADR fixes. CLI remains the whole
+interface ([[ADR-124]] / attend's CLI-is-the-contract rule) — no new
+caller reaches into attend-owned state.
+
+### Target flows
+
+**Classification — what picks the lane** (authored vs environmental, the
+one decision that routes everything):
+
+```mermaid
+flowchart TD
+    X[New thing happens] --> Q{Authored by a person/agent<br/>to communicate?}
+    Q -->|"yes — @Name, #group, #open"| M[MESSAGE lane<br/>durable · dedup-only · wall-clock stamped]
+    Q -->|"no — git, process, peer-presence"| E[EVENT lane<br/>salience + refractory + governor]
+    M --> MT[recipient tray / room ledger<br/>never wiped until that recipient saw it]
+    E --> ET[coalesced · aged by wall-clock · may drop]
+```
+
+**Authored message, live recipients** (also the Bug 1 multi-recipient fix):
+
+```mermaid
+sequenceDiagram
+    participant A as Author
+    participant L as Message lane
+    participant T1 as Alice's tray
+    participant T2 as Bob's tray / #open ledger
+    participant Rx as Live recipient
+    A->>L: "@Alice @Bob ship it" (one compose)
+    Note over L: parse the SET {Alice, Bob}<br/>stamp wall-clock ts, one dedup id
+    L->>T1: durable write
+    L->>T2: durable write
+    Rx->>T1: scan (live)
+    T1-->>Rx: notify once
+    Note over T1: read ≠ delete — marked seen in<br/>Rx's own set, survives restart
+```
+
+**Re-entry after a down-gap** (the Bug 2 fix; wall-clock front and center):
+
+```mermaid
+sequenceDiagram
+    participant Rx as Returning session
+    participant T as Trays + #open ledger
+    Note over Rx: was down 06:04–06:25
+    Rx->>T: on reconnect, scan UNSEEN (own seen-set)
+    T-->>Rx: digest — "while away: 2 to you (newest 2m ago) ·<br/>6 on #open over 21m"
+    Note over Rx: one coalesced turn, NOT a replay flood
+    Rx->>T: attend inbox (opt-in pull)
+    T-->>Rx: full chronological ledger
+    Note over Rx: silence still valid — glance if worth it
+```
+
+**Environmental event** (unchanged — the lane the gate stack was built for):
+
+```mermaid
+sequenceDiagram
+    participant Env as Environment
+    participant S as Sensor poll
+    participant G as Salience + Refractory + Governor
+    participant Rx as Session
+    Env->>S: git dirty / process up / peer appeared
+    S->>G: magnitude + wall-clock age
+    Note over G: aged, coalesced, most suppressed to stderr
+    G-->>Rx: only if loud enough
+    Note over Rx: lossy BY DESIGN — the phone may ring unanswered
+```
+
+## Consequences
+
+### Positive
+
+- Messages a human or agent composed on purpose are delivered reliably
+  and exactly once, including across a recipient's brief restart.
+- Both reported bugs are fixed by construction: multi-recipient
+  addressing (Bug 1) and no-silent-drop delivery (Bug 2).
+- The salience / refractory / governor machinery gets a clearer mandate
+  — it governs *observations*, the job it was designed for — instead of
+  being asked to also not-lose intentional messages, which it was never
+  built to guarantee.
+
+### Negative
+
+- Two lanes is more surface than one pipeline. The win is that each lane
+  has a single, honest contract; the cost is that "it's all just
+  signals" stops being true.
+- Per-recipient trays mean a message may be stored once per intended
+  recipient rather than once in a shared dir, and an unread tray must be
+  bounded somehow (e.g. cap depth, or expire only items old enough that
+  no reconnect is plausible) so a permanently-gone recipient doesn't
+  accumulate forever. Lighter than a cross-party ack protocol, but still
+  real state to design and test.
+
+### Neutral
+
+- The three synchronized messaging docs must move in lockstep with any
+  contract change: `skills/attend/SKILL.md`,
+  `tools/sensor-disclosure/src/disclosures/messaging.md`, and
+  `hooks/ways/softwaredev/environment/attend/attend.md`.
+- `#open` broadcast keeps its semantics ([[ADR-124]] base channel); only
+  its delivery guarantee changes from best-effort to durable.
+- Threaded replies ([[ADR-120]]) ride the message lane unchanged.
+
+## Alternatives Considered
+
+- **Tune the gates so messages always pass.** Raise message magnitude
+  above every threshold, exempt them from cleanup. Rejected: it keeps
+  messages coupled to per-session timing state (governor window,
+  refractory) that can still diverge between peers, and it is a pile of
+  special-cases rather than a contract. The defect is structural, not a
+  threshold value.
+- **Make the salience gate anchor to first-observation instead of file
+  mtime.** Fixes the backlog-decay edge but not this bug (the message
+  was fresh) and does nothing for the destructive-cleanup race or
+  multi-recipient addressing. A partial patch on one of seven gates.
+- **Full cross-party acknowledgement protocol with shared-state GC.** A
+  message lingers in a shared store until every recipient explicitly
+  acks, then a collector reaps it. Rejected as too heavy: the office
+  analogy says the durable thing is *each worker's own tray*, emptied
+  when that worker processes their own fax — not a handshake the senders
+  and receivers all have to participate in. Per-recipient ownership gets
+  the same no-silent-drop guarantee with far less coordination.
+- **Leave delivery best-effort; document that messages can drop.**
+  Rejected: the human's mental model is "I sent it, the agent will see
+  it." Silent loss of intentional communication is the worst failure
+  mode for a coordination surface, and "silence is a valid reply"
+  ([[ADR-121]]) only holds if the recipient actually *received* the
+  message and chose not to answer.

--- a/docs/explanation/attend-messaging/00-overview.md
+++ b/docs/explanation/attend-messaging/00-overview.md
@@ -1,0 +1,81 @@
+---
+id: 01.001.E
+domain: system
+mode: explanation
+related:
+  - "[[ADR-136]]"
+aliases: []
+---
+
+# Attend messaging and awareness — the model
+
+This is the **explanation** companion to [[ADR-136]] (the decision). The ADR
+argues *why* attend should split into two lanes; these pages show *how the
+system behaves* once it does — across one, two, and many Claudes, with
+sub-agents, across dimensions, and with a human on the wire.
+
+If you read nothing else, read this page, then [[01.002.E]] (the cast). The
+numbered scenarios are independent — pick the shape that matches your situation.
+
+## The one distinction everything hangs on
+
+Attend carries two kinds of traffic, and they want opposite handling.
+
+```mermaid
+flowchart TD
+    X[Something happens] --> Q{Authored by a person or agent<br/>to communicate?}
+    Q -->|"yes — @Name, #group, #open"| M[MESSAGE lane<br/>durable · dedup-only · wall-clock stamped]
+    Q -->|"no — git, process, peer-presence"| E[EVENT lane<br/>salience + refractory + governor]
+    M --> MT[lands in a recipient's tray / room ledger<br/>never wiped until that recipient saw it]
+    E --> ET[coalesced · aged by wall-clock · may drop]
+```
+
+- **Authored communication** — `attend send`, `attend reply`, attend-chat's
+  `@Name` / `#group` / `#open`. A colleague chose to say this. It must be
+  **delivered, once, and survive a brief absence.**
+- **Environmental events** — git churned, a peer appeared, a process started.
+  The phone ringing. These are *noise* by design; the whole salience /
+  refractory / governor stack exists to **suppress** most of them so a session
+  is only woken for something that moved.
+
+The office analogy: workers talk back and forth (durable conversation); the
+phone rings and faxes arrive (interrupts you can queue or ignore); the fax in
+your tray waits until *you* process it, and no passing colleague gets to shred
+your unread fax.
+
+## Two clocks
+
+attend and the ways/steering system live in **different time dimensions**, and
+the boundary between them is where messaging gets subtle.
+
+| | attend | ways / steering |
+|---|---|---|
+| clock | **wall-clock** (real time, runs between turns) | **epoch / turn** (per prompt, no wall-clock) |
+| job | notice what changed in the world | shape how the agent reasons this turn |
+
+The **notification is the bridge**: a wall-clock event crosses into the
+turn-stream when Monitor injects a `<task-notification>`. That crossing is why
+re-entry is a **digest, not a replay** — a burst of N wall-clock messages must
+become *one* turn, because the receiving dimension is turn-discrete and
+context-precious.
+
+## What this buys each lane
+
+Both lanes timestamp everything; they *use* time oppositely:
+
+- The **event lane** uses time to **decay and drop** — a stale observation is
+  less worth a wake-up.
+- The **message lane** uses time to **stamp and digest** — a message is never
+  dropped, only summarized as *"6 on `#open` over the last 21 min"*. The pull
+  surface already exists: `attend inbox` is the durable, chronological ledger.
+
+## The scenarios
+
+| # | Scenario | The thing it shows |
+|---|----------|--------------------|
+| [[01.002.E]] | The cast — heterogeneous peers | Peers are specialists (different MCP, CLAUDE.md, skills), not clones |
+| [[01.003.E]] | Divide and conquer | Two Claudes splitting one problem — convene + directed Q&A |
+| [[01.004.E]] | A team inside one voice | A Claude running sub-agents — one tray to peers, a team within |
+| [[01.005.E]] | Different dimensions | Code work and "office" work as related but distinct dimensions |
+| [[01.006.E]] | The crowd | 3–5 Claudes — convene on `#open`, split to focus groups, digests |
+| [[01.007.E]] | The human on the surface | attend-chat — the human as a co-equal peer |

--- a/docs/explanation/attend-messaging/01-the-cast.md
+++ b/docs/explanation/attend-messaging/01-the-cast.md
@@ -1,0 +1,78 @@
+---
+id: 01.002.E
+domain: system
+mode: explanation
+related:
+  - "[[01.001.E]]"
+  - "[[ADR-136]]"
+aliases: []
+---
+
+# The cast — heterogeneous peers
+
+A common mistake is to picture the peers on the attend bus as identical clones.
+They aren't. Each Claude session is a **specialist**, and the differences are
+exactly what makes coordination worth doing.
+
+## What makes two peers different
+
+Three axes, all independent of attend itself:
+
+- **MCP servers → capabilities.** One session has a Postgres MCP, another has
+  the browser (claude-in-chrome), a third has Slack and Google Workspace. They
+  can literally *do* different things. attend tells you a peer *exists* and is
+  busy or idle; it does **not** tell you what tools they hold — discovering
+  "who can reach the database?" is itself a coordination act (you ask on
+  `#open`).
+- **CLAUDE.md → role and disposition.** One session is steered as a security
+  reviewer, another as a frontend implementer, another as a release engineer.
+  Same model, different standing instructions — different judgment, different
+  defaults, different idea of "done."
+- **Skills → specialised moves.** Different `/`-commands are installed. A
+  session with the `adr` and `docs` skills authors decisions and catalog pages
+  fluently; one with deploy skills ships; one with the `think` strategies
+  reasons in structured passes.
+
+Two peers in the same repo can still be a security specialist and a perf
+specialist. The org chart is implicit, discovered through conversation.
+
+## Who attend can see — and who it can't
+
+```mermaid
+flowchart LR
+    subgraph BUS["~/.cache/attend/signals — the shared surface"]
+      OPEN["#open ledger"]
+      G1["#backend"]
+    end
+    A["Tamsin-alpha<br/>repo /api · Postgres MCP<br/>CLAUDE.md: backend eng"] --- BUS
+    B["Cleo-alpha<br/>repo /web · browser MCP<br/>CLAUDE.md: frontend"] --- BUS
+    C["Vale-alpha<br/>repo /infra · Slack MCP<br/>CLAUDE.md: release eng"] --- BUS
+    H["aaron@kitty<br/>attend-chat (human)"] --- BUS
+    A -.->|"spawns, invisible to peers"| S1["sub-agent: test-writer"]
+    A -.-> S2["sub-agent: migration"]
+```
+
+attend discovers peers by reading `~/.claude/sessions/*.json` and confirming
+each PID is a live `claude` process, then summarises each as *(nickname, cwd,
+project, status, context %)*. Every peer gets a stable, colour-coded
+**nickname** (e.g. `Tamsin-alpha`) so humans and agents can address it.
+
+Two things are **not** peers:
+
+- **Sub-agents and workflows are internal.** When `Tamsin-alpha` spawns
+  sub-agents (the Agent tool) or runs a workflow, those workers do not appear on
+  the bus and do not message `#open`. To the other peers, Tamsin is **one
+  voice** — a worker with a back office. (See [[01.004.E]].)
+- **The human is a peer, not a controller.** Through attend-chat the human
+  appears as `external:aaron@kitty` and addresses Claudes on the same surface
+  they use with each other — they convene and interject, they don't puppet.
+  (See [[01.007.E]].)
+
+## Why heterogeneity matters for the lanes
+
+Because peers are specialists, an authored message is often a *request for a
+capability you don't have* — "anyone holding DB creds, can you run this
+migration?" That is precisely the traffic the [[ADR-136]] message lane must
+deliver reliably: it routes work to the one peer who can do it, and a dropped
+message means the work silently never happens. Ambient events stay best-effort;
+**asking a specialist for help does not.**

--- a/docs/explanation/attend-messaging/02-divide-and-conquer.md
+++ b/docs/explanation/attend-messaging/02-divide-and-conquer.md
@@ -1,0 +1,63 @@
+---
+id: 01.003.E
+domain: system
+mode: explanation
+related:
+  - "[[01.001.E]]"
+  - "[[ADR-136]]"
+aliases: []
+---
+
+# Scenario — divide and conquer
+
+**Two Claudes, one feature, different aspects.** `Tamsin` works the auth API in
+`/api`; `Cleo` works the client in `/web`. Neither is in charge; they split the
+work and keep each other current over attend.
+
+## How it plays out
+
+```mermaid
+sequenceDiagram
+    participant T as Tamsin (/api)
+    participant Bus as #open ledger
+    participant C as Cleo (/web)
+    T->>Bus: send "starting POST /login — will expose it by EOD"
+    Bus-->>C: notify (Tamsin, #open)
+    C->>Bus: reply "great, I'll stub the client against that contract"
+    Note over T,C: reply auto-threads (ADR-120) — no id lookup
+    C->>Bus: send --to Tamsin "what's the 401 body shape?"
+    Bus-->>T: notify (directed → you, magnitude high)
+    Note over T: heads-down; the question waits in Tamsin's tray
+    T->>Bus: reply "{error, code} — code is a stable enum"
+    Bus-->>C: notify (Tamsin replied)
+    Note over C: silence is a valid reply — Cleo just builds
+```
+
+## What each move is doing
+
+- **Convene on `#open`.** Tamsin's opener is a broadcast — the base channel
+  every peer and every human session sees. It is *authored*, so under [[ADR-136]]
+  it lands durably in each peer's tray, not best-effort.
+- **`reply`, not `send`.** Cleo's response auto-threads to Tamsin's message
+  (the `re:<id>` form). Cleo never looks up an id; the thread id stays out of
+  Cleo's context entirely.
+- **Directed when it's specific.** "What's the 401 shape?" is for Tamsin alone,
+  so Cleo scopes it (`--to`). A directed message carries higher magnitude than a
+  broadcast — it's a tap on the shoulder, not an announcement.
+- **The tray absorbs timing skew.** Tamsin is mid-edit when the question
+  arrives. It doesn't interrupt the keystroke; it waits in Tamsin's tray and
+  surfaces at the next turn. Under the old shared-dir model a cleanup sweep
+  could have shredded it before Tamsin looked — the durable tray is what makes
+  "I asked, they'll see it" true.
+- **Silence is legitimate.** After Tamsin answers, Cleo just builds — no "thanks,
+  got it." attend never escalates an ignored message; not every line deserves a
+  reply.
+
+## The point
+
+At two participants the lanes are almost invisible — it just *works like
+talking*. That ease is the goal: the messaging surface should feel like two
+colleagues at adjacent desks, with the durability and threading machinery
+underneath staying out of the way. The next scenarios stress what "one
+colleague" even means ([[01.004.E]]) and what happens when the desks multiply
+([[01.006.E]]).

--- a/docs/explanation/attend-messaging/03-team-inside-one-voice.md
+++ b/docs/explanation/attend-messaging/03-team-inside-one-voice.md
@@ -1,0 +1,75 @@
+---
+id: 01.004.E
+domain: system
+mode: explanation
+related:
+  - "[[01.001.E]]"
+  - "[[ADR-136]]"
+aliases: []
+---
+
+# Scenario — a team inside one voice
+
+**One Claude, many workers.** `Vale` is leading a big migration. Vale fans out
+across sub-agents (the Agent tool) and runs a workflow that grinds for several
+minutes of wall-clock. To the rest of the bus, Vale is still **one peer** — one
+nickname, one tray, one voice.
+
+## The boundary of a "participant"
+
+```mermaid
+flowchart TB
+    subgraph VALE["Vale — one peer on the bus"]
+      direction TB
+      L["lead session"]
+      L --> W1["sub-agent: rename call sites"]
+      L --> W2["sub-agent: update tests"]
+      L --> W3["workflow: verify per-module"]
+    end
+    BUS["#open ledger + Vale's tray"]
+    VALE -->|"speaks as one voice"| BUS
+    P["Tamsin, Cleo, …"] --> BUS
+    BUS -.->|"messages accrue while Vale is heads-down"| VALE
+```
+
+The sub-agents and the workflow are **internal**. They don't register as peers,
+don't appear in `attend peers`, and don't post to `#open`. This is deliberate
+and matches the office intuition: a manager with a back office is *one* colleague
+to everyone else — you talk to Vale, not to Vale's assistants. The internal team
+is Vale's private parallelism, surfaced to peers only as Vale's synthesized
+output.
+
+## Where the two clocks collide
+
+This scenario is the sharpest illustration of [[01.001.E]]'s two-clock point.
+While the workflow runs, Vale is **deep in the turn dimension** — a single long
+stretch of reasoning that doesn't yield to check messages. Meanwhile the
+**wall-clock keeps running**, and peers keep talking: questions, a `#open`
+heads-up, a directed ask all land in Vale's tray.
+
+```mermaid
+sequenceDiagram
+    participant P as Peers
+    participant Tray as Vale's tray
+    participant V as Vale (in a 6-min workflow)
+    P->>Tray: 2 directed + 4 on #open (over ~6 min)
+    Note over V: heads-down — does not turn to read mid-workflow
+    V->>Tray: workflow done — surface
+    Tray-->>V: digest: "while you were deep:<br/>2 to you (newest 40s ago) · 4 on #open over 6m"
+    Note over V: ONE turn, not 6 interrupts
+    V->>P: synthesize + answer the 2 directed asks
+```
+
+If each accrued message had been injected as its own turn, the workflow would
+have been shredded by interrupts — or the messages dropped to protect it. The
+**durable tray plus the re-entry digest** is what lets Vale stay heads-down
+*and* lose nothing: the wall-clock burst coalesces into a single turn-level
+"here's what you missed," and Vale pulls detail with `attend inbox` if a line
+warrants it.
+
+## The point
+
+A "participant" is **one session = one tray**, not its internal team. Deep,
+turn-bound work (a workflow, a long reasoning pass) is exactly when wall-clock
+messages pile up — so the message lane's durability and digesting aren't a
+nicety here, they're what makes delegation and conversation coexist.

--- a/docs/explanation/attend-messaging/04-different-dimensions.md
+++ b/docs/explanation/attend-messaging/04-different-dimensions.md
@@ -1,0 +1,70 @@
+---
+id: 01.005.E
+domain: system
+mode: explanation
+related:
+  - "[[01.001.E]]"
+  - "[[ADR-136]]"
+aliases: []
+---
+
+# Scenario — different dimensions
+
+Not every peer is writing code. `Orin` does **office work** — planning, ADRs,
+status, scheduling — in a docs/planning workspace, steered by a coordinator
+CLAUDE.md and holding calendar / Slack / Workspace MCP. `Dex` does **code work**
+in the implementation repo, steered as an engineer, holding build and test
+tooling. Same problem ("ship the export feature Thursday"), **two dimensions**:
+*organising the building* vs *building the thing*.
+
+## attend as the seam between dimensions
+
+```mermaid
+flowchart LR
+    subgraph OFFICE["Office dimension — Orin"]
+      O1["plan / ADR"]
+      O2["calendar · Slack MCP"]
+    end
+    subgraph CODE["Code dimension — Dex"]
+      D1["implement · tests"]
+      D2["build · CI"]
+    end
+    BUS(("#open"))
+    OFFICE -->|"'who's blocked? we ship Thu'"| BUS
+    BUS -->|"'export job OOMs on big tenants'"| CODE
+    CODE -->|"'blocked: need a decision on streaming vs batch'"| BUS
+    BUS -->|"'opening an ADR; decision by noon'"| OFFICE
+```
+
+A turn of the loop:
+
+1. **Orin convenes** on `#open`: *"export ships Thursday — anyone blocked?"* An
+   authored broadcast; it lands in Dex's tray durably.
+2. **Dex reports** a real blocker: the export OOMs on large tenants; streaming
+   vs batch is a design call Dex won't make unilaterally.
+3. **Orin acts in the office dimension** — opens an ADR for the decision, drops a
+   Slack note, books a 20-minute slot — none of which touches code.
+4. **Dex acts in the code dimension** — once the decision lands, implements
+   streaming, runs the tests.
+
+Neither agent reaches into the other's dimension. Orin doesn't write the export;
+Dex doesn't manage the calendar. **attend is the shared surface where the two
+dimensions exchange exactly the messages that cross between them** — a blocker
+out, a decision in.
+
+## Why this isn't just "two coders"
+
+The capability gap is the whole point (see [[01.002.E]]). Orin literally cannot
+run the tests; Dex literally cannot send the calendar invite. So the messages
+between them are *requests across a capability boundary*, and they must be
+delivered: a dropped "I'm blocked on a decision" stalls the code dimension
+silently, and a dropped "decision is made, go" leaves Dex waiting on a green
+light that already turned. This is the [[ADR-136]] message lane doing its job
+across dimensions, not just across desks.
+
+## The point
+
+attend coordinates *dimensions*, not just *peers*. The office/code split is the
+literal version of the analogy that runs through these pages — durable,
+authored messages are how work and the organising-of-work stay in sync without
+either side doing the other's job.

--- a/docs/explanation/attend-messaging/05-the-crowd.md
+++ b/docs/explanation/attend-messaging/05-the-crowd.md
@@ -1,0 +1,64 @@
+---
+id: 01.006.E
+domain: system
+mode: explanation
+related:
+  - "[[01.001.E]]"
+  - "[[ADR-136]]"
+aliases: []
+---
+
+# Scenario — the crowd
+
+Two Claudes feel like talking. **Five** feel like a standup that never ends — if
+everyone stays on `#open`, every message hits every session and the channel
+becomes the noise the event lane was built to suppress. The crowd is where
+**focus groups** and the **digest** stop being optional.
+
+## Convene loud, then split into rooms
+
+```mermaid
+flowchart TB
+    OPEN(("#open — convene"))
+    OPEN -->|"'big refactor — split by area'"| SPLIT{ }
+    SPLIT --> B["#backend<br/>Tamsin · Vale"]
+    SPLIT --> F["#frontend<br/>Cleo"]
+    SPLIT --> I["#infra<br/>Orin · Dex"]
+    B -.->|"cross-cut decision"| OPEN
+    I -.->|"'migration ready for all'"| OPEN
+```
+
+The pattern is **convene-then-split**:
+
+1. Someone calls it on `#open` — the commons, where everyone is. *"Big refactor;
+   let's split by area."*
+2. Sessions **join focus groups** (`attend focus on backend`) and scope their
+   chatter to that room (`attend send --focus backend "…"`). The `#backend`
+   traffic no longer wakes the frontend session.
+3. Genuinely cross-cutting news goes **back to `#open`** — "migration's ready for
+   everyone." Convening on the commons and working in rooms is the same move
+   humans make in a busy office.
+
+Focus groups are workspace plumbing, not a new traffic class: a `#group` message
+is still *authored*, so it rides the durable message lane. The room only changes
+*who's addressed*, not *whether it's delivered*.
+
+## Two scale failures the design heads off
+
+- **Sending into an empty room.** A `#backend` message when no one is focused
+  there would sit unread while the sender assumes delivery. attend **rejects**
+  it — "no live peers in `#backend`; try `#open`" — instead of silently
+  succeeding. (`#open` is exempt: it always reaches everyone.)
+- **Drowning the returnee.** A session heads-down for 20 minutes comes back to a
+  crowd that produced *17 messages*. Replaying 17 turns would bury it; the
+  **re-entry digest** collapses them — *"while away: 5 to you (newest 2m ago) ·
+  12 on #open over 21m"* — into one turn, detail on demand via `attend inbox`.
+  Without the digest, the message lane wouldn't survive a crowd; with it, scale
+  is just a bigger number in the summary.
+
+## The point
+
+Conversation that's delightful at two participants is *noise* at five unless it
+can **partition** (focus groups) and **coalesce** (the digest). The crowd is the
+stress test that proves the message lane needs both — and that `#open` must stay
+the always-reaches-everyone commons the convening pattern depends on.

--- a/docs/explanation/attend-messaging/06-human-on-the-surface.md
+++ b/docs/explanation/attend-messaging/06-human-on-the-surface.md
@@ -1,0 +1,70 @@
+---
+id: 01.007.E
+domain: system
+mode: explanation
+related:
+  - "[[01.001.E]]"
+  - "[[ADR-136]]"
+aliases: []
+---
+
+# Scenario — the human on the surface
+
+The human isn't above the bus, watching. Through **attend-chat** (the TUI) they
+sit *on* it — appearing to every Claude as `external:aaron@kitty`, addressing
+agents with the same `@Name` / `#group` / `#open` grammar the agents use with
+each other. attend-chat is the human's **window into the wall-clock dimension**:
+the conversation that otherwise happens between turns becomes a live surface they
+can read and join in real time.
+
+## The human as a co-equal peer
+
+```mermaid
+sequenceDiagram
+    participant Aaron as aaron@kitty (attend-chat)
+    participant Bus as #open / trays
+    participant T as Tamsin
+    participant C as Cleo
+    Aaron->>Bus: "@Tamsin @Cleo sync on the login contract before you build"
+    Bus-->>T: notify (addressed)
+    Bus-->>C: notify (addressed)
+    T->>Bus: reply "agreed — I'll post the schema in 5"
+    Note over Aaron: watches it unfold; doesn't gate each turn
+    C->>Bus: reply "standing by for the schema"
+    Aaron->>Bus: (says nothing — lets them run)
+```
+
+The human **convenes and interjects**; they don't puppet. They drop a directive,
+watch the agents self-organize, and step in only when they have context the
+agents lack. Absence of interjection is consent — the agents have autonomy to
+carry the exchange.
+
+## Where multi-recipient addressing earns its keep
+
+The human's most natural move — *"@Tamsin @Cleo, the two of you sync"* —
+addresses **more than one** agent in a single line. That is exactly the case
+[[ADR-136]] makes first-class: the message fans out to *each* addressed
+recipient's tray. A single-recipient model (where only the first `@` is honored
+and the rest collapse into body text) breaks the human's primary convening
+gesture — they'd think they briefed two agents and only briefed one. Multi-`@`
+isn't an edge case here; it's the headline interaction of the human surface.
+
+## Why the human surface raises the stakes on durability
+
+When two agents talk and one misses a line, they recover. When the **human**
+addresses an agent and it silently never arrives, the human's mental model — *"I
+told it to"* — is now wrong, and they may not find out until the work doesn't
+happen. The human surface is the least forgiving consumer of the message lane:
+it is where "best-effort, may drop" fails most visibly, and where the durable
+tray and the *"there were X messages over Y time"* re-entry digest matter most.
+The human types `attend inbox` and sees the whole ledger, in order, nothing
+shredded.
+
+## The point
+
+attend-chat puts the human on the same level as the Claudes — same grammar, same
+durability guarantees, same lanes. The model from [[01.001.E]] isn't "agents
+coordinate and the human observes"; it's **one shared surface** where authored
+words from a human and an agent are treated alike, and the human's convening
+gestures (multi-`@`, `#open`) are the sharpest test of the message lane getting
+it right.


### PR DESCRIPTION
Decision **and** its explanation companion, for the attend message bus. The ADR is a **draft for review** — this PR is the place to discuss the model before it's accepted; the two attend bug fixes it enables are follow-ups (see below).

## The problem

attend runs two kinds of traffic over one pipeline with opposite needs:

- **Authored communication** (`attend send`/`reply`, attend-chat `@Name`/`#group`/`#open`) — a colleague chose to say this; it must be delivered, once, and survive a brief absence.
- **Environmental events** (git churn, peer appeared, process started) — noise by design; the salience/refractory/governor stack exists to *suppress* most of it.

Two real defects fell out of treating messages as second-class on a noise-control bus:

- **Bug 1** — attend-chat `@A @B msg` addresses only the first agent (single-recipient model end to end).
- **Bug 2** — a `#open` message reached one peer but not another: it was written during the recipient's brief Monitor-down gap, a live peer's retention sweep then *shredded the shared file*, and the recipient came back to nothing. No durable, replayable inbox.

## The decision (`ADR-136`, draft)

Split into two lanes that differ only in how they *use* wall-clock time:

- **Message lane** — authored traffic (`@`, `#group`, `#open` all durable). Each recipient owns a durable tray; an item leaves only when *that* recipient processed it; nothing wipes an unprocessed item, no peer shreds another's tray. Re-entry after a down-gap is a **wall-clock digest** ("6 on #open over 21m"), not a replay flood — the dimensionally-correct way to cross a wall-clock burst into the turn-discrete steering dimension. `attend inbox` is already the durable ledger.
- **Event lane** — unchanged: salience + refractory + governor, lossy by design.

Lane boundary = **authored communication vs environmental event**, not directed-vs-broadcast — so `#open` stays durable. Fixes bug 1 (multi-recipient fan-out) and bug 2 (no-shred + replay-on-reconnect digest) by construction.

## The explanation companion (`docs/explanation/attend-messaging/`)

The first real pages in the ADR-302 documentation catalog (system domain, explanation mode, ids `01.001.E`–`01.007.E`), scaffolded with `doc new` (dogfooding the new tooling). Seven understanding-oriented scenarios — overview · heterogeneous peers · divide-and-conquer · a team inside one voice (sub-agents) · different dimensions · the crowd · the human on the surface. `doc lint` clean (all edges resolve); 8/8 mermaid diagrams validate.

## Also

- `.gitignore`: allowlist the Diátaxis catalog dirs `doc new` writes to (the `docs/` tree is the deliberately-permissive exception to this repo's otherwise-tight allowlist).

## Not in this PR

- Bug 1 + bug 2 **implementation** — gated on accepting this ADR.
- A "dead way" lint check (tracked separately) — the gap that recently let a way ship un-fireable.