### PR TITLE
ways: prototype-before-accept + generalize-the-ADR

### DIFF
--- a/hooks/ways/documentation/adr/adr.check.md
+++ b/hooks/ways/documentation/adr/adr.check.md
@@ -16,3 +16,4 @@ Before writing or updating this ADR:
 - Do the consequences reflect **real trade-offs**, not just "this is good / this could be bad"?
 - Does an existing ADR already cover this decision? Check with `docs/scripts/adr list --group`.
 - Is the context section capturing the **actual motivation** (who needs this, what constraint drove it)?
+- Does this read as a **generalized decision** a future reader could apply to a different feature — or as a **trip report** of the exploration that birthed it? Lift the principle out; relegate the discovery to a one-line motivating example.

--- a/hooks/ways/documentation/adr/adr.md
+++ b/hooks/ways/documentation/adr/adr.md
@@ -87,6 +87,18 @@ What we're doing and how.
 
 Statuses: `Draft` | `Proposed` | `Accepted` | `Superseded` | `Deprecated`
 
+## Generalize the Decision
+
+An ADR records the **durable principle**, not the discovery path that led to it. After a long exploration the draft wants to accrete the session's specifics — the exact feature, the messy inversion, the trip-report of what you tried. Strip them. The ADR is the *reusable decision*; the exploration is not the artifact.
+
+The test: a future reader who never saw your session should be able to apply this decision to a *different* feature. If the ADR only makes sense if you know the story that birthed it, it's a trip report, not a decision.
+
+- **State the principle** at the altitude where it generalizes — "a unit of work must do bounded work per cycle," not "the poller-wrapped-in-attend-wrapped-in-Monitor stack needs a bound."
+- **Relegate the discovery** to at most a brief motivating example in Context — one or two sentences naming what surfaced the need, not a replay of the debugging.
+- **Decision and Consequences carry no session-specifics.** If a sentence only parses with this week's feature in mind, lift it to the general form or cut it.
+
+A generalized ADR is reusable across everything that hits the same force. A discovery-laden one is single-use.
+
 ## Fixing ADR Issues
 
 **Run `docs/scripts/adr lint` before editing ADR files.** The linter identifies exactly what's wrong (missing frontmatter, invalid status, missing fields). Use its output to guide targeted fixes rather than opening files and guessing.

--- a/hooks/ways/softwaredev/architecture/design/prototype/prototype.check.md
+++ b/hooks/ways/softwaredev/architecture/design/prototype/prototype.check.md
@@ -1,0 +1,18 @@
+---
+description: flipping an ADR or design to Accepted whose decisive claim is about an external system, performance, latency, or data volume
+vocabulary: accept adr ratify external api latency performance cost data volume assumption prototype probe measure
+scope: agent
+---
+
+## anchor
+
+You are about to accept a decision whose load-bearing claim is about something outside your codebase. Reasoning ratifies; measurement decides.
+
+## check
+
+Before flipping this to Accepted:
+- What is the **single load-bearing claim**, stated as a falsifiable prediction (a number, a yes/no), not a vibe?
+- Is that claim about an **external system, latency, cost, or data volume** — something you cannot confirm by reading your own code?
+- Have you **run the real system** (a throwaway probe, a measured payload, a triggered event) — or are you accepting from reasoning alone?
+- If you measured: does the ADR **cite the evidence**? If you didn't: why is this safe to accept unmeasured?
+- Did you probe **each** external assumption the design rests on, or just the first one?

