### PR TITLE
feat(skills): add briefing skill; slim the briefing way to its 5W

### DIFF
--- a/hooks/ways/ea/briefing/briefing.md
+++ b/hooks/ways/ea/briefing/briefing.md
@@ -7,52 +7,34 @@ refire: 0.15
 <!-- epistemic: convention -->
 # Catch-Me-Up Briefing
 
-Unified morning briefing using parallel data gathering for speed. This is the most comprehensive EA workflow — it combines email triage, calendar review, task status, and chat scanning into a single synthesized brief.
+A unified briefing across inboxes, calendar, tasks, and chat — the most
+comprehensive EA workflow. The runnable procedure (parallel scouts, the priority
+structure, suggested task mutations) lives in the **briefing** skill. This way is
+*when* to reach for it, and when a lighter query serves better.
 
-## When to Use Agent Teams
+## When to brief
 
-For multi-account, multi-service briefings, spawn parallel agents to work simultaneously. Each agent handles a domain and shares cross-reference-worthy findings with others in real-time.
+Reach for a full briefing at the start of the day, after time away, or whenever the
+user asks "catch me up / what did I miss" across accounts. The point is synthesis
+across sources — not a dump of each inbox, but the cross-referenced picture of what
+deserves attention now.
 
-**Use a team when:** workflow spans multiple accounts AND services AND benefits from cross-referencing.
+## When to use a team (vs. a single query)
 
-**Skip teams for:** single-account lookups, interactive workflows (drafting, scheduling), quick queries.
+The briefing skill can gather with parallel scout subagents or directly. Use the
+**team** when the briefing spans multiple accounts AND services AND benefits from
+cross-referencing — the parallelism hides slow I/O and keeps raw fetches out of the
+lead's context. **Skip the team** for a single account or service, an interactive
+task (drafting, scheduling), or a quick lookup — there the orchestration overhead
+costs more than it saves.
 
-## Standard Roles
+## Surface, don't act
 
-| Role | Domain | Responsibility |
-|------|--------|----------------|
-| **inbox-scout** | Email (all accounts) | Fetch, classify, filter; share people/topics with ops-scout |
-| **ops-scout** | Calendar + Tasks | Schedule, task status, cross-reference against inbox findings |
-| **Lead (you)** | Synthesis | Combine reports, present to user, suggest actions |
+A briefing ends in *suggestions* — a ranked action list and proposed task mutations
+the user approves, modifies, or dismisses. It never sends, schedules, or mutates on
+its own. Acting is a separate, approved step.
 
-For workflows involving additional platforms (chat, file storage, meeting recaps), add specialist scouts. Keep total to 3-5.
+## See also
 
-## Communication Rules
-
-- Scouts proactively share cross-reference-worthy findings as they work — don't wait until done.
-- Each scout sends a structured final report to the lead.
-- Lead does NOT start synthesis until all scouts have reported.
-
-## Briefing Structure
-
-Present the synthesized briefing in priority order:
-
-1. **Overdue** — Tasks past due, ranked by priority. Broken commitments come first.
-2. **Today's Schedule** — Calendar events with related task count and email context per meeting.
-3. **Due Today** — Tasks due today not yet complete.
-4. **Action Required** — Emails awaiting response, ranked by urgency. Note task/calendar cross-refs.
-5. **Already Addressed** — Messages already responded to. Flag any that resolve open tasks.
-6. **Open Tasks in Play** — Pending tasks with connections to today's emails and calendar.
-7. **Eisenhower Snapshot** — One-line summary (X do-first, Y to schedule, Z in inbox).
-8. **Cross-References** — Key connections found between emails, tasks, and calendar.
-9. **Suggested Actions** — Prioritized list of what to tackle first, considering calendar constraints.
-
-## After the Briefing
-
-Surface suggested task mutations based on cross-reference findings:
-- **Create:** New obligations from emails not yet tracked
-- **Complete:** Tasks that sent emails appear to resolve
-- **Update:** Tasks whose priority or due date changed
-- **Stale?** Tasks not referenced in recent communications
-
-Present as a numbered list the user can approve, modify, or dismiss.
+- the **briefing** skill — the runnable procedure
+- ea / email / calendar / tasks / comms(ea) — per-domain judgment

