### PR TITLE
release(ways): bump ways CLI to 0.9.0

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "ways"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "agent-fmt",
  "anyhow",

--- a/tools/ways-cli/Cargo.toml
+++ b/tools/ways-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ways"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Unified CLI for ways — knowledge guidance for Claude Code"
 license = "MIT"


### PR DESCRIPTION
Version bump to cut **ways-v0.9.0** — first release since v0.8.0 (~40 PRs).

Bumps `tools/ways-cli/Cargo.toml` + `Cargo.lock` to `0.9.0` so `ways --version` matches the tag. Minor bump: substantial binary changes (main.rs split, frontmatter parser) plus new features since 0.8.0, all backwards-compatible.

After merge, tagging the merge commit `ways-v0.9.0` triggers `build-ways.yml` → 4-platform build + tests + GitHub release. Themed release notes to follow on the published release.

## Test plan
- [x] `cargo build --release -p ways` clean; `ways --version` → `0.9.0`
- [x] `Cargo.lock` updated
- [ ] CI 4-platform build green (this PR triggers it)