--- a/hooks/ways/softwaredev/architecture/design/prototype/prototype.md
+++ b/hooks/ways/softwaredev/architecture/design/prototype/prototype.md
@@ -1,0 +1,47 @@
+---
+description: when an ADR or design rests on external-system behavior, performance, latency, or data-volume assumptions, build a throwaway prototype or probe the real system to confirm or kill the decision BEFORE flipping it to Accepted
+vocabulary: prototype probe spike throwaway validate empirically measure benchmark external api third-party rate limit latency budget payload size data volume webhook poll assumption aspirational adr proposed draft accept ratify load-bearing claim feasibility proof of concept
+scope: agent, subagent
+refire: 0.2
+---
+<!-- epistemic: heuristic -->
+# Prototype-Before-Accept Way
+
+An ADR can read as airtight and still be wrong, because the load-bearing claim isn't *in the codebase* — it's a bet about something outside it: how an external API actually behaves, what a payload really weighs, whether the latency fits the budget, whether the webhook even exists. Pure reasoning can't settle those. Only the real system can.
+
+## The tell
+
+You're about to accept a design whose decisive premise is about something you can't read in your own repo:
+
+- an **external/third-party API or service** — its behavior, limits, auth model, what events it actually emits,
+- **performance, latency, or cost** — "this poll fits the budget," "this is cheap enough,"
+- **data volume or shape** — "the payload is small," "this scales."
+
+The ADR sits in `Draft` or `Proposed`. Its conclusion rests on a sentence that *sounds* measured but was never measured.
+
+## The move: probe, then flip
+
+Before you flip the status to `Accepted`, build the smallest throwaway that makes the real system answer the load-bearing question — and let the evidence confirm or kill the decision:
+
+1. **Name the load-bearing claim** as a falsifiable prediction. Not "polling is feasible" — "a full sync is under N seconds and under M API calls."
+2. **Build the minimum probe** that tests *that claim only.* Hit the real endpoint. Measure the real payload. Trigger the real event and watch whether the notification fires. Throwaway means throwaway — it proves a number, it isn't the implementation.
+3. **Let the evidence rule.** Confirm → flip to `Accepted` and cite what you measured. Disprove → the ADR was wrong; revise or kill it *now*, before anything is built on it.
+
+Reasoning ratifies; measurement decides. An ADR accepted from reasoning alone about an external system is an aspiration wearing a decision's clothes.
+
+## Each probe can overturn a different layer
+
+Don't stop at the first measurement. A single design often rests on a stack of unexamined external assumptions, and each probe can knock out a different one: the data turns out trivial *but* serial pagination blows the latency budget; the fast path turns out to be org-only and unavailable to you; the framing the whole ADR is built on turns out to be the wrong model. Probe each load-bearing claim independently — the one you skip is the one that was wrong.
+
+## When this does NOT apply
+
+- The decision is about **your own code** — read it; that's `groundtruth(softwaredev)`, not a new prototype.
+- The claim is **already verified** by an existing benchmark, a prior probe, or measured production data — cite it, don't re-spike.
+- The decision is **cheap to reverse** — if being wrong costs an afternoon, just build it. This discipline is for decisions that will be *built on*.
+
+## See Also
+
+- architecture/design(softwaredev) — the parent: deliberation before committing
+- adr(documentation) — the probe gates the Draft → Accepted transition; cite the evidence in the ADR
+- groundtruth(softwaredev) — the inverse: verify claims against *existing* executable code, not a new throwaway
+- research(softwaredev) — gathers from sources; this runs the real system when sources can't settle a behavioral/performance claim


### PR DESCRIPTION
Two base-way enhancements capturing principles this project hit first-hand this session (exploring, and ultimately *not* building, an external GitHub awareness feature).

## 1. NEW way — `architecture/design/prototype` (Prototype-Before-Accept)
When a design/ADR rests on **external-system behavior, performance, latency, or data-volume** assumptions, build a throwaway probe and let the evidence confirm or kill the decision **before** flipping it to `Accepted`. This session that discipline disproved ADR-137 twice and killed a whole sensor direction.

Overlap-checked (by a fresh-context reviewer) and kept **distinct**:
- not **groundtruth** (which verifies claims against *existing* code) — this builds a *new* throwaway to falsify a *forward* assumption about a system not in the repo;
- not **research** (which gathers from *sources*) — this *runs the real system* when even primary docs can't settle a behavioral/perf claim.

Child of `design`, with a `prototype.check.md` companion firing on the Draft→Accepted moment.

## 2. ENHANCE the ADR way (`adr.md` + `adr.check.md`) — Generalize the Decision
An ADR states the **durable principle, not the discovery path**. Strip the session-specific trip-report so a future reader can apply the decision to a different feature. (Your correction: "write a generalized ADR about boundedness — don't put the turducken inversion in it.") Added as a section in `adr.md` + one `adr.check.md` bullet — not a new way, since it's pure ADR-authoring guidance.

## Validation
`ways lint`: 0 errors, 0 warnings. Frontmatter matches the sibling `design.md`/`.check.md` format (description/vocabulary/scope/refire).

Note: a `ways` corpus rebuild picks up the new way for embedding-based disclosure.