### PR TITLE
docs: apply mermaid styling convention across docs diagrams (26 diagrams, 18 files)

### DIFF
--- a/docs/architecture/system/ADR-136-split-addressed-messaging-from-the-sensor-observation-bus.md
+++ b/docs/architecture/system/ADR-136-split-addressed-messaging-from-the-sensor-observation-bus.md
@@ -95,6 +95,7 @@ boundary.
 
 ```mermaid
 sequenceDiagram
+    autonumber
     participant H as Human / Agent
     participant C as Compose<br/>(attend-chat / attend send)
     participant FS as Shared signal dir<br/>(~/.cache/attend/signals/…)
@@ -102,9 +103,12 @@ sequenceDiagram
     participant G as Gate stack
     participant M as Monitor → session
 
+    rect rgba(124,58,237,0.12)
     H->>C: "@Cleo @Tam hi" / attend send
     Note over C: parse_addressed → ONE Addressed<br/>CLI → ONE --to / --focus
     C->>FS: write_signal (one file per dest dir)
+    end
+    rect rgba(217,119,6,0.12)
     loop each peer polls independently
         S->>FS: scan own-cwd + _broadcast + focus
         S->>G: 1. seen-dedup
@@ -115,6 +119,7 @@ sequenceDiagram
         S->>G: 6. disclosure governor: window cap + cooldown (per-session)
         S->>G: 7. priority filter: magnitude ≥ 3 → stdout
         G-->>M: survivors → stdout line
+    end
     end
     M->>H: <task-notification>
 ```
@@ -284,54 +289,82 @@ flowchart TD
     Q -->|"no — git, process, peer-presence"| E[EVENT lane<br/>salience + refractory + governor]
     M --> MT[recipient tray / room ledger<br/>never wiped until that recipient saw it]
     E --> ET[coalesced · aged by wall-clock · may drop]
+
+    classDef external fill:#f6821f,color:#1a1a1a,stroke:#4a5568
+    classDef decision fill:#fbbf24,color:#1a1a1a,stroke:#4a5568
+    classDef core fill:#7c3aed,color:#ffffff,stroke:#4a5568
+    classDef process fill:#2d7d9a,color:#ffffff,stroke:#4a5568
+    classDef store fill:#2d8e5e,color:#ffffff,stroke:#4a5568
+
+    class X external
+    class Q decision
+    class M core
+    class E process
+    class MT store
+    class ET process
 ```
 
 **Authored message, live recipients** (also the Bug 1 multi-recipient fix):
 
 ```mermaid
 sequenceDiagram
+    autonumber
     participant A as Author
     participant L as Message lane
     participant T1 as Alice's tray
     participant T2 as Bob's tray / #open ledger
     participant Rx as Live recipient
+    rect rgba(124,58,237,0.12)
     A->>L: "@Alice @Bob ship it" (one compose)
     Note over L: parse the SET {Alice, Bob}<br/>stamp wall-clock ts, one dedup id
     L->>T1: durable write
     L->>T2: durable write
+    end
+    rect rgba(45,142,94,0.12)
     Rx->>T1: scan (live)
     T1-->>Rx: notify once
     Note over T1: read ≠ delete — marked seen in<br/>Rx's own set, survives restart
+    end
 ```
 
 **Re-entry after a down-gap** (the Bug 2 fix; wall-clock front and center):
 
 ```mermaid
 sequenceDiagram
+    autonumber
     participant Rx as Returning session
     participant T as Trays + #open ledger
     Note over Rx: was down 06:04–06:25
+    rect rgba(217,119,6,0.12)
     Rx->>T: on reconnect, scan UNSEEN (own seen-set)
     T-->>Rx: digest — "while away: 2 to you (newest 2m ago) ·<br/>6 on #open over 21m"
     Note over Rx: one coalesced turn, NOT a replay flood
+    end
+    rect rgba(45,142,94,0.12)
     Rx->>T: attend inbox (opt-in pull)
     T-->>Rx: full chronological ledger
     Note over Rx: silence still valid — glance if worth it
+    end
 ```
 
 **Environmental event** (unchanged — the lane the gate stack was built for):
 
 ```mermaid
 sequenceDiagram
+    autonumber
     participant Env as Environment
     participant S as Sensor poll
     participant G as Salience + Refractory + Governor
     participant Rx as Session
