### PR TITLE
fix(make): install establishes PATH even if way-embed can't build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,14 @@ help:
 # Build ways CLI + set up embedding engine + generate initial corpus.
 setup: ways attend attend-chat
 	@echo "Setting up embedding engine..."
-	$(MAKE) -C tools/way-embed setup
+	@# Optional accelerator — if its build deps are missing, warn and continue so
+	@# the rest of install (incl. the PATH symlinks) still completes. Without it,
+	@# ways fall back to regex/keyword matching.
+	@$(MAKE) -C tools/way-embed setup || { \
+		echo ""; \
+		echo "  ⚠ Embedding engine not built — semantic (meaning-based) matching is unavailable."; \
+		echo "    Regex/keyword ways still work. Install the build deps shown above, then re-run 'make install'."; \
+	}
 	@echo ""
 	@echo "Setting up mmaid diagram renderer..."
 	@bash tools/mmaid/download-mmaid.sh || echo "  (mmaid optional — skipping)"
@@ -91,6 +98,13 @@ install: hooks-executable setup hooks-install
 	@echo "  attend binary:      $(XDG_BIN)/attend → $(CURDIR)/$(ATTEND_BIN)"
 	@echo "  attend-chat binary: $(XDG_BIN)/attend-chat → $(CURDIR)/$(ATTEND_CHAT_BIN)"
 	@echo "  way-embed binary:   $(CLAUDE_BIN)/way-embed → $(CURDIR)/$(WAY_EMBED_BIN)"
+	@case ":$$PATH:" in \
+		*":$(XDG_BIN):"*) ;; \
+		*) printf '\n  %s\n  %s\n  %s\n' \
+			"NOTE: $(XDG_BIN) is not on your PATH — ways/attend won't be found yet." \
+			"Add it to your shell rc (~/.bashrc or ~/.zshrc), then restart your shell:" \
+			"    export PATH=\"$(XDG_BIN):\$$PATH\"" ;; \
+	esac
 	@echo "  Restart Claude Code for ways to take effect."
 
 hooks-install:

--- a/tools/way-embed/Makefile
+++ b/tools/way-embed/Makefile
@@ -40,6 +40,14 @@ $(BIN): cmake-build
 	@echo "Built: $(PLATFORM_BIN) ($$(ls -lh $(PLATFORM_BIN) | awk '{print $$5}'))"
 
 cmake-build: CMakeLists.txt way-embed.cpp | llama.cpp/CMakeLists.txt
+	@command -v cmake >/dev/null 2>&1 || { \
+		echo "ERROR: cmake not found — required to build way-embed (the semantic matcher) from source."; \
+		echo "  Install cmake + a C++ compiler:"; \
+		echo "    Arch:    sudo pacman -S cmake gcc"; \
+		echo "    Debian:  sudo apt install cmake build-essential"; \
+		echo "    Fedora:  sudo dnf install cmake gcc-c++"; \
+		echo "    macOS:   brew install cmake"; \
+		exit 1; }
 	@mkdir -p $(BUILDDIR)
 	@cd $(BUILDDIR) && cmake $(CMAKE_FLAGS) .. 2>&1 | tail -5
 	cmake --build $(BUILDDIR) --target way-embed $(CMAKE_BUILD_FLAGS) -j$$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)


### PR DESCRIPTION
Greenfield (cube) hit two compounding problems: `cmake: command not found` (way-embed is C++/cmake), then **`ways` not on PATH** — because the way-embed failure aborted `install` *before* its PATH-symlink recipe ran, though ways/attend built fine.

way-embed is an optional accelerator (regex/keyword matching works without it), so:
- **Root `setup`**: the way-embed step is now **non-fatal** (like mmaid already is) — warn + continue so install completes and the `~/.local/bin` symlinks get created.
- **way-embed `cmake-build`**: prechecks `cmake` and bails with **multi-distro install guidance** instead of a cryptic "command not found".
- **`install`**: warns if `~/.local/bin` isn't on PATH and prints the exact `export PATH=…` — so a fresh shell doesn't just say "ways: command not found".

`attend-chat` / `attend-chat-rebuild` targets already exist — no change.

Hardening the install path for org rollout.