### PR TITLE
docs: install-topologies explanation cluster (model + two scenarios, with diagrams)

### DIFF
--- a/docs/explanation/install-topologies/scenario-the-in-place-install.md
+++ b/docs/explanation/install-topologies/scenario-the-in-place-install.md
@@ -1,0 +1,56 @@
+---
+id: 01.015.E
+domain: system
+mode: explanation
+related:
+  - "[[ADR-140]]"
+  - "[[01.014.E]]"
+  - "[[01.016.E]]"
+aliases: []
+---
+
+# Scenario — the in-place install
+
+**A greenfield machine: no existing `~/.claude` worth keeping.** The simplest, default
+shape — the repo *is* your config dir, and `git pull` is the entire update story.
+
+## How it plays out
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Op as Operator
+    participant I as install.sh
+    participant H as ~/.claude (the repo)
+    Op->>I: curl … | bash
+    I->>H: git clone agent-ways → ~/.claude
+    I->>H: make setup (build binaries · fetch model · corpus)
+    Note over H: ~/.claude is now a git checkout
+    rect rgba(45,142,94,0.12)
+    Op->>H: later — make update
+    H->>H: git pull --ff-only · rebuild binaries · reinstall
+    Note over H: the files you run ARE the repo — nothing to project
+    end
+```
+
+## What each move is doing
+
+- **The installer clones straight into `~/.claude`.** Because nothing valuable was
+  there, the directory simply *becomes* the repo. No projection step exists — there's
+  nothing to copy from one place to another.
+- **`make update` is pull + rebuild + reinstall.** It pulls the latest commits,
+  rebuilds the binaries that changed, and re-runs install. One command, because there's
+  only one copy of everything.
+- **Drift is impossible by construction.** The files Claude Code loads and the files in
+  the repo are the *same files*. `git status` in `~/.claude` is the truth; there is no
+  "installed but stale" state to detect.
+- **The update checker just runs git in place.** It classifies the clone (or fork) and
+  nudges you when you're behind upstream — no markers, no indirection.
+
+## The point
+
+This is the topology to choose when you can. Its whole virtue is that there's nothing
+to keep in sync: one repo, one update command, no second moving part. It's the baseline
+the other topology ([[01.016.E]]) has to work to match — and the reason the in-place
+shape stays the default. The decision context is [[ADR-140]]; the conceptual overview
+is [[01.014.E]].

--- a/docs/explanation/install-topologies/scenario-the-subdirectory-install.md
+++ b/docs/explanation/install-topologies/scenario-the-subdirectory-install.md
@@ -1,0 +1,76 @@
+---
+id: 01.016.E
+domain: system
+mode: explanation
+related:
+  - "[[ADR-140]]"
+  - "[[01.014.E]]"
+  - "[[01.015.E]]"
+aliases: []
+---
+
+# Scenario — the subdirectory install
+
+**An operator who already has a `~/.claude` they value installs agent-ways without
+giving it up.** The repo lives in a subdirectory; `make sync-to-home` *projects* its
+outputs up into the existing `~/.claude`, which stays the operator's own directory.
+This is the non-destructive path the installer's conflict menu offers first.
+
+## How it plays out
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Op as Operator
+    participant R as ~/.claude/agent-ways (the repo)
+    participant H as ~/.claude (your own dir)
+    Op->>R: git clone agent-ways → ~/.claude/agent-ways
+    Op->>R: make setup
+    rect rgba(45,125,154,0.12)
+    Op->>R: make sync-to-home
+    R->>H: backup → copy skills/agents/commands/hooks/bin
+    R->>H: merge ONLY hooks + ways permissions into settings.json
+    R->>H: stamp .claude-source (repo path + synced HEAD)
+    Note over H: your model · theme · plugins · credentials untouched
+    end
+    rect rgba(217,119,6,0.12)
+    Op->>R: later — git pull
+    Op->>R: make sync-to-home (re-project)
+    Note over H: forgot to re-sync? checker sees HEAD doesn't match stamp → nudges
+    end
+```
+
+## What each move is doing
+
+- **The repo never touches `~/.claude` wholesale.** `make sync-to-home` copies the
+  repo-owned trees in and merges *only* the hooks block and ways permissions into your
+  existing `settings.json`. Your model, theme, plugins, and credentials are never read
+  or rewritten. It backs up first, to `~/.claude/backups/`.
+- **Projection is deterministic, and it's a `make` target.** The logic lives in a real
+  script behind `make sync-to-home`, not in prose a command improvises — so it's the
+  same every run, testable, and runnable without an agent. The `/sync-to-home` skill is
+  just a thin wrapper that drives it with consent and a report.
+- **Copy is the default; symlink is the opt-in.** `make sync-to-home` *copies* — robust
+  everywhere, including Windows and low-privilege machines ("it copied files in" is a
+  model that survives). `make sync-to-home-link` *symlinks* the trees instead, so a
+  future `git pull` is the whole update with no re-sync — at the cost of symlink
+  fragility where they need admin/developer-mode.
+- **Copies don't delete, so a manifest prunes orphans.** A way or skill removed
+  upstream would otherwise linger in `~/.claude` forever. The sync records what it
+  projected and, next run, removes only files a prior projection wrote that are gone
+  from source — never your own files in the same shared directories.
+- **The cost of this topology is the second step — so the install makes it
+  observable.** `make sync-to-home` stamps a `.claude-source` marker with the repo's
+  path and the HEAD it projected. Because `~/.claude` isn't itself a repo, the update
+  checker follows that marker to the real repo to check "behind upstream," and compares
+  the repo's current HEAD to the stamp to catch "pulled but not synced." Drift that
+  would otherwise be silent becomes a nudge.
+
+## The point
+
+The operator keeps everything they had and still gets agent-ways, fully. The price is
+honest — one extra command per update — and the system refuses to let that price turn
+into silent rot: it nudges when you're behind *and* when you've pulled but not
+re-synced. That observability is what earns the subdirectory shape its place as a
+first-class topology rather than a fragile workaround. The simpler sibling is
+[[01.015.E]]; the model is [[01.014.E]]; the decision is [[ADR-140]].

