### PR TITLE
fix(attend): de-hoard dead config (cleanup.retention, SignalsConfig)

### DIFF
--- a/docs/attend-and-monitor/configuration.md
+++ b/docs/attend-and-monitor/configuration.md
@@ -56,17 +56,10 @@ engagement:
   decay_per_minute: 0.1      # rate at which elevated threshold returns to baseline
   peer_activity_window: 900  # sliding window for per-peer engagement boost
 
-# Presentation-layer aging for peer signals (ADR-121, unified in ADR-123)
-# Consumed by sensor-peers to suppress aged backlog and reset on `re:` replies
-signals:
-  half_life_seconds: 1800    # exponential decay half-life (30 min default)
-  presentation_floor: 0.3    # suppress below this salience
-
 # Background cleanup of the signals base
 cleanup:
   enabled: true              # master switch
   interval: 600              # seconds between auto-sweeps (10 minutes)
-  retention: 2592000         # seconds — signal file age cutoff (30 days)
 
 # Per-sensor configuration — applies to built-ins and script sensors
 sensors:
@@ -135,34 +128,23 @@ The action potential model parameters. Governs per-sensor refractory behavior. S
 
 **Auto-tuning.** Run `attend tune` to derive these from real session history. See [`engagement.md`](engagement.md#tuning-with-attend-tune) for how tuning works and how the linear-derived `decay_per_minute` relates to the engine's exponential half-life.
 
-### `signals`
-
-Presentation-layer aging for peer signals. Consumed by `sensor-peers` to decide whether an about-to-be-emitted observation is loud enough to surface. See [`salience.md`](salience.md) for the full design and ADR-121 / ADR-123 for the decision trail.
-
-- **`half_life_seconds`** (u64, default 1800): exponential decay half-life. A signal's salience halves every `half_life_seconds` seconds of quiet since its arrival (or its last `record_fire` reset). 30 minutes is a conservative first value; subject to `attend tune` once survey coverage exists.
-- **`presentation_floor`** (f64, default 0.3): below-floor signals are suppressed from the peer observation stream, without being deleted from disk. The 30-day retention sweep under `cleanup` is independent and unaffected.
-
-The gate runs inside `sensor-peers::read_signals`, keyed by signal id (= filename stem — the same shape `re:<id>` references in ADR-120 threaded replies). A threaded reply automatically resets the parent signal's salience to 1.0 via `record_fire` at the reply's arrival tick, so thread-alive parents stay presentable for new observers joining the same shared signal dir.
-
-`attend config lint` validates both keys; unknown sub-keys surface as warnings and can be removed with `--fix`.
-
 ### `cleanup`
 
 Background signal-file cleanup. Prevents the signals base from accumulating indefinitely. Scoped strictly to `~/.cache/attend/signals/`; never touches ways data or anything else.
 
+Reaping is by **project liveness** (ADR-136), not by age: a signal is removed when its owning project is gone, mirroring Claude Code's notion of a live project. Durable messages therefore wait as long as their recipient project is alive — there is no age cutoff and no `retention` dial.
+
 - **`enabled`** (bool, default true): master switch. If false, auto-cleanup is skipped and you must run `attend cleanup` manually to reclaim space.
-- **`interval`** (seconds, default 600): how often the auto-sweep runs inside `attend run`. At this interval the loop scans the signals base and removes stale files.
-- **`retention`** (seconds, default 2592000 = 30 days): age cutoff. Signal files older than this are removed.
+- **`interval`** (seconds, default 600): how often the auto-sweep runs inside `attend run`. At this interval the loop scans the signals base and reaps signals whose owning project is no longer live.
 
-The sweep also removes empty encoded-cwd project subdirectories left as shells after their signals are cleaned up. Reserved names (`_broadcast`, `@groups`, anything starting with `_` or `@`) are never removed.
+The sweep also removes empty encoded-cwd project subdirectories left as shells after their signals are reaped. Reserved names (`_broadcast`, `@groups`, anything starting with `_` or `@`) are never removed.
 
-`attend cleanup` can be run manually with overrides:
+`attend cleanup` can be run manually:
 
 ```bash
-attend cleanup                        # use configured retention
-attend cleanup --older-than 5m        # custom age cutoff
+attend cleanup                        # reap signals of dead projects
 attend cleanup --dry-run              # list what would be removed
-attend cleanup --all                  # nuke everything (no age check)
+attend cleanup --all                  # nuke everything (ignore liveness)
 ```
 
 ### `sensors`
@@ -283,7 +265,7 @@ Use this to confirm your config will actually work before launching attend — a
 
 Attend's YAML parser is deliberately minimal — it's a hand-written subset that handles the specific shape described above, with no `serde` dependency. It supports:
 
-- Two-level section headers (`governor:`, `engagement:`, `signals:`, `cleanup:`, `sensors:`)
+- Two-level section headers (`governor:`, `engagement:`, `cleanup:`, `sensors:`)
 - Four-space indent for sensor properties
 - Inline arrays (`requires: [Bash(gh:*), Read]`, `watch: [cargo, mix]`)
 - Block-form lists on a new line (`requires:` followed by indented `- item` lines) for `requires:` and `watch:`

--- a/tools/attend/src/config.rs
+++ b/tools/attend/src/config.rs
@@ -19,52 +19,19 @@ pub struct Config {
     pub governor: GovernorConfig,
     pub engagement: EngagementConfig,
     pub cleanup: CleanupConfig,
-    pub signals: SignalsConfig,
     pub sensors: HashMap<String, SensorConfig>,
 }
 
-/// Presentation-layer aging for peer signals (ADR-121 outward gate, unified
-/// in ADR-123). sensor-peers consults a `Curve::Exponential` keyed by
-/// signal id before emitting an observation; stale backlog signals decay
-/// out of presentation without being deleted from disk, and thread-reply
-/// (`re:`) references reset a signal's salience to 1.0 so the parent
-/// resurfaces.
-#[derive(Debug, Clone)]
-pub struct SignalsConfig {
-    /// Exponential decay half-life in wall-clock seconds. Default 1800
-    /// (30 min) — picked as a conservative first value; subject to
-    /// `attend tune` once survey coverage exists. Signals with arrival
-    /// delta exceeding ~`half_life_seconds × log2(1/floor)` no longer
-    /// surface.
-    pub half_life_seconds: u64,
-    /// Presentation floor. Signals whose current salience drops below
-    /// this value are suppressed from the observation stream (still on
-    /// disk until the retention sweep). Default 0.3 matches the ADR-121
-    /// recommendation.
-    pub presentation_floor: f64,
-}
-
-impl Default for SignalsConfig {
-    fn default() -> Self {
-        Self {
-            half_life_seconds: 1800,
-            presentation_floor: 0.3,
-        }
-    }
-}
-
 /// Background signal-file cleanup. Runs inside `attend run` so the signals
-/// base doesn't accumulate indefinitely. Defaults keep peer discussion
-/// readable for ~30 days, which is long enough to pick up a conversation
-/// the next day or the next week and short enough that nothing lives forever.
+/// base doesn't accumulate indefinitely. Reaping is by project liveness
+/// (ADR-136) — a signal is removed when its owning project is gone — not by
+/// age, so there is no retention dial.
 #[derive(Debug, Clone)]
 pub struct CleanupConfig {
     /// Master switch. Disable to skip auto-cleanup entirely.
     pub enabled: bool,
     /// How often the sensor loop runs a cleanup sweep.
     pub interval: Duration,
-    /// Signal files older than this are removed by auto-cleanup.
-    pub retention: Duration,
 }
 
 impl Default for CleanupConfig {
@@ -73,9 +40,6 @@ impl Default for CleanupConfig {
             enabled: true,
             // Every 10 minutes — directory scan is O(files) and cheap.
             interval: Duration::from_secs(600),
-            // 30 days — conservative enough that peer discussion threads
-            // stay readable across multi-day gaps.
-            retention: Duration::from_secs(30 * 86400),
         }
     }
 }
