### PR TITLE
chore(ways): English vocab tuning for new ways + ways-tests suggest fix

### DIFF
--- a/hooks/ways/meta/goals/goals.md
+++ b/hooks/ways/meta/goals/goals.md
@@ -1,6 +1,6 @@
 ---
 description: When and why to set a /goal — running Claude in goal mode toward a completion condition, and the regime that creates
-vocabulary: goal goal-mode autonomous loop completion condition keep working until evaluator continue persist bounded objective set a goal ralph regime
+vocabulary: goal goal-mode autonomous loop completion condition keep working until evaluator continue persist bounded objective set a goal ralph regime evidence approvals operator turns stopping
 scope: agent, subagent
 refire: 0.15
 ---

--- a/hooks/ways/meta/governance/governance.md
+++ b/hooks/ways/meta/governance/governance.md
@@ -1,6 +1,6 @@
 ---
 description: Grounding recommendations in real governance controls — when and how to cite the standards (NIST, OWASP, ISO, SOC 2, CIS, IEEE) behind a practice
-vocabulary: governance control citation justify justification standard compliance traceability provenance regulatory audit why do we do this NIST OWASP ISO SOC CIS IEEE
+vocabulary: governance control citation justify justification standard compliance traceability provenance regulatory audit why do we do this NIST OWASP ISO SOC CIS IEEE commits security conventional requirement
 scope: agent, subagent
 refire: 0.15
 ---

--- a/hooks/ways/meta/workflows/workflows.md
+++ b/hooks/ways/meta/workflows/workflows.md
@@ -1,6 +1,6 @@
 ---
 description: When to reach for the Workflow tool — deterministic multi-agent orchestration, versus a single agent, a skill, or a plain task list
-vocabulary: workflow orchestrate orchestration fan out pipeline multi-agent parallel stage deterministic deliver decompose verify synthesize substrate
+vocabulary: workflow orchestrate orchestration fan out pipeline multi-agent parallel stage deterministic deliver decompose verify synthesize substrate gate remediate adversarially scale
 pattern: workflow|orchestrat|fan.?out|pipeline|multi.?agent
 scope: agent
 refire: 0.15

--- a/skills/ways-tests/SKILL.md
+++ b/skills/ways-tests/SKILL.md
@@ -99,7 +99,7 @@ match, list them and ask.
 ## Suggest — vocabulary gaps
 
 ```bash
-ways suggest --file "$wayfile" --min-freq 2
+ways suggest "$wayfile" --min-freq 2
 ```
 
 Sections: GAPS (body terms missing from vocabulary), COVERAGE, UNUSED, VOCABULARY.


### PR DESCRIPTION
## Summary
The **English half** of the tuning pass over this session's new ways. The i18n/locale half is deliberately **shelved** — see #160.

- Curated, domain-specific vocabulary added to `meta/goals`, `meta/governance`, `meta/workflows` (terms surfaced by `ways suggest`; generics skipped; `subagents` avoided to not overlap the sibling way).
- `ways-tests` skill fix: `ways suggest` takes a **positional** FILE, not `--file` (the documented flag errored).

## Test plan
- [x] all three ways still fire on their intended prompts (EN) after the vocab change
- [x] corpus rebuilt
- [x] `ways lint` clean on the three ways