--- a/docs/explanation/install-topologies/the-two-install-topologies-the-model.md
+++ b/docs/explanation/install-topologies/the-two-install-topologies-the-model.md
@@ -1,0 +1,77 @@
+---
+id: 01.014.E
+domain: system
+mode: explanation
+related:
+  - "[[ADR-140]]"
+  - "[[01.015.E]]"
+  - "[[01.016.E]]"
+aliases: []
+---
+
+# The two install topologies — the model
+
+agent-ways can live in your `~/.claude` in one of two shapes. They are not two
+products — they are two *topologies* of the same install, and which one you're on
+decides exactly one thing day to day: **how you update.** Everything else — ways,
+skills, the binaries — behaves identically.
+
+## The invariant, and the one place it bends
+
+The original, default shape holds a simple invariant: **the repo *is* your
+config.** `~/.claude` is the git clone. That's why `git pull` is the whole update,
+why `git status` tells the truth, and why there's no such thing as "drift" — the
+files you run *are* the files in the repo.
+
+That invariant is also a wall for one kind of adopter: someone who already has a
+`~/.claude` they care about — sessions, credentials, their own `settings.json` —
+and won't turn it into a clone of someone else's repo. For them the invariant
+bends: the repo moves into a *subdirectory*, and its outputs are **projected** up
+into `~/.claude`, which stays their own directory.
+
+```mermaid
+flowchart TB
+    subgraph InPlace["In-place — the repo IS ~/.claude"]
+        direction TB
+        A1["~/.claude = git clone"] --> A2["git pull / make update"]
+        A2 --> A3["files update in place<br/>zero projection · zero drift"]
+    end
+    subgraph Subdir["Subdirectory — the repo projects INTO ~/.claude"]
+        direction TB
+        B1["~/.claude/agent-ways = git clone<br/>~/.claude = your own dir"] --> B2["git pull"]
+        B2 --> B3["make sync-to-home<br/>(copy, or symlink)"]
+        B3 --> B4["outputs projected up<br/>your sessions/settings untouched"]
+    end
+
+    classDef repo fill:#7c3aed,color:#ffffff,stroke:#4a5568
+    classDef step fill:#2d7d9a,color:#ffffff,stroke:#4a5568
+    classDef done fill:#2d8e5e,color:#ffffff,stroke:#4a5568
+    class A1,B1 repo
+    class A2,B2,B3 step
+    class A3,B4 done
+
+    style InPlace stroke:#8b5cf6,fill:#7c3aed1a,color:#cbd5e1
+    style Subdir stroke:#d97706,fill:#f6821f1a,color:#cbd5e1
+```
+
+## How to pick
+
+- **Greenfield, or you want the least to reason about → in-place.** One repo, one
+  command, no drift. This is the default and what the installer does when `~/.claude`
+  is empty.
+- **You already have a `~/.claude` you value → subdirectory.** Non-destructive: your
+  config stays yours. The cost is a two-step update (`git pull` *then*
+  `make sync-to-home`) — which the install surfaces and nudges you about, so a missed
+  sync can't silently rot.
+
+Within the subdirectory topology there's a second, smaller choice — **copy vs
+symlink** — covered in [[01.016.E]].
+
+## Why two and not one
+
+Forcing every adopter onto the in-place shape would have meant telling the
+existing-config user to clobber or move their directory aside — a destructive choice
+at the worst moment. Supporting both, as first-class and *observable*, is what lets
+the framework reach people who'd otherwise bounce off the install. The decision and
+its trade-offs are recorded in [[ADR-140]]; the two day-to-day experiences are walked
+through in [[01.015.E]] (in-place) and [[01.016.E]] (subdirectory).

