### PR TITLE
fix(attend-chat): address every recipient in a leading @/# run (ADR-136 Bug 1)

### DIFF
--- a/tools/attend-chat/src/app/keys.rs
+++ b/tools/attend-chat/src/app/keys.rs
@@ -8,7 +8,7 @@
 
 use agent_identity::TermCaps;
 
-use crate::chip::{known_identities, resolve_nickname};
+use crate::chip::{known_identities, resolve_nickname, KnownIdentity};
 use crate::groups::{channels, live_peer_count, resolve_group_dir};
 use crate::legend::{
     all_completions, all_group_completions, apply_completion, find_trailing_mention,
@@ -75,43 +75,89 @@ pub fn handle_enter(input_value: &str, signals: &[Signal]) -> EnterAction {
     // against the current registry state.
     let instance_cache = attend_instances::SnapshotCache::new();
     let agents = known_identities(signals, &seeds, caps, &instance_cache);
-    let result = match parse_addressed(&msg) {
-        Some(Addressed::Agent(name)) => match resolve_nickname(name, &agents) {
-            Some(target_cwd) => write_signal(&cwd_dir(&target_cwd), &msg)
-                .map(|n| format!("sent → @{name}: {n}")),
-            None => Err(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!("@{name}: unknown nickname"),
-            )),
-        },
-        // Empty-group rejection (ADR-129 follow-up). Mirrors
-        // `attend send --focus` discipline: a `#groupname` send
-        // to a group with zero live members would land in
-        // `@<name>/` and sit unread, with the chat reporting
-        // "sent" so the user assumes delivery. The base channel
-        // (`#open`) bypasses the check — it rides `_broadcast/`,
-        // where every attend scans regardless of group membership.
-        Some(Addressed::Group(name)) => match resolve_group_dir(name) {
-            Some(dir) if live_peer_count(name) > 0 => {
-                write_signal(&dir, &msg).map(|n| format!("sent → #{name}: {n}"))
+    // A message can address several recipients at once
+    // (`@Tamsin @Cleo …`). Parse the whole leading run; an empty run
+    // means broadcast. Resolve every recipient up front and reject the
+    // entire send if any address is bad, so one typo doesn't
+    // half-deliver and the user can edit + retry the original line.
+    let recipients = parse_addressed(&msg);
+    let result = if recipients.is_empty() {
+        write_broadcast(&msg).map(|n| format!("sent: {n}"))
+    } else {
+        resolve_recipients(&recipients, &agents).and_then(|dests| {
+            for dir in &dests {
+                write_signal(dir, &msg)?;
             }
-            Some(_) => Err(std::io::Error::other(
-                format!(
-                    "#{name}: no live peers — message would not be read. \
-                     Try #open to broadcast."
-                ),
-            )),
-            None => Err(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!("#{name}: unknown group"),
-            )),
-        },
-        None => write_broadcast(&msg).map(|n| format!("sent: {n}")),
+            Ok(format!("sent → {}", recipient_labels(&recipients).join(" ")))
+        })
     };
     match result {
         Ok(s) => EnterAction::ClearWithStatus(s),
         Err(e) => EnterAction::StatusOnly(format!("send failed: {}", e)),
     }
+}
+
+/// Render the addressed recipients back as their `@name` / `#group`
+/// labels for the "sent → …" status line.
+fn recipient_labels(recipients: &[Addressed<'_>]) -> Vec<String> {
+    recipients
+        .iter()
+        .map(|r| match r {
+            Addressed::Agent(name) => format!("@{name}"),
+            Addressed::Group(name) => format!("#{name}"),
+        })
+        .collect()
+}
+
+/// Resolve every addressed recipient to its destination inbox dir, or
+/// return the first addressing error. All-or-nothing on purpose: the
+/// caller writes only when *every* recipient resolves, so a single bad
+/// `@name`/`#group` rejects the whole multi-address send instead of
+/// partially delivering. Adjacent or repeated addresses that resolve to
+/// the same dir are deduped so a message is delivered once per inbox.
+///
+/// The empty-group rejection (ADR-129 follow-up) mirrors
+/// `attend send --focus` discipline: a `#groupname` send to a group
+/// with zero live members would land in `@<name>/` and sit unread while
+/// the chat reports "sent". The base channel (`#open`) bypasses the
+/// check — it rides `_broadcast/`, scanned regardless of membership.
+fn resolve_recipients(
+    recipients: &[Addressed<'_>],
+    agents: &[KnownIdentity],
+) -> std::io::Result<Vec<std::path::PathBuf>> {
+    let mut dests = Vec::with_capacity(recipients.len());
+    let mut seen = std::collections::HashSet::new();
+    for r in recipients {
+        let dir = match r {
+            Addressed::Agent(name) => resolve_nickname(name, agents)
+                .map(|cwd| cwd_dir(&cwd))
+                .ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        format!("@{name}: unknown nickname"),
+                    )
+                })?,
+            Addressed::Group(name) => match resolve_group_dir(name) {
+                Some(dir) if live_peer_count(name) > 0 => dir,
+                Some(_) => {
+                    return Err(std::io::Error::other(format!(
+                        "#{name}: no live peers — message would not be read. \
+                         Try #open to broadcast."
+                    )))
+                }
+                None => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        format!("#{name}: unknown group"),
+                    ))
+                }
+            },
+        };
+        if seen.insert(dir.clone()) {
+            dests.push(dir);
+        }
+    }
+    Ok(dests)
 }
 
 /// Result of a Tab keypress. Always returns the next buffer +

