### PR TITLE
skills: add goal-author + consistency pass across the skill set

### DIFF
--- a/hooks/ways/meta/goals/goals.md
+++ b/hooks/ways/meta/goals/goals.md
@@ -1,0 +1,47 @@
+---
+description: When and why to set a /goal — running Claude in goal mode toward a completion condition, and the regime that creates
+vocabulary: goal goal-mode autonomous loop completion condition keep working until evaluator continue persist bounded objective set a goal ralph regime
+scope: agent, subagent
+refire: 0.15
+---
+<!-- epistemic: convention -->
+# Goals
+
+`/goal` is a Claude Code built-in: it sets a completion condition and keeps the
+session working turn-over-turn until a separate evaluator judges the condition
+met. It's the autonomy primitive — it removes per-turn approvals. This way is the
+*who/what/when/why*; the **goal-author** skill is the *how* (composing a
+well-bounded condition).
+
+## When to set a goal (vs. just act)
+
+Set a goal when the work is **multi-turn, has a checkable end-state, and you'd
+otherwise be re-prompting Claude to "keep going"** — a test suite to get green, a
+consistency pass across many files, a migration. Don't set one for a single-step
+task, or for open-ended exploration where the direction isn't settled yet — there,
+ordinary turns and signposts serve better.
+
+## What changes in goal mode
+
+- **Per-turn approvals are gone.** Claude continues on its own until the condition
+  holds; the `◎` indicator shows the regime is active. Setting a goal is consent
+  to that — the operator should know they've entered it.
+- **The evaluator judges surfaced text, not the world.** It can't run commands
+  itself, so a condition must be met by *shown evidence* (an exit code, a clean
+  status), not by assertion. Author for evidence, not claims.
+- **There is no model-side abort.** Only the operator (`/goal clear`), the met
+  condition, a timeout, or session end stops it. Claude can always *decline* an
+  action and surface a concern — the loop blocks stopping, it never forces an
+  action — but it can't end the loop itself. So the bounds live in the condition.
+
+## Author the condition deliberately
+
+Because the condition is the whole contract once per-turn approval is gone, frame
+it with care: one measurable end-state, the evidence that proves it, a turn/time
+bound, scope limits, and a door clause for any irreversible action (stop before
+it, surface). The **goal-author** skill walks this collaboratively.
+
+## See also
+
+- the **goal-author** skill — composing the condition (the how)
+- choices(meta) — surfacing curated decisions to the operator

--- a/hooks/ways/meta/governance/governance.md
+++ b/hooks/ways/meta/governance/governance.md
@@ -1,0 +1,48 @@
+---
+description: Grounding recommendations in real governance controls — when and how to cite the standards (NIST, OWASP, ISO, SOC 2, CIS, IEEE) behind a practice
+vocabulary: governance control citation justify justification standard compliance traceability provenance regulatory audit why do we do this NIST OWASP ISO SOC CIS IEEE
+scope: agent, subagent
+refire: 0.15
+---
+<!-- epistemic: convention -->
+# Governance Citation
+
+When you recommend a practice — a commit convention, a security default, a quality
+threshold, a documentation rule — there is often a real regulatory control behind
+it. Citing it grounds the recommendation in an actual standard instead of general
+knowledge. The control data lives in a traceability system; the **governance-cite**
+skill is the *how* (the lookup commands). This way is the *when, and how to phrase*.
+
+## When to cite
+
+- Recommending a practice that has a governing control (commits, security, quality, documentation).
+- Answering "why do we do it this way?"
+- Reviewing code and flagging an issue a control covers.
+- A user questions whether a practice matters.
+
+Don't force a citation into every response — use one when it adds authority or clarity.
+
+## How to phrase it
+
+Quote the *justification*, not just the standard — the justification is the evidence
+that maps a specific directive to a specific control requirement.
+
+**Inline** (brief):
+> We use conventional commit format — per NIST CM-3, this "creates structured change records with type classification" for auditable change control.
+
+**Detailed** (explanations / reviews):
+> This aligns with **NIST SP 800-53 CM-3 (Configuration Change Control)**: conventional commit types classify changes, atomic commits make each independently reviewable, and the message body captures rationale.
+
+**Code review** (flagging):
+> This SQL string concatenation violates **OWASP A03:Injection** — the security control requires parameterized queries as the default for all database access.
+
+## Principles
+
+- **Quote the justification, not the standard** — "parameterized queries required as default" beats "per NIST IA-5."
+- **Don't over-cite** — one relevant control with its justification beats listing every standard that tangentially applies.
+- **Cite from the data, not from memory** — run the lookup (the **governance-cite** skill) to get current controls; provenance may have changed since training.
+
+## See also
+
+- the **governance-cite** skill — the lookup commands (`ways governance control` / `trace`)
+- policy(itops) — operation classification and approval gating