+    rect rgba(45,125,154,0.12)
     Env->>S: git dirty / process up / peer appeared
     S->>G: magnitude + wall-clock age
     Note over G: aged, coalesced, most suppressed to stderr
+    end
+    rect rgba(217,119,6,0.12)
     G-->>Rx: only if loud enough
     Note over Rx: lossy BY DESIGN — the phone may ring unanswered
+    end
 ```
 
 ## Validation

--- a/docs/attend-and-monitor/engagement.md
+++ b/docs/attend-and-monitor/engagement.md
@@ -104,6 +104,19 @@ stateDiagram-v2
     AbsoluteRefractory --> RelativeRefractory: absolute_refractory<br/>seconds elapsed
     RelativeRefractory --> Rest: multiplier decayed to ~1.0<br/>via multiplier_half_life
     RelativeRefractory --> Disclosed: high-magnitude event<br/>breaks elevated threshold<br/>AND governor permits
+
+    classDef rest fill:#2d8e5e,color:#ffffff,stroke:#4a5568
+    classDef process fill:#2d7d9a,color:#ffffff,stroke:#4a5568
+    classDef waiting fill:#fbbf24,color:#1a1a1a,stroke:#4a5568
+    classDef boundary fill:#f6821f,color:#1a1a1a,stroke:#4a5568
+    classDef core fill:#7c3aed,color:#ffffff,stroke:#4a5568
+
+    class Rest rest
+    class Accumulating process
+    class FireReady waiting
+    class Disclosed core
+    class AbsoluteRefractory boundary
+    class RelativeRefractory waiting
 ```
 
 **Absolute refractory** is a hard wall. For `absolute_refractory` seconds after any firing, the sensor cannot disclose at all — not even on a maximum-magnitude event. During this window the engine's `current_multiplier(tick)` returns `f64::INFINITY`, which `in_absolute_refractory(tick)` recognizes as "gate fully closed." Events still arrive and still accumulate, but none of them fire.

--- a/docs/attend-and-monitor/loop.md
+++ b/docs/attend-and-monitor/loop.md
@@ -73,6 +73,18 @@ flowchart TD
     CleanupCheck -- yes --> Cleanup
     CleanupCheck -- no --> Continue
     Cleanup --> Continue
+
+    classDef terminal fill:#475569,stroke:#4a5568,color:#ffffff
+    classDef decision fill:#fbbf24,stroke:#4a5568,color:#1a1a1a
+    classDef process fill:#2d7d9a,stroke:#4a5568,color:#ffffff
+    classDef boundary fill:#f6821f,stroke:#4a5568,color:#1a1a1a
+    classDef store fill:#2d8e5e,stroke:#4a5568,color:#ffffff
+
+    class Start,Break,Continue terminal
+    class ReloadCheck,PeekQueue,ReadyCheck,GovernorCheck,CheckpointCheck,CleanupCheck decision
+    class Sleep,Drain,Poll,Batch,Hold,Cleanup process
+    class Exec boundary
+    class Checkpoint store
 ```
 
 The reload branch is a hard exit — `execve(2)` replaces the current process image with a fresh copy of the binary. State is checkpointed first, and the new process restores from that checkpoint during startup, so observed signals, engagement history, and disclosed context thresholds survive the reload.
@@ -117,6 +129,18 @@ stateDiagram-v2
     Accumulating --> Rescheduled: magnitude preserved<br/>for next poll
 
     Rescheduled --> [*]: schedule_next()<br/>pushed back into heap
+
+    classDef resting fill:#475569,stroke:#4a5568,color:#ffffff
+    classDef process fill:#2d7d9a,stroke:#4a5568,color:#ffffff
+    classDef ok fill:#2d8e5e,stroke:#4a5568,color:#ffffff
+    classDef waiting fill:#fbbf24,stroke:#4a5568,color:#1a1a1a
+    classDef held fill:#f6821f,stroke:#4a5568,color:#1a1a1a
+
+    class Resting resting
+    class Polling,GovernorRecord,ReadyCheck,Rescheduled process
+    class Quiet,Ready ok
+    class Changed,Accumulating waiting
+    class Held held
 ```
 
 **Quiet** is the happy path when nothing changed. The sensor's interval grows, its accumulator stays at zero, the loop logs nothing, and it sleeps until next fire.
