### PR TITLE
fix(ways): context-threshold trigger reads tokens, not transcript bytes

### DIFF
--- a/tools/ways-cli/src/cmd/context.rs
+++ b/tools/ways-cli/src/cmd/context.rs
@@ -37,6 +37,25 @@ pub fn get_context_for_session(session_id: &str) -> Result<ContextInfo> {
     get_context_inner(None, Some(session_id))
 }
 
+/// Accurate context-fill percentage (0–100) from a transcript file path.
+///
+/// Single source of truth shared with the `context-threshold` trigger in
+/// `scan/state.rs`: both read the same gauge — real API token counts
+/// (`read_token_usage`) divided by the model window (`model_to_window`) —
+/// never a transcript-byte heuristic. The transcript *file* is far larger
+/// than the live context (it holds full tool output, persisted-output blobs
+/// that aren't in context, and JSON envelope overhead), so byte-size badly
+/// over-counts and fires thresholds early.
+pub fn pct_used_from_transcript(transcript: &str) -> Option<u64> {
+    let content = std::fs::read_to_string(transcript).ok()?;
+    let window = model_to_window(&detect_model(&content));
+    if window == 0 {
+        return None;
+    }
+    let (tokens_used, _method) = read_token_usage(&content);
+    Some(tokens_used * 100 / window)
+}
+
 fn get_context_inner(project_dir: Option<&str>, session_id: Option<&str>) -> Result<ContextInfo> {
     let transcript = if let Some(sid) = session_id {
         find_transcript_by_session(sid).ok_or_else(|| {
@@ -286,3 +305,27 @@ fn find_newest_transcript(dir: &Path) -> Option<PathBuf> {
 }
 
 use crate::util::{detect_project_dir, home_dir};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn pct_used_from_transcript_is_token_based_not_byte_based() {
+        // A transcript whose FILE is tiny but whose API usage reports 500k
+        // tokens on a 1M (opus) window must read as 50% — the regression guard
+        // for the context-threshold byte-heuristic bug: the gauge is token
+        // counts ÷ model window, never transcript file size.
+        let path = std::env::temp_dir()
+            .join(format!("ways_pct_test_{}.jsonl", std::process::id()));
+        let line = r#"{"type":"assistant","message":{"model":"claude-opus-4-8","usage":{"cache_read_input_tokens":500000,"cache_creation_input_tokens":0,"input_tokens":0}}}"#;
+        {
+            let mut f = std::fs::File::create(&path).unwrap();
+            writeln!(f, "{line}").unwrap();
+        }
+        let pct = pct_used_from_transcript(path.to_str().unwrap());
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(pct, Some(50));
+    }
+}

--- a/tools/ways-cli/src/cmd/scan/state.rs
+++ b/tools/ways-cli/src/cmd/scan/state.rs
@@ -137,32 +137,14 @@ fn evaluate_context_threshold(threshold_pct: u64, transcript: Option<&str>) -> b
         _ => return false,
     };
 
-    // Detect model for context window size
-    let window_chars: u64 = detect_window_chars(transcript);
-    let limit = window_chars * threshold_pct / 100;
-    let size = transcript_size_since_summary(transcript);
-
-    size > limit
-}
-
-fn detect_window_chars(transcript: &str) -> u64 {
-    let content = match std::fs::read_to_string(transcript) {
-        Ok(c) => c,
-        Err(_) => return 620_000,
-    };
-    for line in content.lines().rev() {
-        if let Ok(val) = serde_json::from_str::<serde_json::Value>(line) {
-            if val.get("type").and_then(|t| t.as_str()) == Some("assistant") {
-                if let Some(model) = val.get("message").and_then(|m| m.get("model")).and_then(|m| m.as_str()) {
-                    if model.contains("opus-4") {
-                        return 3_800_000;
-                    }
-                }
-                break;
-            }
-        }
-    }
-    620_000 // default: ~155K tokens × 4 chars/token
+    // Single source of truth with `ways context`: accurate API token counts ÷
+    // model window — NOT a transcript-byte heuristic, which over-counts the
+    // full transcript file (out-of-context tool output, persisted blobs, JSON
+    // envelope) and fires thresholds far too early.
+    matches!(
+        crate::cmd::context::pct_used_from_transcript(transcript),
+        Some(pct) if pct >= threshold_pct
+    )
 }
 
 fn transcript_size_since_summary(transcript: &str) -> u64 {


### PR DESCRIPTION
## Summary
The `context-threshold` trigger (todos@75% / memory@80% / compaction-checkpoint@85%) was measuring context fill from **transcript file size in characters**, while `ways context` and the re-disclosure curves already used **accurate API token counts**. Two divergent code paths for the same gauge.

The transcript *file* is far larger than the live context — it holds full tool output, persisted-output blobs that aren't in context, and JSON envelope overhead — so the byte ratio over-counts badly. **At ~52% real usage it read as ~85%, firing the checkpoint and memory ways at half the intended fill.** This is the root cause of "Claude gets concerned about compaction far too early," and it meant the #154 threshold recalibration was tuning numbers against a broken needle.

## Fix
Unify on one gauge:
- Add `context::pct_used_from_transcript` — token counts ÷ model window, the exact logic `ways context` uses.
- Route `evaluate_context_threshold` through it.
- Remove the now-dead `detect_window_chars`. `transcript_size_since_summary` stays for its *legitimate* other use (tiny transcript ⇒ context-was-cleared detection).

## Scope check (the important part)
The decay/re-disclosure **curves** and the **`ways list` state view** were audited and are **not** affected — they already resolve their window from `ways context` (`get_context().tokens_total`) and gate on **epoch distance** (turn count). The byte heuristic was isolated to this one trigger; it was the lone straggler.

## Test plan
- [x] regression unit test: a tiny-file transcript reporting 500k tokens reads as 50% (token-based, not byte-based) — passes
- [x] functional: at 56% real usage, the 75/80/85 ways now stay silent (were all firing pre-fix); verified via `ways scan state` against the live transcript
- [x] `ways` rebuilt