--- a/skills/adr/SKILL.md
+++ b/skills/adr/SKILL.md
@@ -101,3 +101,9 @@ For a full repo scaffold (ADRs + GitHub config + CODEOWNERS + project ways), run
 - **Run `domains` first** when working in an unfamiliar project — domain names and ranges vary
 - **Status lives in frontmatter** — edit the YAML `status:` field, not inline text
 - **Regenerate index** after any ADR changes with `docs/scripts/adr index -y`
+
+## Not for
+
+- Authoring catalog documentation pages — that's the **docs** skill (the decisions half vs. the prose half of the same graph).
+- Hand-editing `ADR-*.md` files directly — always go through the CLI.
+- Designing the decision itself — capture a made decision; deliberation is the human's and `system-architect`'s job.

--- a/skills/attend/SKILL.md
+++ b/skills/attend/SKILL.md
@@ -118,3 +118,8 @@ Use TaskStop with the Monitor's task ID. Attend exits cleanly on signal.
 
 - `/attend` — start the sensor loop via Monitor (default)
 - `/attend status` — run `attend status` via Bash
+
+## Not for
+
+- One-off status snapshots — just run `attend status`, `git status`, or `gh` checks directly; this starts a *persistent* sensor loop.
+- External, task-specific watching (a PR's CI, your GitHub inbox) — that's the **gh-monitor** skill. Attend is ambient local-world awareness, not endpoint polling.

--- a/skills/context-status/SKILL.md
+++ b/skills/context-status/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: context-status
-description: Check how much context window remains in this session. Use when you want to know token budget, context usage, or how much room is left before compaction. Also use proactively when working on long tasks to gauge remaining capacity.
+description: Check how much context window remains in this session — token budget, usage, and room left before compaction. Use when the user asks how much context/room/budget is left, or wants a context-usage gauge.
 allowed-tools: Bash
 ---
 
@@ -22,6 +22,12 @@ echo '{"type":"hbar","data":{"Used (PCT%)":USED,"Free (RPCT%)":REMAINING},"title
 
 Replace `USED`, `REMAINING`, `TOTAL`, `PCT`, `RPCT`, and `MODEL` with actual values from the JSON output. Use `jq` to extract them.
 
-The command auto-detects the context window size from the model in the transcript (1M for Opus 4.6, 200k for others). Override with `CLAUDE_CONTEXT_WINDOW` env var.
+The command auto-detects the context window size from the model in the transcript (it varies by model). Override with `CLAUDE_CONTEXT_WINDOW` env var.
 
 If the remaining percentage is below 20%, mention that compaction is approaching and suggest wrapping up or prioritizing remaining work.
+
+## Not for
+
+- Changing the context window size or compaction threshold — that's `CLAUDE_CONTEXT_WINDOW` and the compaction settings, not this skill.
+- General session status — it reports the context window only.
+- A continuous watch — it's a one-shot snapshot; run it again for a fresh reading.

--- a/skills/direnv/SKILL.md
+++ b/skills/direnv/SKILL.md
@@ -71,7 +71,7 @@ export ANTHROPIC_FOUNDRY_API_KEY="..."
 
 ```bash
 # .envrc — append to any of the above
-export ANTHROPIC_MODEL="claude-opus-4-6"
+export ANTHROPIC_MODEL="claude-opus-4-8"   # pin a specific model snapshot; update as releases land
 export CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000
 export CLAUDE_CODE_EFFORT_LEVEL=high
 export CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE=99
@@ -124,18 +124,17 @@ export ANTHROPIC_API_KEY="sk-ant-..."
 
 No action needed — direnv automatically loads/unloads when you `cd`. Just set up each project's `.envrc` once.
 
-## Reference: Key Claude Code Env Vars
+## Reference: Claude Code env vars
 
-| Variable | Purpose |
-|----------|---------|
-| `ANTHROPIC_API_KEY` | Direct API authentication |
-| `ANTHROPIC_MODEL` | Model selection |
-| `CLAUDE_CODE_USE_BEDROCK` | Enable AWS Bedrock provider |
-| `CLAUDE_CODE_USE_VERTEX` | Enable Google Vertex provider |
-| `CLAUDE_CODE_USE_FOUNDRY` | Enable Azure Foundry provider |
-| `CLAUDE_CODE_EFFORT_LEVEL` | low / medium / high |
-| `CLAUDE_CODE_MAX_OUTPUT_TOKENS` | Max output tokens (up to 64000) |
-| `CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE` | Auto-compaction threshold (1-100) |
-| `CLAUDE_CODE_SUBAGENT_MODEL` | Model for subagents |
-| `CLAUDE_CODE_SHELL` | Override shell detection |
-| `CLAUDE_CONFIG_DIR` | Custom config directory |
+The full, current list of Claude Code environment variables — providers, model,
+effort, token limits, config dir — lives in the canonical settings reference.
+Don't reproduce it here; it drifts:
+
+> https://code.claude.com/docs/en/settings.md
+
+The examples above cover the common provider / model / flag cases.
+
+## Not for
+
+- Global, single-account setups — set the env vars normally; direnv earns its keep only when config differs *per project*.
+- Managing non-Claude-Code environment variables — that's plain `direnv` usage, not this skill.

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -103,6 +103,12 @@ scaffold, run `/project-init`. To decline the catalog for a project:
   move/rename freely, the `id` is what the graph keys on.
 - **Lint before commit** — `docs/scripts/doc lint` is the catalog's test.
 
+## Not for
+
+- Architecture Decision Records — that's the **adr** skill (the decisions half of the same catalog).
+- Hand-authoring `id`/`domain`/`mode` frontmatter — the CLI computes it.
+- Prose that isn't joining the catalog — untagged docs need no tool and are never linted.
+
 ## See also
 
 - the **diataxis** way — picking the mode (the 2×2)

--- a/skills/gh-monitor/SKILL.md
+++ b/skills/gh-monitor/SKILL.md
@@ -95,3 +95,9 @@ id.
 
 - `/gh-monitor ci [pr]` — watch a PR's checks until terminal (default: current branch)
 - `/gh-monitor inbox` — watch your GitHub notifications until stopped
+
+## Not for
+
+- A one-off check — just run `gh pr checks` once; the Monitor is for *not* stopping to poll.
+- Acting on what it sees — it only watches; respond to findings yourself.
+- Ambient local-world awareness (git, peers, processes) — that's the **attend** skill.

--- a/skills/goal-author/SKILL.md
+++ b/skills/goal-author/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: goal-author
+description: Help the operator and Claude jointly compose a well-structured `/goal` condition before it's set — clarifying the end-state, the evidence, and the bounds. Use when the user wants to set a goal, frame a goal, "give Claude a goal", run Claude in goal mode, or asks for help writing a goal condition. Not for clearing a goal (`/goal clear`), not for running multi-stage delivery, and it does not invoke `/goal` itself — it hands you a condition to set.
+allowed-tools: Bash, Read, Grep, Glob, AskUserQuestion
+---
+
+# Goal Author
+
+`/goal` is a Claude Code built-in: it sets a completion condition and keeps Claude
+working turn-over-turn until a separate evaluator judges the condition met. The
+mechanics live in the canonical reference — read it for the "how":
+
+> https://code.claude.com/docs/en/goal.md
+
+This skill is the judgment that doc can't make for you: **how to author a
+condition worth handing to that loop.** A vague goal sends an autonomous loop in a
+vague direction. A well-bounded one is the single highest-leverage moment the
+operator gets — once it's set, per-turn approvals are gone — so it's worth
+authoring deliberately, and authoring it *together*.
+
+## Why together
+
+The operator holds the intent and the bounds that matter; Claude holds the read of
+the actual work. Neither alone writes a good condition. The shape is **assess →
+align → draft**, with Claude doing the work of understanding *first* so the
+operator's choices are informed, not cold. The point isn't to extract a spec from
+the human — it's to converge on a shared one.
+
+## Procedure
+
+### 1. Assess (shallow)
+
+Read just enough to make the conversation concrete: the current state, what "done"
+would plausibly look like, and which irreversible actions this work *could* reach
+(push/merge, publish, deploy, destructive deletes). Don't deep-plan — the only job
+of this step is to earn an informed interview. A few `git` / `Read` / `Grep`
+calls, not a survey.
+
+### 2. Align (interview)
+
+Propose a draft condition, then reach agreement with the operator on:
+
+- **The end-state** — one measurable thing, not a vibe.
+- **The evidence** — what *shown output* proves it (the evaluator judges what
+  Claude surfaces in the conversation, not the world — see Key rules).
+- **The bounds** — a turn or time cap, and the scope (which files/areas are in play).
+- **The doors** — for each irreversible action the work could reach, rule it *in*
+  or *out*. Default: out. The goal stops before it and surfaces.
+
+Use `AskUserQuestion` with curated options and a recommendation. The menu is itself
+how Claude demonstrates it understood the work — a signpost, not a quiz.
+
+### 3. Draft (the condition)
+
+Emit a single paste-ready condition string. The operator sets it. **This skill
+does not run `/goal`** — composing and setting are deliberately separate steps so
+the human reads the condition before entering the regime.
+
+## What a good condition contains
+
+- **One measurable end-state**, phrased so it's met by *shown evidence* — an exit
+  code, a clean `git status`, a passing check — not by assertion.
+- **A turn/time bound** — `…or stop after N turns` — so a stuck loop ends.
+- **Scope constraints** that matter — `…without modifying files outside src/auth`.
+- **A door clause** for any irreversible action ruled out, phrased so the evaluator
+  can recognize the halt-state from the conversation — e.g. `…stop before any push
+  or merge and surface for approval`.
+
+Example:
+
+```
+the auth/ unit tests pass (npm test output shown, exit 0) and lint is clean,
+without touching files outside src/auth, or stop after 15 turns;
+stop before any push or merge and surface for my approval.
+```
+
+## Key rules
+
+- **The evaluator reads surfaced text, not the world.** It can't run commands or
+  read files itself, so the condition must be satisfiable by what Claude *shows*.
+  This is why evidence beats assertion: "tests pass" clears on the claim; "npm test
+  exits 0, output shown" clears on the proof — and that's the antidote to a loop
+  optimizing for convincing prose over real results.
+- **There is no model-side abort.** Once set, Claude cannot clear its own goal —
+  only the operator (`/goal clear`), the met condition, an evaluator timeout, or
+  session end can. A door clause is the only Claude-adjacent early exit, and it's
+  soft (the evaluator judges it from surfaced text). Claude can always *decline* a
+  destructive action and surface — the loop blocks stopping, it never forces an
+  action — but it can't end the loop itself. Author the bounds accordingly.
+- **Setting a goal is a regime change.** It removes per-turn approvals; the `◎`
+  indicator shows it's active. Make sure the operator knows they're entering it —
+  that legibility is what makes the hand-off fair.
+- **One goal per session.** Setting a new one replaces the active goal.
+
+## Not for
+
+- Clearing or inspecting a goal — that's `/goal clear` and bare `/goal`.
+- Running the work — this only authors the condition.
+- Multi-stage delivery orchestration — that's a workflow, not a goal.
+
+## See also
+
+- the canonical `/goal` reference — https://code.claude.com/docs/en/goal.md
+- the **skills** way (`meta/.../skills`) — skill-vs-way conventions in this repo

--- a/skills/governance-cite/SKILL.md
+++ b/skills/governance-cite/SKILL.md
@@ -1,87 +1,43 @@
 ---
 name: governance-cite
-description: Cite governance controls and justifications when making recommendations about code quality, security, commits, or documentation. Use when justifying why a practice matters, when a user asks "why do we do this?", when reviewing code against standards, or when recommending practices that align with NIST, OWASP, ISO, SOC 2, CIS, or IEEE controls.
+description: Look up governance controls and their justifications via the governance CLI, to ground a recommendation in a real standard (NIST, OWASP, ISO, SOC 2, CIS, IEEE). Use when you need the control IDs and justification text behind a practice. Not for deciding whether to cite or how to phrase it — that's the governance citation way.
 allowed-tools: Bash, Read, Grep, Glob
 ---
 
-# Governance Citation
+# Governance Citation Lookup
 
-You have access to a governance traceability system that maps agent guidance (ways) to real regulatory controls with specific justification evidence. Use this to ground your recommendations in actual standards rather than general knowledge.
+A governance traceability system maps agent guidance (ways) to real regulatory
+controls with specific justification evidence. This skill is the **lookup** — run
+it to fetch the control IDs and justification text behind a practice. For *when*
+to cite and *how* to phrase it, see the **governance citation** way.
 
-## When to Cite
-
-Cite governance controls when:
-- Recommending a practice that has a governing control (commits, security, quality, documentation)
-- Answering "why do we do it this way?"
-- Reviewing code and flagging issues covered by a control
-- A user questions whether a practice matters
-
-Don't force citations into every response. Use them when they add authority or clarity.
-
-## How to Look Up Controls
+## Look up controls
 
 ### By topic
 
 ```bash
-ways governance control PATTERN
+ways governance control PATTERN          # e.g. NIST, OWASP, ISO, SOC, CIS, change
 ```
-
-Examples:
-- `control NIST` — all NIST controls
-- `control OWASP` — injection prevention
-- `control ISO` — all ISO standards
-- `control SOC` — SOC 2 controls
-- `control CIS` — CIS controls
-- `control change` — change management controls
 
 ### By way (full trace)
 
 ```bash
 ways governance trace softwaredev/commits
 ways governance trace softwaredev/security
-ways governance trace softwaredev/quality
-ways governance trace meta/knowledge
 ```
 
-### Machine-readable (for structured extraction)
+### Machine-readable
 
 ```bash
 ways governance control PATTERN --json
 ways governance trace WAY --json
+ways governance matrix --json            # the complete traceability matrix
 ```
 
-## Citation Format
+Read the governed ways and controls **from the data** — run `ways governance
+matrix` for the current set. Never cite from memory; provenance changes.
 
-When citing a control, reference the control ID and quote the specific justification:
+## Not for
 
-**Inline** (for brief references):
-> We use conventional commit format — per NIST CM-3, this "creates structured change records with type classification" for auditable configuration change control.
-
-**Detailed** (for explanations or reviews):
-> This aligns with **NIST SP 800-53 CM-3 (Configuration Change Control)**, which our commit guidance implements through:
-> - Conventional commit types (feat/fix/refactor) classify changes by nature
-> - Atomic single-concern commits make each change independently reviewable
-> - Commit message body captures rationale, satisfying change documentation requirements
-
-**Code review** (for flagging issues):
-> This SQL string concatenation violates **OWASP A03:Injection** — our security way requires parameterized queries as default for all database access. The detection table maps this exact pattern to the remediation: "Replace with parameterized queries."
-
-## What Controls Are Available
-
-The system currently tracks 13 controls across 4 governed ways:
-
-| Way | Standards |
-|-----|-----------|
-| **softwaredev/commits** | NIST CM-3, SOC 2 CC8.1, ISO 27001 A.8.32 |
-| **softwaredev/security** | OWASP A03, NIST IA-5, CIS v8 16.12, SOC 2 CC6.1 |
-| **softwaredev/quality** | ISO 25010, NIST SA-15, IEEE 730 |
-| **meta/knowledge** | ISO 9001 7.5, ISO 27001 5.2, NIST PL-2 |
-
-Run `ways governance matrix --json` for the complete traceability matrix.
-
-## Principles
-
-- **Quote the justification, not the standard.** "Parameterized queries required as default" is more useful than "per NIST IA-5."
-- **The justification is the evidence.** Each one maps a specific way directive to a specific control requirement. That's the chain.
-- **Don't over-cite.** One relevant control with its justification is better than listing every standard that tangentially applies.
-- **Cite from the data, not from memory.** Always run the governance operator to get current controls. The provenance metadata may have changed since your training data.
+- Deciding *whether* to cite, or *how* to phrase a citation — that's the **governance citation** way.
+- The full coverage/provenance report — that's the **governance** skill (`ways governance report`).

--- a/skills/project-pulse/SKILL.md
+++ b/skills/project-pulse/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Review what changed in Claude Code upstream and compare against this
   project's commits and ADRs. Surfaces opportunities, gaps, and ADR
   status drift. Discovery conversation, not compliance dashboard.
-user-invocable: true
+allowed-tools: Bash, Read
 ---
 
 # Project Pulse
@@ -102,3 +102,8 @@ When upstream changes suggest new work, propose ADR topics with the upstream ref
 ## Tone
 
 You're a colleague who follows the releases. Casual, suggestive, not prescriptive. The human decides what to act on.
+
+## Not for
+
+- Coverage scoring or "you're N releases behind" reporting — it's a discovery conversation, not a compliance dashboard.
+- Applying the changes — it surfaces what's worth discussing; you decide and act (an ADR, an issue, a `/ship`).

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -160,3 +160,9 @@ If no Makefile targets exist but the changes warrant a release (new feature, bre
 - **One commit is fine** for most changes; only split if there are genuinely separate concerns
 - **Repo flavor drives review**, not just change size — a one-line fix in a team repo still pauses
 - **Merge ≠ ship** for projects with artifacts — check for `make release` after merge
+
+## Not for
+
+- Writing the code being shipped — this delivers finished work, it doesn't author it.
+- Releasing/tagging/publishing artifacts — that's the release way / `make release`.
+- Merging on a team repo without the review gate — the gate is mandatory there.

--- a/skills/think/SKILL.md
+++ b/skills/think/SKILL.md
@@ -68,3 +68,7 @@ again for new problems:
 ```bash
 rm -f /tmp/.claude-think-session /tmp/.claude-way-meta-think-*"${CLAUDE_SESSION_ID:+-$CLAUDE_SESSION_ID}" 2>/dev/null
 ```
+
+## Not for
+
+- Routine work that doesn't need structured reasoning — the strategies add deliberation overhead. Reach for them on genuinely hard problems (branching approaches, competing objectives, high-stakes calls, being stuck), not every task.

--- a/skills/ways-tests/SKILL.md
+++ b/skills/ways-tests/SKILL.md
@@ -32,6 +32,12 @@ Test how well a way matches sample prompts, analyze vocabulary for gaps, and val
 /ways-tests embed-score-all "prompt"     # Cosine similarity ranking across all ways
 ```
 
+## Not for
+
+- Authoring or editing ways themselves — that's the **ways** skill (`/ways`).
+- Updating the agent-ways install — that's **ways-update**.
+- This skill only *measures and validates*: scoring, vocabulary analysis, frontmatter and tree lint.
+
 ## Engine
 
 The matching pipeline uses embedding-based semantic scoring as the sole retrieval tier. The embedding model is a hard dependency of `ways`.
@@ -213,21 +219,21 @@ Present as:
 === "add a make target for linting" ===
 
 Target: softwaredev/environment/makefile
-  Score: 5.2716  Threshold: 1.5  Result: MATCH
+  Score: 0.6213  Threshold: 0.35  Result: MATCH
 
 Cross-way ranking:
   Score   Thr    Match  Way
   ------  -----  -----  ---
-  5.2716  1.5    YES    softwaredev/environment/makefile  ← target
-  1.9580  2.0    no     documentation/standards
-  0.0000  2.0    no     softwaredev/environment/deps
+  0.6213  0.35   YES    softwaredev/environment/makefile  ← target
+  0.2904  0.35   no     documentation/standards
+  0.1102  0.35   no     softwaredev/environment/deps
   ...
 
 Assessment: Clean win. No competing ways above threshold.
 ```
 
 Flag these patterns:
-- **Overlap**: Two ways both match with scores within 20% of each other → potential conflict
+- **Overlap**: Two ways both match with scores within 0.05 cosine of each other → potential conflict
 - **False dominance**: Another way scores higher than the target → the target may need vocabulary tuning
 - **Healthy co-fire**: Both match but serve complementary purposes → note as expected
 
@@ -369,18 +375,18 @@ Structure:
   Total ways: 8 ways + 1 check = 9 files
 
 Threshold Progression:
-  Level 0  supplychain.md  threshold=1.8  ✓
-  Level 1  repoaudit       threshold=2.0  ✓
-  Level 1  sourceaudit     threshold=2.0  ✓
-  Level 1  depscan         threshold=1.8  ⚠ same as parent
-  Level 1  automation      threshold=2.0  ✓
-  Level 1  historysever    threshold=2.0  ✓
-  Level 2  depscan/python  threshold=2.5  ✓
-  Level 2  depscan/node    threshold=2.5  ✓
-  Level 2  depscan/go      threshold=2.5  ✓
-  Level 2  depscan/rust    threshold=2.5  ✓
+  Level 0  supplychain.md  threshold=0.35  ✓
+  Level 1  repoaudit       threshold=0.42  ✓
+  Level 1  sourceaudit     threshold=0.42  ✓
+  Level 1  depscan         threshold=0.35  ⚠ same as parent
+  Level 1  automation      threshold=0.42  ✓
+  Level 1  historysever    threshold=0.42  ✓
+  Level 2  depscan/python  threshold=0.50  ✓
+  Level 2  depscan/node    threshold=0.50  ✓
+  Level 2  depscan/go      threshold=0.50  ✓
+  Level 2  depscan/rust    threshold=0.50  ✓
 
-Assessment: Thresholds increase with depth (1.8→2.0→2.5). Good.
+Assessment: Thresholds increase with depth (0.35→0.42→0.50). Good.
 ```
 
 ### What to Flag
@@ -530,16 +536,16 @@ Detect vocabulary overlap and semantic crowding across the entire ways corpus. T
 === Vocabulary Crowding Analysis ===
 Prompt: "check the npm dependencies for vulnerabilities"
 
-Score Clusters (ways within 20% of each other):
-  Cluster 1: 4.23-5.01
-    supplychain         4.87  threshold=1.8  MATCH
-    supplychain/depscan 5.01  threshold=1.8  MATCH
-    deps                4.23  threshold=2.0  MATCH
+Score Clusters (ways within 0.05 cosine of each other):
+  Cluster 1: 0.58-0.62
+    supplychain         0.60  threshold=0.35  MATCH
+    supplychain/depscan 0.62  threshold=0.35  MATCH
+    deps                0.58  threshold=0.42  MATCH
   → Assessment: Expected co-fire (supplychain tree + deps are complementary)
 
-  Cluster 2: 1.80-2.10
-    security            2.10  threshold=2.0  MATCH
-    supplychain/node    1.80  threshold=2.5  no
+  Cluster 2: 0.40-0.44
+    security            0.44  threshold=0.42  MATCH
+    supplychain/node    0.40  threshold=0.50  no
   → Assessment: Security fires marginally. Node misses (good — prompt is generic npm, not node-specific)
 
 Vocabulary Overlap (Jaccard > 0.15):
@@ -581,8 +587,8 @@ Side-by-side comparison of two way trees. Useful for evaluating whether a refact
                     supplychain     testing
 Depth               3               2
 Total ways          9               3
-Threshold range     1.8 - 2.5      1.8 - 2.5
-Avg threshold       2.08            2.07
+Threshold range     0.35 - 0.50    0.35 - 0.50
+Avg threshold       0.42            0.41
 Worst-case tokens   ~3840           ~1100
 Avg path tokens     ~940            ~680
 Max sibling Jaccard 0.08            0.05
@@ -630,8 +636,8 @@ Tree Coverage:
     Coverage: 3/6 (50%)
 
 Parent-Activated Threshold Lowering:
-  injection scored 1.8 (below normal threshold 2.0)
-    → Parent "security" was active → effective threshold 1.6 → MATCH
+  injection scored 0.40 (below normal threshold 0.42)
+    → Parent "security" was active → effective threshold 0.34 → MATCH
     Without parent: would have been a miss
 
 Epoch Distance Distribution:

--- a/skills/wormhole/SKILL.md
+++ b/skills/wormhole/SKILL.md
@@ -144,3 +144,9 @@ wormhole receive --accept-file --hide-progress -o <target-dir> <code>
 - **Show before acting** (interactive) — display file sizes, paths, and commands before executing
 - **Surface the code prominently** — the wormhole code is the whole point of the send flow
 - **Always use `--accept-file` and `--hide-progress`** — the non-TTY environment can't handle interactive prompts or progress bars
+
+## Not for
+
+- Recurring transfers where SSH is already set up — use `scp`/`rsync`.
+- Same-machine or shared-filesystem/LAN copies — use `cp`/`rsync`.
+- Cloud storage transfers — use the provider CLI (`aws s3`, `gsutil`, …). Wormhole is for ad-hoc peer-to-peer transfers with no prior setup.


### PR DESCRIPTION
## Summary
Audit-driven cleanup of `~/.claude/skills/` (two parallel audits: jagged-skill consistency + way↔skill pairing gaps), plus the new `goal-author` skill and its grounding way.

**New**
- `goal-author` skill — collaboratively compose a well-bounded `/goal` condition (assess → align → draft); evidence-not-assertion, bounds, door clause.
- `meta/goals` way — the *who/what/when/why* of goal mode that grounds `goal-author` (ADR-138 symmetry: skill = how, way = 5W).
- `meta/governance` way — the behavior-shaping half of governance citation (when to cite, how to phrase).

**Consistency pass (12 skills)**
- Added a **"Not for" lane clause** to every skill that lacked one (was only 2/14).
- De-versioned stale model ids (`context-status`, `direnv`).
- `project-pulse`: added `allowed-tools`, dropped non-standard `user-invocable` field.
- `ways-tests`: resolved the **two-engine contradiction** — every example now uses the cosine 0–1 / `embed_threshold` scale, matching the Engine + Principles sections.
- `governance-cite`: moved behavior-shaping guidance to the new `meta/governance` way; reduced the skill to the lookup procedure; dropped the hardcoded "13 controls / 4 ways" count.

## Test plan
- [x] `ways lint hooks/ways` clean — 121 ways, 0 errors, 0 warnings
- [x] every `skills/*/SKILL.md` contains a "Not for" lane clause
- [x] `grep -rni "opus-4-6|opus 4.6" skills/` returns nothing
- [x] no residual old-scale thresholds in `ways-tests`
- [x] corpus rebuilds (new ways embedded)

🤖 Authored under `/goal` (goal mode), stopped at PR per the door clause for review.