--- a/tools/attend-chat/src/legend.rs
+++ b/tools/attend-chat/src/legend.rs
@@ -166,44 +166,64 @@ pub enum Addressed<'a> {
     Group(&'a str),
 }
 
-/// If `msg` starts with an addressing sigil + name, return the kind and
-/// name (without the sigil). Both `@Name` and `#Name` work. Keeps the
-/// original token in the outgoing body so receivers still see the
-/// address they were matched on.
-pub fn parse_addressed(msg: &str) -> Option<Addressed<'_>> {
-    let trimmed = msg.trim_start();
-    let mut chars = trimmed.chars();
-    let sigil = chars.next()?;
-    let kind = match sigil {
-        '@' => Sigil::Agent,
-        '#' => Sigil::Group,
-        _ => return None,
-    };
-    let rest = &trimmed[sigil.len_utf8()..];
-    // First alnum + `-` run is the name; anything after must be
-    // whitespace or nothing. Groups allow `-`; nicknames don't use
-    // it today but accepting it in both keeps the grammar uniform
-    // (and worst case the resolver just returns None).
-    let end = rest
-        .char_indices()
-        .find(|(_, c)| !(c.is_ascii_alphanumeric() || *c == '-'))
-        .map(|(i, _)| i)
-        .unwrap_or(rest.len());
-    if end == 0 {
-        return None;
-    }
-    let name = &rest[..end];
-    let after = &rest[end..];
-    // Allow sigil-plus-name alone (a bare ping), otherwise require a
-    // space so `@Nick,` or `#group.` don't route.
-    if after.is_empty() || after.starts_with(char::is_whitespace) {
-        Some(match kind {
+/// Parse the **leading run** of addressing sigils from `msg`.
+///
+/// A single message can address several recipients at once —
+/// `@Tamsin @Cleo #infra sync up` addresses two agents and a group.
+/// Every `@Name` / `#group` token at the very start of the message
+/// (separated only by whitespace) is a recipient; the run ends at the
+/// first token that isn't a clean mention, and everything from there
+/// on is the body. The original tokens stay in the message so each
+/// receiver sees who else was addressed.
+///
+/// Returns an empty `Vec` when the message doesn't begin with a
+/// mention at all — the caller treats that as a broadcast. Order is
+/// left-to-right as written; the caller dedups by resolved
+/// destination, so a repeated address delivers once.
+///
+/// Grammar per token: sigil + an alnum/`-` name, then whitespace or
+/// end-of-input. Trailing punctuation (`@Nick,`) means "referring",
+/// not "addressing", and ends the run. Groups allow `-`; nicknames
+/// don't use it today but accepting it in both keeps the grammar
+/// uniform (and worst case the resolver just returns None).
+pub fn parse_addressed(msg: &str) -> Vec<Addressed<'_>> {
+    let mut rest = msg.trim_start();
+    let mut out = Vec::new();
+    while let Some(sigil) = rest.chars().next() {
+        let kind = match sigil {
+            '@' => Sigil::Agent,
+            '#' => Sigil::Group,
+            _ => break,
+        };
+        let after_sigil = &rest[sigil.len_utf8()..];
+        let end = after_sigil
+            .char_indices()
+            .find(|(_, c)| !(c.is_ascii_alphanumeric() || *c == '-'))
+            .map(|(i, _)| i)
+            .unwrap_or(after_sigil.len());
+        // `end == 0` is a bare sigil or a sigil glued to punctuation
+        // (`@`, `@ hi`, `#,`) — not a mention; stop the run.
+        if end == 0 {
+            break;
+        }
+        let name = &after_sigil[..end];
+        let tail = &after_sigil[end..];
+        // The name must be followed by whitespace or end-of-input.
+        // `@Nick,` is a reference, not an address — end the run so the
+        // whole message falls through to broadcast (matching the old
+        // single-recipient behavior).
+        if !tail.is_empty() && !tail.starts_with(char::is_whitespace) {
+            break;
+        }
+        out.push(match kind {
             Sigil::Agent => Addressed::Agent(name),
             Sigil::Group => Addressed::Group(name),
-        })
-    } else {
-        None
+        });
+        // Advance past this token's trailing whitespace to the next
+        // candidate mention.
+        rest = tail.trim_start();
     }
+    out
 }
 
 /// Render the **agent** legend row: `@Name @Name ...` across the
