### PR TITLE
fix(attend): suppress reheat on same-hash self-reload

### DIFF
--- a/tools/attend/src/cmd/run/mod.rs
+++ b/tools/attend/src/cmd/run/mod.rs
@@ -218,12 +218,15 @@ pub(crate) fn cmd_run_with_catchup(catchup: bool) {
         ));
     }
 
-    // Self-reload: track own binary mtime
+    // Self-reload: track own binary mtime as the cheap trigger, plus a
+    // content hash so an identical rebuild (mtime bump, same bytes) is
+    // distinguished from a real binary change (issue #140).
     let self_exe = std::env::current_exe().ok();
-    let initial_mtime = self_exe
+    let mut initial_mtime = self_exe
         .as_ref()
         .and_then(|p| std::fs::metadata(p).ok())
         .and_then(|m| m.modified().ok());
+    let initial_hash = tick::initial_self_hash(self_exe.as_deref());
     let mut last_reload_check = Instant::now();
 
     // Heartbeat identifier (ADR-129). Real session id when resolvable,
@@ -243,7 +246,13 @@ pub(crate) fn cmd_run_with_catchup(catchup: bool) {
         attend_heartbeat::touch(&heartbeat_id).ok();
 
         if last_reload_check.elapsed() >= RELOAD_CHECK_INTERVAL {
-            maybe_self_reload(self_exe.as_deref(), initial_mtime.as_ref(), &slots, &state_store);
+            maybe_self_reload(
+                self_exe.as_deref(),
+                &mut initial_mtime,
+                initial_hash,
+                &slots,
+                &state_store,
+            );
             last_reload_check = Instant::now();
         }
 

--- a/tools/attend/src/cmd/run/tick.rs
+++ b/tools/attend/src/cmd/run/tick.rs
@@ -82,18 +82,49 @@ pub(super) fn build_engagement(cfg: &config::Config) -> sensor_trait::Curve {
     }
 }
 
+/// Hash a file's contents with the std default hasher. Returns `None`
+/// if the file can't be read. Used as the binary-identity check on the
+/// self-reload path — cheap, no external dep, and only invoked when the
+/// mtime has already moved (a rare event).
+fn hash_file(path: &Path) -> Option<u64> {
+    use std::hash::{Hash, Hasher};
+    let bytes = std::fs::read(path).ok()?;
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    Some(hasher.finish())
+}
+
+/// Capture the running binary's content hash at startup, paired with its
+/// mtime, so the reload check can tell a real binary change from an
+/// identical rebuild that only bumped the mtime. `None` if the exe path
+/// or its bytes can't be read.
+pub(super) fn initial_self_hash(self_exe: Option<&Path>) -> Option<u64> {
+    self_exe.and_then(hash_file)
+}
+
 /// Compare the running binary's mtime against the captured startup
 /// mtime. On change, checkpoint state and `exec()` self so the new
 /// binary takes over with state preserved. Never returns on success;
 /// `exec()` only returns on failure, which is logged and discarded so
 /// the loop continues against the now-stale binary.
+///
+/// An identical rebuild bumps the mtime without changing a byte (issue
+/// #140 — observed `reloaded fceb69e → fceb69e`). When the mtime has
+/// moved but the content hash still matches the startup hash, there's no
+/// point exec()ing into an identical binary — and the messaging reheat
+/// the reload triggers is pure noise — so we update the baseline mtime
+/// (to avoid rehashing every interval) and return without reloading.
 pub(super) fn maybe_self_reload(
     self_exe: Option<&Path>,
-    initial_mtime: Option<&SystemTime>,
+    baseline_mtime: &mut Option<SystemTime>,
+    baseline_hash: Option<u64>,
     slots: &[SensorSlot],
     state_store: &state::StateStore,
 ) {
-    let (Some(exe), Some(orig_mtime)) = (self_exe, initial_mtime) else {
+    let Some(exe) = self_exe else {
+        return;
+    };
+    let Some(orig_mtime) = *baseline_mtime else {
         return;
     };
     let Ok(meta) = std::fs::metadata(exe) else {
@@ -102,7 +133,17 @@ pub(super) fn maybe_self_reload(
     let Ok(current_mtime) = meta.modified() else {
         return;
     };
-    if current_mtime == *orig_mtime {
+    if current_mtime == orig_mtime {
+        return;
+    }
+    // mtime moved — confirm the bytes actually changed before reloading.
+    // A matching hash means an identical rebuild: skip the pointless
+    // exec() and the reheat noise, but advance the baseline mtime so we
+    // don't rehash on every subsequent interval. A failed hash falls
+    // through to reload (fail safe — behave as the pre-#140 mtime gate).
+    let current_hash = hash_file(exe);
+    if current_hash.is_some() && current_hash == baseline_hash {
+        *baseline_mtime = Some(current_mtime);
         return;
     }
     emit::log("binary changed — checkpointing and reloading");
@@ -378,5 +419,27 @@ mod tests {
             }
             _ => panic!("expected ActionPotential curve"),
         }
+    }
+
+    #[test]
+    fn hash_file_is_stable_and_content_sensitive() {
+        // The same-hash skip on the reload path (issue #140) depends on
+        // hash_file being deterministic for identical bytes and different
+        // for changed bytes.
+        let dir = std::env::temp_dir().join(format!("attend-hash-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let a = dir.join("bin-a");
+        let b = dir.join("bin-b");
+        std::fs::write(&a, b"identical rebuild bytes").unwrap();
+        std::fs::write(&b, b"identical rebuild bytes").unwrap();
+        // Byte-identical files hash equal even as distinct paths — this is
+        // the "mtime moved, content didn't" case we skip the reload on.
+        assert_eq!(hash_file(&a), hash_file(&b));
+
+        std::fs::write(&b, b"a genuinely changed binary").unwrap();
+        assert_ne!(hash_file(&a), hash_file(&b));
+
+        assert!(hash_file(&dir.join("does-not-exist")).is_none());
+        std::fs::remove_dir_all(&dir).ok();
     }
 }


### PR DESCRIPTION
## Summary
attend's self-reload triggered purely on the binary's **mtime** moving, then `exec()`'d itself — re-running startup and re-firing the full sensor-disclosure messaging reheat. An identical rebuild bumps the mtime without changing a byte, so the reheat fired for no reason.

Observed in a live peer test: `reloaded fceb69e → fceb69e` (same commit on both sides of the reload).

## Fix
Gate the reload on a **content hash**, not just mtime:
- Capture a std-hash of the binary's bytes at startup (`tick::initial_self_hash`), paired with the existing startup mtime. No new dependency — uses `std::hash::DefaultHasher`.
- In `maybe_self_reload`, when the mtime has moved, rehash the binary. If the hash matches the startup hash it's an identical rebuild — advance the baseline mtime (so we don't rehash on every subsequent interval) and return without reloading.
- A **changed** hash reloads exactly as before. A **failed** hash falls through to reload (fail safe — matches the pre-#140 mtime-only behavior).

## Cost
Hashing only runs when the mtime has already moved (rare). Steady-state the check is still a single `metadata` stat per interval — unchanged.

## Verification
- `cargo build -p attend` ✅  `cargo clippy -p attend --all-targets` clean ✅  `cargo test -p attend` 46 passed ✅
- New unit test `hash_file_is_stable_and_content_sensitive` locks in: identical bytes → equal hash (the skip case), changed bytes → different hash (reload case), missing file → `None` (fail-safe).

Closes #140