--- a/skills/briefing/SKILL.md
+++ b/skills/briefing/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: briefing
+description: Produce a "catch me up" briefing — a synthesized start-of-day / overnight summary across email, calendar, tasks, and chat, ending in suggested next actions. Use when the user says "catch me up", "what did I miss", "morning briefing", "what's my day", "start of day". Not for acting on findings (sending, scheduling, creating tasks) — it surfaces and suggests; you approve. Not for single-source lookups or deep person/meeting prep.
+---
+
+# Catch-Me-Up Briefing
+
+Synthesize one prioritized brief across the user's inboxes, calendar, tasks, and
+chat. The job is **surface and suggest** — present what needs attention and a
+ranked list of suggested actions; the user decides. Never send, schedule, or
+mutate anything without approval.
+
+This skill is the runnable procedure; the **briefing** way carries *when* to reach
+for it and when a single-source query is enough instead.
+
+## Tool-agnostic by design
+
+Map the scout *domains* below to whatever accounts and services are actually
+connected this session — email, calendar, task, and chat tools vary per setup, so
+discover them rather than assuming a provider. If a domain has no connected tool,
+**say so in the brief** rather than skipping it silently.
+
+This skill deliberately sets **no `allowed-tools`**: it must reach whatever EA
+tools are connected and spawn scout subagents, which can't be enumerated ahead of
+time. Its tight description is what keeps it in its lane.
+
+## Gather in parallel
+
+For a multi-account, multi-service briefing, spawn parallel scout subagents so the
+slow I/O overlaps — and so each scout's raw fetch stays out of the lead's context:
+
+| Scout | Domain | Shares with |
+|---|---|---|
+| inbox-scout | email (all accounts) — fetch, classify, filter | people/topics → ops-scout |
+| ops-scout | calendar + tasks — schedule, status, cross-ref vs. inbox | the lead |
+| + specialists | chat, meeting recaps, files — as connected | the lead |
+
+Keep it to 3–5 scouts. Scouts share cross-reference-worthy findings as they go;
+each returns one structured report; the lead waits for **all** reports before
+synthesizing. **Skip the team** for a single account/service or a quick query —
+just gather directly (that judgment lives in the **briefing** way).
+
+## Synthesize (priority order)
+
+1. **Overdue** — past-due tasks, priority-ranked; broken commitments first.
+2. **Today's schedule** — events, each with related task count + email context.
+3. **Due today** — tasks due today, not yet complete.
+4. **Action required** — emails awaiting reply, urgency-ranked; note cross-refs.
+5. **Already addressed** — replied items; flag any that resolve open tasks.
+6. **Open tasks in play** — pending tasks linked to today's mail/calendar.
+7. **Eisenhower snapshot** — one line (X do-first, Y to schedule, Z in inbox).
+8. **Cross-references** — key connections found across mail, tasks, calendar.
+9. **Suggested actions** — what to tackle first, given calendar constraints.
+
+## Then: suggested task mutations
+
+From the cross-references, surface a numbered list the user can **approve, modify,
+or dismiss** — never applied automatically:
+
+- **Create** — obligations from email not yet tracked.
+- **Complete** — tasks the sent mail appears to resolve.
+- **Update** — tasks whose priority/due date shifted.
+- **Stale?** — tasks not referenced in recent comms.
+
+## Not for
+
+- Acting on findings — sending replies, scheduling, creating/closing tasks. It
+  surfaces and suggests; the user approves each.
+- Single-source lookups — just query that inbox/calendar directly.
+- Deep person/topic/meeting preparation — that's the **intelligence** way's
+  cross-referencing research, a separate workflow.
+
+## See also
+
+- the **briefing** way — when to brief vs. when a single query suffices
+- the **ea** / **email** / **calendar** / **tasks** / **comms** ways — per-domain judgment


### PR DESCRIPTION
## Summary
Second way→skill extraction from the audit: the EA cluster (~12 ways, 0 skills). The `briefing` way was already procedure-heavy, so this is a **how-extraction** (same shape as governance-cite, per ADR-138).

- **New `briefing` skill** — the runnable "catch me up": parallel scout subagents (inbox/ops/+specialists) → 9-section priority synthesis → suggested task mutations (approve/modify/dismiss).
- **Slimmed the `briefing` way** to its 5W: when to brief, when to use a team vs. a single query, surface-not-act. (description/vocabulary unchanged → no corpus rebuild needed.)

## Design calls (flagging for your review, per the cadence)
- **Tool-agnostic** — maps scout *domains* to whatever EA/MCP tools are connected; reports uncovered domains rather than skipping silently.
- **No `allowed-tools`** — deliberate, and noted in the skill: it orchestrates discovered MCP tools and spawns scouts, which can't be enumerated up front. (Distinct from the project-pulse "missing allowed-tools" smell, which was a simple bash skill that should've scoped.)
- **Surface, don't act** — never sends/schedules/mutates without approval.
- **Daily catch-up only** — left weekly review / meeting prep / person deep-context to the `intelligence` way (a separate future skill).

## Test plan
- [x] skill frontmatter parses; name matches dir; "Not for" lane present
- [x] `ways lint` clean on the slimmed way
- [ ] (deferred) live run against connected EA accounts