### PR TITLE
fix(make): robust make update — survive local changes + prune branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,9 +95,12 @@ uninstall:
 	@rm -f "$(XDG_BIN)/ways" "$(XDG_BIN)/attend" "$(XDG_BIN)/attend-chat"
 	@echo "Removed $(XDG_BIN)/ways $(XDG_BIN)/attend $(XDG_BIN)/attend-chat"
 
-# Pull upstream and re-setup.
+# Pull upstream and re-setup. scripts/update.sh wraps the pull so machine-local
+# changes (settings.json, stale build artifacts) and merged branches don't abort
+# the fast-forward — it autostashes, prunes, and surfaces conflicts instead of
+# clobbering. See the script for recovery behavior.
 update:
-	git pull --ff-only
+	@bash scripts/update.sh
 	$(MAKE) update-binaries
 	$(MAKE) install
 


### PR DESCRIPTION
`make update` ran a bare `git pull --ff-only`, which **aborts** when a tracked-but-machine-mutable file has local edits — recurringly `settings.json` (shared hooks/permissions, but machine-local plugin/notification/language state) and stale tracked build artifacts (`tools/way-embed/build/Makefile` on checkouts from before `805bf93` gitignored them). Merged branches also accumulated.

`scripts/update.sh` wraps the pull:
- **autostash** local changes (incl. untracked) so the fast-forward never aborts
- `git pull --ff-only` → `git fetch --prune`
- **restore** the stash — on conflict, **preserve it** and print exact recovery commands (keep machine-local `settings.json` vs take upstream; discard regenerated build artifacts) instead of clobbering
- **prune** local branches whose upstream is gone (merged + deleted on origin)

`Makefile update:` calls the script, then `update-binaries` + `install` as before.

Also done outside this PR: enabled auto-delete-on-merge on the repo and deleted the 11 merged leftover branches (origin is back to just `main`).

Verified: `update.sh` round-trips a local edit cleanly on an up-to-date checkout.

**Recommended follow-up (not in this PR):** `settings.json` is tracked yet machine-divergent — the root cause. The clean fix is the `settings.local.json` split (machine-local keys gitignored, shared defaults tracked). Worth an issue/ADR.