### PR TITLE
feat(ways): give the session-link trailer a control surface

### DIFF
--- a/hooks/ways/softwaredev/delivery/github/macro.sh
+++ b/hooks/ways/softwaredev/delivery/github/macro.sh
@@ -258,3 +258,60 @@ if [[ -z "$HAS_BADGES" ]] && [[ -n "$REPO_FULL_NAME" ]] && [[ "$CAN_PUSH" == "tr
   echo "![Latest Release](https://img.shields.io/github/v/release/${REPO_FULL_NAME}?include_prereleases&label=version)"
   echo '```'
 fi
+
+# ============================================================
+# SECTION 3: Attribution / session-link control surface
+# ============================================================
+# The `attribution` setting (settings.json) governs the text appended to
+# commits and PR bodies — including the `Claude-Session:` trailer and the
+# session URL. Empty string disables it; absent means default (trailer ON).
+# Reporting the effective value here gives that trailer a visible control
+# surface at commit/PR/ship time: you can see whether session links are on,
+# and which settings file decides it.
+#
+# Precedence is an approximation of Claude Code's resolution order
+# (project-local > project > user-global, highest wins). It does not account
+# for managed/enterprise policy or command-line overrides.
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+ATTR_SRC=""
+COMMIT_RAW="__UNSET__"
+PR_RAW="__UNSET__"
+for f in \
+  "$PROJECT_ROOT/.claude/settings.local.json" \
+  "$PROJECT_ROOT/.claude/settings.json" \
+  "$HOME/.claude/settings.json"; do
+  [[ -f "$f" ]] || continue
+  jq -e 'has("attribution")' "$f" >/dev/null 2>&1 || continue
+  COMMIT_RAW=$(jq -r 'if .attribution|has("commit") then .attribution.commit else "__UNSET__" end' "$f" 2>/dev/null)
+  PR_RAW=$(jq -r 'if .attribution|has("pr") then .attribution.pr else "__UNSET__" end' "$f" 2>/dev/null)
+  ATTR_SRC="$f"
+  break
+done
+
+describe_attr() {
+  case "$1" in
+    __UNSET__) echo "default (Claude attribution + session trailer ON)" ;;
+    "")        echo "OFF (empty — no attribution, no session trailer)" ;;
+    *)         echo "custom: \"$1\"" ;;
+  esac
+}
+
+echo ""
+if [[ -z "$ATTR_SRC" ]]; then
+  echo "**Session-link trailer**: default (ON) — set \`attribution.commit\` / \`.pr\` to \`\"\"\` in settings.json to disable"
+else
+  # Shorten $HOME to ~ for display. Don't use ${var/#$HOME/~}: bash
+  # tilde-expands the replacement, turning ~ back into $HOME (a no-op).
+  case "$ATTR_SRC" in
+    "$HOME"/*) SRC_LABEL="~${ATTR_SRC#"$HOME"}" ;;
+    *)         SRC_LABEL="$ATTR_SRC" ;;
+  esac
+  if [[ "$COMMIT_RAW" == "$PR_RAW" ]]; then
+    echo "**Session-link trailer**: $(describe_attr "$COMMIT_RAW") [$SRC_LABEL]"
+  else
+    echo "**Session-link trailer** [$SRC_LABEL]:"
+    echo "- commit: $(describe_attr "$COMMIT_RAW")"
+    echo "- pr: $(describe_attr "$PR_RAW")"
+  fi
+fi

--- a/settings.json
+++ b/settings.json
@@ -5,7 +5,7 @@
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "99",
     "ENABLE_PROMPT_CACHING_1H": "1"
   },
-  "includeCoAuthoredBy": false,
+  "attribution": { "commit": "", "pr": "" },
   "permissions": {
     "allow": [
       "Edit(~/.claude/**)",


### PR DESCRIPTION
## What

Two changes that turn the harness-injected `Claude-Session:` commit/PR trailer from a no-knob behavior into a controllable, *legible* one.

### 1. Disable at the source (`settings.json`)
Replace the deprecated `includeCoAuthoredBy: false` with the documented `attribution` object:

```jsonc
"attribution": { "commit": "", "pr": "" }
```

The schema states commit attribution is *"including any trailers"* and *"Empty string hides commit attribution"* — so this is the official off-switch for the `Claude-Session:` trailer and the PR session URL. `includeCoAuthoredBy` only ever governed the `Co-Authored-By: Claude` line, which is why setting it `false` left the session trailer in place.

Takes effect at **session start** (the Git instructions are injected then).

### 2. A "hook back" in the github way macro
The github macro now reports the *effective* attribution state at commit/PR/`gh`/ship time:

```
**Session-link trailer**: OFF (empty — no attribution, no session trailer) [~/.claude/settings.json]
```

- Resolves precedence project-local > project > user-global, names the deciding file.
- Distinguishes **OFF** (empty) / **custom** / **default (ON)**; when unset, prints `default (ON)` plus the one-liner to disable.
- The knob is now always legible instead of acting silently.

## Note
`${var/#$HOME/~}` does **not** shorten the path under bash — bash tilde-expands the replacement `~` back into `$HOME`, a no-op. Uses a `case` + prefix-strip instead. (zsh doesn't do this, which masked it during interactive testing.)

## Test plan
- [x] `bash macro.sh` reports `Session-link trailer: OFF [~/.claude/settings.json]`
- [x] `~` path shortening verified under bash
- [x] `settings.json` validates (`jq empty`)
- [ ] Confirm next session that commits no longer carry the trailer

https://claude.ai/code/session_01TFyiQNDZ8RTMHX4Tnmp1wY