### PR TITLE
ADR-142/143/144: agent-ways 1.0 — XDG application distribution

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -61,6 +61,9 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-138](./system/ADR-138-skills-own-the-how-ways-own-the-5w.md) | Skills own the how, ways own the 5W | Draft |
 | [ADR-139](./system/ADR-139-shelve-maintainer-i18n-adopter-run-localization-via-ways-localize.md) | Shelve maintainer i18n; adopter-run localization via ways-localize | Accepted |
 | [ADR-140](./system/ADR-140-two-install-topologies-in-place-repo-and-subdirectory-projection.md) | Two install topologies: in-place repo and subdirectory projection | Accepted |
+| [ADR-142](./system/ADR-142-agent-ways-1-0-xdg-application-distribution.md) | agent-ways 1.0 — XDG application distribution | Draft |
+| [ADR-143](./system/ADR-143-three-root-way-runtime-core-user-project.md) | Three-root way runtime — core, user, project | Draft |
+| [ADR-144](./system/ADR-144-install-repair-migrate-as-one-manifest-reconciler.md) | Install / repair / migrate as one manifest reconciler | Draft |
 
 ## Documentation
 _Documentation structure, tooling, coherence_

--- a/docs/architecture/system/ADR-142-agent-ways-1-0-xdg-application-distribution.md
+++ b/docs/architecture/system/ADR-142-agent-ways-1-0-xdg-application-distribution.md
@@ -1,0 +1,332 @@
+---
+status: Draft
+date: 2026-06-29
+deciders:
+  - aaronsb
+  - claude
+related:
+  - "[[ADR-140]]"
+  - "[[ADR-141]]"
+  - "[[ADR-112]]"
+  - "[[ADR-128]]"
+---
+
+# ADR-142: agent-ways 1.0 — XDG application distribution
+
+## Context
+
+Since its first release agent-ways has held one identity invariant: **`~/.claude`
+*is* agent-ways.** You install by cloning the repo into `~/.claude`; the installed
+files and the source files are literally the same files. ADR-140 named this the
+**in-place topology** and made it the default. Almost everything in the install/update
+machinery quietly depends on it: `git pull` (or `make update`) *is* the whole update;
+`git status` in `~/.claude` tells the truth; the update checker just runs
+`git -C ~/.claude rev-parse`; there is zero drift, because there is nothing to drift
+*from*.
+
+That invariant is load-bearing, and it is also the source of every structural problem
+1.0 exists to resolve. Three forces have converged:
+
+1. **The application and the user's workspace are the same directory, so we cannot
+   safely replace the application.** `~/.claude` holds agent-ways' shipped files (ways,
+   skills, hooks, `bin/`) *and* the user's own `settings.json` (model, theme, plugins),
+   their sessions, their credentials, and any ways they wrote themselves. Because these
+   are interleaved in one tree with no manifest distinguishing them, "update agent-ways"
+   cannot mean "replace the shipped files" — it can only mean "git pull and hope the
+   merge is clean." This is precisely why **auto-update has never been safe**: today
+   out-of-date is a *notification*, never auto-applied, because we cannot tell the
+   application's files apart from the user's and so cannot mutate one without risking the
+   other.
+
+2. **ADR-140 forked the deployment model but left the fork unresolved.** Faced with the
+   adopter who already has a `~/.claude` they value, ADR-140 introduced the
+   **subdirectory topology**: clone into `~/.claude/<dir>`, then *project* the outputs up
+   into `~/.claude`. It chose **copy** as the projection default (Windows / low-privilege
+   robustness) and explicitly recorded **symlink-projection as a rejected default,
+   retained as an advanced opt-in** — flagging in its own Neutral consequences that it
+   "leaves room for an opt-in symlink mode later without re-deciding the topology
+   question." Copy-projection, however, *creates drift as a first-class state* ("pulled
+   but didn't re-sync"), which ADR-140 then had to detect and nag about. We now have two
+   topologies, two update workflows, two `settings.json` writers, and a drift failure mode
+   that exists only because of the copy choice.
+
+3. **"global" conflates the application with the user.** The `ways` runtime today scans
+   two root classes — **global** (everything shipped, under `~/.claude`) and **project**
+   (per-repo ways). A way the *user* writes and a way agent-ways *ships* land in the same
+   global root, indistinguishable. There is no way to shadow a shipped way without editing
+   it in place — which the next update then clobbers. The "can't safely update" problem and
+   the "can't tell app from user" problem are the same problem viewed from the runtime side.
+
+The underlying realization: **agent-ways has outgrown being a dotfile and become an
+application.** Applications that respect their host don't own the user's home directory;
+they separate code from config from state from cache, install into well-known locations,
+and replace their own code wholesale on update without touching the user's data. The XDG
+Base Directory specification is exactly that contract. The cache half of it is already
+here — derived corpus, embeddings, and the model live in `$XDG_CACHE_HOME`
+(`~/.cache/claude-ways/`) and are regenerated, not version-controlled. 1.0 finishes the
+job: it makes agent-ways a real XDG application and reduces `~/.claude` to the thin
+**projection surface that Claude Code owns**.
+
+This is a 1.0-scale change: it re-decides ADR-140's defaults, restructures the runtime's
+root model (→ child ADR-143), and replaces the install/update/repair scripts with a single
+reconciler engine (→ child ADR-144). This ADR is the spine; it records the identity shift,
+the state taxonomy everything else falls out of, and the lifecycle for getting existing
+users there without stranding them.
+
+**A note on who this affects, and how much we know about them.** The migration-relevant
+population is specifically the **in-place-clone adopters** — those running a `~/.claude`-*is*-the-repo
+install that the migrator (§5, §8) must handle; everyone else is a fresh install. The maintainer
+does **not** know that population's exact size. The passive signals available are weak and
+ambiguous: roughly 19 stars and ~10 forks; release-asset downloads are low *and* undercounted
+because adopters typically build from source (`make ways`) rather than pull a release artifact;
+clone traffic is polluted by CI. The honest read is **small, real, and unknown-exact**, with the
+forkers (~10+) the best proxy for in-place adopters. The deprecation lifecycle (§8) is therefore
+designed to be **population-independent** — its safety must not, and does not, depend on knowing N.
+
+## Decision
+
+**Restructure agent-ways from "a clone that lives in `~/.claude`" into an XDG application
+that *projects into* `~/.claude`.** `~/.claude` stops being the application and becomes a
+thin, regenerable projection surface; the application, the operator's config, and the
+durable session substrate move to their proper XDG homes.
+
+### 1. The state taxonomy (the core decision — durability and repair fall out of it)
+
+The single decision from which everything else derives is **classifying every file agent-ways
+touches by its durability and ownership**, and putting each class in the XDG location whose
+contract matches:
+
+| Location | Holds | Durability contract |
+|---|---|---|
+| `$XDG_DATA_HOME/agent-ways/` | **The application** — exactly what is on GitHub: ways, skills, hooks, `bin/`, docs. | Read-only to the user; **replaced wholesale on update**. Losing it is a re-install, not data loss. |
+| `$XDG_CONFIG_HOME/agent-ways/` | **The operator's own** ways and macros, plus `ways.json`. | Durable; **never touched by update**. Out of every mutation's blast radius. |
+| `$XDG_STATE_HOME/agent-ways/` | **Session substrate** — ledger, memory, focus — that should survive a `~/.claude` wipe. | Durable; survives reinstall/repair. (Boundary vs. Claude-Code-owned state is an open question, below.) |
+| `$XDG_CACHE_HOME/claude-ways/` | **Derived** — corpus, embeddings, model. Already here today. | Regenerable; safe to delete; rebuilt on demand. |
+| `~/.claude/` | **The projection** — a merged `settings.json` (hooks + ways permissions only) and the projected tree. | The irreducible **Claude-Code-owned floor**; regenerable from the manifest. |
+
+The payoff is that **durability and ownership are now structural, not conventional.** "Can we
+auto-update?" stops being a judgment call and becomes a lookup: update mutates only
+`$XDG_DATA` (replaceable by definition) plus one surgical merge into `settings.json`; it never
+goes near `$XDG_CONFIG` or `$XDG_STATE`. Repair regenerates the projection from the manifest;
+losing the projection loses nothing. This is the separation of concerns that the single-tree
+model made impossible.
+
+### 2. Manifest-driven projection (symlink default, copy fallback, git-derived)
+
+A **manifest** is the contract describing what should exist in `~/.claude` and where each entry
+points back into `$XDG_DATA`. The projection is *whatever materializes that manifest* — so the
+ADR-140 "copy vs symlink" question stops being a topology fork and becomes an **implementation
+detail of materialization**:
+
+- **Symlink (default, Unix).** `~/.claude/hooks → $XDG_DATA/agent-ways/hooks`, etc. With symlinks,
+  `git pull` in `$XDG_DATA` makes most updates **live with zero projection step and zero drift** —
+  it restores every good property the original in-place topology had, without owning the user's home.
+- **Copy (fallback, Windows / low-privilege).** Where symlinks require developer-mode/admin or are
+  fragile, the same manifest is satisfied by copying. Drift is reintroduced here, but it is now the
+  *exception*, confined to environments that can't symlink, and the reconciler (child ADR-144) detects
+  and closes it.
+
+**The manifest is derived from the agent-ways git-tracked file set.** Git is the authoritative answer
+to "what does agent-ways ship." This makes the manifest do double duty as the **app-vs-user
+disentangler**: a file present in a project-owned directory (e.g. `hooks/ways/...`) but **not
+git-tracked-by-agent-ways** is, by set difference, user-scope. The thing we could never compute in the
+single-tree model — *which of these files are mine and which are the user's* — is now a `git ls-files`
+set difference against ground truth. (Format and mechanics: child ADR-144.)
+
+### 3. Flip the default — supersede ADR-140's defaults (not ADR-140)
+
+**Projection becomes the default, and within projection, symlink becomes the default
+materialization.** This **supersedes the *defaults* ADR-140 decided** — its in-place-default and its
+copy-default — while leaving ADR-140 *valid as the origin of the two-materialization idea*. ADR-140
+explicitly parked "an opt-in symlink mode later, without re-deciding the topology question" in its
+Neutral consequences; **this ADR is that future, promoted from opt-in to default.** The in-place model
+does not vanish — it becomes the legacy from-state the migrator reconciles away from (§5, child ADR-144).
+
+### 4. One reconciler engine, four from-states
+
+There is **no separate installer, updater, repairer, and migrator.** There is **one state-reconciler**
+that drives the live `~/.claude` tree toward the manifest, entered from four different source states:
+
+| From-state | What reconciliation means |
+|---|---|
+| **fresh** (no prior install) | Materialize the manifest from nothing. |
+| **drifted** (projection damaged) | Re-materialize the missing/broken entries. *Repair.* |
+| **out-of-date** ($XDG_DATA behind) | Advance $XDG_DATA, re-derive manifest, re-materialize the delta. *Update.* |
+| **legacy-in-place** (`~/.claude` *is* an old clone) | Relocate the app to $XDG_DATA, lift user files to $XDG_CONFIG/$XDG_STATE, replace the tree with the projection. *Migrate.* |
+
+Collapsing four tools into one engine is the design's central SOLID claim: the *logic* (converge the
+tree to the manifest, idempotently) has **one reason to change**; the four entrypoints differ only in
+*starting state and trust posture*, not in mechanism. Detailed engine, manifest format, and bootstrap:
+**child ADR-144**.
+
+### 5. The autonomy gradient (the load-bearing safety model)
+
+The same engine runs under **two trust postures, keyed on blast radius** — this is what makes "one
+engine for both a silent repair and a destructive migration" safe rather than reckless:
+
+- **update / repair → act silently and autonomously.** They touch only replaceable app-scope
+  (`$XDG_DATA` + the regenerable projection) and the surgical `settings.json` merge. Reversible, low
+  blast radius, no consent needed — consistent with the framework's silent-on-success convention.
+- **migration → a higher tier.** Migration rewrites the user's actual `~/.claude`. It must: **back up
+  the whole `~/.claude` first**; **announce loudly** (with the backup path); **gate the first run behind
+  explicit consent** (a `migrate` skill / installer invocation — never a silent SessionStart side
+  effect); and be **crash-safe and resumable** (marker-driven phases, back-up-before-mutate, atomic
+  moves). A half-migrated `~/.claude` is worse than an un-migrated one; the kept backup is the escape
+  hatch behind "things are broken."
+
+### 6. Manifest check on every SessionStart (escalating, silent-on-success)
+
+A SessionStart manifest check, mirroring the framework's existing escalation convention:
+
+- **all good → silent.** (As `ways init` / check-setup are silent today when healthy.)
+- **fixable drift → repair, then emit "X was repaired."**
+- **unfixable → emit "things are broken" loudly**, pointing at the backup / re-install path.
+
+The chicken-and-egg this raises (if hooks are gone, nothing runs to repair them) and its resolution
+(the self-sufficient bootstrap hook, and why that one entrypoint must be *exempt* from the breakage it
+repairs) are **child ADR-144's** core problem. The one cross-cutting fact the spine must state: because
+`settings.json` is read once at session start, a repaired hook **takes effect next session** — so the
+first post-install run is a one-time **bootstrap → "start a new session to pick up agent-ways" →
+restart** flow.
+
+### 7. Auto-update, finally safe — decomposed
+
+Auto-update was unsafe because *any* update risked clobbering user customizations. The taxonomy removes
+the risk by construction:
+
+- User ways live in `$XDG_CONFIG` — **never in the blast radius** of an update.
+- Under symlink projection, `git pull` in `$XDG_DATA` makes most updates **live with zero projection**.
+- The **only** mutation to a user-owned file is the **surgical `settings.json` merge** (hooks block +
+  ways permissions). That single shared-write seam is the entire remaining risk surface — and it is
+  named, bounded, and testable rather than diffuse.
+
+Therefore the stance flips: **out-of-date becomes auto-applied** (silently, per the gradient), not a
+notification the user must act on. This retires ADR-140's drift-nudge machinery for the default
+(symlink) path; it survives only as the copy-fallback's exception handling.
+
+### 8. Deprecation lifecycle (concrete, and population-independent)
+
+Existing in-place users must reach the new architecture without being stranded. The lifecycle is
+designed so that **the absolute size of the adopter base is irrelevant to its safety** — the maintainer
+does not know N exactly (small, real, unknown-exact; see Context), and the design must not depend on
+knowing it.
+
+The mechanism that makes this work: **1.1.0 is a per-user, update-gated transition, not a global flag
+day.** Each in-place user encounters the 1.1.0 "last migration release" gate **only when *they* update
+to it, on their own clock** — there is no calendar date at which anyone is cut off.
+
+- **1.0** — new architecture ships; the migrator (legacy-in-place from-state) goes live. Migration path
+  first viable.
+- **1.0.x** (1.0.1 … 1.0.N, N may be large) — migration supported throughout. The in-place check and the
+  assisted migrator run for everyone still in-place.
+- **1.1.0** — the **final** migration release. *When a user updates to it*, it migrates them (or confirms
+  they already are) and announces that the *next* release will no longer check or migrate: from 1.1.0's
+  successor on, ensuring `~/.claude` is how you want it becomes the user's responsibility, and agent-ways
+  manages only itself under the concern-separated architecture.
+- **post-1.1.0** — XDG-only; no in-place checking or migration. We distinguish **"remove the migrator"**
+  (stop assisted migration and the in-place check) from **forcibly breaking anyone still in-place**: the
+  design must not strand un-migrated users — removing assistance is not the same as actively breaking them.
+
+Two properties fall out of the per-user gate, and they are the whole point:
+
+- **"Remove the migrator" is safe by construction, not by hope.** Releases are sequential, so a user
+  cannot reach a post-1.1.0 release without having passed *through* 1.1.0's gate — which migrated them on
+  the way. By the time the migrator is gone, everyone who got there was migrated *en route*. Safety never
+  depends on "did everyone migrate by some date"; the update path itself enforces it. This is exactly why
+  N is irrelevant.
+- **A user who never updates past 1.1.0 stays frozen at 1.1.0 — working but unsupported.** This is an
+  **explicitly acceptable outcome**, not a failure: their in-place install keeps functioning; they simply
+  stop receiving updates and assisted migration. Nobody is stranded by a date — they self-select out by
+  declining to update, and what they decline into is a working frozen version.
+
+## Consequences
+
+### Positive
+
+- **Auto-update becomes safe and can be turned on**, because durability is now structural: the only
+  user-owned write is one bounded `settings.json` merge, and user ways are physically outside the blast
+  radius.
+- **App, config, state, and cache are separable for the first time** — clean separation of concerns. A
+  `~/.claude` wipe loses nothing durable; a re-install is a manifest re-materialization; corrupted cache
+  is regenerated.
+- **The copy-vs-symlink fork collapses** into one manifest with two materializations; symlink restores
+  the original in-place model's zero-drift, zero-step update without owning the user's home.
+- **Users can shadow a shipped way** (via `$XDG_CONFIG`, child ADR-143) instead of forking it in place and
+  losing the edit on the next update.
+- **Four lifecycle tools collapse into one reconciler** with a single reason to change; the four
+  entrypoints are starting-state + trust-posture, not duplicated logic.
+- **The app-vs-user question becomes computable** — a `git ls-files` set difference against ground truth,
+  not a heuristic.
+
+### Negative
+
+- **The `settings.json` merge is a genuine shared-write seam and the design's leakiest boundary.** Two
+  writers (Claude Code owns the file; agent-ways surgically merges hooks + ways permissions) write one
+  file agent-ways does not own. This is the one place the otherwise-clean separation of concerns breaks,
+  and it is exactly where a botched merge can corrupt a user-owned file. It must be idempotent,
+  key-scoped (touch only hooks + ways permissions), and backed up before write. Calling it out honestly:
+  this seam is the residual risk the whole taxonomy could not eliminate, only shrink.
+- **Migration is the highest-risk operation agent-ways has ever performed** — it rewrites the user's home
+  config tree. Crash-safety, resumability, and a full backup are mandatory, not optional; a half-migrated
+  `~/.claude` is worse than not migrating. The risk is real even with the gradient.
+- **More moving parts and more locations.** A user debugging their setup now reasons across four XDG roots
+  plus the projection, rather than one directory. `git status` in `~/.claude` no longer tells the truth;
+  the truth is in `$XDG_DATA`. This is a real loss of the in-place model's one-directory legibility.
+- **Symlink-vs-copy divergence persists at the edges.** Windows / low-priv installs still get copy, still
+  get drift, and still need the exception-handling path — the fork is narrowed to a fallback, not removed.
+- **Bootstrap is a known race with a one-time restart UX cost** (§6); the first post-install session is a
+  bootstrap-then-restart, which is friction at the worst possible moment (first impression).
+- **A long 1.0.x tail of dual-mode support.** For the whole 1.0.x window we maintain both the in-place
+  check / migrator and the XDG runtime — the very "reason about it twice" cost ADR-140 already flagged,
+  extended across the deprecation window.
+
+### Neutral
+
+- `$XDG_CACHE_HOME/claude-ways/` already exists and already behaves as derived/regenerable state; 1.0
+  ratifies the convention rather than inventing it. (Note the cache dir is `claude-ways`, while the
+  app/config/state dirs are proposed as `agent-ways` — a naming inconsistency to reconcile, see Open
+  Questions.)
+- The session ledger (ADR-112) and the KG evidential backend (ADR-141) become tenants of `$XDG_STATE`;
+  their "survive a `~/.claude` wipe" expectation is exactly what the state tier provides. Memory routing
+  (ADR-128) is unaffected in intent but its files' XDG-vs-Claude-Code ownership is an open question.
+- The two-topology framing of ADR-140 is folded into a one-manifest / two-materialization framing; ADR-140
+  is superseded only on its *defaults*, and remains the cited origin of the materialization choice.
+
+## Alternatives Considered
+
+- **Keep the single-tree model; make update smarter.** Try to teach the updater to diff and preserve user
+  edits inside the shared tree. Rejected: this is the status quo's unwinnable problem — without a manifest
+  grounding "what we ship" in git truth, app and user files are indistinguishable, so a "smart" merge is a
+  heuristic that will eventually clobber something. The taxonomy makes the distinction structural instead
+  of heuristic.
+- **Copy-projection as the default (ADR-140's choice), just better instrumented.** Rejected as the
+  *default*: copy makes drift a permanent first-class state, which then needs continuous detection and
+  nagging. Symlink eliminates drift on the platforms that can symlink (the majority), so copy is correctly
+  the *fallback*, not the default. ADR-140's instinct was right for its Windows-first rollout framing; 1.0
+  re-weights for the whole population.
+- **Put everything (app + config + state) under one new `~/.agent-ways/` directory.** Rejected: it would
+  re-create the single-tree conflation in a new location and ignore the XDG contracts that *exactly* encode
+  the durability classes we need. The value is in the *separation*, not in merely moving out of `~/.claude`.
+- **Stay in-place forever; never migrate.** Rejected: it permanently forecloses safe auto-update and
+  shadowable user ways, which are the two capabilities driving 1.0. But its *spirit* is honored in the
+  deprecation lifecycle's "don't strand un-migrated users" clause.
+
+## Open Questions
+
+These are recorded deliberately undecided; they do not block the Draft but must be resolved before
+Accepted:
+
+- **`$XDG_STATE` vs. Claude-Code-owned boundary.** Which of sessions / memory are Claude-Code-owned (and
+  stay in `~/.claude`) vs. agent-ways-owned (and move to `$XDG_STATE`)? The ledger and focus are clearly
+  ours; auto-memory (ADR-128) sits in Claude Code's `projects/<slug>/memory/` and may not be ours to move.
+- **App / config / state dir naming.** Cache is `claude-ways`; this ADR proposes `agent-ways` for the
+  others. Reconcile to one name, or accept the split and document why.
+- **Exact length of the 1.0.x migration window** before 1.1.0 retires assisted migration.
+- **Whether to add a lightweight, privacy-respecting adoption signal** so future lifecycle decisions
+  aren't blind. Note this is **explicitly not a prerequisite**: passive GitHub signals (forks, release
+  downloads) already exist, and the per-user-gated deprecation (§8) is population-independent by design —
+  so telemetry would only inform *future* judgment calls, never gate the safety of *this* lifecycle. Any
+  such signal must clear the project's own anti-surveillance bar before it's worth adding.
+- **Whether the two children stay separate ADRs or fold into this spine** — see ADR-143 / ADR-144;
+  current recommendation is to keep them separate (below).
+- Bootstrap-exemption mechanism and Windows materialization specifics are parked in **child ADR-144**.

