### PR TITLE
docs(i18n): root-anchored tuning way + config-layer reconcile

### DIFF
--- a/docs/design-notes/adopter-localization-lifecycle-and-tuning.md
+++ b/docs/design-notes/adopter-localization-lifecycle-and-tuning.md
@@ -86,10 +86,12 @@ every localization is measured against it.
 ## Decision
 
 1. **The agent-ways config is the mode switch that routes the whole intl pipeline.**
-   The flag is `output_language` in `~/.claude/ways.json` (already present; read into
-   `Config.language`). It is `ways-localize` that writes it — flipping it from `en` to a
-   target language is what *activates* intl. Read once, upstream — not sniffed for
-   per-component.
+   The switch is the resolved `Config.language`, which is *layered*: `output_language`
+   in `~/.claude/ways.json` (Layer 1) is **overridden** by `language` in the user-scope
+   `~/.config/ways/config.yaml` (Layer 2, default `auto`). So the *effective* switch is
+   the user-scope `language` — and that is the layer **`ways-localize` writes** to
+   activate intl (writing `ways.json` alone would be masked by the `auto` default).
+   Read once, upstream — not sniffed for per-component.
    - **English mode** (`output_language: en` / `auto` — the default): the *intl* pipeline
      is not engaged. No multilingual corpus is built, **the matcher never loads the
      768-dim multilingual model** (see §5), no English-root anchoring in a multi corpus,

--- a/docs/explanation/localization/the-mode-gate-mechanism-under-the-scenarios.md
+++ b/docs/explanation/localization/the-mode-gate-mechanism-under-the-scenarios.md
@@ -17,8 +17,11 @@ note *Adopter localization lifecycle and tuning*; this is the operational map.
 
 ## The flag
 
-`output_language` in `~/.claude/ways.json` (read into `Config.language`). Default
-`en`/`auto`. `ways-localize` is the only thing that writes a non-English value. It is
+The resolved `Config.language`, default `en`/`auto`. It is *layered*: `output_language`
+in `~/.claude/ways.json` (Layer 1) is overridden by `language` in the user-scope
+`~/.config/ways/config.yaml` (Layer 2). So the effective switch is the user-scope
+`language` — the layer `ways-localize` writes. It is the only thing that writes a
+non-English value. It is
 read **once, upstream** — components do not each sniff for locale data; they consult the
 mode.
 

--- a/hooks/ways/meta/knowledge/optimization/tuning/tuning.md
+++ b/hooks/ways/meta/knowledge/optimization/tuning/tuning.md
@@ -1,90 +1,85 @@
 ---
-description: locale alias fidelity and discrimination audit, ways tune workflow, fixing ambiguous stubs
-vocabulary: tune tuning audit fidelity discrimination confuser peer alias gap margin re-author stub locales
+description: locale alias tuning — root-anchored fidelity and discrimination audit, the ways tune acceptance gate for adopter-run localization
+vocabulary: tune tuning audit fidelity discrimination confuser anchor root gap margin re-author stub locale lang acceptance gate localized
 scope: agent
 refire: 0.15
 ---
 <!-- epistemic: convention -->
 # Locale Alias Audit
 
-`ways tune` measures per-locale embedding health against the multilingual model. It does not write thresholds — per-ADR-125, thresholds are per-node (English frontmatter), and stub quality is fixed by re-authoring, not by adjusting gates.
+`ways tune` is the **acceptance gate** for adopter-run localization (ADR-139). It runs
+only in **localized mode** (a non-English `output_language`); in English mode there is
+nothing to audit and it returns clean. It measures embedding health against the
+multilingual model and does not write thresholds — per ADR-125 thresholds are per-node
+(the English frontmatter), and stub quality is fixed by re-authoring, not by moving gates.
 
-## Two Measurements
+English is the **source of truth.** Each way's English frontmatter is embedded into the
+multilingual corpus as the per-way **anchor**, and every localized alias is scored
+*against the root* — not against sibling translations. A cluster of mutually-agreeing
+bad translations cannot self-certify; each stands or falls by its alignment to English.
 
