### PR TITLE
agent-ways 1.0 runtime: events→$XDG_STATE + three-root way runtime

### DIFF
--- a/hooks/ways/check-post.sh
+++ b/hooks/ways/check-post.sh
@@ -29,9 +29,15 @@ export CLAUDE_PROJECT_DIR="${PROJECT_DIR}"
 # Project-local is kept symmetric with predictive hooks; trust is
 # enforced at the `ways show way` gate (which honors
 # trusted-project-macros for project-local macros) rather than here.
+# Precedence project > user > core (ADR-143). User root is the operator's own
+# ways in $XDG_CONFIG; core is the shipped tree (projected at ~/.claude/hooks/ways).
 WAYS_ROOTS=()
 if [[ -d "${PROJECT_DIR}/.claude/ways" ]]; then
   WAYS_ROOTS+=("${PROJECT_DIR}/.claude/ways")
+fi
+_USER_WAYS="${XDG_CONFIG_HOME:-$HOME/.config}/agent-ways/ways"
+if [[ -d "${_USER_WAYS}" ]]; then
+  WAYS_ROOTS+=("${_USER_WAYS}")
 fi
 WAYS_ROOTS+=("${HOME}/.claude/hooks/ways")
 

--- a/tools/ways-cli/src/cmd/corpus.rs
+++ b/tools/ways-cli/src/cmd/corpus.rs
@@ -65,12 +65,30 @@ pub fn run(
     };
 
     let excluded = crate::util::load_excluded_segments();
+    let empty_skip: std::collections::HashSet<String> = std::collections::HashSet::new();
 
-    // Scan global ways
-    let global_count = scan_ways_dir(&global_dir, "", &excluded, &mut w)?;
+    // Scan USER ways first (ADR-143): the operator's own root in $XDG_CONFIG.
+    // Its ids become the skip set for core, so a user way shadows a same-named
+    // shipped way (precedence project > user > core).
+    let user_dir = crate::paths::user_ways_root();
+    let mut user_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let user_count = if user_dir.is_dir() {
+        let c = scan_ways_dir(&user_dir, "", &excluded, &mut w, &empty_skip, &mut user_ids)?;
+        if c > 0 {
+            log(&format!("User ways: {c} ({})", user_dir.display()));
+        }
+        c
+    } else {
+        0
+    };
+    let user_hash = content_hash(&user_dir);
+
+    // Scan CORE (shipped) ways, dropping any id a user way already claimed.
+    let mut core_written = user_ids.clone();
+    let global_count = scan_ways_dir(&global_dir, "", &excluded, &mut w, &user_ids, &mut core_written)?;
     let global_hash = content_hash(&global_dir);
     log(&format!(
-        "Global ways: {global_count} (hash: {}...)",
+        "Core ways: {global_count} (hash: {}...)",
         &global_hash[..16.min(global_hash.len())]
     ));
 