--- a/docs/architecture/system/ADR-142-agent-ways-1-0-xdg-application-distribution.md
+++ b/docs/architecture/system/ADR-142-agent-ways-1-0-xdg-application-distribution.md
@@ -63,7 +63,7 @@ they separate code from config from state from cache, install into well-known lo
 and replace their own code wholesale on update without touching the user's data. The XDG
 Base Directory specification is exactly that contract. The cache half of it is already
 here — derived corpus, embeddings, and the model live in `$XDG_CACHE_HOME`
-(`~/.cache/claude-ways/`) and are regenerated, not version-controlled. 1.0 finishes the
+(`~/.cache/claude-ways/` today, renamed to `agent-ways/` for one consistent name) and are regenerated, not version-controlled. 1.0 finishes the
 job: it makes agent-ways a real XDG application and reduces `~/.claude` to the thin
 **projection surface that Claude Code owns**.
 
@@ -101,7 +101,7 @@ contract matches:
 | `$XDG_DATA_HOME/agent-ways/` | **The application** — exactly what is on GitHub: ways, skills, hooks, `bin/`, docs. | Read-only to the user; **replaced wholesale on update**. Losing it is a re-install, not data loss. |
 | `$XDG_CONFIG_HOME/agent-ways/` | **The operator's own** ways and macros, plus `ways.json`. | Durable; **never touched by update**. Out of every mutation's blast radius. |
 | `$XDG_STATE_HOME/agent-ways/` | **Session substrate** — ledger, memory, focus — that should survive a `~/.claude` wipe. | Durable; survives reinstall/repair. (Boundary vs. Claude-Code-owned state is an open question, below.) |
