### PR TITLE
chore(plugins): remove ralph-loop plugin

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -304,7 +304,6 @@
     "code-simplifier@claude-plugins-official": true,
     "rust-analyzer-lsp@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,
-    "ralph-loop@claude-plugins-official": false,
     "gopls-lsp@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
@@ -317,5 +316,8 @@
   },
   "skipWorkflowUsageWarning": true,
   "autoCompactEnabled": false,
-  "teammateMode": "auto"
+  "teammateMode": "auto",
+  "remoteControlAtStartup": true,
+  "inputNeededNotifEnabled": true,
+  "agentPushNotifEnabled": true
 }


### PR DESCRIPTION
## Summary
- Uninstall the `ralph-loop` plugin — its iterative-loop role is effectively superseded by `/goal` (built-in completion-condition autonomy). Removed from the `enabledPlugins` map; manifest + cache (gitignored) cleaned up locally via `claude plugin uninstall`.
- Enable `inputNeededNotifEnabled`, `agentPushNotifEnabled`, `remoteControlAtStartup` (toggled on this session).

## Test plan
- `claude plugin list` no longer shows ralph-loop; cache dir removed; `settings.json` has no ralph reference.

https://claude.ai/code/session_01DUyCtuGK5uewAdgp2aE3Dt