### PR TITLE
feat(skills): gh-monitor skill (ci + inbox modes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,8 @@ hooks/ways/.obsidian/
 !scripts/hook-fire-detector.sh
 !scripts/signal-report.py
 !scripts/audit-permissions.sh
+!scripts/gh-monitor-ci-watch.sh
+!scripts/gh-monitor-inbox-watch.sh
 !docs/signal-analysis/
 !docs/signal-analysis/*.md
 !docs/signal-analysis/*.png

--- a/scripts/gh-monitor-ci-watch.sh
+++ b/scripts/gh-monitor-ci-watch.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# gh-monitor ci-watch — until-terminal CI watch for one PR's checks.
+#
+# Launched by the gh-monitor skill via the Monitor tool (persistent: false).
+# Each stdout line becomes a notification; the script exits when CI reaches a
+# terminal state, which ends the watch. That boundedness is the point — this
+# watches *this push's* CI and stops, it is not an ambient sensor (ADR-137).
+#
+# Shape: poll `gh pr checks` every INTERVAL seconds, announce each check the
+# first time it lands in a terminal bucket, and emit one final PASS/FAIL
+# aggregate before exiting once nothing is pending. On fast CI where the first
+# poll already finds everything terminal, that single poll emits and exits.
+#
+# Adapted from the retired attend sensor tools/attend/examples/gh-pr-checks.sh
+# (recover with: git show 78028f3~1:tools/attend/examples/gh-pr-checks.sh).
+# That version rolled the raw statusCheckRollup into one aggregate because an
+# ambient sensor wants aggregate-only; here we want per-check visibility, so we
+# read gh's own per-check buckets (pass|fail|pending|skipping|cancel) directly.
+#
+# Usage: ci-watch.sh [<pr-number> | <url> | <branch>]   (default: current branch)
+# Env:   GH_MONITOR_INTERVAL  poll seconds (default 30)
+#
+# Coverage note: emits on PASS *and* fail/cancel — a watch that only announced
+# success would be silent through a failure, and silence reads as "still
+# running." See the Monitor tool's "silence is not success" guidance.
+
+set -uo pipefail
+
+PR="${1:-}"
+INTERVAL="${GH_MONITOR_INTERVAL:-30}"
+
+command -v gh >/dev/null 2>&1 || { echo "gh-monitor ci: gh not installed"; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "gh-monitor ci: jq not installed"; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "gh-monitor ci: gh not authenticated (run: gh auth login)"; exit 1; }
+
+# Resolve the PR once: gives a stable identity for the notifications and lets
+# us distinguish "no PR to watch" (a clean exit) from a transient query failure.
+pr_num=$(gh pr view $PR --json number --jq .number 2>/dev/null || true)
+if [[ -z "$pr_num" ]]; then
+  echo "gh-monitor ci: no open PR found${PR:+ for '$PR'} — nothing to watch"
+  exit 0
+fi
+
+echo "gh-monitor ci: watching checks on PR #$pr_num (polling every ${INTERVAL}s)…"
+
+declare -A announced   # check name -> bucket already announced
+
+while true; do
+  # `|| true`: one failed poll (rate limit, blip) must not kill the watch.
+  json=$(gh pr checks "$pr_num" --json name,bucket 2>/dev/null || true)
+
+  if [[ -z "$json" || "$json" == "[]" ]]; then
+    # gh exits non-zero with empty stdout when a PR has no checks at all.
+    echo "gh-monitor ci: PR #$pr_num has no checks configured — done"
+    exit 0
+  fi
+
+  # Announce each check the first time it reaches a terminal bucket.
+  while IFS=$'\t' read -r name bucket; do
+    [[ -z "$name" || "$bucket" == "pending" ]] && continue
+    if [[ "${announced[$name]:-}" != "$bucket" ]]; then
+      case "$bucket" in
+        pass)     echo "✓ $name — passed" ;;
+        fail)     echo "✗ $name — FAILED" ;;
+        cancel)   echo "⊘ $name — cancelled" ;;
+        skipping) echo "↪ $name — skipped" ;;
+        *)        echo "• $name — $bucket" ;;
+      esac
+      announced[$name]="$bucket"
+    fi
+  done < <(jq -r '.[] | "\(.name)\t\(.bucket)"' <<<"$json")
+
+  # Terminal once nothing is pending. Emit one aggregate line, then exit.
+  if ! jq -e 'any(.[]; .bucket=="pending")' <<<"$json" >/dev/null 2>&1; then
+    fails=$(jq -r '[.[] | select(.bucket=="fail" or .bucket=="cancel") | .name] | join(", ")' <<<"$json")
+    if [[ -n "$fails" ]]; then
+      echo "gh-monitor ci: PR #$pr_num — CI FAILED ($fails)"
+    else
+      n=$(jq 'length' <<<"$json")
+      echo "gh-monitor ci: PR #$pr_num — CI PASSED ($n checks)"
+    fi
+    exit 0
+  fi
+
+  sleep "$INTERVAL"
+done

--- a/scripts/gh-monitor-inbox-watch.sh
+++ b/scripts/gh-monitor-inbox-watch.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# gh-monitor inbox-watch — persistent watch over your GitHub notifications.
+#
+# Launched by the gh-monitor skill via the Monitor tool (persistent: true).
+# Each new, relevant notification since the previous poll becomes one line —
+# one notification in the chat. Runs until you stop it with TaskStop.
+#
+# This is the session-scoped, opt-in home for notification awareness — the
+# thing that this project established is a Monitor concern, not an ambient
+# attend sensor (ADR-137). The reason->tier filter is lifted from the example
+# sensor tools/attend/examples/gh-notifications.sh; the magnitude floats are
+# dropped here because Monitor lines are plain text, not attend's mag|text.
+#
+# Env: GH_MONITOR_INTERVAL  poll seconds (default 60 — matches GitHub's
+#                           X-Poll-Interval header on the notifications API)
+#
+# Marker: a rolling wall-clock timestamp passed as `?since=`. We start at
+# "now" so launch doesn't dump the whole backlog, and we advance it only after
+# a *successful* poll — a failed request leaves the window intact so the next
+# poll catches what we missed.
+#
+# Upgrade path (verified supported, deferred for v1): the notifications API
+# honors `If-None-Match` against a stored ETag and returns 304 Not Modified
+# when nothing changed, making idle polls free against the rate-limit budget.
+# `gh api --include` exposes the ETag header. At a 60s interval the `since=`
+# approach here stays comfortably within rate limits, so this is pure
+# efficiency, not correctness.
+
+set -uo pipefail
+
+INTERVAL="${GH_MONITOR_INTERVAL:-60}"
+
+command -v gh >/dev/null 2>&1 || { echo "gh-monitor inbox: gh not installed"; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "gh-monitor inbox: jq not installed"; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "gh-monitor inbox: gh not authenticated (run: gh auth login)"; exit 1; }
+
+since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+echo "gh-monitor inbox: watching GitHub notifications since $since (polling every ${INTERVAL}s)…"
+
+while true; do
+  now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  # `|| true` so a transient failure can't kill the watch. On success gh
+  # returns a JSON array ([] when nothing is new); on failure it returns "".
+  resp=$(gh api "notifications?since=${since}&per_page=100" 2>/dev/null || true)
+  if [[ -z "$resp" ]]; then
+    # Transient failure / offline / rate-limited: keep the window, retry.
+    sleep "$INTERVAL"
+    continue
+  fi
+
+  # Success — advance the marker before emitting so a downstream jq error
+  # can't make us replay the same notifications next poll.
+  since="$now"
+
+  if [[ "$resp" != "[]" ]]; then
+    # Tier filter keyed on GitHub's `reason`: only surface reasons we have a
+    # tier for; `subscribed`, `ci_activity`, etc. fall through to nothing —
+    # CI watching is the `ci` mode's job, repo-watch chatter is noise.
+    (jq -r '
+      ["security_alert","review_requested","mention","team_mention",
+       "assign","invitation","author","push","state_change","comment","manual"] as $tiers
+      | .[]
+      | select(.unread == true)
+      | select(.reason as $r | $tiers | index($r))
+      | { reason,
+          kind:  (.subject.type // "Thread"),
+          repo:  (.repository.full_name // "?"),
+          title: ((.subject.title // "")
+                  | if length > 80 then .[0:77] + "..." else . end) }
+      | "[\(.reason)] \(.kind) in \(.repo): \(.title)"
+    ' <<<"$resp") || true
+  fi
+
+  sleep "$INTERVAL"
+done

--- a/skills/gh-monitor/SKILL.md
+++ b/skills/gh-monitor/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: gh-monitor
+description: Watch GitHub from a running session by launching a Monitor instead of polling by hand. `ci` watches the current PR's checks until they resolve; `inbox` watches your GitHub notifications while you work. Use when the user says "watch CI", "tell me when checks finish", "watch my PR", "watch my notifications/inbox", or invokes /gh-monitor.
+allowed-tools: Bash, Monitor, Read
+argument-hint: [ci | inbox]
+---
+
+# gh-monitor — watch GitHub without stopping to check
+
+The wrong way to learn that CI went red, or that someone requested your review,
+is to stop work every few minutes and run `gh pr checks` / `gh api notifications`
+by hand. This skill launches a **Monitor** that does the polling in the
+background and drops a notification into the chat only when something actually
+happens.
+
+**Why a Monitor and not an attend sensor.** External, session-specific watching
+(one PR's CI, *your* inbox) is not ambient local-world observation — it is
+bounded to the task in front of you, and it belongs in a Monitor the agent
+launches when the work is relevant, not in attend's uniform per-tick sensor loop
+(ADR-137; the GitHub sensors were retired for exactly this reason). Monitor
+natively does "poll endpoint → emit line → notify"; that is the whole job.
+
+## Pre-flight
+
+Both modes need an authenticated `gh`. Check once before launching:
+
+```bash
+gh auth status
+```
+
+If that fails, tell the user to run `gh auth login` and stop — Claude inherits
+the user's GitHub account, so there is nothing else to configure.
+
+## Mode `ci` — watch this PR's checks until they resolve
+
+**Lifecycle: until-terminal, NOT persistent.** It watches *this push's* CI and
+exits when every check has resolved. That bound is the point — there is nothing
+to leave running afterward.
+
+Launch with the **Monitor tool** (not Bash):
+
+- **command**: `bash ~/.claude/scripts/gh-monitor-ci-watch.sh` — append a PR
+  number/branch/URL only if watching something other than the current branch,
+  e.g. `bash ~/.claude/scripts/gh-monitor-ci-watch.sh 142`
+- **description**: `gh-monitor ci: <repo>#<pr>` (fill in the PR you're watching)
+- **persistent**: `false`
+- **timeout_ms**: `1800000` (30 min — a generous cap so a wedged/never-running
+  required check can't watch forever; raise it for known-slow pipelines)
+
+The script announces each check the first time it lands (`✓ name — passed`,
+`✗ name — FAILED`), then one aggregate line (`CI PASSED (N checks)` /
+`CI FAILED (names)`), then exits. If the branch has no open PR or the PR has no
+checks, it says so once and exits cleanly.
+
+## Mode `inbox` — watch your notifications while you work
+
+**Lifecycle: persistent** (session-length). Stop it with **TaskStop** when the
+work it was supporting is done.
+
+Launch with the **Monitor tool**:
+
+- **command**: `bash ~/.claude/scripts/gh-monitor-inbox-watch.sh`
+- **description**: `gh-monitor: GitHub notifications`
+- **persistent**: `true`
+- **timeout_ms**: `3600000` (ignored when persistent, but pass it anyway)
+
+It starts from "now" (no backlog dump) and emits one line per new, relevant
+notification — `[review_requested] PullRequest in org/repo: title`. It tiers on
+GitHub's `reason` and silently drops `subscribed` / `ci_activity` chatter (CI is
+the `ci` mode's job).
+
+## Correct-invocation rules (already baked into the scripts — preserve them)
+
+If you ever inline a variant instead of calling these scripts, keep these — they
+are the difference between a useful watch and a silent or runaway one:
+
+- **Use the Monitor tool, never Bash.** Bash blocks and discards the stream;
+  only Monitor delivers stdout lines as async notifications.
+- **Cover every terminal state, not just success.** A watch that greps only for
+  the happy path is silent through a failure, and silence reads as "still
+  running." `ci` emits on pass *and* fail/cancel.
+- **Flush every pipe stage** (`grep --line-buffered`, `awk 'fflush()'`); never
+  `| head` — it buffers until N matches accumulate, then ends the stream.
+- **Remote poll intervals ≥ 30s** (rate limits); honor `X-Poll-Interval` when a
+  feed advertises it (the inbox does: 60s).
+- **Guard transient failures** (`gh ... || true`) so one bad poll doesn't kill a
+  long watch; advance any `since=` marker only after a successful poll.
+
+## Stopping
+
+`ci` exits on its own. For `inbox`, stop with **TaskStop** on its Monitor task
+id.
+
+## Arguments
+
+- `/gh-monitor ci [pr]` — watch a PR's checks until terminal (default: current branch)
+- `/gh-monitor inbox` — watch your GitHub notifications until stopped


### PR DESCRIPTION
## What

A `gh-monitor` skill that launches a **Monitor** (not a Bash poll-by-hand, not an attend sensor) to watch GitHub from inside a session. v1 ships two modes:

- **`ci`** — until-terminal watch of a PR's checks. Polls `gh pr checks`, announces each check as it lands (`✓ name — passed` / `✗ name — FAILED`), emits one `CI PASSED/FAILED` aggregate, and **exits** when nothing is pending. That boundedness is the point.
- **`inbox`** — persistent watch over your GitHub notifications. `since=`-marker poll over `gh api notifications`, with a `reason`→tier filter that drops `subscribed`/`ci_activity` noise. Stop with TaskStop.

`SKILL.md` launches both via the Monitor tool and carries the correct-invocation rules (cover all terminal states, flush pipes, ≥30s remote intervals, advance markers only on success).

## Why this shape

This is the right-shaped home for the GitHub awareness that this project established is **not** an attend sensor: external, session-specific watching belongs in a Monitor the agent launches when the work is relevant, not attend's uniform per-tick sensor loop (**ADR-137 boundedness**; the `gh-pr-checks` sensor was retired in #146 for exactly this). Monitor natively does "poll → emit → notify" — wrapping a GitHub poller in an attend sensor inverted the stack.

`ci` adapts the rollup logic from the retired `gh-pr-checks.sh`; `inbox` reuses `gh-notifications.sh`'s reason→tier table.

## Validation (prototype-before-accept)

Tested against the **live** GitHub API, not just reasoned about:
- `ci` on merged PR #148 → emitted the 3-OS matrix checks + `CI PASSED (3 checks)` and exited 0; no-PR branch → clean "nothing to watch" + exit 0.
- `inbox` one-shot → filtered a 43-notification window down to 2 tiered unread; null title/type handled, 80-char truncation works.

## Scope / follow-ups (not in this PR)

- `comments` mode (watch one thread) deferred — lowest value per the spec.
- Whether to retire `tools/attend/examples/gh-notifications.sh` now that `inbox` covers it (same antipattern).
- A proactive nudge-way (on `git push` → "watch CI?").

Refs: `todo-monitoring-skill-clusters-continuance.md`