@@ -513,55 +533,93 @@ mod tests {
 
     #[test]
     fn addressed_at_start_with_body() {
-        assert_eq!(parse_addressed("@Tamsin hello"), Some(Addressed::Agent("Tamsin")));
+        assert_eq!(parse_addressed("@Tamsin hello"), vec![Addressed::Agent("Tamsin")]);
     }
 
     #[test]
     fn addressed_bare_ping() {
         // `@Nick` with nothing after is a valid addressed ping.
-        assert_eq!(parse_addressed("@Urban"), Some(Addressed::Agent("Urban")));
+        assert_eq!(parse_addressed("@Urban"), vec![Addressed::Agent("Urban")]);
     }
 
     #[test]
     fn addressed_with_leading_whitespace() {
-        assert_eq!(parse_addressed("   @Tamsin hello"), Some(Addressed::Agent("Tamsin")));
+        assert_eq!(parse_addressed("   @Tamsin hello"), vec![Addressed::Agent("Tamsin")]);
     }
 
     #[test]
     fn not_addressed_if_not_at_start() {
-        assert_eq!(parse_addressed("hi @Tamsin"), None);
+        assert!(parse_addressed("hi @Tamsin").is_empty());
     }
 
     #[test]
     fn not_addressed_if_trailing_punctuation() {
         // `@Tamsin,` — punctuation immediately after the name means
         // the user isn't really addressing, just referring.
-        assert_eq!(parse_addressed("@Tamsin, hi"), None);
+        assert!(parse_addressed("@Tamsin, hi").is_empty());
     }
 
     #[test]
     fn not_addressed_on_bare_at_sign() {
-        assert_eq!(parse_addressed("@ hi"), None);
-        assert_eq!(parse_addressed("@"), None);
+        assert!(parse_addressed("@ hi").is_empty());
+        assert!(parse_addressed("@").is_empty());
     }
 
     #[test]
     fn addressed_group_with_body() {
-        assert_eq!(parse_addressed("#deploy rollout at 3pm"), Some(Addressed::Group("deploy")));
+        assert_eq!(parse_addressed("#deploy rollout at 3pm"), vec![Addressed::Group("deploy")]);
     }
 
     #[test]
     fn addressed_group_with_dash() {
-        assert_eq!(parse_addressed("#my-team ping"), Some(Addressed::Group("my-team")));
+        assert_eq!(parse_addressed("#my-team ping"), vec![Addressed::Group("my-team")]);
     }
 
     #[test]
     fn addressed_group_bare_ping() {
-        assert_eq!(parse_addressed("#infra"), Some(Addressed::Group("infra")));
+        assert_eq!(parse_addressed("#infra"), vec![Addressed::Group("infra")]);
     }
 
     #[test]
     fn addressed_group_rejects_punctuation() {
-        assert_eq!(parse_addressed("#deploy, now"), None);
+        assert!(parse_addressed("#deploy, now").is_empty());
+    }
+
+    #[test]
+    fn addressed_multiple_agents() {
+        // The headline multi-address case: both `@`s become recipients,
+        // not just the first (the bug ADR-136 fixes).
+        assert_eq!(
+            parse_addressed("@Tamsin @Cleo sync on the contract"),
+            vec![Addressed::Agent("Tamsin"), Addressed::Agent("Cleo")],
+        );
+    }
+
+    #[test]
+    fn addressed_mixed_agent_and_group() {
+        // A run can mix sigils: address an agent and a group together.
+        assert_eq!(
+            parse_addressed("@Tamsin #infra heads up"),
+            vec![Addressed::Agent("Tamsin"), Addressed::Group("infra")],
+        );
+    }
+
+    #[test]
+    fn addressed_run_with_no_body() {
+        // Pure address line, no trailing message — still all recipients.
+        assert_eq!(
+            parse_addressed("@Tamsin @Cleo"),
+            vec![Addressed::Agent("Tamsin"), Addressed::Agent("Cleo")],
+        );
+    }
+
+    #[test]
+    fn addressed_run_stops_at_body() {
+        // Only the *leading* run addresses. A `@Cleo` after body text is
+        // a reference inside the message, not a second recipient.
+        assert_eq!(
+            parse_addressed("@Tamsin hello @Cleo"),
+            vec![Addressed::Agent("Tamsin")],
+        );
     }
 }