-The tool runs each locale's `description + vocabulary` text as a query against the multilingual corpus, and reports two numbers:
+## Two measurements
 
-**Fidelity** — `min cosine` between this alias and its **same-way peers** (other languages of the same way). High fidelity means all translations of a way embed in the same neighborhood — they share the objective match words in local form. Low fidelity means one of the translations diverges.
+The tool runs each locale's `description + vocabulary` as a query against the
+multilingual corpus, scoped to the active (or `--lang`) language, and reports:
 
-**Discrimination** — `min_peer − top_confuser.score`. The top confuser is the best-scoring alias on any *other* way. A negative gap means another way outranks this way's own peers in embedding space — the stub is being dominated by a competitor.
+**Fidelity** — cosine alignment to the **English root anchor**. For a single localized
+language the alias's only same-way peer is the root, so `min_peer` *is* root-alignment:
+how well the translation tracks the source of truth. Low fidelity → the stub drifted
+from the English meaning.
+
+**Discrimination** — `min_peer − top_confuser.score`. The top confuser is the
+best-scoring alias on any *other* way. A negative gap means another way outranks this
+stub — it collides and will mis-route. Orthogonal to fidelity; both must hold.
 
 ## Workflow
 
 ```bash
-# Run the audit on all ways
-ways tune
-
-# Single-way filter
+ways tune                       # audit the active localized language
+ways tune --lang es             # scope to one language
 ways tune --way delivery/commits
-
-# Tune thresholds for flagging
 ways tune --fidelity-threshold 0.55 --discrimination-threshold 0.05
-
-# Machine-readable output
 ways tune --json
 ```
 
-## Interpreting Output
+`ways tune` is the loop the **ways-localize** skill drives: translate → corpus → tune →
+re-author flagged stubs → repeat until clean. "Clean" (no flagged entries) is the
+*evidence* a localization is done — not an assertion.
 
-Each flagged entry looks like:
+## Two failure modes
 
-```
-Way                          Lang  MinPeer MeanPeer     Gap Top confuser
-softwaredev/delivery/commits ru     0.4688   0.6255 -0.1791 softwaredev/code/quality (0.648)
-```
+### 1. Low fidelity — drifted from the root
 
-- `MinPeer 0.47` — tightest cross-lingual agreement with same-way peers. Low means translations disagree.
-- `MeanPeer 0.63` — average peer agreement. Calibrates MinPeer against the typical spread.
-- `Gap -0.18` — `code/quality` outranks this locale's own peers by 0.18 in cosine. The stub is being dominated.
-- `Top confuser` — which way is winning; also why the user's query might mis-route.
+The translation embeds far from the English original: a mistranslation, or a stub that
+misread the way's intent. **Fix:** re-author the offending locale against the English
+frontmatter (the root). Translate the *intent* and the objective match words in local
+form, not word-for-word.
 
-## Three Failure Modes
+### 2. Negative discrimination — collides with another way
 
-Each flagged entry falls into one category. The fix differs per category.
+The stub embeds closer to a *different* way than its own anchor. **Fix** by what the
+confuser is:
+- **Sibling way** (e.g. `delivery/commits` vs `delivery/branching`) — genuine neighbors;
+  sharpen both so each holds a distinct region.
+- **Parent/ancestor** (e.g. `delivery/commits` vs `delivery`) — some overlap is
+  expected; add child-specific terminology.
+- **Unrelated** (e.g. outranked by `code/quality`) — accidental vocabulary overlap,
+  often a generic term doing too much work. Remove or specialize it.
 
-### 1. Fidelity problem (low MinPeer, Gap OK)
+A broad-vocabulary way that keeps appearing as the confuser across many stubs is a
+signal to trim *its* vocabulary so it stops hoovering traffic meant for specialized
+children.
 
-One translation is different from the others. The stub doesn't carry the objective match words in local form.
+## Output signal, not verdict
 