@@ -156,9 +174,9 @@ pub fn run(
     // Atomic move
     std::fs::rename(&tmpfile, &corpus_path)?;
 
-    let total = global_count + project_total;
+    let total = global_count + user_count + project_total;
     log(&format!(
-        "Generated {}: {total} ways ({global_count} global, {project_total} project)",
+        "Generated {}: {total} ways ({global_count} core, {user_count} user, {project_total} project)",
         corpus_path.display()
     ));
 
@@ -169,6 +187,8 @@ pub fn run(
     let manifest = json!({
         "global_hash": global_hash,
         "global_count": global_count,
+        "user_hash": user_hash,
+        "user_count": user_count,
         "total_count": total,
         "projects": manifest_projects,
     });
@@ -208,7 +228,11 @@ fn embed_one_project(
     }
 
     let prefix = format!("{key}/");
-    let local_count = scan_ways_dir(ways_path, &prefix, excluded, w)?;
+    // Project ids are namespaced ({key}/…), so they can't collide with core/user;
+    // pass fresh dedup sets.
+    let skip = std::collections::HashSet::new();
+    let mut written = std::collections::HashSet::new();
+    let local_count = scan_ways_dir(ways_path, &prefix, excluded, w, &skip, &mut written)?;
 
     if local_count > 0 {
         let local_hash = content_hash(ways_path);
@@ -231,7 +255,19 @@ fn embed_one_project(
 
 /// Scan a ways directory for semantic ways (having description + vocabulary).
 /// Writes JSONL to the writer. Returns the number of ways found.
-fn scan_ways_dir(dir: &Path, id_prefix: &str, excluded: &[String], w: &mut impl Write) -> Result<usize> {
+///
+/// `skip` holds ids already claimed by a higher-precedence root — a matching way
+/// here is shadowed and dropped (ADR-143 dedup-by-name). Every id actually
+/// written is recorded in `written` so the caller can build the next root's skip
+/// set (precedence: project > user > core).
+fn scan_ways_dir(
+    dir: &Path,
+    id_prefix: &str,
+    excluded: &[String],
+    w: &mut impl Write,
+    skip: &std::collections::HashSet<String>,
+    written: &mut std::collections::HashSet<String>,
+) -> Result<usize> {
     let mut count = 0;
 
     let mut md_files: Vec<PathBuf> = Vec::new();
@@ -322,6 +358,14 @@ fn scan_ways_dir(dir: &Path, id_prefix: &str, excluded: &[String], w: &mut impl 
         let id_body = crate::util::path_to_id(relpath.parent().unwrap_or(Path::new("")));
         let id = format!("{id_prefix}{id_body}");
 
+        // Dedup-by-name (ADR-143): a higher-precedence root already claimed this
+        // id, so this shadowed way is dropped from the corpus. Otherwise record it
+        // so lower-precedence roots skip it.
+        if skip.contains(&id) {
+            continue;
+        }
+        written.insert(id.clone());
+
         // Capture the English root for the multilingual anchor (Pass 2, localized mode).
         en_roots.insert(
             id.clone(),
@@ -352,6 +396,10 @@ fn scan_ways_dir(dir: &Path, id_prefix: &str, excluded: &[String], w: &mut impl 
             let parent = path.parent().unwrap_or(Path::new(""));
             let relparent = parent.strip_prefix(dir).unwrap_or(parent);
             let id = format!("{}{}", id_prefix, crate::util::path_to_id(relparent));
+            // Same dedup as Pass 1: don't emit locale aliases for a shadowed id.
+            if skip.contains(&id) {
+                continue;
+            }
 
             let entries = match frontmatter::parse_locales_jsonl(path) {
                 Ok(e) => e,
@@ -640,17 +688,22 @@ use crate::util::home_dir;
 
 /// Check if any way file is newer than the manifest.
 fn is_stale(manifest: &Path, global_dir: &Path, project_dir: &str) -> bool {
-    // Check global ways
-    for entry in WalkDir::new(global_dir)
-        .follow_links(true)
-        .into_iter()
-        .filter_map(|e| e.ok())
-    {
-        let path = entry.path();
-        if path.is_file() {
-            let ext = path.extension().and_then(|e| e.to_str());
-            if (ext == Some("md") || ext == Some("jsonl")) && is_newer_than(path, manifest) {
-                return true;
+    // Check core + user ways (both unnamespaced roots feed the corpus).
+    for root in [global_dir.to_path_buf(), crate::paths::user_ways_root()] {
+        if !root.is_dir() {
+            continue;
+        }
+        for entry in WalkDir::new(&root)
+            .follow_links(true)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let path = entry.path();
+            if path.is_file() {
+                let ext = path.extension().and_then(|e| e.to_str());
+                if (ext == Some("md") || ext == Some("jsonl")) && is_newer_than(path, manifest) {
+                    return true;
+                }
             }
         }
     }

--- a/tools/ways-cli/src/cmd/corpus.rs
+++ b/tools/ways-cli/src/cmd/corpus.rs
@@ -71,9 +71,9 @@ pub fn run(
     // Its ids become the skip set for core, so a user way shadows a same-named
     // shipped way (precedence project > user > core).
     let user_dir = crate::paths::user_ways_root();
-    let mut user_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut user_sink: std::collections::HashSet<String> = std::collections::HashSet::new();
     let user_count = if user_dir.is_dir() {
-        let c = scan_ways_dir(&user_dir, "", &excluded, &mut w, &empty_skip, &mut user_ids)?;
+        let c = scan_ways_dir(&user_dir, "", &excluded, &mut w, &empty_skip, &mut user_sink)?;
         if c > 0 {
             log(&format!("User ways: {c} ({})", user_dir.display()));
         }
@@ -83,9 +83,13 @@ pub fn run(
     };
     let user_hash = content_hash(&user_dir);
 
-    // Scan CORE (shipped) ways, dropping any id a user way already claimed.
-    let mut core_written = user_ids.clone();
-    let global_count = scan_ways_dir(&global_dir, "", &excluded, &mut w, &user_ids, &mut core_written)?;
+    // Scan CORE (shipped) ways, dropping any id a user way claimed. The shadow
+    // set is ALL user way ids by directory (crate::cmd::scan::candidates::way_ids)
+    // — incl. non-semantic ones — so it matches the predictive scanner's dedup
+    // and a pattern-only user override still suppresses the core way.
+    let user_shadow = crate::cmd::scan::candidates::way_ids(&user_dir);
+    let mut core_sink: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let global_count = scan_ways_dir(&global_dir, "", &excluded, &mut w, &user_shadow, &mut core_sink)?;
     let global_hash = content_hash(&global_dir);
     log(&format!(
         "Core ways: {global_count} (hash: {}...)",

--- a/tools/ways-cli/src/cmd/governance/helpers.rs
+++ b/tools/ways-cli/src/cmd/governance/helpers.rs
@@ -64,8 +64,7 @@ pub fn find_incomplete(manifest: &Value) -> Vec<String> {
 }
 
 pub fn load_events() -> Vec<Value> {
-    let home = std::env::var("HOME").unwrap_or_default();
-    let path = format!("{home}/.claude/stats/events.jsonl");
+    let path = crate::paths::events_log();
     let content = match std::fs::read_to_string(&path) {
         Ok(c) => c,
         Err(_) => return Vec::new(),

--- a/tools/ways-cli/src/cmd/list.rs
+++ b/tools/ways-cli/src/cmd/list.rs
@@ -258,8 +258,7 @@ fn detect_session() -> Option<String> {
 }
 
 fn latest_session_for_project(project: &str) -> Option<String> {
-    let home = std::env::var("HOME").ok()?;
-    let path = format!("{home}/.claude/stats/events.jsonl");
+    let path = crate::paths::events_log();
     let content = std::fs::read_to_string(&path).ok()?;
 
     let mut latest: Option<String> = None;

--- a/tools/ways-cli/src/cmd/rethink.rs
+++ b/tools/ways-cli/src/cmd/rethink.rs
@@ -112,7 +112,7 @@ impl Drop for TermGuard {
 
 #[cfg(feature = "tui")]
 pub fn run(session: Option<&str>, project: Option<&str>, speed: Option<u64>, list: bool) -> Result<()> {
-    let events_file = home_dir().join(".claude/stats/events.jsonl");
+    let events_file = crate::paths::events_log();
     if !events_file.is_file() {
         println!("No events recorded yet.");
         return Ok(());
@@ -188,7 +188,7 @@ pub fn run(session: Option<&str>, project: Option<&str>, speed: Option<u64>, lis
 #[cfg(not(feature = "tui"))]
 pub fn run(_session: Option<&str>, _project: Option<&str>, _speed: Option<u64>, list: bool) -> Result<()> {
     if list {
-        let events_file = home_dir().join(".claude/stats/events.jsonl");
+        let events_file = crate::paths::events_log();
         if !events_file.is_file() {
             println!("No events recorded yet.");
             return Ok(());

--- a/tools/ways-cli/src/cmd/rethink_dump.rs
+++ b/tools/ways-cli/src/cmd/rethink_dump.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeMap;
 
 use super::rethink;
 use crate::session;
-use crate::util::{detect_project_dir, home_dir};
+use crate::util::detect_project_dir;
 
 // ── Output shape ──────────────────────────────────────────────
 
@@ -84,7 +84,7 @@ struct NearMiss {
 /// Emit a session's reconstructed timeline as a single pretty-printed JSON
 /// document. With no `session`, dumps the most recent session in scope.
 pub fn run_json(session: Option<&str>, project: Option<&str>) -> Result<()> {
-    let events_file = home_dir().join(".claude/stats/events.jsonl");
+    let events_file = crate::paths::events_log();
     if !events_file.is_file() {
         println!("{{\"error\":\"no events recorded yet\"}}");
         return Ok(());

--- a/tools/ways-cli/src/cmd/scan/candidates.rs
+++ b/tools/ways-cli/src/cmd/scan/candidates.rs
@@ -1,5 +1,6 @@
 //! Candidate collection: finding, parsing, and filtering way files.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
@@ -12,35 +13,89 @@ use super::WayCandidate;
 pub(crate) fn collect_candidates(project_dir: &str) -> Vec<WayCandidate> {
     let mut candidates = Vec::new();
 
+    // Full ADR-143 precedence, by bare id: project > user > core. A higher root
+    // shadows a same-named way in every lower root, so what *fires* matches what
+    // `resolve_way_file` *renders* (no match/render divergence). `seen`
+    // accumulates the claimed bare ids down the chain.
+    let mut seen: HashSet<String> = HashSet::new();
+
     // Project-local first. The corpus namespaces project ways as
     // `{encode_project_key(project_dir)}/{id}`; we compute the identical prefix
     // here so the embedding lookup (best_en/best_multi) finds them (Bug B fix).
     let project_ways = PathBuf::from(project_dir).join(".claude/ways");
     if project_ways.is_dir() {
         let prefix = project_corpus_prefix(project_dir);
-        collect_from_dir(&project_ways, &prefix, &mut candidates);
+        collect_from_dir(&project_ways, &prefix, &mut candidates, &HashSet::new(), &mut seen);
     }
 
-    // Global ways are not namespaced — corpus id == bare id.
+    // User ways ($XDG_CONFIG/agent-ways/ways) — bare ids; drop any project shadows.
+    let user_ways = crate::paths::user_ways_root();
+    if user_ways.is_dir() {
+        let claimed = seen.clone();
+        collect_from_dir(&user_ways, "", &mut candidates, &claimed, &mut seen);
+    }
+
+    // Core ways — bare ids; drop any project- or user-claimed id.
     let global_ways = super::scoring::home_dir().join(".claude/hooks/ways");
-    collect_from_dir(&global_ways, "", &mut candidates);
+    let claimed = seen.clone();
+    collect_from_dir(&global_ways, "", &mut candidates, &claimed, &mut seen);
 
     candidates
 }
 
 pub(crate) fn collect_checks(project_dir: &str) -> Vec<WayCandidate> {
     let mut candidates = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
 
     let project_ways = PathBuf::from(project_dir).join(".claude/ways");
     if project_ways.is_dir() {
         let prefix = project_corpus_prefix(project_dir);
-        collect_checks_from_dir(&project_ways, &prefix, &mut candidates);
+        collect_checks_from_dir(&project_ways, &prefix, &mut candidates, &HashSet::new(), &mut seen);
+    }
+
+    let user_ways = crate::paths::user_ways_root();
+    if user_ways.is_dir() {
+        let claimed = seen.clone();
+        collect_checks_from_dir(&user_ways, "", &mut candidates, &claimed, &mut seen);
     }
 
     let global_ways = super::scoring::home_dir().join(".claude/hooks/ways");
-    collect_checks_from_dir(&global_ways, "", &mut candidates);
+    let claimed = seen.clone();
+    collect_checks_from_dir(&global_ways, "", &mut candidates, &claimed, &mut seen);
 
     candidates
+}
+
+/// Bare ids of all ways under `root` (dirs holding a frontmatter `.md`).
+///
+/// The user-shadows-core dedup key, shared with the corpus builder so the two
+/// enumerations agree. Deliberately by-directory (any user way, semantic or
+/// pattern-only, shadows a same-named core way) — this is what makes a
+/// non-semantic user override actually suppress the core way for firing.
+pub(crate) fn way_ids(root: &Path) -> HashSet<String> {
+    let mut ids = HashSet::new();
+    if !root.is_dir() {
+        return ids;
+    }
+    for entry in WalkDir::new(root).follow_links(true).into_iter().filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if name.contains(".check.") {
+            continue;
+        }
+        match std::fs::read_to_string(path) {
+            Ok(c) if crate::util::has_frontmatter(&c) => {}
+            _ => continue,
+        }
+        let id = way_id_from_path(path, root);
+        if !id.is_empty() {
+            ids.insert(id);
+        }
+    }
+    ids
 }
 
 /// The corpus-id prefix for project-local ways: `{key}/`, where `key` is the
@@ -49,7 +104,13 @@ fn project_corpus_prefix(project_dir: &str) -> String {
     format!("{}/", crate::util::encode_project_key(Path::new(project_dir)))
 }
 
-fn collect_from_dir(dir: &Path, corpus_prefix: &str, out: &mut Vec<WayCandidate>) {
+fn collect_from_dir(
+    dir: &Path,
+    corpus_prefix: &str,
+    out: &mut Vec<WayCandidate>,
+    skip: &HashSet<String>,
+    written: &mut HashSet<String>,
+) {
     for entry in WalkDir::new(dir)
         .follow_links(true)
         .into_iter()
@@ -77,6 +138,12 @@ fn collect_from_dir(dir: &Path, corpus_prefix: &str, out: &mut Vec<WayCandidate>
             continue;
         }
 
+        // Dedup-by-name (ADR-143): a higher-precedence root already claimed this
+        // id, so the shadowed candidate is dropped before it can fire.
+        if skip.contains(&id) {
+            continue;
+        }
+
         // Check domain disable (user scope) and per-way disable (project scope, ADR-131)
         let domain = id.split('/').next().unwrap_or(&id);
         if session::domain_disabled(domain) || session::way_disabled(&id) {
@@ -84,12 +151,19 @@ fn collect_from_dir(dir: &Path, corpus_prefix: &str, out: &mut Vec<WayCandidate>
         }
 
         if let Some(candidate) = parse_candidate(&id, corpus_prefix, path, &content) {
+            written.insert(id.clone());
             out.push(candidate);
         }
     }
 }
 
-fn collect_checks_from_dir(dir: &Path, corpus_prefix: &str, out: &mut Vec<WayCandidate>) {
+fn collect_checks_from_dir(
+    dir: &Path,
+    corpus_prefix: &str,
+    out: &mut Vec<WayCandidate>,
+    skip: &HashSet<String>,
+    written: &mut HashSet<String>,
+) {
     for entry in WalkDir::new(dir)
         .follow_links(true)
         .into_iter()
@@ -117,7 +191,12 @@ fn collect_checks_from_dir(dir: &Path, corpus_prefix: &str, out: &mut Vec<WayCan
             continue;
         }
 
+        if skip.contains(&id) {
+            continue;
+        }
+
         if let Some(candidate) = parse_candidate(&id, corpus_prefix, path, &content) {
+            written.insert(id.clone());
             out.push(candidate);
         }
     }
@@ -254,5 +333,44 @@ mod tests {
         assert_eq!(get_fm_field(&lf, "pattern").as_deref(), Some("foo"));
         assert_eq!(get_fm_field(&crlf, "pattern").as_deref(), Some("foo"));
         assert_eq!(get_fm_field(&crlf, "description").as_deref(), Some("hello"));
+    }
+
+    fn write_way(root: &Path, id: &str) {
+        let leaf = id.rsplit('/').next().unwrap_or(id);
+        let dir = root.join(id);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(format!("{leaf}.md")), "---\npattern: x\n---\n# w\n").unwrap();
+    }
+
+    #[test]
+    fn user_candidate_fires_and_shadows_core() {
+        // collect_from_dir takes the dir explicitly (no env), so the dedup chain
+        // is testable directly. Models the user→core leg of collect_candidates.
+        let base =
+            std::env::temp_dir().join(format!("ways-cand-{}-{}", std::process::id(), "shadow"));
+        let _ = std::fs::remove_dir_all(&base);
+        let user = base.join("user");
+        let core = base.join("core");
+        write_way(&user, "meta/foo"); // shadows core foo
+        write_way(&user, "meta/baz"); // unique user way — must still become a candidate
+        write_way(&core, "meta/foo");
+        write_way(&core, "meta/bar");
+
+        let mut candidates = Vec::new();
+        let mut seen = HashSet::new();
+        collect_from_dir(&user, "", &mut candidates, &HashSet::new(), &mut seen);
+        let claimed = seen.clone();
+        collect_from_dir(&core, "", &mut candidates, &claimed, &mut seen);
+
+        let ids: Vec<&str> = candidates.iter().map(|c| c.id.as_str()).collect();
+        // The blocker: a unique user way must be a candidate (i.e. can fire).
+        assert!(ids.contains(&"meta/baz"), "unique user way must become a candidate: {ids:?}");
+        assert!(ids.contains(&"meta/bar"), "core-only way present: {ids:?}");
+        // Shadow: foo appears once, and it's the USER file (its gating fields win).
+        assert_eq!(ids.iter().filter(|i| **i == "meta/foo").count(), 1, "foo deduped: {ids:?}");
+        let foo = candidates.iter().find(|c| c.id == "meta/foo").unwrap();
+        assert!(foo.path.starts_with(&user), "the surviving foo candidate is the user's");
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -3,7 +3,7 @@
 //! Combines file walking, frontmatter extraction, matching (pattern + semantic),
 //! scope/precondition gating, parent-threshold lowering, and show (display).
 
-mod candidates;
+pub(crate) mod candidates;
 mod reduce;
 mod scoring;
 mod state;

--- a/tools/ways-cli/src/cmd/stats.rs
+++ b/tools/ways-cli/src/cmd/stats.rs
@@ -15,7 +15,7 @@ pub fn run(days: Option<u32>, project_filter: Option<&str>, json_output: bool, g
         None
     };
     let project_filter = project_filter.or(detected_project.as_deref());
-    let stats_file = home_dir().join(".claude/stats/events.jsonl");
+    let stats_file = crate::paths::events_log();
 
     if !stats_file.is_file() {
         if !json_output {
@@ -277,4 +277,4 @@ fn days_to_ymd(days: u64) -> (u64, u64, u64) {
     (y, m, d)
 }
 
-use crate::util::{detect_project_dir, home_dir};
+use crate::util::detect_project_dir;

--- a/tools/ways-cli/src/cmd/status.rs
+++ b/tools/ways-cli/src/cmd/status.rs
@@ -25,8 +25,10 @@ pub fn run(json_output: bool) -> Result<()> {
         "none"
     };
 
-    // Global way counts
+    // Way counts: core (shipped) + user (operator's own, $XDG_CONFIG) — ADR-143.
     let (global_total, global_semantic) = count_ways(&ways_dir);
+    let user_ways_dir = crate::paths::user_ways_root();
+    let (user_total, user_semantic) = count_ways(&user_ways_dir);
 
     // Corpus stats
     let corpus_count = if corpus_exists {
@@ -103,6 +105,8 @@ pub fn run(json_output: bool) -> Result<()> {
             "ways": {
                 "global_total": global_total,
                 "global_semantic": global_semantic,
+                "user_total": user_total,
+                "user_semantic": user_semantic,
             },
             "projects": projects,
             "output_language": output_language,
@@ -159,7 +163,10 @@ pub fn run(json_output: bool) -> Result<()> {
         println!();
 
         // Ways
-        println!("Global ways: {} total, {} semantic", global_total, global_semantic);
+        println!("Core ways: {} total, {} semantic", global_total, global_semantic);
+        if user_total > 0 {
+            println!("User ways: {} total, {} semantic", user_total, user_semantic);
+        }
 
         if !disabled.is_empty() {
             println!("Disabled domains: {}", disabled.join(", "));

--- a/tools/ways-cli/src/cmd/tune_curves.rs
+++ b/tools/ways-cli/src/cmd/tune_curves.rs
@@ -22,7 +22,6 @@ use agent_fmt::{Align, Table};
 
 use crate::frontmatter;
 use crate::session::resolve_way_file;
-use crate::util::home_dir;
 
 /// Rule-of-thumb: suggest a half_life equal to the median observed token
 /// delta between fires, rounded to the nearest 500 tokens for readability.
@@ -38,7 +37,7 @@ pub fn run(
     project_filter: Option<String>,
     way_filter: Option<String>,
 ) -> Result<()> {
-    let events_path = home_dir().join(".claude/stats/events.jsonl");
+    let events_path = crate::paths::events_log();
     if !events_path.is_file() {
         println!("no events log found at {}", events_path.display());
         println!("ways tune-curves needs real firing data — run ways for a few sessions first.");

--- a/tools/ways-cli/src/cmd/tune_precision.rs
+++ b/tools/ways-cli/src/cmd/tune_precision.rs
@@ -43,7 +43,6 @@ use anyhow::Result;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::Path;
 
-use crate::util::home_dir;
 
 /// A family's share of a session's fires must clear this to count as part of
 /// the session's activity class. 0.15 keeps incidental single fires out of the
@@ -122,7 +121,7 @@ pub fn run(
     way_filter: Option<String>,
     json_output: bool,
 ) -> Result<()> {
-    let events_path = home_dir().join(".claude/stats/events.jsonl");
+    let events_path = crate::paths::events_log();
     if !events_path.is_file() {
         println!("no events log found at {}", events_path.display());
         println!("ways tune-precision needs real firing data — run ways for a few sessions first.");

--- a/tools/ways-cli/src/paths.rs
+++ b/tools/ways-cli/src/paths.rs
@@ -165,10 +165,30 @@ pub fn user_config() -> PathBuf {
 
 // --- state ($XDG_STATE) ---
 
-/// Telemetry/event log: `$XDG_STATE/agent-ways/events.jsonl` (migrated from the
-/// Claude-Code-adjacent `~/.claude/stats/events.jsonl`; it is *our* telemetry).
+/// Telemetry/event log: `$XDG_STATE/agent-ways/events.jsonl` (our telemetry).
+///
+/// Fallback-aware during the transition, mirroring [`cache_root`]: prefers the
+/// `$XDG_STATE` location, but if that doesn't exist yet while the legacy
+/// `~/.claude/stats/events.jsonl` does, returns the legacy file so an
+/// un-migrated install keeps appending to its existing history. The migrator
+/// lifts the file to `$XDG_STATE`, after which the preferred path wins. Reads
+/// and the writer both route through here, so they never diverge.
 pub fn events_log() -> PathBuf {
-    state_root().join("events.jsonl")
+    resolve_events(&state_root(), &projection_root())
+}
+
+/// Pure fallback resolution for the event log, factored out for testing without
+/// touching `$XDG_STATE`/`$HOME`.
+fn resolve_events(state: &Path, projection: &Path) -> PathBuf {
+    let preferred = state.join("events.jsonl");
+    if preferred.exists() {
+        return preferred;
+    }
+    let legacy = projection.join("stats").join("events.jsonl");
+    if legacy.exists() {
+        return legacy;
+    }
+    preferred
 }
 
 // --- cache ($XDG_CACHE) ---
@@ -227,6 +247,28 @@ mod tests {
         // New exists → new wins even with legacy present (post-migration).
         std::fs::create_dir_all(base.join(APP)).unwrap();
         assert!(resolve_cache(&base).ends_with(APP));
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn events_log_prefers_state_falls_back_to_legacy_stats() {
+        let base = std::env::temp_dir().join(format!("ways-events-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let state = base.join("state");
+        let projection = base.join(".claude");
+        std::fs::create_dir_all(&state).unwrap();
+        std::fs::create_dir_all(&projection).unwrap();
+
+        // Neither exists → preferred (state).
+        assert!(resolve_events(&state, &projection).starts_with(&state));
+        // Only legacy ~/.claude/stats/events.jsonl exists → legacy (continuity).
+        std::fs::create_dir_all(projection.join("stats")).unwrap();
+        std::fs::write(projection.join("stats/events.jsonl"), "{}\n").unwrap();
+        assert!(resolve_events(&state, &projection).starts_with(&projection));
+        // State events present → state wins (post-migration).
+        std::fs::write(state.join("events.jsonl"), "{}\n").unwrap();
+        assert!(resolve_events(&state, &projection).starts_with(&state));
 
         let _ = std::fs::remove_dir_all(&base);
     }

--- a/tools/ways-cli/src/session.rs
+++ b/tools/ways-cli/src/session.rs
@@ -423,11 +423,13 @@ const MAX_EVENTS_BYTES: u64 = 32 * 1024 * 1024;
 /// compactions, so the rewrite is rare, not per-append.
 const KEEP_EVENTS_BYTES: u64 = 24 * 1024 * 1024;
 
-/// Log an event to ~/.claude/stats/events.jsonl.
+/// Log an event to the telemetry log ($XDG_STATE/agent-ways/events.jsonl, with a
+/// legacy ~/.claude/stats fallback for un-migrated installs — see paths::events_log).
 pub fn log_event(fields: &[(&str, &str)]) {
-    let stats_dir = home_dir().join(".claude/stats");
-    let _ = std::fs::create_dir_all(&stats_dir);
-    let events_file = stats_dir.join("events.jsonl");
+    let events_file = crate::paths::events_log();
+    if let Some(stats_dir) = events_file.parent() {
+        let _ = std::fs::create_dir_all(stats_dir);
+    }
 
     let ts = chrono_utc_now();
     let mut obj = serde_json::Map::new();

--- a/tools/ways-cli/src/session.rs
+++ b/tools/ways-cli/src/session.rs
@@ -562,12 +562,18 @@ pub fn way_disabled(way_id: &str) -> bool {
 
 // ── Way file resolution ─────────────────────────────────────────
 
-/// Resolve a way ID to its file path. Project-local takes precedence.
-/// Returns (path, is_project_local).
+/// Resolve a way ID to its file path. Precedence: project > user > core (ADR-143).
+/// Returns (path, is_project_local). User and core both report `false` (non-project),
+/// but the user root is checked first so a user way shadows a same-named core way.
 pub fn resolve_way_file(way_id: &str, project_dir: &str) -> Option<(PathBuf, bool)> {
     let local_dir = PathBuf::from(project_dir).join(format!(".claude/ways/{way_id}"));
     if let Some(f) = find_way_in_dir(&local_dir) {
         return Some((f, true));
+    }
+
+    let user_dir = crate::paths::user_ways_root().join(way_id);
+    if let Some(f) = find_way_in_dir(&user_dir) {
+        return Some((f, false));
     }
 
     let global_dir = home_dir().join(format!(".claude/hooks/ways/{way_id}"));
@@ -578,11 +584,16 @@ pub fn resolve_way_file(way_id: &str, project_dir: &str) -> Option<(PathBuf, boo
     None
 }
 
-/// Resolve a way ID to its check file path.
+/// Resolve a way ID to its check file path. Precedence: project > user > core.
 pub fn resolve_check_file(way_id: &str, project_dir: &str) -> Option<(PathBuf, bool)> {
     let local_dir = PathBuf::from(project_dir).join(format!(".claude/ways/{way_id}"));
     if let Some(f) = find_check_in_dir(&local_dir) {
         return Some((f, true));
+    }
+
+    let user_dir = crate::paths::user_ways_root().join(way_id);
+    if let Some(f) = find_check_in_dir(&user_dir) {
+        return Some((f, false));
     }
 
     let global_dir = home_dir().join(format!(".claude/hooks/ways/{way_id}"));

--- a/tools/ways-cli/tests/project_ways.rs
+++ b/tools/ways-cli/tests/project_ways.rs
@@ -56,6 +56,7 @@ struct Env {
     base: PathBuf,
     home: PathBuf,
     xdg_cache: PathBuf,
+    xdg_config: PathBuf,
     xdg_runtime: PathBuf,
 }
 
@@ -65,11 +66,24 @@ impl Env {
         let _ = std::fs::remove_dir_all(&base);
         let home = base.join("home");
         let xdg_cache = base.join("cache");
+        let xdg_config = base.join("config");
         let xdg_runtime = base.join("runtime");
-        for d in [&home, &xdg_cache, &xdg_runtime] {
+        for d in [&home, &xdg_cache, &xdg_config, &xdg_runtime] {
             std::fs::create_dir_all(d).unwrap();
         }
-        Env { base, home, xdg_cache, xdg_runtime }
+        Env { base, home, xdg_cache, xdg_config, xdg_runtime }
+    }
+
+    /// Write a semantic way file at `<root>/<id>/<leaf>.md`.
+    fn write_way(root: &Path, id: &str, desc: &str, vocab: &str) {
+        let leaf = id.rsplit('/').next().unwrap_or(id);
+        let dir = root.join(id);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join(format!("{leaf}.md")),
+            format!("---\ndescription: {desc}\nvocabulary: {vocab}\n---\n# {leaf}\n"),
+        )
+        .unwrap();
     }
 
     /// Apply the isolated environment so neither the real `~/.claude/projects`
@@ -78,6 +92,7 @@ impl Env {
         cmd.env("HOME", &self.home)
             .env("USERPROFILE", &self.home)
             .env("XDG_CACHE_HOME", &self.xdg_cache)
+            .env("XDG_CONFIG_HOME", &self.xdg_config)
             .env("XDG_RUNTIME_DIR", &self.xdg_runtime)
             .env_remove("CLAUDE_PROJECT_DIR")
             .env_remove("PWD");
@@ -315,4 +330,36 @@ fn ways_dir_without_output_warns_about_canonical() {
         stderr.contains("WARNING") && stderr.contains("--output"),
         "Bug C: expected a footgun warning steering to --output.\nstderr: {stderr}"
     );
+}
+
+/// ADR-143: a user way in $XDG_CONFIG shadows a same-named core way (dedup-by-name),
+/// and a unique user way is embedded alongside core ways.
+#[test]
+fn user_way_shadows_core_way() {
+    let env = Env::new("shadow");
+    // core ways at ~/.claude/hooks/ways (the default core root).
+    let core = env.home.join(".claude/hooks/ways");
+    Env::write_way(&core, "meta/foo", "CORE foo about deployment", "deploy ci release");
+    Env::write_way(&core, "meta/bar", "core bar about migrations", "migrate schema sql");
+    // user ways at $XDG_CONFIG/agent-ways/ways — foo shadows core foo, baz is unique.
+    let user = env.xdg_config.join("agent-ways/ways");
+    Env::write_way(&user, "meta/foo", "USER foo override about kubernetes", "k8s pod cluster");
+    Env::write_way(&user, "meta/baz", "user baz personal notes", "note journal todo");
+
+    let mut cmd = Command::new(ways_bin());
+    env.apply(&mut cmd);
+    assert!(cmd.args(["corpus", "--quiet"]).status().expect("run ways corpus").success());
+
+    let ids = corpus_ids(&env.corpus_jsonl());
+    assert_eq!(
+        ids.iter().filter(|i| *i == "meta/foo").count(),
+        1,
+        "meta/foo must appear exactly once (user shadows core, not double-embedded): {ids:?}"
+    );
+    assert!(ids.iter().any(|i| i == "meta/bar"), "core-only bar present: {ids:?}");
+    assert!(ids.iter().any(|i| i == "meta/baz"), "user-only baz present: {ids:?}");
+
+    let content = std::fs::read_to_string(env.corpus_jsonl()).unwrap();
+    assert!(content.contains("USER foo override"), "the surviving foo must be the user's");
+    assert!(!content.contains("CORE foo about"), "core foo must be shadowed out of the corpus");
 }


### PR DESCRIPTION
## What

The two correctness gaps the #204 review flagged as follow-ups, closing the loop on the migrator's lifts.

## Item 1 — events.jsonl → `$XDG_STATE`

The telemetry writer (`session::log_event`) + 8 readers now resolve the event log via `paths::events_log()` instead of the hardcoded `~/.claude/stats` path. Fallback-aware (mirrors `cache_root`): prefer `$XDG_STATE/agent-ways/events.jsonl`, reuse the legacy `~/.claude/stats` file if present so an un-migrated install keeps its history; the migrator lifts it, then the preferred path wins. Writer + readers share the resolver.

## Item 2 — three-root way runtime (ADR-143)

Promote two roots → three (core/user/project). The operator's own ways load from `$XDG_CONFIG/agent-ways/ways`, precedence `project > user > core`, **dedup-by-name** so a user way shadows a same-named shipped way without forking.

- `corpus.rs`: scan the user root, dedup user-shadows-core (both passes), `user_hash` staleness, manifest + counts split core/user
- `session.rs`: `resolve_way_file`/`resolve_check_file` insert the user tier
- `check-post.sh`: user root in `WAYS_ROOTS`
- `status`: `Core ways` + `User ways` lines

This is what makes the migrator's lifted user ways actually **load** — without it they were preserved but dead.

## Verified

- Three-root corpus: a user way shadows a same-named core way (user's content wins, core dropped, no double-embed); a unique user way embeds alongside — new `user_way_shadows_core_way` integration test.
- Both fallbacks have deterministic pure-resolver tests.
- `cargo test -p ways` — 182 unit + 18 integration green (1 ignored); `cargo clippy` clean.

Both items carry the same legacy-fallback discipline as the foundation, so un-migrated installs keep working unchanged.

Refs ADR-142, ADR-143.