### PR TITLE
fix(ways): fire memory way at write-time via files: trigger

### DIFF
--- a/hooks/ways/meta/memory/memory.md
+++ b/hooks/ways/meta/memory/memory.md
@@ -4,6 +4,7 @@ vocabulary: remember memory save note forget recall persist session learning got
 trigger: context-threshold
 threshold: 80
 pattern: remember|save.*(to|this|that).*memory|note.*(for|this).*(later|next)|don't forget|keep.*in.*mind
+files: projects/[^/]+/memory/.*\.md$
 macro: prepend
 scope: agent
 requires: ["Bash(jq:*)", "Bash(sed:*)", "Bash(ways:*)", "Bash(wc:*)"]
@@ -16,12 +17,15 @@ Memory is Claude Code's auto-memory — the `MEMORY.md` file and topic files in 
 
 ## When This Fires
 
-This way fires in two contexts:
+This way fires in three contexts:
 
 1. **User asks to remember something** — explicit request like "remember this" or "note this for later"
 2. **Context threshold** — context is filling up and it's time to checkpoint before compaction
+3. **About to write a memory file** — a Write/Edit targets the auto-memory directory, firing this way at the tool call *before the write commits*
 
-For explicit requests, just record what the user asked. For threshold checkpoints, apply the surprise test below.
+The third trigger exists because the first two can't catch the most common over-save: a *spontaneous, content-shaped self-save* mid-session — writing "X is the active income source" while the conversation is about income, not about memory. Semantic matching scores that against a memory way describing the *memory subsystem* and comes up cold; the user said no memory words; context isn't full. Nothing fires, and the harness's "save broadly" default goes unchallenged. The file trigger observes the **write event** the semantic layer structurally cannot see, and injects the routing check at the only moment it matters.
+
+For explicit requests, just record what the user asked. For threshold checkpoints and write-time interceptions, apply the surprise test and routing table below — the write hasn't committed yet, so a better home is still reachable.
 
 ## Surprise Test (threshold checkpoint only)
 


### PR DESCRIPTION
## Problem

The memory way carries the right guidance — route facts to a way/ADR first, memory silently overrides reality, memory is narrow — but it only **disclosed** on two surfaces:

1. `trigger: context-threshold` at ≥80% context fill
2. `pattern:`/vocabulary match against **the user's prompt**

Neither catches the failure that prompted this: a **spontaneous, content-shaped self-save** mid-session — writing "X is the active income source" while the conversation is about income, with context nowhere near full and no memory words in the user's turn. The guidance stayed dormant and the harness's "save broadly" default went unchallenged.

## Evidence it's structural, not a tuning bug

Measured the semantic path against realistic save content. The way's description embeds as a way *about the memory subsystem*, so it scores save-worthy **content** cold:

| Prompt | memory-way cosine | Fires (thr 0.35)? |
|---|---|---|
| `save this to memory` | ~0.40 | ✅ |
| `remember and persist this across sessions` | ~0.60 | ✅ |
| `remember this for next time` | ~0.20 | ❌ |
| `remember that CPRIME is the active income source` | not ranked | ❌ |
| `let me note the income stream details for next session` | not ranked | ❌ |

You cannot write vocabulary that semantically matches arbitrary save-worthy content, because save-worthy content is by definition *about anything*. The trigger we need is "Claude is about to write a memory file" — a **tool-call event**, not a prompt topic, which the semantic layer cannot observe.

## Fix

Add one frontmatter line:

```
files: projects/[^/]+/memory/.*\.md$
```

The already-wired `Edit|Write` PreToolUse hook (`check-file-pre.sh` → `ways scan file`) now matches the memory path and injects the routing check **before the write commits**. Deterministic, scoring-independent, fires on the write event itself. `authoring.md` already combines `files:` with `context-threshold`, so the pattern is proven.

Body updated to document the third firing context.

## Deliberately not changed

Vocabulary and `embed_threshold` are untouched. The `pattern:` regex already backstops explicit user requests ("remember this for next time" matches `remember`); tuning the semantic layer to catch the spontaneous case would be tuning the wrong layer.

## Verification

- `ways lint hooks/ways/meta/memory/` → 0 errors, 0 warnings
- Simulated PreToolUse scan on `…/memory/income-stream.md` returns the full memory way body (routing table + write-time section) as `additionalContext` before the write — the exact interception that was missing.

https://claude.ai/code/session_01PBb7ShHUxH6zmAts83aXbf