### PR TITLE
fix(make): install no longer self-links way-embed when repo is ~/.claude

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,14 @@ install: hooks-executable setup hooks-install
 	@$(LINK) "$(CURDIR)/$(ATTEND_BIN)" "$(XDG_BIN)/attend"
 	@$(LINK) "$(CURDIR)/$(ATTEND_CHAT_BIN)" "$(XDG_BIN)/attend-chat"
 	@mkdir -p "$(CLAUDE_BIN)"
-	@$(LINK) "$(CURDIR)/$(WAY_EMBED_BIN)" "$(CLAUDE_BIN)/way-embed"
+	@# When the repo IS ~/.claude, $(CURDIR)/bin/way-embed already equals
+	@# $(CLAUDE_BIN)/way-embed — linking a file to itself errors ("same file").
+	@# Skip the link in that case; the binary is already where tools look for it.
+	@if [ "$(CURDIR)/$(WAY_EMBED_BIN)" -ef "$(CLAUDE_BIN)/way-embed" ]; then \
+		echo "  way-embed: already in place ($(CLAUDE_BIN)/way-embed) — no link needed"; \
+	else \
+		$(LINK) "$(CURDIR)/$(WAY_EMBED_BIN)" "$(CLAUDE_BIN)/way-embed"; \
+	fi
 	@echo ""
 	@echo "Install complete."
 	@echo "  ways binary:        $(XDG_BIN)/ways → $(CURDIR)/$(WAYS_BIN)"


### PR DESCRIPTION
`install` symlinks `way-embed` into `$(CLAUDE_BIN)` = `~/.claude/bin`. When the repo **is** `~/.claude` (the common case), `$(CURDIR)/bin/way-embed` already equals `$(CLAUDE_BIN)/way-embed`, so `ln -sf X X` errors (`are the same file`) and aborts `make install` / `make update` at `Makefile:80`. The other three binaries link into `~/.local/bin`, so only `way-embed` collided.

Fix: guard the link with `-ef` (same-file test) — skip when source and dest are the same file (binary's already where tools look), link normally otherwise.

Surfaced by `make update` on a freshly-synced `~/.claude` checkout.