### PR TITLE
feat(ways): non-interactive rethink --json + how-ways-works explanation cluster

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Map of the documentation tree. For the project overview, see the [main README](.
 | [architecture.md](architecture.md) | System architecture diagrams (Mermaid) for the ways mechanics |
 | [architecture/](architecture/) | Architecture Decision Records (managed by `docs/scripts/adr`) |
 | [design-notes/](design-notes/) | Prose-first framing documents that justify multiple related decisions (complement to ADRs) |
+| [explanation/](explanation/) | Diátaxis explanation pages — conceptual walkthroughs grounded in real scenarios (install topologies, localization, attend messaging, and [how ways works](explanation/how-ways-works/how-ways-works-the-model.md) — the observable companion to cognitive-loop.md) |
 
 ## Guides vs Reference
 

--- a/docs/explanation/how-ways-works/how-ways-works-the-model.md
+++ b/docs/explanation/how-ways-works/how-ways-works-the-model.md
@@ -1,0 +1,152 @@
+---
+id: 01.017.E
+domain: system
+mode: explanation
+related:
+  - "[[ADR-104]]"
+  - "[[ADR-123]]"
+  - "[[ADR-134]]"
+  - "[[01.018.E]]"
+  - "[[01.019.E]]"
+aliases: []
+---
+
+# How ways works — the model
+
+When ways is doing its job, you don't notice it. A premise lands in Claude's
+context at the moment it's relevant, Claude reasons with it, and the work moves
+on. Nothing announces itself. That invisibility is the design working — but it
+makes the system hard to *believe in*, because the help leaves no mark on the
+conversation you can point to.
+
+It does leave a mark somewhere else. **Every time a way fires, the cheap
+substrate writes a line to `~/.claude/stats/events.jsonl`.** That append-only
+record is the observable shadow of the cognitive loop: a turn-by-turn account of
+which premises surfaced, why, and when. This cluster is about reading that
+shadow — what it records, what it reveals about how ways helps, and how to pull
+it out for a session of your own ([[01.019.E]]) or walk a real long one
+([[01.018.E]]).
+
+For the *design* — substrate separation, progressive disclosure, the ledger, the
+awareness layer — read [the cognitive loop](../../cognitive-loop.md). This page
+sits one level lower: not how the system is built, but how you *watch it run*.
+
+## The five things the record captures
+
+Each line is one event with a timestamp, a session id, a project, and a trigger.
+Five event types, and each one is a distinct kind of help made visible:
+
+| Event | What it means | What it tells you |
+|-------|---------------|-------------------|
+| `way_fired` | A premise crossed its threshold and was injected | The system decided this guidance was relevant *here* |
+| `way_redisclosed` | An already-seen way surfaced again after its cooldown | The premise had faded from attention and was refreshed |
+| `check_fired` | A depth-on-demand sub-way pulled in under a fired way | Claude got *more* detail because the situation warranted it |
+| `way_nearmiss` | A way scored close to its threshold but did **not** fire | The boundary — what the system *almost* surfaced, and held back |
+| `session_start` | A session began | The anchor every other event hangs off |
+
+The first four are the load-bearing ones, and they map onto four distinct
+behaviours worth understanding separately.
+
+## Four behaviours, made observable
+
+```mermaid
+flowchart TB
+    subgraph Loop["Claude's turn — the expensive substrate"]
+        direction TB
+        Prompt["user prompt<br/>+ tool calls<br/>+ prior topics"]
+    end
+
+    subgraph Match["the matcher — cheap, runs before Claude sees anything"]
+        direction TB
+        Fire["<b>first-fire</b><br/>crosses threshold<br/>→ way_fired"]
+        Near["<b>near-miss</b><br/>close but under<br/>→ way_nearmiss"]
+        Re["<b>re-disclosure</b><br/>seen before, cooled down<br/>→ way_redisclosed"]
+        Chk["<b>check</b><br/>depth pulled on demand<br/>→ check_fired"]
+    end
+
+    Record[("events.jsonl<br/>the observable shadow")]
+
+    Prompt --> Fire
+    Prompt --> Near
+    Prompt --> Re
+    Fire --> Chk
+    Fire --> Record
+    Near --> Record
+    Re --> Record
+    Chk --> Record
+
+    classDef expensive fill:#7c3aed,color:#ffffff,stroke:#4a5568
+    classDef cheap fill:#2d7d9a,color:#ffffff,stroke:#4a5568
+    classDef miss fill:#f6821f,color:#1a1a1a,stroke:#4a5568
+    classDef durable fill:#2d8e5e,color:#ffffff,stroke:#4a5568
+    class Prompt expensive
+    class Fire,Re,Chk cheap
+    class Near miss
+    class Record durable
+
+    style Loop stroke:#8b5cf6,fill:#7c3aed1a,color:#cbd5e1
+    style Match stroke:#2d7d9a,fill:#2d7d9a1a,color:#cbd5e1
+```
+
+**First-fire — precision matching.** A way fires the first time its trigger
+matches: a keyword in the prompt, a semantic embedding score over threshold, a
+file being edited, a bash command about to run, a context-threshold crossed.
+The trigger type is recorded verbatim (`keyword`, `semantic:embedding:en`,
+`semantic:embedding:multi`, `state`, `bash`, `file`, `check-pull`). The mix of
+trigger types across a session is the clearest single signal of *how* ways is
+reaching Claude — a session dominated by `semantic` fires is being steered by
+meaning; one dominated by `bash` and `file` is being steered by what Claude is
+physically doing.
+
+**Re-disclosure — habituation.** Once a way has fired, it is marked disclosed
+and won't fire again until its cooldown — measured in *tokens of context
+consumed*, not turns or wall-clock — expires ([[ADR-104]]). When the trigger
+recurs after the cooldown, the way re-surfaces fresh as a `way_redisclosed`
+event. This is the mechanism that keeps a long session from either drowning in
+repeated guidance or silently losing premises it surfaced eighty turns ago. The
+ratio of re-disclosures to first-fires is the signature of session *length*: a
+short session is almost all first-fires; a multi-day session re-discloses its
+core premises many times over. The cadence of that re-disclosure is itself
+tunable from this data ([[ADR-123]]).
+
+**Near-miss — the threshold boundary.** When a way scores within a small margin
+of its effective threshold but doesn't clear it, the matcher records the
+would-be fire — its English and multilingual scores, both thresholds, and the
+margin by which it missed ([[ADR-134]]). Near-misses are the only window onto
+*false silence*: the guidance that almost helped and was held back. They are
+invisible in the conversation and invisible in the TUI replay; the JSON dump
+([[01.019.E]]) is the only way to see them. A way that near-misses constantly is
+a vocabulary-tuning opportunity; a near-miss right before a mistake is a
+threshold set too high.
+
+**Check — depth on demand.** Some ways are trees: a parent premise fires, and
+under it sit *checks* — finer-grained sub-ways that pull in only when their own
+trigger matches in the window the parent opened. A `check_fired` event means
+Claude didn't just get "think about code quality," it got the specific
+sub-premise about, say, performance or supply-chain, because that's what the
+moment called for. Checks are how progressive disclosure goes *deep* without the
+parent way having to carry every detail at all times.
+
+## Why the record is trustworthy
+
+The events are written by the same code path that does the matching, at the
+moment the decision is made — not reconstructed after the fact, not inferred from
+the transcript. The `fire_score` on a first-fire is the exact embedding score
+that cleared the threshold; the near-miss scores are the exact scores that
+didn't. This is persistence of a decision already made, not new computation
+([[ADR-134]]). What you read back is what actually happened.
+
+The one caveat worth holding: re-disclosure thresholds shown in a *replay*
+reflect each way's curve as it stands *today*, because the curve lives in the
+way's frontmatter, not in the event line. If you've retuned a curve since the
+session ran, the replay shows the new value. Everything else — what fired, when,
+at what score, against what threshold — is frozen at the moment it happened.
+
+## Where this sits
+
+- **The design behind all of this:** [the cognitive loop](../../cognitive-loop.md)
+  and the ADRs it cites.
+- **The same model in a real long session:** [[01.018.E]] walks a 97-hour,
+  78-way session and shows each of the four behaviours in its actual numbers.
+- **Pulling the record yourself:** [[01.019.E]] covers `ways list`, `ways stats`,
+  and `ways rethink --json` — what each shows and what the data means.

--- a/docs/explanation/how-ways-works/reading-the-session-data.md
+++ b/docs/explanation/how-ways-works/reading-the-session-data.md
@@ -1,0 +1,149 @@
+---
+id: 01.019.E
+domain: system
+mode: explanation
+related:
+  - "[[ADR-112]]"
+  - "[[ADR-134]]"
+  - "[[01.017.E]]"
+  - "[[01.018.E]]"
+aliases: []
+---
+
+# Reading the session data yourself
+
+[[01.017.E]] explains *what* the event record captures; [[01.018.E]] walks one
+session through it. This page is about getting the record into your own hands —
+which command answers which question, and what the data means once you have it.
+
+Everything here reads the same append-only log the matcher writes to,
+`~/.claude/stats/events.jsonl`, plus each session's transcript for token
+positions. Nothing here changes state; these are all observation commands. (For
+the full command reference, see [the ways CLI reference](../../reference/ways-cli.md).)
+
+## Three lenses, three questions
+
+```mermaid
+flowchart TB
+    Log[("~/.claude/stats/events.jsonl<br/>append-only firing record")]
+
+    List["<b>ways list</b><br/>this session, now"]
+    Stats["<b>ways stats</b><br/>across all sessions"]
+    Json["<b>ways rethink --json</b><br/>one whole session, in full"]
+
+    Log --> List
+    Log --> Stats
+    Log --> Json
+
+    Q1["What just fired,<br/>and in what order?"]
+    Q2["Which ways earn their<br/>keep — and which never fire?"]
+    Q3["How did this one<br/>session actually unfold?"]
+
+    List --> Q1
+    Stats --> Q2
+    Json --> Q3
+
+    classDef durable fill:#2d8e5e,color:#ffffff,stroke:#4a5568
+    classDef tool fill:#2d7d9a,color:#ffffff,stroke:#4a5568
+    classDef q fill:#fbbf24,color:#1a1a1a,stroke:#4a5568
+    class Log durable
+    class List,Stats,Json tool
+    class Q1,Q2,Q3 q
+```
+
+**`ways list` — what fired this session, right now.** Run after a turn to see the
+table of ways that have fired so far: epoch, match distance, trigger type,
+re-disclosure eligibility, and which agent received each. This is the live view —
+the immediate "did the way I expected actually fire?" check. Add `--json` for the
+machine-readable form.
+
+**`ways stats` — which ways earn their keep.** Aggregates fires across sessions
+into a ranked frequency chart with a trigger-type breakdown. This is the lens for
+*the corpus*, not a session: it surfaces the ways that fire constantly (candidates
+for tuning down) and the dead vocabulary that never fires at all (candidates for
+re-authoring or removal). Scope it with `--days N`, `--global`, or run it inside a
+project to scope to that project.
+
+**`ways rethink --json` — one whole session, in full.** This is the deep lens, and
+the one built for programmatic reading. Where the interactive `ways rethink`
+*animates* a session's timeline in a TUI, `--json` dumps the entire reconstructed
+timeline as a single document — no terminal required, so it runs in scripts and
+headless contexts where the animation can't. It is also the **only** view that
+surfaces near-misses; the animation omits them.
+
+## What the dump contains
+
+```
+ways rethink --json                   # most recent session in scope
+ways rethink --session <id> --json    # a specific session
+```
+
+The output is one JSON object with four parts:
+
+| Field | Contents |
+|-------|----------|
+| top-level | `session`, `project`, `context_window_k` |
+| `summary` | epoch count, duration, distinct ways, total fires, re-disclosures, checks, near-misses, the trigger breakdown, and the top ways by fire count |
+| `frames` | the turn-by-turn timeline — each frame has its epoch, timestamp, token position, the cumulative set of active ways (with per-way trigger, fire epoch, check count, and new / re-disclosed flags), and a `new_events` list of what changed that turn |
+| `near_misses` | every way that scored close but didn't fire — with its English and multilingual scores, both thresholds, the margin, and the epoch it occurred in |
+
+The `summary` is the at-a-glance shape of the session — the five numbers that open
+[[01.018.E]] come straight from it. The `frames` are the replay. The `near_misses`
+are the part you can't see any other way.
+
+## Reading it with jq
+
+The dump is built to be sliced. A few recipes, each framed by the question it
+answers:
+
+```bash
+# The shape of the session at a glance
+ways rethink --session <id> --json | jq '.summary'
+
+# How was this session steered? (trigger mix)
+ways rethink --session <id> --json | jq '.summary.trigger_breakdown'
+
+# What fired turn by turn — just the changes, not the running totals
+ways rethink --session <id> --json \
+  | jq '.frames[] | select(.new_events|length>0) | {epoch, token_position_k, new_events}'
+
+# Which ways almost fired most often? (tuning candidates)
+ways rethink --session <id> --json \
+  | jq '.near_misses | group_by(.way)
+        | map({way: .[0].way, near_misses: length})
+        | sort_by(-.near_misses)'
+
+# The closest misses — smallest margin first (threshold-too-high candidates)
+ways rethink --session <id> --json \
+  | jq '[.near_misses[]] | sort_by(.margin) | .[:10]'
+```
+
+## What the numbers mean
+
+A few readings that turn raw fields into judgement:
+
+- **Re-disclosures ≫ first-fires** is the signature of a *long* session — premises
+  refreshed across context pressure and compaction, exactly as
+  [[ADR-104]] intends. A session that's nearly all first-fires was short.
+- **A trigger mix dominated by `semantic`** means the session was steered by
+  *meaning* — Claude's intent matched ways without anyone having anticipated the
+  keyword. A mix dominated by `bash`/`file` means it was steered by what Claude
+  physically did. Neither is wrong; they're different shapes of work.
+- **A way with many near-misses and few fires** is brushing the work without
+  matching it — a vocabulary-tuning opportunity. **A near-miss with a tiny margin
+  right before a mistake** is a threshold set too high. Both feed the empirical
+  tuning loop ([[ADR-134]]); `ways tune-curves` and `ways tune-precision` read the
+  same log to suggest the adjustments.
+- **`context_window_k`** anchors every token figure. The same way re-discloses far
+  more often in a 200K window than a 1M one, because the token-gated cooldown is a
+  fraction of the window — so always read fire counts against the window size.
+
+## Where this fits
+
+The event log is the *telemetry* layer — fine-grained, per-fire, recent (it
+tail-compacts past ~32 MiB, so it forgets its oldest tail). It is not the durable
+memory of the project; that's the **session ledger** ([[ADR-112]]), which records
+*what was understood* rather than *what fired*. The two are complementary: the
+ledger is the journal, the event log is the instrument trace. This cluster is
+about the instrument trace — for the journal and the rest of the architecture,
+read [the cognitive loop](../../cognitive-loop.md).

--- a/docs/explanation/how-ways-works/scenario-a-long-session.md
+++ b/docs/explanation/how-ways-works/scenario-a-long-session.md
@@ -1,0 +1,172 @@
+---
+id: 01.018.E
+domain: system
+mode: explanation
+related:
+  - "[[ADR-104]]"
+  - "[[ADR-134]]"
+  - "[[01.017.E]]"
+  - "[[01.019.E]]"
+aliases: []
+---
+
+# A long session, read through ways
+
+The model in [[01.017.E]] describes four behaviours in the abstract. This page
+takes one real, recorded session and shows all four in their actual numbers —
+the kind of session ways was built for, long enough that every mechanism gets
+exercised.
+
+The session: ninety-seven hours of work on a knowledge-graph project, spread
+across many sittings under a one-million-token context window. Pulled with
+`ways rethink --session <id> --json`, its summary reads:
+
+```
+epochs            342        distinct ways      78
+duration          97h        total fires       490
+re-disclosures    276        checks fired       95
+near-misses       821
+```
+
+Those five numbers already tell the story the conversation can't: across 342
+turns the record logged roughly **1,700 events** — 861 times surfacing a premise
+(fires, re-disclosures, and checks) and **821 times deciding to stay quiet** at
+the threshold's edge. The help is as much in what it held back as in what it
+surfaced.
+
+## Turn one: orientation before a word is typed
+
+The very first event, at token position zero, is `softwaredev/freshness` firing
+on a `state` trigger — before the user's first prompt is even matched. Nothing
+semantic happened yet; the way fired because the *situation* (a fresh session in
+a project with derived artifacts) matched a state condition. This is ways doing
+the cheapest, earliest thing it can: orienting Claude to the project's standing
+concerns before the work defines itself.
+
+## The trigger mix: how this session was steered
+
+Across all 490 fires, the trigger breakdown is:
+
+```mermaid
+flowchart LR
+    subgraph Sem["by meaning — 221 fires (45%)"]
+        direction TB
+        M["semantic multilingual<br/>167"]
+        E["semantic English<br/>54"]
+    end
+    subgraph Act["by action — 82 fires (17%)"]
+        direction TB
+        B["bash command<br/>61"]
+        F["file edited<br/>21"]
+    end
+    subgraph Ctx["by context — 71 fires (14%)"]
+        S["state / threshold<br/>71"]
+    end
+    subgraph Lex["by word — 70 fires (14%)"]
+        K["keyword<br/>70"]
+    end
+    subgraph Depth["by depth — 46 fires (9%)"]
+        direction TB
+        CP["check-pull<br/>42"]
+        PC["postcheck<br/>4"]
+    end
+
+    classDef sem fill:#7c3aed,color:#ffffff,stroke:#4a5568
+    classDef act fill:#2d7d9a,color:#ffffff,stroke:#4a5568
+    classDef ctx fill:#2d8e5e,color:#ffffff,stroke:#4a5568
+    classDef lex fill:#fbbf24,color:#1a1a1a,stroke:#4a5568
+    classDef depth fill:#475569,color:#ffffff,stroke:#4a5568
+    class M,E sem
+    class B,F act
+    class S ctx
+    class K lex
+    class CP,PC depth
+
+    style Sem stroke:#8b5cf6,fill:#7c3aed1a,color:#cbd5e1
+    style Act stroke:#2d7d9a,fill:#2d7d9a1a,color:#cbd5e1
+    style Ctx stroke:#2d8e5e,fill:#2d8e5e1a,color:#cbd5e1
+    style Lex stroke:#d97706,fill:#fbbf241a,color:#cbd5e1
+    style Depth stroke:#94a3b8,fill:#4755691a,color:#cbd5e1
+```
+
+Nearly half of all guidance reached Claude through **meaning** — the matcher
+embedding the prompt and finding ways whose vocabulary scored over threshold.
+This is the layer that needs no keyword to have been anticipated: Claude
+describing intent in its own words, and the right premise surfacing anyway. The
+rest is split across what Claude *did* (bash/file), where the session *was*
+(state/threshold), exact *words*, and ways pulling in their own *depth*
+(check-pull). A session steered this way isn't following a script; it's being
+met where it is.
+
+## Re-disclosure: the same premise, kept alive for 97 hours
+
+`softwaredev/delivery/branching` fired once and then **re-disclosed 19 times**.
+Each refresh happened after roughly 100K tokens of context had passed since the
+last one — its token-gated cooldown ([[ADR-104]]). But the token positions where
+it re-disclosed aren't a clean rising line; they sawtooth:
+
+```
+172K → 317K → 431K → 549K → 180K → 277K → 223K → 360K → ...
+```
+
+That drop from 549K back to 180K is a **compaction**. Over 97 hours the context
+window filled and was distilled many times; each time, the token counter fell,
+and the branching premise — having survived in the ledger and the matcher's
+bookkeeping but faded from the working window — re-surfaced fresh on the far
+side. This is the single clearest picture of why long sessions need
+re-disclosure at all: without it, the premise Claude saw at hour two would be
+gone by hour twenty, buried or compacted away, and nothing would bring it back.
+The `delivery/github` way tells the same story (17 re-disclosures), as do
+`freshness`, `meta/memory`, and `compaction-checkpoint` (13–15 each) — the
+session's standing concerns, refreshed on a cadence the cheap substrate manages
+so Claude doesn't have to.
+
+By the final turn, all 78 distinct ways had been disclosed at least once. (In the
+record, a frame's active set is *cumulative* — every way that has ever fired
+stays listed, with flags marking what was new or re-disclosed that turn; what
+changed each turn is the short `new_events` list, not the running total.)
+
+## Checks: going deep only when the moment asked
+
+The session fired 95 checks. The `softwaredev/code` check alone fired **44
+times** — every time Claude was working in code under the broad code-quality
+premise, the matcher pulled the specific sub-premise that fit. Behind it:
+`makefile` and `architecture/design` (8 each), `deps` (8), `performance` (7),
+`supplychain` (6), `security` (5), `migrations` (5). None of these were carried
+in Claude's context the whole time. They arrived when the work touched their
+subject and left the running set otherwise — depth on demand, not depth always.
+
+## Near-misses: the 821 decisions to stay quiet
+
+The largest single category of events isn't a fire at all — it's the **821
+near-misses**, ways that scored close to their threshold and were held back. They
+cluster tellingly:
+
+| Near-missed way | Times | What it means |
+|-----------------|-------|---------------|
+| `code/security/injection` | 27 | Injection-risk guidance hovered at the edge all session |
+| `code/supplychain/sourceaudit` | 27 | Source-audit depth kept almost-qualifying |
+| `code/security/auth` | 25 | Auth guidance, repeatedly near the line |
+| `environment/config` | 25 | Config-handling premise, just under |
+
+These are deep, specialized ways whose vocabulary kept *brushing* the work
+without quite matching it. That's the matcher being honest about precision: it
+would rather stay silent than fire `security/injection` into a session that only
+glancingly touched the topic. But the record makes the trade-off *visible* — and
+that's the point. A concrete example from this session: at epoch 26,
+`architecture/adr/migration` scored **0.4203** against its multilingual threshold
+of **0.44** — a margin of **0.0197**. It missed by two hundredths. If that miss
+sat right before a migration mistake, it's evidence the threshold is a touch too
+high; if the session never did a migration, it's the precision discipline
+working exactly as intended. Either way, you can now *see it* and decide —
+which is the whole basis of the empirical tuning loop ([[ADR-134]]).
+
+## What the session shows
+
+Read end to end, the record makes a claim the conversation never could: ways
+helped this session not by issuing instructions but by *managing attention* over
+ninety-seven hours — surfacing the right premise on a state trigger before work
+began, meeting Claude's intent through meaning 221 times, refreshing the
+half-dozen standing concerns across every compaction, going deep into code
+specifics 95 times only when the work asked, and staying silent 821 times when
+it didn't. To pull this same record for a session of your own, see [[01.019.E]].

--- a/docs/reference/ways-cli.md
+++ b/docs/reference/ways-cli.md
@@ -78,14 +78,18 @@ ways stats --json
 
 **Run from:** Anywhere — launches an interactive session picker.
 
-**Tells you:** An animated frame-by-frame replay of way firings across the session timeline, showing epoch, way name, and trigger at each step. `--list` skips the animation and gives a plain session table.
+**Tells you:** An animated frame-by-frame replay of way firings across the session timeline, showing epoch, way name, and trigger at each step. `--list` skips the animation and gives a plain session table. `--json` skips the animation entirely and dumps the reconstructed timeline as a single JSON document — for agents, scripts, and CI where a TUI can't run.
 
 ```
 ways rethink                          # interactive picker
 ways rethink --session <id>           # jump to a specific session
 ways rethink --list                   # non-interactive session table
 ways rethink --speed 500              # faster animation (ms per frame)
+ways rethink --json                   # dump most recent session as JSON
+ways rethink --session <id> --json    # dump a specific session as JSON
 ```
+
+**`--json` output:** a single object with `session`, `project`, `context_window_k`, a `summary` (epoch count, duration, distinct ways, total fires, re-disclosures, checks, near-misses, trigger breakdown, top ways), the full `frames` timeline (each with epoch, timestamp, token position, active ways, and what newly fired that turn), and `near_misses` (ways that scored close to their threshold but didn't fire — each with its EN/multilingual scores, thresholds, and margin). Unlike the animation, the dump runs without the `tui` feature and surfaces near-misses, which the TUI omits. Slice large sessions with `jq` — a multi-day session can run to thousands of frames.
 
 ---
 

--- a/tools/ways-cli/src/cmd/mod.rs
+++ b/tools/ways-cli/src/cmd/mod.rs
@@ -16,6 +16,7 @@ pub mod provenance;
 pub mod render;
 pub mod reset;
 pub mod rethink;
+pub mod rethink_dump;
 pub mod siblings;
 pub mod scan;
 pub mod show;

--- a/tools/ways-cli/src/cmd/rethink.rs
+++ b/tools/ways-cli/src/cmd/rethink.rs
@@ -24,7 +24,7 @@ use crate::util::{detect_project_dir, home_dir};
 // ── Data structures ───────────────────────────────────────────
 
 /// A way event from events.jsonl.
-struct WayEvent {
+pub(crate) struct WayEvent {
     ts: String,
     event: String,
     way: String,
@@ -34,15 +34,15 @@ struct WayEvent {
 
 /// An active way at a given frame.
 #[derive(Clone)]
-struct ActiveWay {
-    id: String,
-    trigger: String,
-    epoch_fired: u64,
-    token_pos: u64,
-    check_fires: u64,
-    is_new: bool,
-    is_redisclosed: bool,
-    refire_threshold_k: u64,
+pub(crate) struct ActiveWay {
+    pub(crate) id: String,
+    pub(crate) trigger: String,
+    pub(crate) epoch_fired: u64,
+    pub(crate) token_pos: u64,
+    pub(crate) check_fires: u64,
+    pub(crate) is_new: bool,
+    pub(crate) is_redisclosed: bool,
+    pub(crate) refire_threshold_k: u64,
 }
 
 impl WayRow for ActiveWay {
@@ -55,13 +55,13 @@ impl WayRow for ActiveWay {
 }
 
 /// A single frame in the replay.
-struct Frame {
-    epoch: u64,
-    timestamp: String,
-    elapsed_secs: u64,
-    token_position_k: u64,
-    ways: Vec<ActiveWay>,
-    new_events: Vec<String>,
+pub(crate) struct Frame {
+    pub(crate) epoch: u64,
+    pub(crate) timestamp: String,
+    pub(crate) elapsed_secs: u64,
+    pub(crate) token_position_k: u64,
+    pub(crate) ways: Vec<ActiveWay>,
+    pub(crate) new_events: Vec<String>,
 }
 
 /// Playback state.
@@ -157,22 +157,7 @@ pub fn run(session: Option<&str>, project: Option<&str>, speed: Option<u64>, lis
 
     let context_window = session::detect_context_window_for(&project_name, &session_id);
     let context_window_k = context_window / 1000;
-    let token_timeline = build_token_timeline(&project_name, &session_id);
-    // Pre-resolve per-way refire thresholds once per session. Rethink is
-    // a replay, so if a way's curve has been edited since the recorded
-    // session we'll see the current value — that's the best we can do
-    // without also snapshotting frontmatter in events.jsonl.
-    let fallback_refire_k = context_window_k * 25 / 100;
-    let mut refire_cache: HashMap<String, u64> = HashMap::new();
-    for ev in &events {
-        if ev.way.is_empty() || refire_cache.contains_key(&ev.way) {
-            continue;
-        }
-        let threshold_k = session::way_refire_threshold_k(&ev.way, &project_name, context_window)
-            .unwrap_or(fallback_refire_k);
-        refire_cache.insert(ev.way.clone(), threshold_k);
-    }
-    let frames = build_frames(&events, &token_timeline, &refire_cache, fallback_refire_k);
+    let frames = reconstruct_frames(&events, &project_name, &session_id, context_window);
 
     if frames.is_empty() {
         println!("No frames to replay.");
@@ -408,6 +393,35 @@ fn render_status_bar(out: &mut String, player: &Player) {
 
 // ── Frame construction ────────────────────────────────────────
 
+/// Reconstruct the full replay frame timeline for a session. Loads the token
+/// timeline, pre-resolves per-way refire thresholds, and clusters events into
+/// epoch frames. Shared by the interactive replay (`run`) and the JSON dump
+/// (`rethink_dump::run_json`).
+///
+/// Refire thresholds reflect each way's *current* curve — rethink is a replay,
+/// so a curve edited since the recorded session shows today's value. That's the
+/// best we can do without snapshotting frontmatter into events.jsonl.
+pub(crate) fn reconstruct_frames(
+    events: &[WayEvent],
+    project_name: &str,
+    session_id: &str,
+    context_window: u64,
+) -> Vec<Frame> {
+    let context_window_k = context_window / 1000;
+    let token_timeline = build_token_timeline(project_name, session_id);
+    let fallback_refire_k = context_window_k * 25 / 100;
+    let mut refire_cache: HashMap<String, u64> = HashMap::new();
+    for ev in events {
+        if ev.way.is_empty() || refire_cache.contains_key(&ev.way) {
+            continue;
+        }
+        let threshold_k = session::way_refire_threshold_k(&ev.way, project_name, context_window)
+            .unwrap_or(fallback_refire_k);
+        refire_cache.insert(ev.way.clone(), threshold_k);
+    }
+    build_frames(events, &token_timeline, &refire_cache, fallback_refire_k)
+}
+
 fn build_frames(
     events: &[WayEvent],
     token_timeline: &[(String, u64)],
@@ -580,7 +594,7 @@ fn find_token_position(timeline: &[(String, u64)], ts: &str) -> u64 {
 
 // ── Event loading ─────────────────────────────────────────────
 
-fn load_session_events(content: &str, session_id: &str) -> Vec<WayEvent> {
+pub(crate) fn load_session_events(content: &str, session_id: &str) -> Vec<WayEvent> {
     content
         .lines()
         .filter(|l| l.contains(session_id))
@@ -600,7 +614,7 @@ fn load_session_events(content: &str, session_id: &str) -> Vec<WayEvent> {
         .collect()
 }
 
-fn find_session_project(content: &str, session_id: &str) -> Option<String> {
+pub(crate) fn find_session_project(content: &str, session_id: &str) -> Option<String> {
     for line in content.lines() {
         if !line.contains(session_id) || !line.contains("session_start") {
             continue;

--- a/tools/ways-cli/src/cmd/rethink_dump.rs
+++ b/tools/ways-cli/src/cmd/rethink_dump.rs
@@ -1,0 +1,312 @@
+//! Non-interactive JSON dump of a session's way-firing timeline.
+//!
+//! `rethink` renders the replay through a TUI; this module emits the same
+//! reconstructed timeline — plus a session summary and the near-miss events the
+//! TUI omits — as a single JSON document on stdout, for agents and scripts.
+//! It depends on no terminal feature, so it runs in headless / CI contexts
+//! where the interactive replay can't.
+
+use anyhow::Result;
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+use super::rethink;
+use crate::session;
+use crate::util::{detect_project_dir, home_dir};
+
+// ── Output shape ──────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct SessionDump {
+    session: String,
+    project: String,
+    context_window_k: u64,
+    summary: Summary,
+    frames: Vec<DumpFrame>,
+    near_misses: Vec<NearMiss>,
+}
+
+#[derive(Serialize)]
+struct Summary {
+    epochs: usize,
+    duration_secs: u64,
+    distinct_ways: usize,
+    total_fires: u64,
+    redisclosures: u64,
+    checks_fired: u64,
+    near_misses: u64,
+    trigger_breakdown: BTreeMap<String, u64>,
+    top_ways: Vec<TopWay>,
+}
+
+#[derive(Serialize)]
+struct TopWay {
+    way: String,
+    fires: u64,
+}
+
+#[derive(Serialize)]
+struct DumpFrame {
+    epoch: u64,
+    timestamp: String,
+    elapsed_secs: u64,
+    token_position_k: u64,
+    active_ways: Vec<DumpWay>,
+    new_events: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct DumpWay {
+    id: String,
+    trigger: String,
+    epoch_fired: u64,
+    token_pos_k: u64,
+    check_fires: u64,
+    is_new: bool,
+    is_redisclosed: bool,
+    refire_threshold_k: u64,
+}
+
+#[derive(Serialize)]
+struct NearMiss {
+    epoch: u64,
+    timestamp: String,
+    way: String,
+    score_en: f64,
+    score_multi: f64,
+    thr_en: f64,
+    thr_multi: f64,
+    margin: f64,
+}
+
+// ── Entry point ───────────────────────────────────────────────
+
+/// Emit a session's reconstructed timeline as a single pretty-printed JSON
+/// document. With no `session`, dumps the most recent session in scope.
+pub fn run_json(session: Option<&str>, project: Option<&str>) -> Result<()> {
+    let events_file = home_dir().join(".claude/stats/events.jsonl");
+    if !events_file.is_file() {
+        println!("{{\"error\":\"no events recorded yet\"}}");
+        return Ok(());
+    }
+    let content = std::fs::read_to_string(&events_file)?;
+
+    // Auto-detect project scope when not given, mirroring `rethink::run`.
+    let detected = if project.is_none() {
+        std::env::var("CLAUDE_PROJECT_DIR")
+            .ok()
+            .or_else(detect_project_dir)
+    } else {
+        None
+    };
+    let scope = project.map(|s| s.to_string()).or(detected);
+
+    let session_id = match session {
+        Some(s) => s.to_string(),
+        None => match most_recent_session(&content, scope.as_deref()) {
+            Some(s) => s,
+            None => {
+                println!("{{\"error\":\"no sessions found\"}}");
+                return Ok(());
+            }
+        }
+    };
+
+    match build_dump(&content, &session_id) {
+        Some(dump) => println!("{}", serde_json::to_string_pretty(&dump)?),
+        None => println!("{{\"error\":\"no events for session\",\"session\":\"{session_id}\"}}"),
+    }
+    Ok(())
+}
+
+// ── Assembly ──────────────────────────────────────────────────
+
+fn build_dump(content: &str, session_id: &str) -> Option<SessionDump> {
+    let project =
+        rethink::find_session_project(content, session_id).unwrap_or_else(|| "unknown".to_string());
+    let events = rethink::load_session_events(content, session_id);
+    if events.is_empty() {
+        return None;
+    }
+
+    let context_window = session::detect_context_window_for(&project, session_id);
+    let frames = rethink::reconstruct_frames(&events, &project, session_id, context_window);
+
+    let near_misses = build_near_misses(content, session_id, &frames);
+    let summary = build_summary(content, session_id, &frames, near_misses.len());
+    let dump_frames = frames.iter().map(to_dump_frame).collect();
+
+    Some(SessionDump {
+        session: session_id.to_string(),
+        project,
+        context_window_k: context_window / 1000,
+        summary,
+        frames: dump_frames,
+        near_misses,
+    })
+}
+
+fn to_dump_frame(f: &rethink::Frame) -> DumpFrame {
+    let active_ways = f
+        .ways
+        .iter()
+        .map(|w| DumpWay {
+            id: w.id.clone(),
+            trigger: w.trigger.clone(),
+            epoch_fired: w.epoch_fired,
+            token_pos_k: w.token_pos / 1000,
+            check_fires: w.check_fires,
+            is_new: w.is_new,
+            is_redisclosed: w.is_redisclosed,
+            refire_threshold_k: w.refire_threshold_k,
+        })
+        .collect();
+    DumpFrame {
+        epoch: f.epoch,
+        timestamp: f.timestamp.clone(),
+        elapsed_secs: f.elapsed_secs,
+        token_position_k: f.token_position_k,
+        active_ways,
+        new_events: f.new_events.clone(),
+    }
+}
+
+fn build_summary(
+    content: &str,
+    session_id: &str,
+    frames: &[rethink::Frame],
+    near_miss_count: usize,
+) -> Summary {
+    let mut total_fires = 0u64;
+    let mut redisclosures = 0u64;
+    let mut checks_fired = 0u64;
+    let mut triggers: BTreeMap<String, u64> = BTreeMap::new();
+    let mut way_fires: BTreeMap<String, u64> = BTreeMap::new();
+
+    for v in session_events(content, session_id) {
+        match v["event"].as_str() {
+            Some("way_fired") => {
+                total_fires += 1;
+                if let Some(t) = v["trigger"].as_str() {
+                    *triggers.entry(t.to_string()).or_insert(0) += 1;
+                }
+                if let Some(w) = v["way"].as_str() {
+                    *way_fires.entry(w.to_string()).or_insert(0) += 1;
+                }
+            }
+            Some("way_redisclosed") => redisclosures += 1,
+            Some("check_fired") => checks_fired += 1,
+            _ => {}
+        }
+    }
+
+    let mut top_ways: Vec<TopWay> = way_fires
+        .iter()
+        .map(|(w, n)| TopWay {
+            way: w.clone(),
+            fires: *n,
+        })
+        .collect();
+    top_ways.sort_by(|a, b| b.fires.cmp(&a.fires).then(a.way.cmp(&b.way)));
+    top_ways.truncate(15);
+
+    Summary {
+        epochs: frames.len(),
+        duration_secs: frames.last().map(|f| f.elapsed_secs).unwrap_or(0),
+        distinct_ways: way_fires.len(),
+        total_fires,
+        redisclosures,
+        checks_fired,
+        near_misses: near_miss_count as u64,
+        trigger_breakdown: triggers,
+        top_ways,
+    }
+}
+
+fn build_near_misses(content: &str, session_id: &str, frames: &[rethink::Frame]) -> Vec<NearMiss> {
+    session_events(content, session_id)
+        .filter(|v| v["event"].as_str() == Some("way_nearmiss"))
+        .map(|v| {
+            let ts = v["ts"].as_str().unwrap_or("").to_string();
+            NearMiss {
+                epoch: epoch_for_ts(frames, &ts),
+                timestamp: ts,
+                way: v["way"].as_str().unwrap_or("").to_string(),
+                score_en: field_f64(&v, "score_en"),
+                score_multi: field_f64(&v, "score_multi"),
+                thr_en: field_f64(&v, "thr_en"),
+                thr_multi: field_f64(&v, "thr_multi"),
+                margin: field_f64(&v, "margin"),
+            }
+        })
+        .collect()
+}
+
+// ── Parsing helpers ───────────────────────────────────────────
+
+/// Parsed events.jsonl rows belonging to one session.
+fn session_events<'a>(
+    content: &'a str,
+    session_id: &'a str,
+) -> impl Iterator<Item = serde_json::Value> + 'a {
+    content
+        .lines()
+        .filter(move |l| l.contains(session_id))
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .filter(move |v| v["session"].as_str() == Some(session_id))
+}
+
+/// Latest session (by session_start timestamp) within an optional project scope.
+fn most_recent_session(content: &str, scope: Option<&str>) -> Option<String> {
+    let mut best: Option<(String, String)> = None; // (ts, session)
+    for line in content.lines() {
+        if !line.contains("session_start") {
+            continue;
+        }
+        let v: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if v["event"].as_str() != Some("session_start") {
+            continue;
+        }
+        let sid = match v["session"].as_str() {
+            Some(s) if !s.is_empty() => s,
+            _ => continue,
+        };
+        if let Some(sc) = scope {
+            if !v["project"].as_str().unwrap_or("").contains(sc) {
+                continue;
+            }
+        }
+        let ts = v["ts"].as_str().unwrap_or("").to_string();
+        if best.as_ref().map(|(b, _)| ts > *b).unwrap_or(true) {
+            best = Some((ts, sid.to_string()));
+        }
+    }
+    best.map(|(_, s)| s)
+}
+
+/// Map a near-miss timestamp to the epoch of the frame it falls within —
+/// the last frame whose timestamp is at or before it.
+fn epoch_for_ts(frames: &[rethink::Frame], ts: &str) -> u64 {
+    let mut epoch = frames.first().map(|f| f.epoch).unwrap_or(0);
+    for f in frames {
+        if f.timestamp.as_str() <= ts {
+            epoch = f.epoch;
+        } else {
+            break;
+        }
+    }
+    epoch
+}
+
+/// Numeric fields in events.jsonl are stored as strings ("0.1693"); accept
+/// either a stringified or native number.
+fn field_f64(v: &serde_json::Value, key: &str) -> f64 {
+    v[key]
+        .as_str()
+        .and_then(|s| s.parse().ok())
+        .or_else(|| v[key].as_f64())
+        .unwrap_or(0.0)
+}

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -206,6 +206,10 @@ enum Commands {
         /// List sessions (non-interactive)
         #[arg(long)]
         list: bool,
+        /// Dump the reconstructed timeline as JSON instead of animating it
+        /// (non-interactive; includes a session summary and near-miss events)
+        #[arg(long)]
+        json: bool,
     },
     /// Engine health dashboard — binary, model, corpus, project status
     Status {
@@ -562,8 +566,12 @@ fn main() -> Result<()> {
             cmd::stats::run(days, project.as_deref(), json, global)
         }
         Commands::List { session, sort, json } => cmd::list::run(session.as_deref(), &sort, json),
-        Commands::Rethink { session, project, speed, list } => {
-            cmd::rethink::run(session.as_deref(), project.as_deref(), speed, list)
+        Commands::Rethink { session, project, speed, list, json } => {
+            if json {
+                cmd::rethink_dump::run_json(session.as_deref(), project.as_deref())
+            } else {
+                cmd::rethink::run(session.as_deref(), project.as_deref(), speed, list)
+            }
         }
         Commands::Status { json } => cmd::status::run(json),
         Commands::Scan { mode } => match mode {


### PR DESCRIPTION
## Why

`ways rethink` could only show a session's way-firing timeline through the crossterm TUI — the reconstructed record of *how ways actually steered a session* was unreachable for agents, scripts, and CI. And while `cognitive-loop.md` explains how ways is **designed**, nothing showed it **operating** in a real session. This PR closes both gaps, and they reinforce each other: the new dump produces the very artifact the new docs explain.

## What

**`ways rethink --json`** — dumps the full reconstructed timeline as one JSON document:
- `summary` — trigger mix, top ways, and fire / re-disclosure / check / near-miss totals
- `frames` — the per-turn timeline (epoch, token position, active ways, what changed)
- `near_misses` — ways that scored close to threshold but didn't fire, with scores + margins (the TUI omits these entirely)

Runs without the `tui` feature, so it works headless. The frame-reconstruction prelude is extracted into `reconstruct_frames` (shared by TUI + dump, behavior-preserving); the new logic lives in a `rethink_dump` module rather than growing the already-oversized `rethink.rs`.

**`docs/explanation/how-ways-works/`** — a three-page Diátaxis explanation cluster (`01.017–019.E`), the observable companion to `cognitive-loop.md`:
1. **The model** — the five event types and four observable behaviours (first-fire, re-disclosure, near-miss, check)
2. **A long session, read through ways** — a real 97h / 78-way / 490-fire / 821-near-miss session, each behaviour shown in its actual numbers (including the compaction sawtooth in re-disclosure)
3. **Reading the session data yourself** — `ways list` / `stats` / `rethink --json`, with jq recipes and what the numbers mean

Reference doc and the docs README are updated to match.

## Verification

- `cargo build` + `cargo clippy` clean; `cargo test` 11/11 pass (incl. `session_sim`)
- Ran `--json` against the real 97h KG session — summary matches independent analysis exactly; most-recent-session and error paths return clean JSON
- `docs/scripts/doc lint` — 0 errors, 0 warnings

https://claude.ai/code/session_01TgPLxh8Ls2kKTN6AGaMeDM