### PR TITLE
release(ways): bump to 0.9.1 (signed re-tag of 0.9.0)

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "ways"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "agent-fmt",
  "anyhow",

--- a/tools/ways-cli/Cargo.toml
+++ b/tools/ways-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ways"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "Unified CLI for ways — knowledge guidance for Claude Code"
 license = "MIT"


### PR DESCRIPTION
Bumps `ways-cli` `0.9.0 → 0.9.1`. **0.9.1 is a signed re-tag of identical code** — 0.9.0 shipped unsigned because the signing pinentry/YubiKey was unreachable from a remote session; this restores the signed-tag convention (v0.8.0).

No functional changes since 0.9.0; only the version string moves so `ways --version` matches the tag.

After merge, the signed `ways-v0.9.1` tag triggers `build-ways.yml` → 4-platform build + release.

## Test plan
- [x] `cargo build --release -p ways` clean; `ways --version` → `0.9.1`
- [ ] CI 4-platform build green (this PR triggers it)