### PR TITLE
docs(localization): Phase B design package — mechanics + scenarios

### DIFF
--- a/docs/design-notes/adopter-localization-lifecycle-and-tuning.md
+++ b/docs/design-notes/adopter-localization-lifecycle-and-tuning.md
@@ -1,0 +1,182 @@
+## Single-Language Localization Tuning — the English anchor as a peer
+
+> **Type:** Design note (not an ADR)
+> **Status:** Working draft — core principle settled (English root as source of truth)
+> **Cites:** ADR-139 (adopter-run localization), ADR-125 (coordinate-alias model)
+> **Motivates:** `ways tune --lang` implementation; the `ways-localize` skill's acceptance gate
+
+## What this note is
+
+ADR-139 makes localization adopter-run: a native speaker activates **one** language
+and Claude re-hydrates every way's `description`+`vocabulary` into it, with `ways tune`
+as the language-agnostic acceptance gate. This note settles a problem that only
+surfaces in that adopter-run world: **`ways tune` as built cannot measure a single
+language.** It proposes the fix and the `ways tune --lang` surface the workflow needs.
+
+## The problem
+
+`ways tune` (`tune.rs:measure_way`) scores each locale alias against the multilingual
+corpus and derives two numbers:
+
+- **Fidelity** = `min cosine` between this alias and its **same-way peers** — *other
+  languages of the same way*. It measures whether all translations of a way embed in
+  the same neighborhood.
+- **Discrimination** = `min_peer − top_confuser.score` — whether the way's own peers
+  outrank the best-scoring alias of any *other* way.
+
+Both are defined in terms of **peers**, and a peer is another *non-English language*
+of the same way (the ~1.0 self-match is excluded; the English frontmatter is not in
+the multilingual corpus at all). `emit_report` only counts and flags entries with
+`peer_count > 0`.
+
+In the maintainer world (18 languages shipped together) every way had 17 peers, so
+this worked. In the adopter world the common case is **one** active language. Then:
+
+- `peer_scores` is empty for every entry → `peer_count == 0`,
+- fidelity and discrimination are both `NaN`,
+- every entry is dropped from the report → `ways tune` prints **"0/0 entries flagged"**
+  and silently measures nothing.
+
+A gate that passes by measuring nothing is worse than no gate — it reads as "clean"
+while verifying nothing. This is the blind spot that has to close before `ways-localize`
+can claim "tune clean" means anything.
+
+## The governing principle: English is the root, the source of truth
+
+The thing a single-language adopter most needs verified is *not* cross-language
+agreement (there are no other languages) — it is **"does my French translation of way
+X still mean way X?"** That is a comparison against the **English original**.
+
+This is not merely a convenient peer to fill the empty-peer hole — it is the
+architecture. **English (the way's `.md` frontmatter) is the root: the single source of
+truth. Localizations (the `.locales.jsonl` aliases) are subordinate derivations,
+validated by their alignment *to the root*, never against each other.** If translations
+were instead tuned for agreement among themselves, a cluster of bad translations that
+happen to agree would pass while drifting collectively away from the English meaning —
+a multilingual free-for-all where there is no longer a fixed source of truth. The root
+must be the anchor every localization is measured against.
+
+**Why English specifically.** The choice is pragmatic, not a claim of linguistic
+primacy. Computer science and engineering are still conducted predominantly in English —
+the terms of art, the library names, the docs — so grounding the source of truth there
+is where the field already operates, and it is what a single (English-speaking)
+maintainer can realistically keep coherent. A project with a different center of gravity
+could legitimately pick a different root. What the architecture *requires* is that there
+be exactly **one** root, not that it be English. Here it is English; the only real
+alternative is no fixed source of truth at all — the free-for-all this note exists to
+prevent.
+
+This corrects the metric, not just plugs a hole:
+
+- **Fidelity is alignment to the English root**, measured per-language and
+  independently: `cosine(localized alias, English root)`. A French stub is valid iff it
+  embeds near the English original. It is *not* `min` over sibling translations — that
+  would let a bad sibling poison a good one, and let a drifting cluster self-certify.
+  Sibling translations are at most diagnostic; they are never the gate.
+- **Discrimination** = `localized alias − top_confuser` stays as-is → catches a stub
+  that collides with a *different* way's stub (e.g. `commits` vs `branching`).
+  Orthogonal to root-alignment; both must hold.
+- **One language or N**, the rule is identical: every localized alias must align to the
+  English root and not collide. N languages add diagnostics, not a different gate.
+
+No "single-language degenerate mode," no discrimination-only fallback, no peer-democracy.
+The English root is structurally present in the multilingual space as the anchor, and
+every localization is measured against it.
+
+## Decision
+
+1. **The agent-ways config is the mode switch that routes the whole intl pipeline.**
+   The flag is `output_language` in `~/.claude/ways.json` (already present; read into
+   `Config.language`). It is `ways-localize` that writes it — flipping it from `en` to a
+   target language is what *activates* intl. Read once, upstream — not sniffed for
+   per-component.
+   - **English mode** (`output_language: en` / `auto` — the default): the *intl* pipeline
+     is not engaged. No multilingual corpus is built, **the matcher never loads the
+     768-dim multilingual model** (see §5), no English-root anchoring in a multi corpus,
+     and **no locale tuning** (`ways tune` is not in the flow). The mode wins over data
+     presence: a stray multi corpus is ignored, not run. *English corpus tuning is
+     unaffected — it is always on:* a new or materially-changed English way recomputes
+     its embedding and re-verifies match/discrimination regardless of mode.
+   - **Localized mode** (`output_language` = a non-English code): the intl pipeline turns
+     on — multilingual corpus built with the English root as anchor, multilingual
+     matching enabled, root-anchored tuning runs.
+
+   **This is distinct from Claude Code's `settings.json` `language`** (CC's *response*
+   language). Two flags, one bridge: the detection macro compares them — CC set to `es`
+   but ways `output_language` still `en` means "not localized yet" → nudge; once
+   `ways-localize` flips `output_language`, the macro self-silences. Merely setting CC to
+   Spanish must *not* trigger a 127MB-model download + translate-all-ways; localization
+   is explicit work `ways-localize` does, and only then does it flip the ways flag.
+
+2. **The English root is the anchor in the multilingual space** (localized mode only).
+   Each way contributes its English frontmatter (`description`+`vocabulary`) to the
+   multilingual corpus, embedded with the multilingual model, as the reference `en`
+   entry. Every localized alias is scored *against this root*. The root is the fixed
+   source of truth, not a co-equal peer — translations align to it; it never averages
+   with them.
+
+3. **`ways tune` runs in localized mode, scoped by `--lang <code>`** (the workflow passes
+   the adopter's language; default is the active languages). It is simply never invoked
+   in English mode, so it has no dormant/empty path to special-case.
+
+4. **Acceptance semantics for the `ways-localize` gate:** a language passes when, for
+   every way, the localized alias (a) has fidelity ≥ threshold **against the English
+   root** (it still means what the source of truth means) **and** (b) has a non-negative
+   discrimination gap (it does not collide with another way). Re-author the flagged
+   stubs and re-run until clean — meaningful at N=1.
+
+5. **Matching compute is gated on the mode switch.** Both modes match by embedding
+   cosine; the difference is the model, not the method. English mode runs the 384-dim
+   English model only; localized mode adds the 768-dim multilingual model as a *second
+   lane* (the English lane still runs). The matcher (`scan/scoring.rs`) currently runs
+   that multilingual lane whenever a multi corpus is *present* (`run_if_ready`) —
+   presence-gated, not mode-gated. Change it to consult `output_language`: in English
+   mode it **never loads the 768-dim multilingual model**, a per-match saving on every
+   prompt for the default install, instead of relying on corpus-file absence to skip it.
+   In localized mode it runs as today. (Phase A removed the multi corpus, so English mode
+   is already cheap *incidentally*; this makes it explicit and robust against a stray
+   corpus.)
+
+## Resolution: the English root lives in the multilingual space
+
+Given the source-of-truth principle, the English root must be **structurally present**
+in the multilingual space as the anchor — so localizations are always measured against
+the truth, not reconstructed from each other at measure time. That means English
+entries go into the **multi corpus** (a `corpus.rs` change), embedded with the
+multilingual model, generated whenever a language is localized.
+
+This is decided, not a fork — it follows from "English root first." The runtime side
+effect is a *bonus that fits the architecture*, not the justification: because the multi
+corpus is also the runtime retrieval index, a non-English query gets cross-lingual
+fallback routing via the English anchors the moment the user switches language — exactly
+the un-localized state the detection macro fires in. The change is bounded to the
+multilingual lane (English-only installs never build it), and it keeps `ways tune` a
+thin read-over-the-corpus rather than an on-the-fly embedder.
+
+The rejected alternative — injecting the English anchor at measure time only (`tune.rs`
+embeds English on the fly, runtime corpus untouched) — keeps tuning and runtime separate
+but reconstructs the root per-run instead of letting it *be* the corpus's anchor, and
+forgoes the fallback. It contradicts "the root is structurally primary," so it is out.
+
+## Consequences
+
+- `ways tune` is meaningful at one active language — the adopter-run common case.
+- The acceptance gate the `ways-localize` skill leans on verifies real translation
+  quality (alignment to the English original + non-collision), not cross-language
+  agreement that doesn't exist yet.
+- Non-English queries gain English-anchor fallback routing in the multilingual lane —
+  useful in precisely the un-localized state the nudge targets.
+- **English-mode matching never loads the heavier 768-dim multilingual model** — gated
+  on the mode switch rather than on corpus-file absence. A per-match compute saving on
+  every prompt for the default install (the 99% case).
+- The maintainer-era tuning way (`meta/knowledge/optimization/tuning`) describes the
+  old peers-only model and must be rewritten to this one (tracked with the Phase B docs
+  pass).
+
+## See also
+
+- ADR-139 — adopter-run localization (the world this note operates in)
+- ADR-125 — coordinate-alias model (`description`+`vocabulary` as embedding-space alias)
+- `docs/explanation/localization/` (catalog `01.009.E`–`01.013.E`) — the user-facing
+  scenarios this note is the mechanics for
+- `meta/knowledge/optimization/tuning` way — to be rewritten to this model

--- a/docs/explanation/localization/adopter-localization-the-model.md
+++ b/docs/explanation/localization/adopter-localization-the-model.md
@@ -1,0 +1,75 @@
+---
+id: 01.009.E
+domain: system
+mode: explanation
+related:
+  - "[[ADR-139]]"
+  - "[[01.010.E]]"
+  - "[[01.011.E]]"
+  - "[[01.012.E]]"
+  - "[[01.013.E]]"
+aliases: []
+---
+
+# Adopter localization — the model
+
+This is the **explanation** companion to [[ADR-139]] (the decision to shelve
+maintainer-maintained i18n and make localization adopter-run) and the design note
+*Adopter localization lifecycle and tuning* (the mechanics). The ADR argues *why*;
+these pages show *how the system behaves* for a real adopter — from a fresh install,
+through switching languages, to the steady state.
+
+If you read nothing else, read this page, then [[01.011.E]] (the language switch). The
+numbered scenarios are independent — pick the one that matches your situation.
+
+## The one distinction everything hangs on
+
+agent-ways runs in one of two **modes**, and a single flag decides which.
+
+```mermaid
+flowchart TD
+    Q{ways.json<br/>output_language} -->|"en / auto (default)"| EN[ENGLISH MODE<br/>embedding match · 384-dim English model only · corpus tuning always on · no locale tuning]
+    Q -->|"a non-English code (es, zh, ...)"| LOC[LOCALIZED MODE<br/>adds a 2nd embedding lane · 768-dim multilingual model × English-root-anchored multi corpus · root-anchored locale tuning]
+```
+
+- **English mode** is the default and the 99% case. The English corpus is still built
+  and **tuned** — a new way, or a way whose `description`/`vocabulary` materially
+  changes, recomputes its embedding and re-verifies its match and sibling
+  discrimination (the semantic-intent decision belongs to the English root either way).
+  What is **dormant** is the *locale* layer: nothing extra downloads, the heavier
+  multilingual model is never loaded at match time, and there is no locale-alias tuning.
+- **Localized mode** is what an adopter opts into. It is **explicit work**, performed
+  once by the `ways-localize` skill, that flips the flag and builds the localized layer
+  on top of the unchanged English root.
+
+## Two flags, one bridge
+
+Localization touches **two** different configs, and conflating them is the most common
+confusion:
+
+| Flag | Lives in | Means | Written by | Read by |
+|---|---|---|---|---|
+| `language` | Claude Code `settings.json` | CC's **response** language | the operator (or ways-localize, as a courtesy) | the detection nudge (trigger) |
+| `output_language` | agent-ways `ways.json` | ways **intl mode** | **`ways-localize`** | corpus build · matcher · tuning |
+
+The **nudge bridges them**: when CC is set to Spanish but ways is still in English mode,
+ways is under-serving the operator — and says so. Setting CC to Spanish must never, by
+itself, trigger a 127 MB model download and a translate-everything pass; localization is
+deliberate, consented work. The flag ways acts on is its own.
+
+## The English root never moves
+
+Whatever the mode, **English is the source of truth.** A localization is a *derivation*
+validated against the English root, never a co-equal sibling — that is what keeps a
+multilingual install from becoming a free-for-all with no fixed meaning. The mechanics
+(root-anchored fidelity, the `output_language` gate, the match-compute saving) are in
+[[01.013.E]] and the design note.
+
+## The scenarios
+
+| # | Scenario | The thing it shows |
+|---|----------|--------------------|
+| [[01.010.E]] | The English-native install | The default path — nothing to flag, nothing to do |
+| [[01.011.E]] | The language switch | CC in Spanish → nudge → consented ways-localize → satisfied |
+| [[01.012.E]] | Steady-state authoring | English root + one localization, maintained together |
+| [[01.013.E]] | The mode gate | The mechanism: one flag, two modes, root-anchored tuning |

--- a/docs/explanation/localization/scenario-steady-state-authoring.md
+++ b/docs/explanation/localization/scenario-steady-state-authoring.md
@@ -1,0 +1,54 @@
+---
+id: 01.012.E
+domain: system
+mode: explanation
+related:
+  - "[[01.009.E]]"
+  - "[[01.011.E]]"
+  - "[[01.013.E]]"
+  - "[[ADR-139]]"
+aliases: []
+---
+
+# Scenario — steady-state authoring
+
+**A localized install (Spanish active) evolves: a way is added or edited.** Once an
+adopter is in localized mode, maintenance settles into a stable two-part shape: **the
+English root + its one localization, kept together.**
+
+## How it plays out
+
+```mermaid
+flowchart LR
+    A[author / edit a way] --> E[English .md root<br/>source of truth]
+    E --> L[regenerate its Spanish alias<br/>translate vs root · tune]
+    L --> C[multi corpus rebuilt<br/>English anchor + Spanish layer]
+    C --> G{ways tune clean?}
+    G -->|no| L
+    G -->|yes| D[done — both layers current]
+```
+
+## What each move is doing
+
+- **The English root is authored normally.** Writing or editing a way means writing
+  English `description`+`vocabulary` — exactly as on an English install. The 17×
+  all-languages stub tax is gone ([[ADR-139]], Phase A); the root is just English.
+- **One localization, not eighteen.** Because `output_language` is `es`, the steady
+  state is the root **plus Spanish** — the single active language — regenerated for the
+  new or changed way. Not a matrix of every language the project ever shipped; only
+  what this adopter actually uses.
+- **Re-localization is incremental and root-anchored.** The changed way's Spanish alias
+  is re-translated against the (possibly updated) English root and re-tuned. A drifting
+  English root pulls its Spanish alias back into alignment — the root leads, the
+  localization follows.
+- **Tuning gates the change.** `ways tune` re-checks the touched alias: does it still
+  align to the English root, and does it still avoid colliding with another way? Clean →
+  done; flagged → re-author the stub (see [[01.013.E]]).
+
+## The point
+
+Localized maintenance is not a perpetual translation marathon — it is "write English,
+keep one shadow in sync." The cost scales with *one* language and with *what changed*,
+not with a language matrix or the whole corpus. This is the steady state the
+adopter-run model converges to, and it is sustainable for a single maintainer precisely
+because the English root does the anchoring, not a committee of equal translations.

--- a/docs/explanation/localization/scenario-the-english-native-install.md
+++ b/docs/explanation/localization/scenario-the-english-native-install.md
@@ -1,0 +1,54 @@
+---
+id: 01.010.E
+domain: system
+mode: explanation
+related:
+  - "[[01.009.E]]"
+  - "[[01.011.E]]"
+  - "[[ADR-139]]"
+aliases: []
+---
+
+# Scenario — the English-native install
+
+**An English-speaking operator, Claude Code in English, installs agent-ways.** This is
+the default and the overwhelming-majority case. The point of the scenario is that
+**nothing happens** — and that the nothing is by design, not by omission.
+
+## How it plays out
+
+```mermaid
+sequenceDiagram
+    participant Op as Operator (English)
+    participant CC as Claude Code
+    participant W as agent-ways
+    Op->>CC: settings.json language unset → English
+    Op->>W: make install
+    Note over W: ways.json output_language = en (default)
+    W->>W: build English corpus only
+    Note over W: multilingual model never downloaded or loaded
+    Op->>CC: start a session
+    W-->>Op: session-start nudge reads CC lang vs output_language
+    Note over W: en == en → match → silent
+```
+
+## What each move is doing
+
+- **No language is set, so English mode is the default.** `ways.json` ships with
+  `output_language: en`. There is no step to opt into; English *is* the built state.
+- **The build is English-only.** `make setup` fetches one model (the 384-dim English
+  model) and builds one corpus. The 127 MB multilingual model is never downloaded — it
+  is on-demand, and nothing has demanded it.
+- **The nudge runs but finds nothing.** At session start the detection check reads CC's
+  `language` and ways' `output_language`. Both resolve to English, so there is no
+  mismatch and it emits nothing. The check is cheap — a single config read — and
+  silence is the correct, common outcome (see [[01.013.E]] on why running-but-silent is
+  not the same as absent).
+
+## The point
+
+The default install pays nothing for a capability it does not use. An English operator
+never sees a localization prompt, never downloads a second model, and never pays
+multilingual match compute. The intl system is present but fully dormant — the
+adopter-run model ([[ADR-139]]) puts the cost on whoever asks for the benefit. The next
+scenario is what "asking" looks like ([[01.011.E]]).

--- a/docs/explanation/localization/scenario-the-language-switch.md
+++ b/docs/explanation/localization/scenario-the-language-switch.md
@@ -1,0 +1,65 @@
+---
+id: 01.011.E
+domain: system
+mode: explanation
+related:
+  - "[[01.009.E]]"
+  - "[[01.010.E]]"
+  - "[[01.012.E]]"
+  - "[[ADR-139]]"
+aliases: []
+---
+
+# Scenario — the language switch
+
+**A Spanish-speaking operator sets Claude Code to Spanish, then installs agent-ways.**
+This is the ladder the whole adopter-run design exists to serve: ways notices it is
+under-serving, asks permission, and — only on consent — localizes itself.
+
+## How it plays out
+
+```mermaid
+sequenceDiagram
+    participant Op as Operator (Spanish)
+    participant CC as Claude Code · language = spanish
+    participant W as agent-ways · output_language = en
+    participant L as ways-localize skill
+    Op->>CC: set language = spanish
+    Op->>W: install + start session
+    W-->>Op: nudge "CC is Spanish, ways is en → not localized. Optimize?"
+    Note over W,Op: emitted in Spanish — CC already responds in Spanish
+    Op->>L: yes, localize for Spanish (consent)
+    L->>W: flip output_language → es
+    L->>L: fetch multilingual model · translate every way vs English root
+    L->>L: pack stubs · rebuild multi corpus (English anchor) · ways tune until clean
+    Note over Op,W: next session CC=es, output_language=es → match → nudge silent
+```
+
+## What each move is doing
+
+- **The operator switches CC, not ways.** Setting `settings.json language: spanish` is
+  the operator's own choice, for their own reasons. Ways is untouched — still English
+  mode. There is *no* automatic cascade from "CC is Spanish" to "rebuild the world";
+  that would be a heavyweight surprise.
+- **Ways notices the mismatch and speaks up — in Spanish.** The session-start nudge
+  reads both flags, sees `es ≠ en`, and emits guidance. Because CC is already responding
+  in Spanish, the guidance reaches the operator *in Spanish* for free — the bootstrap
+  paradox (a non-English user can't read an English how-to) dissolves.
+- **It asks permission; it does not act.** Localization is expensive — a 127 MB model
+  download, a translate-every-way pass, a tuning loop. So the nudge **requests operator
+  consent** and stops. Human-in-the-loop on a heavy, consequential operation.
+- **On consent, `ways-localize` does the work and flips the flag.** It sets
+  `output_language → es`, fetches the multilingual model, translates each way's
+  `description`+`vocabulary` against the **English root**, packs the stubs, rebuilds the
+  multi corpus with the English anchor, and runs `ways tune` until the Spanish layer is
+  clean — aligned to the root, no collisions (see [[01.013.E]]).
+- **The flag flip is what satisfies the nudge.** Next session, `output_language` is `es`,
+  matching CC, so the mismatch is gone and the nudge stays silent — *self-silencing via
+  the config flag*, not by sniffing whether data happens to exist.
+
+## The point
+
+The operator gets a localized experience exactly when they want one, pays its cost
+themselves (as the beneficiary), and is the native speaker best able to judge the
+result. Ways never assumes; it observes, asks, and — only on a yes — acts. After this,
+the install sits in localized steady state ([[01.012.E]]).

--- a/docs/explanation/localization/the-mode-gate-mechanism-under-the-scenarios.md
+++ b/docs/explanation/localization/the-mode-gate-mechanism-under-the-scenarios.md
@@ -1,0 +1,65 @@
+---
+id: 01.013.E
+domain: system
+mode: explanation
+related:
+  - "[[01.009.E]]"
+  - "[[ADR-139]]"
+  - "[[ADR-125]]"
+aliases: []
+---
+
+# The mode gate — mechanism under the scenarios
+
+The scenarios describe behavior; this page is the machinery they share. One flag, two
+modes, and three things that flip with it. The decision rationale lives in the design
+note *Adopter localization lifecycle and tuning*; this is the operational map.
+
+## The flag
+
+`output_language` in `~/.claude/ways.json` (read into `Config.language`). Default
+`en`/`auto`. `ways-localize` is the only thing that writes a non-English value. It is
+read **once, upstream** — components do not each sniff for locale data; they consult the
+mode.
+
+## What flips with it
+
+```mermaid
+flowchart TD
+    F[output_language] --> M{en?}
+    M -->|"yes — English mode"| EN[corpus: English only<br/>matcher: embedding, 384-dim English model only<br/>locale tuning: not in the flow]
+    M -->|"no — localized mode"| LO[corpus: + multi, English-root anchored<br/>matcher: + 2nd embedding lane, 768-dim multilingual model<br/>locale tuning: root-anchored, --lang scoped]
+```
+
+1. **Corpus build** (`corpus.rs`). Localized mode emits each way's English root into the
+   multilingual corpus (embedded with the multilingual model) as the anchor, plus the
+   localized aliases. English mode builds the English corpus only.
+2. **Match compute** (`scan/scoring.rs`). *Both modes match by embedding cosine* — the
+   difference is the model, not the method. English mode runs the 384-dim English model
+   only; localized mode adds the 768-dim multilingual model as a **second lane** (English
+   lane still runs too). The matcher gates that second lane on the mode, not on
+   corpus-file presence, so English mode **never loads the heavier 768-dim model** — a
+   per-prompt saving on every match for the default install.
+3. **Locale tuning** (`tune.rs`). The root-anchored locale-alias audit runs only in
+   localized mode, scoped by `--lang`. (English *corpus* tuning — vocabulary health,
+   sibling discrimination, and threshold calibration of the English ways themselves — is
+   a separate, always-on concern: a new or materially-changed English way retunes
+   regardless of mode.) There is no empty / "0/0" path to special-case, because locale
+   tuning is simply never invoked in English mode.
+
+## Root-anchored tuning, in one breath
+
+Fidelity is **alignment to the English root**, measured per language and independently —
+`cosine(localized alias, English root)`. *Not* agreement among sibling translations
+(which would let a drifting cluster self-certify). Discrimination stays as
+`alias − top_confuser`: the alias must not collide with a *different* way. A language
+passes the `ways-localize` gate when every alias both aligns to its root and avoids
+collision. This works identically for one language or many — the English root is the
+fixed peer that makes N=1 meaningful. Full treatment: the design note and [[ADR-125]].
+
+## Running-but-silent ≠ absent
+
+The session-start nudge always runs — it must read the flags to know the mode — but only
+the mismatch state (CC non-English, ways `en`) produces output. English mode runs the
+check, finds nothing to do, and emits nothing, at the cost of one config read. Silence
+is the check working, not the check missing.


### PR DESCRIPTION
The Phase B design for adopter-run localization (ADR-139 / #160), captured before implementation.

## Contents
- **Design note** (`docs/design-notes/adopter-localization-lifecycle-and-tuning.md`) — mechanics & decisions: English as the source-of-truth **root**, **root-anchored fidelity** (alignment to the root, not peer-democracy), `output_language` as the **single mode switch** routing corpus build + match compute + tuning, and the **two-config bridge** (CC `settings.json language` vs ways `ways.json output_language`).
- **Scenario series** (`docs/explanation/localization/`, catalog `01.009.E`–`01.013.E`, sibling to attend-messaging) — the model, the English-native no-op, the language-switch ladder (nudge → consent → ways-localize → self-silence), steady-state authoring, and the mode-gate mechanism.

## Two clarifications baked in
- English-**corpus** tuning is always on (new/materially-changed ways retune); **locale** tuning is localized-mode-only.
- Both modes match by **embedding cosine** — English with the 384-dim model, localized adding the 768-dim multilingual lane. Same method, different model.

Design only — no code. Implementation (corpus + scoring + tune, then the ways-localize skill + workflow + detection macro) follows.

Part of #160.

https://claude.ai/code/session_01DUyCtuGK5uewAdgp2aE3Dt