@@ -151,6 +175,7 @@ If the governor rejects the batch, the magnitudes stay on the accumulators and t
 
 ```mermaid
 sequenceDiagram
+    autonumber
     participant World as External state<br/>(git, peers, processes)
     participant Sensor
     participant Slot as SensorSlot
@@ -160,6 +185,7 @@ sequenceDiagram
     participant Monitor as Claude Code Monitor
     participant Agent as Conversation
 
+    rect rgba(45,125,154,0.12)
     World->>Sensor: filesystem / process state changes
     Note right of Sensor: waits until next poll
 
@@ -169,15 +195,20 @@ sequenceDiagram
     Slot->>Governor: record_event() if changed
     Slot->>Engagement: ready_to_disclose()?
     Engagement-->>Slot: yes / held / absolute refractory
+    end
 
+    rect rgba(217,119,6,0.12)
     Slot->>Governor: can_disclose()?
     Governor-->>Slot: yes / rate-limited
+    end
 
+    rect rgba(45,142,94,0.12)
     Slot->>Emit: batch of (name, priority, events)
     Emit->>Monitor: println! — one line per event
     Monitor->>Agent: async notification
 
     Note over Governor,Engagement: Governor.record_disclosure()<br/>Engagement.record_fire(epoch_secs, 1.0) per sensor
+    end
 ```
 
 This is the one-way data flow. Signals enter via sensors (reading the environment) and leave via stdout (intercepted by Monitor). Nothing in attend's runtime is event-driven — every transition is a poll that happened to find something new.

--- a/docs/attend-and-monitor/signals.md
+++ b/docs/attend-and-monitor/signals.md
@@ -115,6 +115,17 @@ flowchart LR
     Age -->|re-engaged| Present
     Below --> Cleanup
     Cleanup --> Delete
+
+    classDef core fill:#7c3aed,stroke:#4a5568,color:#ffffff
+    classDef process fill:#2d7d9a,stroke:#4a5568,color:#ffffff
+    classDef store fill:#2d8e5e,stroke:#4a5568,color:#ffffff
+    classDef caution fill:#fbbf24,stroke:#4a5568,color:#1a1a1a
+
+    class Create core
+    class Write store
+    class Scan,Present,Cleanup process
+    class Age,Below caution
+    class Delete store
 ```
 
 **Phase 1 — creation.** The sender (an agent via `attend send`, a sensor via an internal emit path, or a human via `attend chat`) constructs the `from|project|cwd|message` line — or `from|project|cwd|re:signal-id|message` if `--re <signal-id>` was passed to mark the send as a threaded reply — and writes it atomically to the right scope directory. Routing flags pick the directory: `--broadcast` → `_broadcast/`, `--focus <name>` → `@<name>/`, `--to <path>` → the encoded path, no flags → the sender's own project scope. The threading flag composes with any routing flag.

--- a/docs/explanation/attend-messaging/00-overview.md
+++ b/docs/explanation/attend-messaging/00-overview.md
@@ -28,6 +28,20 @@ flowchart TD
     Q -->|"no — git, process, peer-presence"| E[EVENT lane<br/>salience + refractory + governor]
     M --> MT[lands in a recipient's tray / room ledger<br/>never wiped until that recipient saw it]
     E --> ET[coalesced · aged by wall-clock · may drop]
+
+    classDef source fill:#475569,stroke:#4a5568,color:#ffffff
+    classDef decision fill:#2d7d9a,stroke:#4a5568,color:#ffffff
+    classDef message fill:#7c3aed,stroke:#4a5568,color:#ffffff
+    classDef event fill:#f6821f,stroke:#4a5568,color:#1a1a1a
+    classDef durable fill:#2d8e5e,stroke:#4a5568,color:#ffffff
+    classDef ephemeral fill:#fbbf24,stroke:#4a5568,color:#1a1a1a
+
+    class X source
+    class Q decision
+    class M message
+    class MT durable
+    class E event
+    class ET ephemeral
 ```
 
 - **Authored communication** — `attend send`, `attend reply`, attend-chat's