@@ -220,7 +184,6 @@ impl Default for Config {
             governor: GovernorConfig::default(),
             engagement: EngagementConfig::default(),
             cleanup: CleanupConfig::default(),
-            signals: SignalsConfig::default(),
             sensors,
         }
     }
@@ -284,23 +247,13 @@ engagement:
   decay_per_minute: 0.1      # relative refractory decay rate
   peer_activity_window: 900  # per-peer engagement window
 
-# Presentation-layer aging for peer signals (ADR-121 outward gate, unified
-# in ADR-123). sensor-peers consults an exponential salience curve keyed
-# by signal id before emitting: old backlog signals decay out silently,
-# replies via the `re:` threading field reset the parent's salience and
-# resurface it. Disk retention (see `cleanup` below) is independent and
-# unaffected.
-signals:
-  half_life_seconds: 1800    # exponential decay half-life (30 min default)
-  presentation_floor: 0.3    # suppress below this salience
-
 # Background signal-file cleanup. Runs inside `attend run` so the signals
-# base doesn't accumulate indefinitely. `attend cleanup` is the manual
-# escape hatch with --older-than / --all / --dry-run.
+# base doesn't accumulate indefinitely. Reaping is by project liveness
+# (ADR-136), not by age. `attend cleanup` is the manual escape hatch with
+# --all / --dry-run.
 cleanup:
   enabled: true
   interval: 600              # seconds — how often the sweep runs (10 min)
