### PR TITLE
fix(attend): calmer, earlier-anchored compaction surfacing

### DIFF
--- a/hooks/ways/meta/compaction-checkpoint/compaction-checkpoint.md
+++ b/hooks/ways/meta/compaction-checkpoint/compaction-checkpoint.md
@@ -1,6 +1,6 @@
 ---
 trigger: context-threshold
-threshold: 95
+threshold: 85
 scope: agent
 refire: 0.15
 ---

--- a/tools/sensor-context/src/lib.rs
+++ b/tools/sensor-context/src/lib.rs
@@ -138,15 +138,14 @@ impl Sensor for ContextSensor {
         let mut observations = Vec::new();
 
         // Attend handles trajectory awareness. Ways handles threshold
-        // actions (todos@75%, memory@80%, checkpoint@95%).
+        // actions (todos@75%, memory@80%, checkpoint@85%).
         // Attend's thresholds are early warnings *before* ways fires,
         // plus velocity context that ways can't provide.
         let thresholds: &[(u8, f64, &str)] = &[
-            (40, 1.5, "approaching midpoint — plan wrap-up scope"),
-            (50, 2.0, "midpoint — wrap-up window opening"),
-            (65, 3.0, "ways will fire todos checkpoint at 75%"),
-            (85, 4.0, "ways fired memory save at 80% — verify it happened"),
-            (92, 5.0, "compaction checkpoint at 95% — finish current task"),
+            (50, 1.5, "halfway through the context window — if the work's on track, keep going; if you've barely started, this is a calm moment to scope the next stages"),
+            (65, 3.0, "ways will capture todos (75%) and memory (80%) shortly"),
+            (83, 4.0, "compaction checkpoint fires at 85% — finish the current task and sync"),
+            (90, 5.0, "stop or compact right now — quality degrades past here, and auto-compact is off"),
         ];
 
         for &(pct, magnitude, label) in thresholds {
@@ -161,8 +160,8 @@ impl Sensor for ContextSensor {
                 if let Some(vel) = self.velocity() {
                     if vel > 0.1 {
                         msg.push_str(&format!(" (burning {:.1}%/min", vel));
-                        if pct < 95 {
-                            if let Some(mins) = self.project_minutes_to(95.0, current.pct_used) {
+                        if pct < 90 {
+                            if let Some(mins) = self.project_minutes_to(90.0, current.pct_used) {
                                 if mins < 60.0 {
                                     msg.push_str(&format!(", ~{:.0} min to critical", mins));
                                 }


### PR DESCRIPTION
## Summary
Recalibrates how compaction pressure is surfaced so it stops alarming too early and stops acting too late, per observed 1M-window behavior (quality drops ~800k).

- **`sensor-context`** (attend's interoceptive sensor):
  - First heads-up is now a **calm midpoint check at 50%** — "halfway through; if on track, carry on; if you've barely started, scope the next stages." (Was a premature 40% "plan wrap-up" + 50% "wrap-up window opening" — the source of getting concerned far too early.)
  - **83%** — checkpoint imminent, finish the current task.
  - **90%** — hard last-call: "stop or compact right now" (auto-compact is off, so no naive safety net).
  - Time-to-critical now projects against 90% (the last-call), not the old 95%.
- **`compaction-checkpoint` way** — fires at **85%** (was 95%) so directed compaction completes **before** the ~800k quality cliff on a 1M window, not after.
- `todos`/`memory` captures (75/80%) unchanged.

## Notes
- `attend` rebuilt (`sensor-context` compiles into it).
- The **90% last-call lives in the attend sensor** (surfaces when attend is running). The **85% checkpoint is always-on** via the context-threshold hook. If you want the 90% last-call always-on regardless of attend, that'd be a second context-threshold way — say the word.

## Test plan
- [x] `ways lint` clean on the edited way
- [x] `make attend-rebuild` succeeds; new threshold strings present in the binary source
- [x] only source files changed (binary is a build artifact)