--- a/docs/explanation/attend-messaging/01-the-cast.md
+++ b/docs/explanation/attend-messaging/01-the-cast.md
@@ -50,6 +50,18 @@ flowchart LR
     H["aaron@kitty<br/>attend-chat (human)"] --- BUS
     A -.->|"spawns, invisible to peers"| S1["sub-agent: test-writer"]
     A -.-> S2["sub-agent: migration"]
+
+    classDef store fill:#2d8e5e,color:#ffffff,stroke:#4a5568
+    classDef peer fill:#7c3aed,color:#ffffff,stroke:#4a5568
+    classDef human fill:#475569,color:#ffffff,stroke:#4a5568
+    classDef sub fill:#475569,color:#ffffff,stroke:#4a5568
+
+    class OPEN,G1 store
+    class A,B,C peer
+    class H human
+    class S1,S2 sub
+
+    style BUS stroke:#2d8e5e,fill:#2d8e5e1a,color:#cbd5e1
 ```
 
 attend discovers peers by reading `~/.claude/sessions/*.json` and confirming

--- a/docs/explanation/attend-messaging/02-divide-and-conquer.md
+++ b/docs/explanation/attend-messaging/02-divide-and-conquer.md
@@ -18,19 +18,26 @@ work and keep each other current over attend.
 
 ```mermaid
 sequenceDiagram
+    autonumber
     participant T as Tamsin (/api)
     participant Bus as #open ledger
     participant C as Cleo (/web)
+    rect rgba(45,125,154,0.12)
     T->>Bus: send "starting POST /login — will expose it by EOD"
     Bus-->>C: notify (Tamsin, #open)
     C->>Bus: reply "great, I'll stub the client against that contract"
     Note over T,C: reply auto-threads (ADR-120) — no id lookup
+    end
+    rect rgba(217,119,6,0.12)
     C->>Bus: send --to Tamsin "what's the 401 body shape?"
     Bus-->>T: notify (directed → you, magnitude high)
     Note over T: heads-down; the question waits in Tamsin's tray
+    end
+    rect rgba(45,142,94,0.12)
     T->>Bus: reply "{error, code} — code is a stable enum"
     Bus-->>C: notify (Tamsin replied)
     Note over C: silence is a valid reply — Cleo just builds
+    end
 ```
 
 ## What each move is doing

--- a/docs/explanation/attend-messaging/03-team-inside-one-voice.md
+++ b/docs/explanation/attend-messaging/03-team-inside-one-voice.md
@@ -30,6 +30,16 @@ flowchart TB
     VALE -->|"speaks as one voice"| BUS
     P["Tamsin, Cleo, …"] --> BUS
     BUS -.->|"messages accrue while Vale is heads-down"| VALE
+
+    classDef core fill:#7c3aed,color:#ffffff,stroke:#4a5568
+    classDef process fill:#2d7d9a,color:#ffffff,stroke:#4a5568
+    classDef store fill:#2d8e5e,color:#ffffff,stroke:#4a5568
+    classDef external fill:#475569,color:#ffffff,stroke:#4a5568
+    class L core
+    class W1,W2,W3 process
+    class BUS store
+    class P external
+    style VALE stroke:#8b5cf6,fill:#7c3aed1a,color:#cbd5e1
 ```
 
 The sub-agents and the workflow are **internal**. They don't register as peers,
@@ -49,15 +59,22 @@ heads-up, a directed ask all land in Vale's tray.
 
 ```mermaid
 sequenceDiagram
+    autonumber
     participant P as Peers
     participant Tray as Vale's tray
     participant V as Vale (in a 6-min workflow)
+    rect rgba(217,119,6,0.12)
     P->>Tray: 2 directed + 4 on #open (over ~6 min)
     Note over V: heads-down — does not turn to read mid-workflow
+    end
+    rect rgba(45,125,154,0.12)
     V->>Tray: workflow done — surface
     Tray-->>V: digest: "while you were deep:<br/>2 to you (newest 40s ago) · 4 on #open over 6m"
     Note over V: ONE turn, not 6 interrupts
+    end
+    rect rgba(45,142,94,0.12)
     V->>P: synthesize + answer the 2 directed asks
+    end
 ```
 
 If each accrued message had been injected as its own turn, the workflow would

--- a/docs/explanation/attend-messaging/04-different-dimensions.md
+++ b/docs/explanation/attend-messaging/04-different-dimensions.md
@@ -34,6 +34,17 @@ flowchart LR
     BUS -->|"'export job OOMs on big tenants'"| CODE
     CODE -->|"'blocked: need a decision on streaming vs batch'"| BUS
     BUS -->|"'opening an ADR; decision by noon'"| OFFICE
+
+    classDef office fill:#7c3aed,color:#ffffff,stroke:#4a5568
+    classDef code fill:#2d7d9a,color:#ffffff,stroke:#4a5568
+    classDef seam fill:#f6821f,color:#1a1a1a,stroke:#4a5568
+
+    class O1,O2 office
+    class D1,D2 code
+    class BUS seam
+
+    style OFFICE stroke:#8b5cf6,fill:#7c3aed1a,color:#cbd5e1
+    style CODE stroke:#2d7d9a,fill:#2d7d9a1a,color:#cbd5e1
 ```
 
 A turn of the loop:

--- a/docs/explanation/attend-messaging/05-the-crowd.md
+++ b/docs/explanation/attend-messaging/05-the-crowd.md
@@ -26,6 +26,14 @@ flowchart TB
     SPLIT --> I["#infra<br/>Orin · Dex"]
     B -.->|"cross-cut decision"| OPEN
     I -.->|"'migration ready for all'"| OPEN
+
+    classDef commons fill:#7c3aed,color:#ffffff,stroke:#4a5568
+    classDef split fill:#2d7d9a,color:#ffffff,stroke:#4a5568
+    classDef room fill:#2d8e5e,color:#ffffff,stroke:#4a5568
+
+    class OPEN commons
+    class SPLIT split
+    class B,F,I room
 ```
 
 The pattern is **convene-then-split**:

--- a/docs/explanation/attend-messaging/06-human-on-the-surface.md
+++ b/docs/explanation/attend-messaging/06-human-on-the-surface.md
@@ -21,17 +21,22 @@ can read and join in real time.
 
 ```mermaid
 sequenceDiagram
+    autonumber
     participant Aaron as aaron@kitty (attend-chat)
     participant Bus as #open / trays
     participant T as Tamsin
     participant C as Cleo
+    rect rgba(217,119,6,0.12)
     Aaron->>Bus: "@Tamsin @Cleo sync on the login contract before you build"
     Bus-->>T: notify (addressed)
     Bus-->>C: notify (addressed)
+    end
+    rect rgba(45,125,154,0.12)
     T->>Bus: reply "agreed — I'll post the schema in 5"
     Note over Aaron: watches it unfold; doesn't gate each turn
     C->>Bus: reply "standing by for the schema"
     Aaron->>Bus: (says nothing — lets them run)
+    end
 ```
 
 The human **convenes and interjects**; they don't puppet. They drop a directive,

--- a/docs/explanation/attend-messaging/07-the-lane-gate.md
+++ b/docs/explanation/attend-messaging/07-the-lane-gate.md
@@ -31,6 +31,16 @@ stateDiagram-v2
     Observed --> Gate
     Gate --> MessageLane : yes · @Name · #group · #open · a human on attend-chat
     Gate --> EventLane : no · git churn · a process · a peer appearing or going idle
+
+    classDef process fill:#2d7d9a,color:#ffffff,stroke:#4a5568
+    classDef gate fill:#fbbf24,color:#1a1a1a,stroke:#4a5568
+    classDef store fill:#2d8e5e,color:#ffffff,stroke:#4a5568
+    classDef external fill:#f6821f,color:#1a1a1a,stroke:#4a5568
+
+    class Observed process
+    class Gate gate
+    class MessageLane store
+    class EventLane external
 ```
 
 - **Yes → message lane.** A person or agent *chose* to say this. It is a unit
@@ -78,6 +88,25 @@ stateDiagram-v2
             fresh one.
         end note
     }
+
+    classDef process fill:#2d7d9a,color:#ffffff,stroke:#4a5568
+    classDef gate fill:#fbbf24,color:#1a1a1a,stroke:#4a5568
+    classDef store fill:#2d8e5e,color:#ffffff,stroke:#4a5568
+    classDef external fill:#f6821f,color:#1a1a1a,stroke:#4a5568
+
+    class Trayed process
+    class Deduped process
+    class Digested process
+    class Surfaced store
+    class Salience gate
+    class Refractory process
+    class Governor process
+    class Disclosed store
+    class Held external
+    class Decayed external
+
+    style MessageLane stroke:#2d8e5e,fill:#2d8e5e1a,color:#cbd5e1
+    style EventLane stroke:#d97706,fill:#f6821f1a,color:#cbd5e1
 ```
 
 ## Why handling the same moment two ways is the whole point

--- a/docs/explanation/localization/adopter-localization-the-model.md
+++ b/docs/explanation/localization/adopter-localization-the-model.md
@@ -30,6 +30,14 @@ agent-ways runs in one of two **modes**, and a single flag decides which.
 flowchart TD
     Q{ways.json<br/>output_language} -->|"en / auto (default)"| EN[ENGLISH MODE<br/>embedding match · 384-dim English model only · corpus tuning always on · no locale tuning]
     Q -->|"a non-English code (es, zh, ...)"| LOC[LOCALIZED MODE<br/>adds a 2nd embedding lane · 768-dim multilingual model × English-root-anchored multi corpus · root-anchored locale tuning]
+
+    classDef config fill:#fbbf24,stroke:#4a5568,color:#1a1a1a
+    classDef steady fill:#2d8e5e,stroke:#4a5568,color:#ffffff
+    classDef core fill:#7c3aed,stroke:#4a5568,color:#ffffff
+
+    class Q config
+    class EN steady
+    class LOC core
 ```
 
 - **English mode** is the default and the 99% case. The English corpus is still built

--- a/docs/explanation/localization/scenario-steady-state-authoring.md
+++ b/docs/explanation/localization/scenario-steady-state-authoring.md
@@ -26,6 +26,18 @@ flowchart LR
     C --> G{ways tune clean?}
     G -->|no| L
     G -->|yes| D[done — both layers current]
+
+    classDef authoring fill:#7c3aed,stroke:#4a5568,color:#ffffff
+    classDef root fill:#2d8e5e,stroke:#4a5568,color:#ffffff
+    classDef process fill:#2d7d9a,stroke:#4a5568,color:#ffffff
+    classDef gate fill:#fbbf24,stroke:#4a5568,color:#1a1a1a
+    classDef done fill:#2d8e5e,stroke:#4a5568,color:#ffffff
+
+    class A authoring
+    class E root
+    class L,C process
+    class G gate
+    class D done
 ```
 
 ## What each move is doing

--- a/docs/explanation/localization/scenario-the-english-native-install.md
+++ b/docs/explanation/localization/scenario-the-english-native-install.md
@@ -19,17 +19,24 @@ the default and the overwhelming-majority case. The point of the scenario is tha
 
 ```mermaid
 sequenceDiagram
+    autonumber
     participant Op as Operator (English)
     participant CC as Claude Code
     participant W as agent-ways
+    rect rgba(45,125,154,0.12)
     Op->>CC: settings.json language unset → English
     Op->>W: make install
     Note over W: ways.json output_language = en (default)
+    end
+    rect rgba(124,58,237,0.12)
     W->>W: build English corpus only
     Note over W: multilingual model never downloaded or loaded
+    end
+    rect rgba(45,142,94,0.12)
     Op->>CC: start a session
     W-->>Op: session-start nudge reads CC lang vs output_language
     Note over W: en == en → match → silent
+    end
 ```
 
 ## What each move is doing

--- a/docs/explanation/localization/scenario-the-language-switch.md
+++ b/docs/explanation/localization/scenario-the-language-switch.md
@@ -20,19 +20,26 @@ under-serving, asks permission, and — only on consent — localizes itself.
 
 ```mermaid
 sequenceDiagram
+    autonumber
     participant Op as Operator (Spanish)
     participant CC as Claude Code · language = spanish
     participant W as agent-ways · output_language = en
     participant L as ways-localize skill
+    rect rgba(217,119,6,0.12)
     Op->>CC: set language = spanish
     Op->>W: install + start session
     W-->>Op: nudge "CC is Spanish, ways is en → not localized. Optimize?"
     Note over W,Op: emitted in Spanish — CC already responds in Spanish
     Op->>L: yes, localize for Spanish (consent)
+    end
+    rect rgba(45,125,154,0.12)
     L->>W: flip output_language → es
     L->>L: fetch multilingual model · translate every way vs English root
     L->>L: pack stubs · rebuild multi corpus (English anchor) · ways tune until clean
+    end
+    rect rgba(45,142,94,0.12)
     Note over Op,W: next session CC=es, output_language=es → match → nudge silent
+    end
 ```
 
 ## What each move is doing

--- a/docs/explanation/localization/the-mode-gate-mechanism-under-the-scenarios.md
+++ b/docs/explanation/localization/the-mode-gate-mechanism-under-the-scenarios.md
@@ -32,6 +32,16 @@ flowchart TD
     F[output_language] --> M{en?}
     M -->|"yes — English mode"| EN[corpus: English only<br/>matcher: embedding, 384-dim English model only<br/>locale tuning: not in the flow]
     M -->|"no — localized mode"| LO[corpus: + multi, English-root anchored<br/>matcher: + 2nd embedding lane, 768-dim multilingual model<br/>locale tuning: root-anchored, --lang scoped]
+
+    classDef config fill:#fbbf24,color:#1a1a1a,stroke:#4a5568
+    classDef process fill:#2d7d9a,color:#ffffff,stroke:#4a5568
+    classDef done fill:#2d8e5e,color:#ffffff,stroke:#4a5568
+    classDef core fill:#7c3aed,color:#ffffff,stroke:#4a5568
+
+    class F config
+    class M process
+    class EN done
+    class LO core
 ```
 
 1. **Corpus build** (`corpus.rs`). Localized mode emits each way's English root into the

--- a/docs/hooks-and-ways/rationale.md
+++ b/docs/hooks-and-ways/rationale.md
@@ -118,6 +118,18 @@ stateDiagram-v2
     test --> capture : yes — corrections,\nnew conventions
     test --> skip : no — routine session
     capture --> running : propose new ways\nfrom learnings
+
+    classDef core fill:#7c3aed,color:#ffffff,stroke:#4a5568
+    classDef process fill:#2d7d9a,color:#ffffff,stroke:#4a5568
+    classDef store fill:#2d8e5e,color:#ffffff,stroke:#4a5568
+    classDef wait fill:#fbbf24,color:#1a1a1a,stroke:#4a5568
+    classDef inert fill:#475569,color:#ffffff,stroke:#4a5568
+
+    class running core
+    class transition,inject,test process
+    class boundary wait
+    class capture store
+    class skip inert
 ```
 
 **As trigger for injection:** When the agent is about to do something where it might get surprised -- committing code, editing config files, running tests -- the hook system fires and injects guidance. The trigger patterns encode our prediction about when surprise is likely. We don't inject testing guidance during documentation work because there's no prediction error to reduce.


### PR DESCRIPTION
## Summary

Applies the repo's **mermaid styling way** (role→color legend) to every previously-unstyled diagram in `docs/` — **26 diagrams across 18 files**. Diagrams now read by *meaning* and stay legible against both light and dark GitHub backgrounds, and they match the install-topologies diagrams from #187.

One legend, used verbatim everywhere (one hue = one role):

| Color | Role |
|---|---|
| violet `#7c3aed` | repo / core / our system |
| teal `#2d7d9a` | process / a step |
| green `#2d8e5e` | done / data-at-rest / store |
| amber `#fbbf24` | caution / config / waiting |
| orange `#f6821f` | external / boundary / warning |
| slate `#475569` | inert / out-of-scope (user, browser) |

Opaque node fills with text matched to fill brightness, neutral `#4a5568` borders, translucent (`…1a`) mid-tone subgraph regions. SequenceDiagrams (whose participants can't be `classDef`'d) get `autonumber` + `rect` phase tints instead.

## How it was produced

An 18-agent workflow — one agent per file — each applying the **same pinned legend** and self-validating via `mmaid`.

## Verification (independent of the agents)

- **Styling-only:** the diff is **247 insertions, 0 deletions** — no labels, structure, or prose changed; every added line is a `classDef`/`class`/`style`/`rect`/`autonumber` directive.
- **All render:** re-rendered all 26 diagrams via `mmaid` — 0 failures.
- **Palette consistent:** hex audit shows only legend colors across the whole diff.
- `docs/scripts/doc lint` — 0 errors, 0 warnings.

## Test plan

Eyeball a sample in GitHub's light and dark themes to confirm contrast.