-| `$XDG_CACHE_HOME/claude-ways/` | **Derived** — corpus, embeddings, model. Already here today. | Regenerable; safe to delete; rebuilt on demand. |
+| `$XDG_CACHE_HOME/agent-ways/` | **Derived** — corpus, embeddings, model. (Exists today as `claude-ways/`; the reconciler renames it.) | Regenerable; safe to delete; rebuilt on demand. |
 | `~/.claude/` | **The projection** — a merged `settings.json` (hooks + ways permissions only) and the projected tree. | The irreducible **Claude-Code-owned floor**; regenerable from the manifest. |
 
 The payoff is that **durability and ownership are now structural, not conventional.** "Can we
@@ -282,10 +282,11 @@ Two properties fall out of the per-user gate, and they are the whole point:
 
 ### Neutral
 
-- `$XDG_CACHE_HOME/claude-ways/` already exists and already behaves as derived/regenerable state; 1.0
-  ratifies the convention rather than inventing it. (Note the cache dir is `claude-ways`, while the
-  app/config/state dirs are proposed as `agent-ways` — a naming inconsistency to reconcile, see Open
-  Questions.)
+- `$XDG_CACHE_HOME/agent-ways/` already exists today as `claude-ways/` and already behaves as
+  derived/regenerable state; 1.0 ratifies the convention rather than inventing it, and **harmonizes the
+  name to `agent-ways`** so all four XDG tiers share one application name. The rename
+  (`claude-ways` → `agent-ways`) is a one-time move the reconciler performs; because the tier is
+  regenerable, a missed rename costs only a rebuild.
 - The session ledger (ADR-112) and the KG evidential backend (ADR-141) become tenants of `$XDG_STATE`;
   their "survive a `~/.claude` wipe" expectation is exactly what the state tier provides. Memory routing
   (ADR-128) is unaffected in intent but its files' XDG-vs-Claude-Code ownership is an open question.