### PR DESCRIPTION
## What

`@Tamsin @Cleo sync` now reaches **both** agents. Previously `parse_addressed` parsed only the first sigil token and returned a single `Addressed`, so only Tamsin got the message and `@Cleo` collapsed into body text — the human's primary convening gesture silently half-delivered. This is **Bug 1** from [ADR-136](../blob/main/docs/architecture/system/ADR-136-split-addressed-messaging-from-the-sensor-observation-bus.md).

## How

- **`legend.rs::parse_addressed`** now returns the whole **leading run** of `@`/`#` mentions as a `Vec<Addressed>`. The run ends at the first non-mention token (the body begins) or at trailing punctuation (`@Nick,` is a *reference*, not an address). An empty run = broadcast, exactly as before.
- **`keys.rs::handle_enter`** resolves every recipient up front via `resolve_recipients`, then fans out one durable `write_signal` per destination. **All-or-nothing**: if any address is bad (unknown nickname / empty group / unknown group) the whole send is rejected with a clear error and the input is left intact to edit and retry — one typo can't half-deliver. Destinations are **deduped**, so a repeated address delivers once per inbox.

## Behavior preserved

Every prior single-recipient rule still holds — leading-only addressing, bare ping (`@Nick`), trailing-punctuation rejection, empty-group rejection (ADR-129), `#open` broadcast. The existing tests were updated to the `Vec` shape and four multi-address cases were added (two agents, mixed agent+group, no-body run, run-stops-at-body).

## Scope

This fixes the **attend-chat** surface — the reported defect and the headline human gesture (multi-`@`). The CLI `attend send` reaches multiple recipients idiomatically via `--focus` groups; adding per-flag multiple `--to` is a separate public-contract change, redundant with focus groups, and is **not** in scope here. ADR-136 §4's wording will be reconciled with what shipped at the Draft→Accepted flip (after Bug 2).

## Verification

- `cargo build` (full workspace) ✅
- `cargo test -p attend-chat` — 154 passed ✅
- `cargo clippy -p attend-chat` — clean ✅

Refs ADR-136.