-  retention: 2592000         # seconds — age cutoff (30 days)
 
 sensors:
   context:
@@ -523,27 +476,6 @@ fn apply_config(config: &mut Config, content: &str) {
                                 config.cleanup.interval = Duration::from_secs(v);
                             }
                         }
-                        "retention" => {
-                            if let Ok(v) = value.parse::<u64>() {
-                                config.cleanup.retention = Duration::from_secs(v);
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-            } else if current_section == "signals" {
-                if let Some((key, value)) = parse_kv(trimmed) {
-                    match key {
-                        "half_life_seconds" => {
-                            if let Ok(v) = value.parse::<u64>() {
-                                config.signals.half_life_seconds = v;
-                            }
-                        }
-                        "presentation_floor" => {
-                            if let Ok(v) = value.parse::<f64>() {
-                                config.signals.presentation_floor = v;
-                            }
-                        }
                         _ => {}
                     }
                 }
@@ -732,27 +664,25 @@ fn parse_kv(line: &str) -> Option<(&str, &str)> {
 mod tests {
     use super::*;
 
-    // ── watch: list (inline + block form) ──────────────────────────────
-
-    // ── signals: block ─────────────────────────────────────────────────
+    // ── back-compat: retired keys are ignored, not fatal ───────────────
 
     #[test]
-    fn signals_block_parses_half_life_and_floor() {
+    fn retired_signals_and_retention_are_silently_ignored() {
+        // The `signals:` section and `cleanup.retention` were removed
+        // (issue #141). An existing config carrying them from the old
+        // shipped template must still load — the loader ignores unknown
+        // keys, and the surviving cleanup keys still parse around them.
         let mut cfg = Config::default();
         apply_config(
             &mut cfg,
-            "signals:\n  half_life_seconds: 3600\n  presentation_floor: 0.5\n",
+            "signals:\n  half_life_seconds: 3600\n  presentation_floor: 0.5\n\
+             cleanup:\n  enabled: false\n  interval: 900\n  retention: 2592000\n",
         );
-        assert_eq!(cfg.signals.half_life_seconds, 3600);
-        assert!((cfg.signals.presentation_floor - 0.5).abs() < 1e-9);
+        assert!(!cfg.cleanup.enabled);
+        assert_eq!(cfg.cleanup.interval, Duration::from_secs(900));
     }
 
-    #[test]
-    fn signals_absent_retains_defaults() {
-        let cfg = Config::default();
-        assert_eq!(cfg.signals.half_life_seconds, 1800);
-        assert!((cfg.signals.presentation_floor - 0.3).abs() < 1e-9);
-    }
+    // ── watch: list (inline + block form) ──────────────────────────────
 
     #[test]
     fn watch_inline_array_replaces_defaults() {

--- a/tools/attend/src/config_lint.rs
+++ b/tools/attend/src/config_lint.rs
@@ -14,7 +14,7 @@
 use std::path::{Path, PathBuf};
 
 /// Known top-level sections of attend config.
-const SECTIONS: &[&str] = &["governor", "engagement", "cleanup", "signals", "sensors"];
+const SECTIONS: &[&str] = &["governor", "engagement", "cleanup", "sensors"];
 
 /// Valid keys under `governor:`.
 const GOVERNOR_KEYS: &[&str] = &["base_cooldown", "max_per_window", "rate_window"];
@@ -41,12 +41,11 @@ const ENGAGEMENT_KEYS: &[&str] = &[
 /// soft deprecation is needed.
 const ENGAGEMENT_DEPRECATED: &[(&str, &str)] = &[];
 
-/// Valid keys under `cleanup:`.
-const CLEANUP_KEYS: &[&str] = &["enabled", "interval", "retention"];
-
-/// Valid keys under `signals:`. ADR-121 outward-gate parameters consumed
-/// by sensor-peers.
-const SIGNALS_KEYS: &[&str] = &["half_life_seconds", "presentation_floor"];
+/// Valid keys under `cleanup:`. `retention` was removed with the switch to
+/// project-liveness reaping (issue #141) — a leftover `retention:` is now
+/// flagged UNKNOWN and `--fix` removes it, same as any foreign key. The
+/// retired `signals:` section is likewise off the schema (see SECTIONS).
+const CLEANUP_KEYS: &[&str] = &["enabled", "interval"];
 
 /// Valid per-sensor properties (indent 4 under any sensor block).
 const SENSOR_KEYS: &[&str] = &[
@@ -157,13 +156,6 @@ fn classify_section_key(section: &str, key: &str) -> KeyClass {
         }
         "cleanup" => {
             if CLEANUP_KEYS.contains(&key) {
-                KeyClass::Known
-            } else {
-                KeyClass::Unknown
-            }
-        }
-        "signals" => {
-            if SIGNALS_KEYS.contains(&key) {
                 KeyClass::Known
             } else {
                 KeyClass::Unknown
@@ -514,23 +506,25 @@ mod tests {
     }
 
     #[test]
-    fn classify_signals_keys() {
+    fn classify_cleanup_keys() {
+        assert_eq!(classify_section_key("cleanup", "enabled"), KeyClass::Known);
+        assert_eq!(classify_section_key("cleanup", "interval"), KeyClass::Known);
+        // retention was retired with project-liveness reaping (issue #141)
+        // — now a generic unknown key the `--fix` pass removes.
         assert_eq!(
-            classify_section_key("signals", "half_life_seconds"),
-            KeyClass::Known
-        );
-        assert_eq!(
-            classify_section_key("signals", "presentation_floor"),
-            KeyClass::Known
-        );
-        assert_eq!(
-            classify_section_key("signals", "bogus"),
+            classify_section_key("cleanup", "retention"),
             KeyClass::Unknown
         );
-        assert_eq!(
-            classify_section_key("signals", "x-experimental"),
-            KeyClass::Known
-        );
+    }
+
+    #[test]
+    fn signals_section_is_retired() {
+        // The `signals:` section is off the schema (issue #141). It is no
+        // longer a recognized top-level section, so a leftover block draws
+        // an UNKNOWN-section warning. (`classify_section_key` itself returns
+        // Known via its catch-all arm because section-level recognition is
+        // handled in `lint_one_file` against SECTIONS, not here.)
+        assert!(!SECTIONS.contains(&"signals"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
After the ADR-136 message-lane refactor, two config blocks were parsed but **never read** — the serde-free loader kept them from warning, so they sat as silent dead config. This removes them.

- **`SignalsConfig`** (`half_life_seconds`, `presentation_floor`) — its only consumer was the per-signal salience gate (`set_salience_params`), removed with the message-lane split. Verified no live reader remains.
- **`cleanup.retention`** — age-based cleanup was replaced by project-liveness reaping (`run_cleanup` takes no age cutoff; the CLI already dropped `--older-than`). Verified `retention` is no longer consulted anywhere.

## Changes
- `config.rs`: remove the `SignalsConfig` struct/default, the `Config.signals` field, the `cleanup.retention` field/default, and both parser branches. Strip the matching lines from the embedded default template.
- `config_lint.rs`: drop `signals` from `SECTIONS` and `retention` from `CLEANUP_KEYS`. This follows the same de-schema pattern as the ADR-123 `burst_window` removal — a leftover `retention:` flags UNKNOWN and `--fix` removes it surgically; a stale `signals:` block draws an unknown-section warning.
- **Back-compat:** the loader stays forgiving — a config still carrying the retired keys loads fine (new regression test `retired_signals_and_retention_are_silently_ignored`). The user's own config carried neither.
- `docs/attend-and-monitor/configuration.md`: drop the `signals` section and `cleanup.retention` from the schema reference; rewrite the `cleanup` section to describe liveness reaping (no age cutoff, no `--older-than`, both of which were stale from ADR-136).

## Verification
- `cargo build -p attend` ✅  `cargo clippy -p attend --all-targets` clean ✅  `cargo test -p attend` 45 passed ✅

## Out of scope — follow-up doc debt
`salience.md`, `signals.md` (Phase 5 age-based cleanup), and ADR-121 still narrate the salience-decay gate and age-based retention as live features. Those were removed in **code** by ADR-136, so this is pre-existing reconciliation debt, not introduced here. Worth a separate docs-reconciliation pass — happy to file an issue.

Closes #141