--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -138,6 +138,8 @@ The built-in update checker (`hooks/check-config-updates.sh`) detects forks and 
 
 This is the **subdirectory topology** (ADR-140): the agent-ways repo lives in a subdirectory (e.g. `~/.claude/agent-ways`) and is *projected* into `~/.claude` without replacing it. Your sessions, credentials, and settings stay where they are.
 
+> For the conceptual model and walked-through scenarios of both topologies, see [docs/explanation/install-topologies/](explanation/install-topologies/) — the model, the in-place install, and the subdirectory install, each with diagrams.
+
 **Steps:**
 
 ```bash


### PR DESCRIPTION
## Summary

Answers "is there a doc about the two modes of use?" — there wasn't a single conceptual one. Adds a catalog **explanation** cluster under `docs/explanation/install-topologies/`, mirroring the localization scenario pages:

- **`01.014.E` — the model** — the in-place invariant (*the repo IS your config*), where it bends for the subdirectory topology, and how to pick. Flowchart comparing both.
- **`01.015.E` — scenario: the in-place install** — greenfield; `git pull` is the whole update; drift impossible by construction.
- **`01.016.E` — scenario: the subdirectory install** — brownfield; the projection, copy vs symlink, and the `.claude-source` synced-HEAD drift nudge. Sequence diagram.

## Styling

Diagrams follow the **mermaid styling way**: opaque, role-mapped node fills (violet = the repo, teal = a command/step, green = a healthy end state), translucent mid-tone subgraph tints that clear both light/dark backgrounds, and theme-safe `rect` phase-highlights on the sequence diagrams (teal = the projection mechanism, amber = update/drift caution).

## Verification

- `docs/scripts/doc lint` — 0 errors, 0 warnings (16 catalog pages)
- All three diagrams validated via `mmaid` (syntax parses)
- Cross-linked: ADR-140 ↔ the cluster ↔ install-guide Scenario 5

## Note

The repo's *existing* diagrams don't yet follow the styling way — a good candidate to fan out across the docs in a separate pass.