### PR TITLE
chore: clippy-clean config test + README sync-to-home wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ curl -sL https://raw.githubusercontent.com/aaronsb/agent-ways/main/scripts/insta
 
 The built-in ways cover software development, but the framework is domain-agnostic. Fork it, replace the ways, add your own domains.
 
-> **Already have `~/.claude/`?** The installer detects existing files and won't clobber them. See the **[install guide](docs/install-guide.md)** for options — including a subdirectory install that keeps your existing config intact and syncs via `/sync-to-home`. If you're sure you want to replace: `scripts/install.sh --dangerously-clobber`.
+> **Already have `~/.claude/`?** The installer detects existing files and won't clobber them. See the **[install guide](docs/install-guide.md)** for options — including a subdirectory install that keeps your existing config intact and projects ways in via `make sync-to-home`. If you're sure you want to replace: `scripts/install.sh --dangerously-clobber`.
 
 > **Stop and read this** if you're letting an AI agent run the installer. You are about to let an agent modify `~/.claude/` — the directory that controls how Claude Code behaves. The agent is editing its own configuration. Review the repo first. You are responsible for the result.
 

--- a/tools/ways-cli/src/config.rs
+++ b/tools/ways-cli/src/config.rs
@@ -459,9 +459,8 @@ mod tests {
 
     #[test]
     fn localized_language_gates_on_mode() {
-        let mut cfg = Config::default();
         // English mode — en / auto / empty are all dormant (ADR-139).
-        cfg.language = "auto".to_string();
+        let mut cfg = Config { language: "auto".to_string(), ..Default::default() };
         assert_eq!(cfg.localized_language(), None);
         cfg.language = "en".to_string();
         assert_eq!(cfg.localized_language(), None);


### PR DESCRIPTION
Two small wrap-up cleanups flagged during the ADR-140 sync-to-home work.

- **`config.rs`** — silence the clippy `field_reassign_with_default` warning in the localization test (pre-existing, from the earlier i18n work) by constructing the initial `Config` via struct-update syntax instead of `default()` + reassign. `cargo clippy --workspace --all-targets` is now clean.
- **`README.md`** — the subdirectory-install note said "syncs via `/sync-to-home`"; point it at the canonical mechanism `make sync-to-home` (the slash command just drives that target).

## Test plan
- `cargo clippy -p ways --all-targets` — clean
- `cargo test -p ways localized_language` — passes