@@ -319,8 +320,6 @@ Accepted:
 - **`$XDG_STATE` vs. Claude-Code-owned boundary.** Which of sessions / memory are Claude-Code-owned (and
   stay in `~/.claude`) vs. agent-ways-owned (and move to `$XDG_STATE`)? The ledger and focus are clearly
   ours; auto-memory (ADR-128) sits in Claude Code's `projects/<slug>/memory/` and may not be ours to move.
-- **App / config / state dir naming.** Cache is `claude-ways`; this ADR proposes `agent-ways` for the
-  others. Reconcile to one name, or accept the split and document why.
 - **Exact length of the 1.0.x migration window** before 1.1.0 retires assisted migration.
 - **Whether to add a lightweight, privacy-respecting adoption signal** so future lifecycle decisions
   aren't blind. Note this is **explicitly not a prerequisite**: passive GitHub signals (forks, release

--- a/docs/architecture/system/ADR-143-three-root-way-runtime-core-user-project.md
+++ b/docs/architecture/system/ADR-143-three-root-way-runtime-core-user-project.md
@@ -1,0 +1,161 @@
+---
+status: Draft
+date: 2026-06-29
+deciders:
+  - aaronsb
+  - claude
+related:
+  - "[[ADR-142]]"
+  - "[[ADR-140]]"
+  - "[[ADR-111]]"
+---
+
+# ADR-143: Three-root way runtime — core, user, project
+
+## Context
+
+This is a child of ADR-142 (agent-ways 1.0). The spine moves the *application* to
+`$XDG_DATA` and the *operator's own ways* to `$XDG_CONFIG`. This ADR records what that
+split means for the **runtime that loads ways**.
+
+Today the `ways` runtime scans **two** root classes:
+
+- **global** — `~/.claude/hooks/ways` (`home_dir().join(".claude/hooks/ways")`, e.g.
+  `tools/ways-cli/src/cmd/language.rs:18`, `permissions.rs:12`). The corpus builder scans
+  it as the first root (`tools/ways-cli/src/cmd/corpus.rs:69-74`, "Scan global ways").
+- **project** — `<project>/.claude/ways`, resolved from `CLAUDE_PROJECT_DIR`
+  (`corpus.rs:89-94`), scanned second and namespaced per project.
+
+`ways status` reports exactly these two: a single **"Global ways"** count and a **Projects**
+list (verified against a live `ways status`: "Global ways: 115 total, 107 semantic" followed
+by per-project counts).
+
+A two-tier **precedence already exists** at file-resolution time: `resolve_way_file`
+(`tools/ways-cli/src/session.rs:563-577`) looks up a way ID in `<project>/.claude/ways/<id>`
+first and falls back to `~/.claude/hooks/ways/<id>` — "Project-local takes precedence." So
+*project > global* is not new; what is missing is a tier *between* them for the operator's own
+ways, because there is no operator-owned root distinct from global to resolve against.
+
+The defect is that **"global" conflates two different owners in one directory.** A way
+agent-ways *ships* and a way the *user wrote themselves* both land in `~/.claude/hooks/ways`,
+indistinguishable to the runtime. Three consequences follow:
+
+1. **You cannot shadow a shipped way without forking it.** To change how a core way behaves,
+   the only lever is editing the shipped file in place — which the next update clobbers (and,
+   pre-1.0, which made update unsafe to automate at all; ADR-142 §1).
+2. **The corpus cannot tell app ways from user ways**, so neither can any tooling built on it
+   (telemetry, tuning, `siblings`, permissions audit).
+3. **The runtime's root model contradicts the storage model ADR-142 just created.** The spine
+   puts core ways in `$XDG_DATA` and user ways in `$XDG_CONFIG` — two physically separate
+   locations — but a two-root runtime can only see one "global." The runtime has to learn the
+   split or the storage split is invisible at match time.
+
+## Decision
+
+**Promote the runtime from two roots to three — core, user, project — scanned as one runtime
+class, with precedence `project > user > core` and dedup-by-name.** This splits today's
+single "global" into its two real owners and makes shadowing a first-class, non-destructive
+operation.
+
+### 1. Three roots, one runtime class
+
+| Root | Location | Owner | Updatable |
+|---|---|---|---|
+| **core** | `$XDG_DATA_HOME/agent-ways/hooks/ways` (today's `~/.claude/hooks/ways` content) | agent-ways (shipped) | replaced wholesale on update |
+| **user** | `$XDG_CONFIG_HOME/agent-ways/ways` | the operator | never touched by update |
+| **project** | `<project>/.claude/ways` (unchanged) | the repo | per-repo, committed |
+
+They are scanned as **one runtime class**: a way is a way regardless of which root it came
+from. The runtime tags each loaded way with its origin root so downstream consumers (corpus
+namespacing, `status`, telemetry, permissions audit) can distinguish them — the tag is what
+today's model structurally lacks.
+
+### 2. Precedence `project > user > core`, dedup-by-name
+
+When the same way *name* appears in more than one root, the higher-precedence root wins and the
+lower one is dropped from the active set (dedup-by-name). Precedence runs **project > user >
+core** — this *inserts the user tier* into the project-over-global order `resolve_way_file`
+already implements (session.rs:563-577), rather than inventing precedence from scratch: a repo
+can override anything for its own checkout; an operator can override a shipped way for all their
+work; core is the floor. This is the mechanism that lets a user **shadow** a shipped way — drop a same-named way in `$XDG_CONFIG`, and it wins over core without editing or
+forking the shipped file.
+
+(Open question, below: whether shadow should be *whole-file replacement* by name or *field-level
+overlay*. This ADR commits to whole-file-by-name as the 1.0 semantics and parks overlay.)
+
+### 3. Corpus builder and `ways status` extend from two roots to three
+
+- **Corpus** (`cmd/corpus.rs`): the "Scan global ways" step splits into "Scan core ways" +
+  "Scan user ways," each content-hashed for staleness (the existing `global_hash` mechanism,
+  `corpus.rs:71`, generalizes to per-root hashes). Project scanning is unchanged. Dedup-by-name
+  is applied across the three before embedding so a shadowed core way isn't double-embedded.
+- **`ways status`**: the single "Global ways" line becomes two — **core** and **user** — making
+  the split observable, and surfacing shadowing (e.g. "3 user ways, 1 shadowing a core way").
+
+### 4. Scope boundary
+
+This ADR changes *where the runtime looks and how it resolves collisions*. It does **not** change
+the matching pipeline (ADR-108 embeddings), progressive disclosure (ADR-105), or the single-binary
+consolidation (ADR-111) — three roots feed the same matcher. It depends on ADR-142 for the
+existence of the `$XDG_CONFIG` user root; absent the spine, "user root" has no home.
+
+## Consequences
+
+### Positive
+
+- **Shadowing without forking.** An operator overrides a shipped way by name in `$XDG_CONFIG`;
+  the override survives every update because user scope is never in the update blast radius
+  (ADR-142 §7). This is the runtime-side payoff of the whole 1.0 restructure.
+- **Clean open/closed boundary.** Core is extended (by user/project ways) without being modified —
+  the SOLID open/closed principle expressed structurally rather than by convention. Today's only
+  extension mechanism is *modifying* the shipped tree, the exact opposite.
+- **App-vs-user becomes visible to every corpus consumer**, because origin is now a tag, not a lost
+  distinction — tuning, telemetry, `siblings`, and the permissions audit can all scope by root.
+- **The runtime model and the storage model finally agree** (ADR-142's two physical locations map
+  to two runtime roots).
+
+### Negative
+
+- **Precedence is a new surface for surprise.** "My way isn't firing" can now mean "a
+  higher-precedence root shadows it." `ways status` must make shadowing legible or it becomes a
+  silent debugging trap — the same class of "topology-fragile, went stale once already" failure
+  ADR-140 flagged for path-based checks.
+- **Dedup-by-name needs a defined collision policy across three roots**, including the awkward case
+  of a project way and a user way colliding with *different intent* — name collision is now load-
+  bearing where before there was one namespace per scope.
+- **More roots to scan at every corpus build**, with per-root staleness hashing; modest added cost
+  and more cache-invalidation paths.
+- **Whole-file shadow is coarse.** Overriding one frontmatter field (e.g. a trigger threshold)
+  requires copying the whole way into user scope, which then *won't* track upstream improvements to
+  the rest of that way — a real maintenance cliff the overlay alternative would avoid (parked).
+
+### Neutral
+
+- The two-root corpus namespacing (`encode_project_key`, `corpus.rs:94`) generalizes to three; the
+  on-disk corpus format gains a root tag but is otherwise unchanged.
+- Project scope is entirely unaffected in mechanism — only its position in a now-explicit precedence
+  order is stated.
+
+## Alternatives Considered
+
+- **Keep two roots; put user ways in the same dir as core and tag by some marker.** Rejected: it
+  re-creates the exact conflation ADR-142 §1 exists to remove, and leaves user ways inside the
+  update blast radius (a marker file doesn't move them out of `$XDG_DATA`). The split must be
+  physical to make update safe.
+- **Field-level overlay instead of whole-file shadow** (user way patches named fields of a core
+  way; unspecified fields inherit). More powerful and avoids the maintenance-cliff Negative — but
+  needs a merge semantics, conflict rules, and a way to express "remove this field," none of which
+  exist today. Deferred to a follow-on ADR; 1.0 ships whole-file-by-name and learns from it.
+- **Four roots** (split project into project-shipped vs project-local, or add an org/team root).
+  Rejected for 1.0 as scope the brief doesn't call for; the org-rollout need ADR-140 raised could
+  motivate a team root later, but it would slot into the same precedence chain without re-deciding
+  this model.
+
+## Open Questions
+
+- **Shadow semantics: whole-file vs field-level overlay** (committed to whole-file for 1.0; overlay
+  parked as a follow-on).
+- **Collision policy detail** when project and user ways collide by name with divergent intent.
+- **Whether this child stays a separate ADR or folds into ADR-142.** Recommendation: keep separate —
+  it has its own decision (precedence + dedup), its own consequences (the shadow maintenance cliff),
+  and touches a distinct subsystem (the matcher/corpus), which is enough to stand alone.

--- a/docs/architecture/system/ADR-144-install-repair-migrate-as-one-manifest-reconciler.md
+++ b/docs/architecture/system/ADR-144-install-repair-migrate-as-one-manifest-reconciler.md
@@ -7,6 +7,7 @@ deciders:
 related:
   - "[[ADR-142]]"
   - "[[ADR-140]]"
+  - "[[ADR-133]]"
   - "[[ADR-128]]"
 ---
 
@@ -218,6 +219,54 @@ date reaching the population.
 - **Auto-migrate silently at SessionStart** (no gate). Rejected outright by ADR-142's autonomy gradient:
   rewriting the user's home config without consent and without a loud backup announcement is exactly the
   blast radius the gradient exists to prevent.
+
+- **Bootstrap via a thin marketplace plugin.** *Viable alternative, not the chosen approach* — recorded
+  here so the reviewer can weigh it against §3's self-sufficient copied/stable-path entrypoint, which
+  stands. (Research-grounded: Claude Code plugins-reference plus adversarial cross-verification of the
+  named issues below.)
+
+  - **The crux is documented to work.** A plugin can ship a `SessionStart` hook that auto-fires the
+    moment the plugin is *enabled*, with **no `settings.json` edit by the user** (plugins-reference; the
+    shipped `explanatory-output-style` plugin is an existing example of an auto-firing plugin hook). The
+    hook file lives in Claude-Code's managed plugin cache
+    (`~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`), which is **independent of agent-ways'
+    own `~/.claude` projection** — a different tree, owned by a different system.
+
+  - **Effect on the bootstrap exemption: it *relocates* the exemption, it does not eliminate it.** Because
+    the hook is a real file in a Claude-Code-managed cache (loader-guaranteed to exist, *not* a symlink
+    into the projected tree agent-ways manages), it satisfies §3's exemption requirement by construction.
+    The burden of "guarantee a stable entry point" shifts **from agent-ways** (a copied file we keep in
+    sync) **to Claude Code's plugin loader**. That is a genuinely cleaner exemption — but it is a
+    **dependency on a third-party surface, not the removal of the dependency.**
+
+  - **Corrected risk-ranking — the exemption is *not* the headline risk here.** The headline risk is
+    **coupling a load-bearing bootstrap to Anthropic's plugin subsystem, which agent-ways does not control
+    and which is visibly churning**: an ephemeral, version-stamped `CLAUDE_PLUGIN_ROOT` (#15642); a
+    stale-marketplace-clone update bug (#35752); repeated Windows symlink regressions
+    (#23819 / #24140 / #53948 / #50052); and an uninstall path that deletes the plugin *and* its
+    `CLAUDE_PLUGIN_DATA` — which would make the projection persist while its **healer vanishes**. A
+    secondary facet is *fit with the official model*: plugins are meant to *contribute artifacts*, not
+    *mutate `~/.claude`*. A bootstrap hook that symlinks and merges `settings.json` into `~/.claude` is
+    **technically allowed** (hooks run unsandboxed at full user privilege) but is **off-label** use of the
+    plugin contract.
+
+  - **Three hard constraints if pursued:** (1) the bootstrap must resolve `$XDG_DATA` **independently** and
+    treat `CLAUDE_PLUGIN_ROOT` as ephemeral/throwaway (it rotates every plugin update); (2) any durable
+    bootstrap state goes to `$CLAUDE_PLUGIN_DATA` (survives updates) or `$XDG_STATE` — **never**
+    `CLAUDE_PLUGIN_ROOT`; (3) the plugin must be a genuinely self-contained **thin shim** (the hook plus a
+    small launcher only). Plugins deliberately skip outside-pointing symlinks for security, so the shim
+    **cannot symlink-bridge into `$XDG_DATA`**; and the binaries / model / corpus do not fit git-clone
+    plugin delivery — so **"ship the whole app as a plugin" is not viable** (wrong shape), full stop.
+
+  - **When it earns its keep — and when it doesn't.** The real payoff is **discoverability**:
+    `claude plugin install agent-ways@aaronsb` via a self-published single-plugin marketplace, riding
+    Anthropic's managed install channel, with the exemption-maintenance shift as a *bonus*. For the
+    exemption *alone* it is a **bad trade** — standing up a whole marketplace plus lifecycle coupling to
+    replace one copied file. It implies a **two-channel update model**: the thin plugin updates rarely via
+    the marketplace, while the bulk app updates independently via the reconciler / `git` in `$XDG_DATA`.
+    This is adjacent to **ADR-133**, which already shells `claude plugin list --json` at `SessionStart` to
+    discover plugin-contributed ways — so the framework already touches the plugin surface, just for
+    discovery rather than bootstrap.
 
 ## Open Questions
 

--- a/docs/architecture/system/ADR-144-install-repair-migrate-as-one-manifest-reconciler.md
+++ b/docs/architecture/system/ADR-144-install-repair-migrate-as-one-manifest-reconciler.md
@@ -1,0 +1,233 @@
+---
+status: Draft
+date: 2026-06-29
+deciders:
+  - aaronsb
+  - claude
+related:
+  - "[[ADR-142]]"
+  - "[[ADR-140]]"
+  - "[[ADR-128]]"
+---
+
+# ADR-144: Install / repair / migrate as one manifest reconciler
+
+## Context
+
+This is a child of ADR-142 (agent-ways 1.0). The spine declared **one reconciler engine,
+four from-states** (fresh / drifted / out-of-date / legacy-in-place) and an **autonomy
+gradient** (silent for update/repair, gated-and-loud for migration). This ADR records the
+engine: the **manifest** it converges toward, the **bootstrap** that lets it run at all, and
+the **migrator** plus its deprecation lifecycle.
+
+The current reality is several scripts with overlapping jobs:
+
+- `install.sh` — clone-in-place or `--dangerously-clobber` (ADR-140 §5).
+- `scripts/update.sh` / `make update` — `git pull` for the in-place topology.
+- `scripts/sync-to-home.sh` — the subdirectory projector. It already does most of what the
+  engine needs: it has **both `copy` (default) and `symlink` modes** (`SYNC_MODE`, lines
+  11-33), projects trees idempotently (`project_tree`, lines 68-90, which already skips when a
+  link/dir already resolves to source), backs up before overwrite (lines 47-55), merges
+  `settings.json` for hooks + ways permissions only (lines 167-198), and writes a source marker
+  + synced-HEAD stamp (`.claude-source`, lines 189-199).
+- `hooks/check-config-updates.sh` — the out-of-date detector that runs at session start.
+
+Two facts from the real script are load-bearing for this ADR:
+
+1. **A manifest already exists** — `.claude-source-manifest` (lines 143-165). In copy mode the
+   script enumerates the source subtrees it projects (`build_manifest`, lines 144-156:
+   `skills`, `agents`, `commands`, `hooks/ways`, two named hooks, four named binaries), diffs
+   against the previous manifest, and **prunes only orphans it previously created** — explicitly
+   leaving user-owned files in the same shared dirs untouched ("User-owned files in the same
+   shared dirs are never in the manifest, so they are never touched," line 141). The
+   app-vs-user disentangling ADR-142 frames as the manifest's "double duty" is **already the
+   stated rationale of this code** — but the manifest is built by *filesystem enumeration of
+   hardcoded source subtrees*, not from git.
+2. **The manifest is copy-mode-only.** Symlink mode "reflects source live — no orphans" (line
+   142), so it writes no manifest. There is today no single artifact that describes the desired
+   `~/.claude` state across *both* materializations.
+
+So the engine is less a green-field build than a **consolidation and a grounding correction**:
+unify the scripts into one reconciler, lift the manifest from a copy-mode pruning side-effect to
+*the* projection contract, and re-base it on git truth.
+
+## Decision
+
+**One idempotent reconciler that converges `~/.claude` toward a git-derived manifest, plus a
+self-sufficient bootstrap that is exempt from the breakage it repairs, plus a gated crash-safe
+migrator with an explicit deprecation lifecycle.**
+
+### 1. Manifest format, derived from the git-tracked file set
+
+The manifest is the list of projection entries — for each, the relative path in `~/.claude` and
+the source path in `$XDG_DATA` it points back to. It is **derived from `git ls-files` in
+`$XDG_DATA/agent-ways`**, not from filesystem enumeration of hardcoded subtrees. This is the
+correction to today's `build_manifest`:
+
+- **Git is the authoritative "what we ship."** A way/skill/command added or removed upstream is
+  reflected automatically; the hardcoded `for t in skills agents commands hooks/ways` list
+  (line 146) stops being a thing anyone can forget to update.
+- **The set difference becomes exact.** "What is app vs. user" is `git ls-files` (app) vs. what's
+  present in the shared dirs (everything); the complement is user scope. Today's manifest gets
+  the *spirit* right (don't touch what we didn't write) but its membership test is "did a prior
+  projection write it," which is weaker than "is it git-tracked-by-agent-ways."
+
+Both materializations (symlink default, copy fallback — ADR-142 §2) are driven from the *same*
+manifest; symlink mode now also has a manifest (it just materializes entries as links), closing
+the "no single desired-state artifact" gap.
+
+### 2. The four from-states are one convergence with different entry conditions
+
+The engine computes (desired = manifest) vs. (actual = live `~/.claude`) and applies the delta
+idempotently. The four from-states differ only in *starting actual* and *trust posture*:
+
+- **fresh** — actual is empty → materialize all entries.
+- **drifted** — actual is missing/broken entries → re-materialize just those (repair).
+- **out-of-date** — `$XDG_DATA` HEAD advanced → re-derive manifest, materialize the delta, prune
+  orphans (the existing `comm -23` orphan logic, lines 159-163, generalized).
+- **legacy-in-place** — actual *is an old clone* → the migrator (§4) first relocates, then this
+  same convergence runs.
+
+Idempotence is already the discipline in `project_tree` (skip when already linked/resolved, lines
+75-85); the engine generalizes it to every entry and to the prune step.
+
+### 3. Bootstrap and the exemption (the engine's hardest problem)
+
+**Chicken-and-egg:** the reconciler runs from a SessionStart hook; if the hooks are gone, nothing
+runs to repair them. Resolution:
+
+- The **installer detects Claude Code and writes the minimum self-sufficient hook** into
+  `~/.claude` — the irreducible Claude-Code-owned floor (ADR-142's `~/.claude` row). On SessionStart
+  that hook invokes the manifest check/repair.
+- **CRITICAL exemption: the bootstrap/repair entrypoint must not be a symlink into the tree it
+  manages.** If the healer is itself a link into `$XDG_DATA`, a broken `$XDG_DATA` (or a wiped link)
+  takes out its own healer. So the bootstrap entrypoint is **the one deliberate copy** (a small
+  copied script) *or* a call to a binary at a **stable absolute XDG path** — never a link into the
+  managed tree. This is a deliberate, named exception to the symlink default, justified precisely
+  because it is the thing that repairs the symlinks.
+- **The restart seam.** `settings.json` is read once at session start, so a repaired hook **takes
+  effect next session**. The first post-install session is therefore a one-time **bootstrap →
+  "start a new session to pick up agent-ways" → restart** flow. The reconciler must make this
+  legible (say it plainly), not silently leave the user in a half-armed session.
+
+### 4. SessionStart check — escalating, silent-on-success
+
+Mirroring the framework's existing convention (and today's silent `ways init` / `check-setup`):
+
+- all entries satisfied → **silent**;
+- fixable drift → repair autonomously, emit **"X was repaired"**;
+- unfixable → emit **"things are broken"** loudly, pointing at the backup / re-install path.
+
+This replaces `check-config-updates.sh`'s in-place-only detection with a manifest check that works
+across all materializations; the in-place git classifier survives only for the legacy from-state
+during the deprecation window (§5).
+
+### 5. The migrator and its deprecation lifecycle
+
+Migration (legacy-in-place → XDG) is the **higher trust tier** (ADR-142 §5): it rewrites the user's
+actual `~/.claude`.
+
+- **Gated, not silent.** Entered only via an explicit `migrate` skill / installer invocation — never
+  a SessionStart side effect.
+- **Back up first, announce loudly** with the backup path (the existing pre-overwrite backup, lines
+  47-55, generalized from "the projected dirs" to "the whole `~/.claude`").
+- **Crash-safe and resumable.** Marker-driven phases, back-up-before-mutate, atomic moves. A
+  half-migrated `~/.claude` is worse than an un-migrated one; on crash the next run resumes from the
+  last completed phase, and the backup is the escape hatch.
+- **Migration ground truth is git.** What to *relocate to `$XDG_DATA`* (the app) vs. *lift to
+  `$XDG_CONFIG`/`$XDG_STATE`* (the user's ways, sessions, settings) is the same `git ls-files` set
+  difference as §1: app files are git-tracked-by-agent-ways; everything else in the old clone is the
+  user's and must be preserved, not replaced.
+
+**Deprecation lifecycle** (concrete, per ADR-142 §8). The governing property: **the transition is
+per-user and update-gated, not a global flag day.** A user meets the 1.1.0 gate only when *they* update
+to it, on their own clock — so the engine never needs to know how many in-place adopters exist (the
+maintainer doesn't; ADR-142 Context). The migrator is invoked *by an update reaching the user*, not by a
+date reaching the population.
+
+- **1.0** — migrator ships and is active.
+- **1.0.x** — migration supported throughout; the in-place check + assisted migrator run for anyone
+  still in-place.
+- **1.1.0** — *final* migration release. When a user's update lands on 1.1.0, the migrator runs (or
+  confirms already-migrated), then announces that the *next* release stops checking/migrating.
+- **post-1.1.0** — remove the migrator and the in-place check. This is **safe by construction**: releases
+  are sequential, so no one reaches a post-1.1.0 release without having passed *through* 1.1.0's migrating
+  gate. **"Remove assistance" is not "break the un-migrated":** a user still in-place keeps a working
+  in-place install; agent-ways simply stops *helping* them move and stops *checking*. A user who never
+  updates past 1.1.0 stays **frozen at 1.1.0, working but unsupported** — an acceptable, self-selected
+  outcome, not a stranding. The design must not actively break them.
+
+## Consequences
+
+### Positive
+
+- **One engine, one reason to change.** The convergence logic lives once; install/update/repair/
+  migrate become entry conditions, not four scripts to keep in sync (the SOLID payoff ADR-142 §4
+  claims, realized here).
+- **The manifest stops being a copy-mode afterthought** and becomes the single desired-state contract
+  for both materializations, git-grounded — which is also what makes the app-vs-user split exact
+  rather than "whatever a prior sync happened to write."
+- **Repair is real and idempotent**, reusing the already-idempotent `project_tree` discipline; a
+  damaged projection self-heals at the next SessionStart, silently when it can.
+- **Migration is auditable and recoverable** — gated, backed up, resumable — rather than a one-shot
+  destructive script.
+- Much of this is **consolidation of code that already exists and works** (copy/symlink modes,
+  backup, settings merge, orphan prune, marker/stamp), lowering implementation risk.
+
+### Negative
+
+- **The bootstrap exemption is a permanent, deliberate violation of the symlink default** — a copied
+  (or stable-path-binary) entrypoint that must be kept in sync with the engine it launches by some
+  *other* mechanism than the manifest, because it can't be a managed link. If that copy goes stale,
+  the healer and the thing it heals disagree. This is irreducible complexity, not an oversight.
+- **The git-derived manifest assumes `$XDG_DATA` is a clean agent-ways checkout.** If a user has
+  hand-edited core files in place (exactly what pre-1.0 forced them to do to customize), those edits
+  are now "drift from git truth" and the reconciler may revert them — the migrator must detect and
+  rescue such edits into user scope, or it silently destroys the customization it was meant to
+  preserve. This is the migration's sharpest edge.
+- **Migration crash-safety is genuinely hard to get right** and easy to get subtly wrong; resumable
+  marker-driven phases over a directory the user also has open in live sessions is a concurrency
+  problem, not just a sequencing one.
+- **The `settings.json` merge remains the shared-write seam** (ADR-142 Negative) and is the one engine
+  output that touches a user-owned file; it must be idempotent and key-scoped or the engine corrupts
+  the very floor it depends on.
+- **A long dual-mode window:** the in-place git classifier and the manifest reconciler both ship for
+  all of 1.0.x.
+
+### Neutral
+
+- `.claude-source` (marker) and `.claude-source-manifest` already exist (ADR-140 observability); this
+  ADR re-bases the manifest on git and extends it to symlink mode, but the marker mechanism is reused,
+  not invented.
+- The session substrate this engine must preserve across migration (ledger, focus, and possibly memory)
+  is defined by ADR-142's `$XDG_STATE` boundary open question and ADR-128's memory ownership — the engine
+  inherits whatever that boundary resolves to.
+
+## Alternatives Considered
+
+- **Keep separate install / update / sync / repair scripts; just fix the manifest.** Rejected: the four
+  scripts already duplicate backup, projection, and settings-merge logic three ways (`install.sh`,
+  `update.sh`, `sync-to-home.sh`), which is how the broken settings-merge shipped in #182 (ADR-140) —
+  duplicated lifecycle logic is the defect generator. One engine is the structural fix.
+- **Make the bootstrap hook a symlink like everything else** (no exemption). Rejected: a broken target
+  takes out the healer; the entrypoint that repairs the tree cannot live inside the tree it repairs.
+- **Keep the filesystem-enumeration manifest** (today's `build_manifest`). Rejected: it requires a
+  hand-maintained subtree list, and its "is it ours" test ("did a prior sync write it") is weaker than
+  git truth — it can't classify a file the user dropped into a shared dir that happens to match a name we
+  later ship. Git ls-files is the authoritative membership test.
+- **Auto-migrate silently at SessionStart** (no gate). Rejected outright by ADR-142's autonomy gradient:
+  rewriting the user's home config without consent and without a loud backup announcement is exactly the
+  blast radius the gradient exists to prevent.
+
+## Open Questions
+
+- **Bootstrap-exemption mechanism: copied script vs. stable-path binary call.** Both satisfy "not a link
+  into the managed tree"; which is chosen affects how the entrypoint is kept current. Parked per ADR-142.
+- **Windows materialization specifics** — copy fallback details, developer-mode requirement, path quoting
+  (the #182 author already started this); how the reconciler detects "can't symlink here" and falls back.
+- **Rescue policy for hand-edited core files** found during migration (revert to git, or lift the diff
+  into user scope as a shadow — see ADR-143's user root).
+- **Exact 1.0.x window length** before 1.1.0 (shared with ADR-142).
+- **Whether this child stays separate or folds into ADR-142.** Recommendation: keep separate — the
+  bootstrap exemption and the crash-safe migrator are each substantial enough to warrant their own
+  recorded decision and their own Consequences.


### PR DESCRIPTION
**Draft for review** — three Draft-status ADRs proposing the most significant architectural change since the project's origin: agent-ways stops *living in* `~/.claude` and becomes an XDG application that *projects into* it. Authored by `system-architect`, grounded against the real repo (not just a brief). No code — decision records only.

## The set

- **ADR-142 — agent-ways 1.0: XDG application distribution** (spine)
  Identity shift: `~/.claude` becomes a thin, regenerable, Claude-Code-owned projection surface. Core decision is the **state taxonomy** — DATA (app, replaced wholesale) / CONFIG (user, never touched) / STATE (session substrate, survives wipe) / CACHE (derived) / `~/.claude` (projection). Durability + ownership become *structural*, so "can we auto-update?" becomes a lookup, not a judgment call. Also: manifest-driven projection (symlink default / copy fallback / **git-derived**), flips the default and **supersedes ADR-140's defaults only**, one-reconciler/four-from-states, the autonomy gradient, and the **population-independent** deprecation lifecycle (1.1.0 as a per-user update-gate; "remove the migrator" safe by construction).

- **ADR-143 — Three-root way runtime: core, user, project**
  Splits today's single "global" root into **core (DATA) + user (CONFIG)**; precedence `project > user > core`, dedup-by-name, shadow-a-shipped-way-without-forking. *Inserts* a user tier into the existing two-tier precedence (not new machinery).

- **ADR-144 — Install/repair/migrate as one manifest reconciler**
  One idempotent reconciler; git-derived manifest (an elevation of the existing `.claude-source-manifest`); the self-sufficient **bootstrap exemption** (the healer can't be a link into the tree it heals); gated, crash-safe migrator; git-as-migration-ground-truth.

## Open decisions to resolve in review

1. **ADR-141 dependency.** ADR-141 (KG memory) is unmerged (#198), so `related: [[ADR-141]]` **dangles** until that lands. Numbering reserved 141 for it. → merge #198 first?
2. **Naming.** Cache is `~/.cache/claude-ways/`; proposed data/config/state are `agent-ways`. Parked as an Open Question rather than silently harmonized. → harmonize to `agent-ways`?

## The two honest leaks (in each ADR's Consequences/Negative — managed, not solved)

- **`settings.json` merge** — the one shared-write seam; two writers on a file agent-ways doesn't own. The single place separation genuinely breaks.
- **Bootstrap-exemption copy** — a permanent, deliberate violation of the symlink default, kept in sync by a non-manifest mechanism. The cost of escaping the bootstrap chicken-and-egg.

## Grounding findings (where the real repo refined the design)

Manifest already exists (copy-only, filesystem-enumerated → elevate to git-derived); precedence already project>global (insert user tier); `way-embed` already the copy-not-symlink binary (validates the bootstrap exemption); XDG cache leg already correct. Net: this *completes a separation the codebase already started*, not a from-scratch reorg.

Related: ADR-140 (supersedes defaults), ADR-141 (#198), ADR-112, ADR-128.