### PR TITLE
fix: migrator cache rename target must be canonical (not fallback-aware)

### DIFF
--- a/tools/ways-cli/src/cmd/migrate_exec.rs
+++ b/tools/ways-cli/src/cmd/migrate_exec.rs
@@ -49,7 +49,10 @@ impl Ctx {
             data: paths::data_root(),
             config: paths::config_root(),
             cache_old: crate::util::xdg_cache_dir().join("claude-ways"),
-            cache_new: paths::cache_root(),
+            // Canonical (NOT fallback-aware): the rename destination must be the
+            // new name even though it doesn't exist yet, or it collapses onto
+            // cache_old and the rename no-ops.
+            cache_new: paths::cache_root_canonical(),
             markers: state.join("migration"),
             state,
             dest,

--- a/tools/ways-cli/src/paths.rs
+++ b/tools/ways-cli/src/paths.rs
@@ -106,6 +106,15 @@ pub fn cache_root() -> PathBuf {
     resolve_cache(&xdg_cache_base())
 }
 
+/// The canonical cache root (`$XDG_CACHE/agent-ways`), ignoring the legacy
+/// fallback. Use this where the target must be the NEW location regardless of
+/// what exists yet — specifically the migrator's rename *destination*. Runtime
+/// reads use [`cache_root`] (fallback-aware); the migrator must not, or its
+/// rename destination collapses onto the legacy source and the rename no-ops.
+pub fn cache_root_canonical() -> PathBuf {
+    normalize_path_sep(&xdg_cache_base().join(APP))
+}
+
 /// Pure fallback resolution, factored out so it's testable without mutating the
 /// process-global `$XDG_CACHE_HOME`.
 fn resolve_cache(base: &Path) -> PathBuf {
@@ -271,6 +280,14 @@ mod tests {
         assert!(resolve_events(&state, &projection).starts_with(&state));
 
         let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn cache_root_canonical_ignores_legacy_fallback() {
+        // Always the new name regardless of what exists — the migrator's rename
+        // destination must never collapse onto the legacy source (cache_root's
+        // fallback would, which is correct for reads but wrong as a rename target).
+        assert!(cache_root_canonical().ends_with("agent-ways"));
     }
 
     #[test]


### PR DESCRIPTION
## What

A real bug surfaced by running `ways migrate --what-if` on an actual in-place install.

The migrator computed its cache-rename **destination** via `paths::cache_root()`, which — after the #205 legacy fallback — resolves to `claude-ways` when `agent-ways` doesn't exist yet. So destination == source, and the rename silently no-ops: `claude-ways` would persist forever, the name harmonization quietly incomplete.

Before: `cache target …/claude-ways exists — would merge/skip`
After:  `rename …/claude-ways → …/agent-ways`

## Fix

`paths::cache_root_canonical()` (always `$XDG_CACHE/agent-ways`, no fallback) for the migrator's rename **target**. The fallback stays for runtime **reads** (`cache_root`) — only the rename destination must be canonical, or it collapses onto the source. Regression test locks the distinction.

## Test plan
- `cargo test -p ways paths::` green incl. new `cache_root_canonical_ignores_legacy_fallback`
- Verified live: `ways migrate --what-if` on the in-place install now shows the correct rename.

Refs ADR-142.