### PR TITLE
feat(i18n): localization detection nudge (state-triggered macro)

### DIFF
--- a/hooks/ways/meta/localize/localize.md
+++ b/hooks/ways/meta/localize/localize.md
@@ -1,0 +1,9 @@
+---
+description: when Claude Code is set to a non-English language but agent-ways is still running in English, surfacing the ways-localize option
+vocabulary: localize localization translate language non-english multilingual locale internationalization i18n spanish french german japanese chinese
+trigger: session-start
+macro: prepend
+scope: agent
+refire: 0.15
+requires: ["Bash(jq:*)", "Bash(tr:*)"]
+---

--- a/hooks/ways/meta/localize/macro.sh
+++ b/hooks/ways/meta/localize/macro.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Localization nudge (ADR-139, scenario 01.011.E).
+#
+# Fires only on the mismatch state: Claude Code is set to a non-English language
+# but agent-ways is still in English mode (output_language en/auto — not localized).
+# Then it recommends the ways-localize skill. Silent otherwise — English installs
+# (the 99% case) and already-localized installs emit nothing.
+#
+# The body of localize.md is intentionally empty, so this macro's stdout is the
+# way's entire output: silent here ⇒ the way is suppressed (no English-mode noise).
+# CLI is the contract — ways' effective language comes from `ways language`, not a
+# raw config file.
+
+ROOT="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+
+# Claude Code's own response language (settings.json `language`, a NAME like "spanish").
+cc_lang=$(jq -r '.language // empty' "$ROOT/settings.json" 2>/dev/null | tr '[:upper:]' '[:lower:]')
+case "$cc_lang" in
+  ""|english|en) exit 0 ;;   # Claude Code is English (or unset) → nothing to offer
+esac
+
+# agent-ways' effective language (resolved across config layers). The CLI reports a
+# NAME in `resolved_language` ("English", "Spanish", ...); English (en / auto) is the
+# unlocalized state we nudge on.
+ways_lang=$("$ROOT/bin/ways" language --json 2>/dev/null | jq -r '.resolved_language // "English"' | tr '[:upper:]' '[:lower:]')
+case "$ways_lang" in
+  english|en|auto|"") : ;;   # ways still English → the mismatch we nudge on
+  *) exit 0 ;;               # ways already localized → satisfied, stay silent
+esac
+
+# Mismatch: Claude Code is non-English, ways is not. Nudge — the operator is already
+# reading in their language, so this reaches them there.
+echo "🌐 **Localization available.** Claude Code is set to **${cc_lang}**, but agent-ways is still running in English. With your consent, the **ways-localize** skill can translate every way into ${cc_lang} and tune it against the English source of truth. Ask before running it — it downloads a multilingual model and translates the whole corpus. This note stops once localization is done."
+echo ""


### PR DESCRIPTION
Slice 5 of Phase B (ADR-139 / scenario `01.011.E`). A session-start way whose macro fires only on the mismatch state and self-silences otherwise.

`hooks/ways/meta/localize/` — `localize.md` (frontmatter only; **empty body** so the macro's stdout is the way's entire output → a silent macro means the way is suppressed → no English-mode noise) + `macro.sh`:
- Reads Claude Code's `settings.json` `language` and ways' effective language via `ways language` (CLI-is-the-contract, not a raw config read).
- Emits the **ways-localize** recommendation only when CC is non-English **and** ways is still English (`output_language` en/auto). Asks for consent; notes it self-silences once localized.

## Verification
All three states: English → **silent**; CC non-English + ways English → **nudge**; CC non-English + ways localized → **silent**. Corpus rebuilds clean; `ways lint` clean (`requires` auto-populated).

Last slice: docs reconcile (#6).

Part of #160.

https://claude.ai/code/session_01DUyCtuGK5uewAdgp2aE3Dt