### PR TITLE
fix(ways): close the lint/corpus frontmatter parser divergence

### DIFF
--- a/tools/ways-cli/src/cmd/corpus.rs
+++ b/tools/ways-cli/src/cmd/corpus.rs
@@ -286,9 +286,20 @@ fn scan_ways_dir(dir: &Path, id_prefix: &str, excluded: &[String], w: &mut impl 
     // English roots captured here become the multilingual anchor in Pass 2 (localized mode).
     let mut en_roots: HashMap<String, (String, String)> = HashMap::new();
     for path in &md_files {
-        let fm = match frontmatter::parse(path) {
-            Ok(fm) => fm,
-            Err(_) => continue,
+        let fm = match frontmatter::parse_if_present(path) {
+            Ok(Some(fm)) => fm,
+            // No frontmatter at all — a template/catalog/prose file, not a way. Skip
+            // it silently, the way it always has been.
+            Ok(None) => continue,
+            // Frontmatter present but unparseable (e.g. an unquoted value containing
+            // ": ") would vanish from matching with no signal. `ways lint` is the hard
+            // gate (it now runs this same parse), but warn here too so a runtime
+            // rebuild still surfaces it. See ADR-125.
+            Err(e) => {
+                let rel = path.strip_prefix(dir).unwrap_or(path);
+                eprintln!("[ways corpus] WARN: {} — frontmatter present but did not parse, dropped from corpus ({})", rel.display(), e.root_cause());
+                continue;
+            }
         };
 
         // ADR-126: surface malformed refire specs at corpus time. Corpus is a

--- a/tools/ways-cli/src/cmd/lint/per_file.rs
+++ b/tools/ways-cli/src/cmd/lint/per_file.rs
@@ -77,6 +77,19 @@ pub(super) fn lint_file(
     // rules see the collapsed form.
     let fm_str = extract_frontmatter_raw(&content).unwrap_or_default();
 
+    // Strict YAML parse gate (ways only). The matching pipeline (corpus, scan)
+    // loads frontmatter via serde_yaml, so a value that isn't valid YAML drops the
+    // way from matching with no other symptom — and the field-by-field rules below
+    // never notice. Run the same parse the matcher uses so lint is a real gate.
+    // Checks aren't loaded this way, so they're exempt.
+    if !is_check {
+        if let Err(e) = crate::frontmatter::parse_str(&fm_str) {
+            let root = e.root_cause();
+            eprintln!("  ERROR: {rel} — frontmatter is not valid YAML, so the matcher would silently drop this way: {root}. Common cause: an unquoted value containing a colon-space (\": \") — wrap the value in double quotes.");
+            *errors += 1;
+        }
+    }
+
     // Unknown top-level fields. x-* prefixed fields are intentionally
     // skipped. With --fix, remove the field (and any indented block value
     // that follows) and emit FIXED; otherwise emit UNKNOWN as a warning.

--- a/tools/ways-cli/src/frontmatter.rs
+++ b/tools/ways-cli/src/frontmatter.rs
@@ -185,11 +185,31 @@ pub fn parse(path: &Path) -> Result<Frontmatter> {
     let yaml_str = extract_frontmatter_str(&content)
         .with_context(|| format!("no frontmatter in {}", path.display()))?;
 
-    detect_legacy_redisclose(&yaml_str)
-        .with_context(|| format!("legacy frontmatter in {}", path.display()))?;
+    parse_str(&yaml_str)
+}
 
-    serde_yaml::from_str(&yaml_str)
-        .with_context(|| format!("parsing frontmatter in {}", path.display()))
+/// Parse an already-extracted frontmatter YAML block. This is the single
+/// strict-parse path the matching pipeline relies on; `ways lint` calls it too
+/// so the gate can't pass a way the corpus/scanner would silently reject (e.g.
+/// an unquoted value containing ": ", which is invalid YAML).
+pub fn parse_str(yaml_str: &str) -> Result<Frontmatter> {
+    detect_legacy_redisclose(yaml_str).context("legacy frontmatter")?;
+    serde_yaml::from_str(yaml_str).context("parsing frontmatter")
+}
+
+/// Like `parse`, but distinguishes "not a way" from "malformed way" so corpus
+/// generation warns only on genuine breakage:
+///
+/// - `Ok(None)` — no `---` frontmatter block (a template/catalog/prose file that isn't a way; skip silently).
+/// - `Ok(Some(_))` — frontmatter present and valid.
+/// - `Err(_)` — frontmatter present but unparseable (a real defect to surface, not a silent drop).
+pub fn parse_if_present(path: &Path) -> Result<Option<Frontmatter>> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("reading {}", path.display()))?;
+    match extract_frontmatter_str(&content) {
+        None => Ok(None),
+        Some(yaml_str) => parse_str(&yaml_str).map(Some),
+    }
 }
 
 /// Extract the raw YAML string between `---` delimiters.
@@ -316,6 +336,46 @@ mod tests {
 
     fn parse_yaml(yaml: &str) -> Frontmatter {
         serde_yaml::from_str(yaml).expect("frontmatter parse failed")
+    }
+
+    #[test]
+    fn parse_str_accepts_valid_frontmatter() {
+        assert!(parse_str("description: a way\nvocabulary: a b c\n").is_ok());
+    }
+
+    #[test]
+    fn parse_str_rejects_unquoted_colon_space() {
+        // The exact shape that silently dropped a way from the corpus: a colon-space
+        // in an unquoted scalar is invalid YAML. lint runs this so it can't pass.
+        assert!(parse_str("description: a way about X: the thing\nvocabulary: a b\n").is_err());
+    }
+
+    #[test]
+    fn parse_str_accepts_colon_when_quoted() {
+        assert!(parse_str("description: \"a way about X: the thing\"\nvocabulary: a b\n").is_ok());
+    }
+
+    #[test]
+    fn parse_if_present_distinguishes_absent_from_malformed() {
+        let dir = std::env::temp_dir().join(format!("ways-fm-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // No frontmatter delimiters → not a way → Ok(None) (silent skip).
+        let prose = dir.join("prose.md");
+        std::fs::write(&prose, "# Just prose\nno frontmatter here\n").unwrap();
+        assert!(matches!(parse_if_present(&prose), Ok(None)));
+
+        // Present but malformed → Err (a real defect to surface).
+        let bad = dir.join("bad.md");
+        std::fs::write(&bad, "---\ndescription: broken: yaml\n---\nbody\n").unwrap();
+        assert!(parse_if_present(&bad).is_err());
+
+        // Present and valid → Ok(Some).
+        let good = dir.join("good.md");
+        std::fs::write(&good, "---\ndescription: fine\nvocabulary: a b\n---\nbody\n").unwrap();
+        assert!(matches!(parse_if_present(&good), Ok(Some(_))));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
## The bug

A way whose frontmatter isn't valid YAML — most commonly an **unquoted value containing a colon-space** (`description: X: the thing`) — was **silently dropped from the matching corpus** while `ways lint` reported it clean. The matcher (corpus + scan) parses frontmatter with `serde_yaml` (strict), but `ways lint` validated **field-by-field with string extraction** and never ran a real parse. So lint was a hollow gate: a way could pass it yet never fire.

Surfaced while authoring the `meta/deployment` way in #184 — its description had a colon-space, lint passed, and it just never matched until I noticed it missing from the corpus.

## The fix (defense in depth)

- **lint is now a real gate.** It runs the *same* strict parse the matcher uses (`frontmatter::parse_str`) on every way and ERRORs with an actionable message — *"...wrap the value in double quotes"* — instead of passing a way that can't load.
- **corpus no longer drops silently.** `frontmatter::parse_if_present` distinguishes *"no frontmatter"* (a template/catalog/prose file — skip quietly, as always) from *"frontmatter present but malformed"* (warn to stderr, naming the file and the YAML error location). Templates and frontmatter-less think-strategies stay silent; only genuine breakage warns.

`parse_str` is extracted as the single strict-parse path so lint and the matcher can't drift again.

## Verification

- New unit tests: `parse_str` (valid / colon-space rejected / quoted accepted) and `parse_if_present` (absent → `Ok(None)`, malformed → `Err`, valid → `Ok(Some)`).
- Manually verified: lint ERRORs on a colon-space way and accepts it once quoted; corpus warns on a malformed way (with line/col) and is **silent** on the real 149-way tree.
- `cargo test -p ways` 155+6+11 green · clippy clean on changed files · `ways lint --global` 0/0.

## Out of scope (flagged)

A pre-existing clippy nit in `config.rs:464` test code (`Default::default()` field assignment, from the earlier localization work, already on main) is unrelated and left for a separate cleanup.