### PR TITLE
fix(make): precheck Rust >= 1.85 before source build (bail early)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ hooks/ways/.obsidian/
 !scripts/gh-monitor-ci-watch.sh
 !scripts/gh-monitor-inbox-watch.sh
 !scripts/update.sh
+!scripts/check-rust.sh
 !docs/signal-analysis/
 !docs/signal-analysis/*.md
 !docs/signal-analysis/*.png

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ ways:
 		echo "Pre-built binary installed."; \
 	elif command -v cargo >/dev/null 2>&1; then \
 		echo "No pre-built binary, building from source..."; \
+		bash scripts/check-rust.sh || exit 1; \
 		cargo build --release --manifest-path tools/Cargo.toml -p ways; \
 		mkdir -p bin; \
 		$(LINK) "$(CURDIR)/tools/target/release/ways$(EXE)" $(WAYS_BIN); \
@@ -144,6 +145,7 @@ ways-rebuild:
 		echo "error: cargo not found. Install Rust: https://rustup.rs/"; \
 		exit 1; \
 	fi
+	@bash scripts/check-rust.sh
 	cargo build --release --manifest-path tools/Cargo.toml -p ways
 	@mkdir -p bin
 	@$(LINK) "$(CURDIR)/tools/target/release/ways$(EXE)" $(WAYS_BIN)

--- a/scripts/check-rust.sh
+++ b/scripts/check-rust.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Precheck: building agent-ways from source needs Rust/Cargo >= 1.85.
+#
+# A transitive dependency (getrandom) uses Rust edition 2024, which was
+# stabilized in 1.85. On older toolchains `cargo build` fails deep in dependency
+# compilation with a cryptic "feature `edition2024` is required" error. Catch it
+# up front with an actionable message instead.
+#
+# Called from the source-build branches of the Makefile. If cargo is absent the
+# build target's own fallback handles it, so this exits 0 (don't double-report).
+
+set -u
+MIN_MAJOR=1
+MIN_MINOR=85
+
+command -v cargo >/dev/null 2>&1 || exit 0   # no cargo → build target reports it
+
+ver=$(cargo --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+[ -z "$ver" ] && exit 0                       # unparseable → don't block
+
+maj=${ver%%.*}
+min=${ver#*.}; min=${min%%.*}
+
+if [ "$maj" -lt "$MIN_MAJOR" ] || { [ "$maj" -eq "$MIN_MAJOR" ] && [ "$min" -lt "$MIN_MINOR" ]; }; then
+  cat >&2 <<EOF
+
+  ──────────────────────────────────────────────────────────────────────────
+  ERROR: agent-ways needs Rust/Cargo >= ${MIN_MAJOR}.${MIN_MINOR} to build from source.
+
+    you have:  cargo ${ver}
+    why:       a dependency (getrandom) uses Rust edition 2024 (stabilized in 1.85)
+
+    fix:       rustup update            # if Rust came from rustup
+               # or install rustup:     https://rustup.rs
+
+    (A pre-built binary may also be available — see the releases page.)
+  ──────────────────────────────────────────────────────────────────────────
+EOF
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Building from source on an old toolchain (e.g. `cargo 1.82`) fails deep in dependency compilation — `getrandom` uses Rust **edition 2024** (stabilized in 1.85), yielding a cryptic `feature edition2024 is required` error partway through.

`scripts/check-rust.sh` parses `cargo --version`; if `< 1.85` it prints an actionable message (`rustup update` / install rustup / pre-built may exist) and exits 1 **before cargo runs**. Wired into the source-build branch of `ways` (make setup/install) and `ways-rebuild` (make update) — the first Rust builds in each flow. No-op when cargo is absent or new enough.

Greenfield (fresh-install) surface fix. Verified: passes on 1.92, bails on a simulated 1.82 stub.