-**Fix:** re-author the offending locale. Look at the sibling stubs (other languages on the same way) to see what vocabulary they share; add local-language equivalents.
-
-### 2. Discrimination problem (MinPeer OK, Gap negative)
-
-Translations agree with each other, but another way's stub embeds closer to this locale's text than its own peers do.
-
-**Fix options** depending on what the confuser is:
-
-- **Confuser is a sibling way** (e.g., `delivery/commits` confused with `delivery/branching`) — the two ways are genuinely neighbors in meaning. Sharpen vocabulary on both so each occupies a distinct region.
-- **Confuser is a parent/ancestor** (e.g., `delivery/commits` confused with `delivery`) — expected to some extent (parent has overlapping scope), but strong overlap means the child is too close to its parent's general description. Add child-specific terminology.
-- **Confuser is unrelated** (e.g., `delivery/commits` outranked by `code/quality`) — the stub has accidental vocabulary overlap with something semantically far away. Often means a generic term (like "refactor") is doing too much work. Remove or specialize it.
-
-### 3. Both problems (low MinPeer AND negative Gap)
-
-The translation is both divergent AND outranked. Usually means the stub is just bad — short, generic, or a misunderstanding of the way's intent. Re-author from scratch using the English frontmatter and at least two good sibling translations as reference.
-
-## Top Confusers Pattern
-
-Broad-vocabulary ways tend to dominate their neighborhoods. When a domain-general way like `architecture` or `writing` or `environment/deps` keeps appearing as the confuser across many ways, the fix might be on *the confuser's* side: trim its vocabulary so it stops hoovering up traffic meant for specialized children.
-
-## Output Signal, Not Verdict
-
-The audit is diagnostic, not prescriptive. A flagged entry doesn't always mean "re-author now." Read the gap values:
-
-- Gap > 0 — stub clearly wins, ignore any fidelity flag unless MinPeer is catastrophically low
-- Gap between -0.05 and 0 — marginal, watch but not urgent
-- Gap more negative than -0.10 — real problem, prioritize
-- MinPeer < 0.40 — translation likely wrong regardless of discrimination
+Diagnostic, not prescriptive. Read the values:
+- Gap > 0 — stub clears its neighbors; ignore a mild fidelity flag.
+- Gap between −0.05 and 0 — marginal; watch.
+- Gap more negative than −0.10 — real collision; prioritize.
+- Fidelity < 0.40 — translation likely wrong regardless of discrimination.
 
 ## See Also
 
 - knowledge/optimization(meta) — broader vocabulary tuning and sparsity principles
 - knowledge/authoring(meta) — way file format, coordinate-alias model
+- the design note `adopter-localization-lifecycle-and-tuning` — the root-anchored model in full


### PR DESCRIPTION
Slice 6 of Phase B (ADR-139 / #160) — the docs reconcile, closing the implementation.

- **Tuning way** (`meta/knowledge/optimization/tuning`) rewritten from the maintainer-era peers-only model to the adopter-run **root-anchored** model: fidelity = alignment to the English root anchor (not agreement among siblings), `ways tune --lang` is the localized-mode acceptance gate the `ways-localize` skill drives, English mode returns clean. Two failure modes (drifted-from-root, collides-with-another-way).
- **Config-layer reconcile** in the design note + mode-gate scenario (`01.013.E`): the effective switch is the resolved `Config.language` — `ways.json output_language` (Layer 1) is overridden by the user-scope `~/.config/ways/config.yaml language` (Layer 2, default `auto`), the layer `ways-localize` writes. Docs previously said "ways.json" alone.

Verified: corpus rebuilds clean, `doc lint` clean.

**Deferred (small):** the `docs/hooks-and-ways/` reference pages (`languages.md`, `matching.md`) still describe the pre-mode-switch system — noted for a follow-up.

Part of #160.

https://claude.ai/code/session_01DUyCtuGK5uewAdgp2aE3Dt