### PR TITLE
release: agent-ways 1.0.0 — accept ADRs, deprecation schedule, dev docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,15 @@ The recommended setup is to **fork this repo** and customize it for your own wor
 
 When you build something that would benefit everyone — a new domain, a better trigger pattern, a macro that detects something clever — we'd love a PR back to upstream. The framework improves when people bring different workflows to it.
 
+## Development setup
+
+As of 1.0, **your dev checkout is not your install.** `~/.claude` is a projection of an XDG
+application; the app source lives in `$XDG_DATA_HOME/agent-ways`. So you develop from a
+**separate clone** (e.g. `~/src/agent-ways`) and choose when your changes reach your install —
+editing `~/.claude` directly no longer "just works." See **[docs/development.md](docs/development.md)**
+for the full setup, the sandbox/reconcile/worktree testing patterns, and why the worktree must
+hang off your standalone clone rather than `$XDG_DATA`.
+
 ## Adding a Way
 
 1. Create `hooks/ways/{domain}/{wayname}/{wayname}.md` with YAML frontmatter
@@ -44,7 +53,7 @@ Fix drift in small batches. If a lint is genuinely wrong for a specific case, `#
 
 The `.gitignore` uses an **exclusive pattern**: `*` (ignore everything) with explicit `!` exceptions for tracked files. This is intentional, not lazy.
 
-This repo *is* `~/.claude/` — the directory that controls how Claude Code thinks and acts. Every file here can influence agent behavior: hooks execute shell commands, ways inject guidance, CLAUDE.md steers reasoning, settings.json controls permissions. An accidental commit of a malicious or poorly-written file could steer Claude to do undesirable things for anyone who pulls it.
+This repo **controls `~/.claude/`** — directly when installed in-place, or via the projection after 1.0 — the directory that governs how Claude Code thinks and acts. Every file here can influence agent behavior: hooks execute shell commands, ways inject guidance, CLAUDE.md steers reasoning, settings.json controls permissions. An accidental commit of a malicious or poorly-written file could steer Claude to do undesirable things for anyone who pulls it.
 
 The exclusive gitignore ensures:
 - **No accidental file inclusion.** New files must be explicitly opted in via `.gitignore`. You can't push a file you didn't mean to track.

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -62,9 +62,9 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-139](./system/ADR-139-shelve-maintainer-i18n-adopter-run-localization-via-ways-localize.md) | Shelve maintainer i18n; adopter-run localization via ways-localize | Accepted |
 | [ADR-140](./system/ADR-140-two-install-topologies-in-place-repo-and-subdirectory-projection.md) | Two install topologies: in-place repo and subdirectory projection | Accepted |
 | [ADR-141](./system/ADR-141-knowledge-graph-as-evidential-memory-backend.md) | Knowledge Graph as Evidential Memory Backend | Accepted |
-| [ADR-142](./system/ADR-142-agent-ways-1-0-xdg-application-distribution.md) | agent-ways 1.0 — XDG application distribution | Draft |
-| [ADR-143](./system/ADR-143-three-root-way-runtime-core-user-project.md) | Three-root way runtime — core, user, project | Draft |
-| [ADR-144](./system/ADR-144-install-repair-migrate-as-one-manifest-reconciler.md) | Install / repair / migrate as one manifest reconciler | Draft |
+| [ADR-142](./system/ADR-142-agent-ways-1-0-xdg-application-distribution.md) | agent-ways 1.0 — XDG application distribution | Accepted |
+| [ADR-143](./system/ADR-143-three-root-way-runtime-core-user-project.md) | Three-root way runtime — core, user, project | Accepted |
+| [ADR-144](./system/ADR-144-install-repair-migrate-as-one-manifest-reconciler.md) | Install / repair / migrate as one manifest reconciler | Accepted |
 
 ## Documentation
 _Documentation structure, tooling, coherence_

--- a/docs/architecture/system/ADR-142-agent-ways-1-0-xdg-application-distribution.md
+++ b/docs/architecture/system/ADR-142-agent-ways-1-0-xdg-application-distribution.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-06-29
 deciders:
   - aaronsb

--- a/docs/architecture/system/ADR-143-three-root-way-runtime-core-user-project.md
+++ b/docs/architecture/system/ADR-143-three-root-way-runtime-core-user-project.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-06-29
 deciders:
   - aaronsb

--- a/docs/architecture/system/ADR-144-install-repair-migrate-as-one-manifest-reconciler.md
+++ b/docs/architecture/system/ADR-144-install-repair-migrate-as-one-manifest-reconciler.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-06-29
 deciders:
   - aaronsb
@@ -146,17 +146,31 @@ to it, on their own clock — so the engine never needs to know how many in-plac
 maintainer doesn't; ADR-142 Context). The migrator is invoked *by an update reaching the user*, not by a
 date reaching the population.
 
-- **1.0** — migrator ships and is active.
-- **1.0.x** — migration supported throughout; the in-place check + assisted migrator run for anyone
-  still in-place.
-- **1.1.0** — *final* migration release. When a user's update lands on 1.1.0, the migrator runs (or
-  confirms already-migrated), then announces that the *next* release stops checking/migrating.
-- **post-1.1.0** — remove the migrator and the in-place check. This is **safe by construction**: releases
-  are sequential, so no one reaches a post-1.1.0 release without having passed *through* 1.1.0's migrating
-  gate. **"Remove assistance" is not "break the un-migrated":** a user still in-place keeps a working
-  in-place install; agent-ways simply stops *helping* them move and stops *checking*. A user who never
-  updates past 1.1.0 stays **frozen at 1.1.0, working but unsupported** — an acceptable, self-selected
-  outcome, not a stranding. The design must not actively break them.
+The lifecycle is an **escalating-pressure curve across the 1.0.x line**, dormant at first so adopters
+meet the migrator before they're pushed by it:
+
+- **1.0.0** — the migrator ships **functional but dormant**: `ways migrate` (plan / what-if / execute)
+  is available on demand, with **no SessionStart pressure**. The release exists to make the path real
+  and prove it end-to-end; updating to it is idempotent-in-use to 0.9.x (the runtime behaves identically
+  until the operator chooses to migrate). This is the verify-before-you-push release.
+- **1.0.1 … 1.0.5** — the migrator stays available while a SessionStart nudge **escalates each release**,
+  keyed to version and **silent for already-migrated installs**: a gentle offer at 1.0.1 ("agent-ways can
+  migrate — want to?") → progressively more insistent → at **1.0.5**, the last-chance warning that the
+  *next* release drops the migrator and that migrating after this point means checking out the 1.0.5 tag.
+- **1.1.0** — migrator and in-place check **removed**. Safe by construction: releases are sequential, so
+  reaching 1.1.0 means having passed through the escalation. Two properties make the removal humane:
+  - **The escape hatch is the immutable tag.** A user still in-place migrates with
+    `git clone --branch ways-v1.0.5 … && ways migrate` — the migrator lives *forever* at that tag, so
+    "we removed it" never means "you can't." This is the concrete form of the never-strand clause.
+  - **The cliff is a ramp.** "Remove assistance" is not "break the un-migrated." A 1.1.0 binary on an
+    un-migrated `~/.claude` still **reads correctly** through the transition fallbacks — core ways from
+    the clone's own `hooks/ways`, cache from the legacy `claude-ways`, events from `~/.claude/stats`. It
+    loses assisted migration and in-place *checking*, not *function*. A user frozen pre-1.1.0 stays
+    working and unsupported by their own choice; a user who updates *to* 1.1.0 while in-place keeps
+    running via the fallbacks. The design never actively breaks them.
+
+(The specific patch numbers above are the *cadence*, not a contract — the mechanism is "pressure level
+keyed to release, escalating to a final 1.0.x before 1.1.0," and any 1.0.x spacing satisfies it.)
 
 ## Consequences
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,80 @@
+# Developing agent-ways
+
+> **The 1.0 shift:** before 1.0, *the repo **was** your install* — you cloned into
+> `~/.claude` and edited it live. 1.0 dissolves that identity. `~/.claude` becomes a
+> thin **projection** of an XDG application, and the app source lives in
+> `$XDG_DATA_HOME/agent-ways`. So development now starts from a **separate checkout**,
+> and you *choose* when your changes reach your install — they no longer leak in by
+> default. (Background: [ADR-142](architecture/system/ADR-142-agent-ways-1-0-xdg-application-distribution.md).)
+
+## The three roles that used to be one directory
+
+| Role | Where it lives | Do you edit it? |
+|---|---|---|
+| **Your install** | `~/.claude` (projection) + `$XDG_DATA_HOME/agent-ways` (the app) | **No.** `$XDG_DATA` is replaced wholesale on update; editing it is undone on the next update. |
+| **Your dev checkout** | a standalone clone, e.g. `~/src/agent-ways` (**not** `~/.claude`, **not** `$XDG_DATA`) | **Yes.** Branch, edit, commit, PR here. |
+| **A sandbox** | a throwaway `$HOME`/`$XDG_*` under `/tmp` | Only the test harness writes here. |
+
+## Setup
+
+```bash
+git clone https://github.com/aaronsb/agent-ways ~/src/agent-ways   # or your fork
+cd ~/src/agent-ways
+cargo build --release --manifest-path tools/Cargo.toml -p ways      # build the binary
+cargo test -p ways                                                  # 180+ unit + integration tests
+```
+
+The built binary is `tools/target/release/ways`. Run it by path, or alias it while
+developing — **don't** put it ahead of your installed `ways` on `PATH` unless you mean to.
+
+## Testing your changes — pick by blast radius
+
+1. **Sandbox (default, zero-risk).** Point `$HOME` and the `$XDG_*` vars at a tmpdir and run
+   your binary against it. Nothing touches your real install. This is how the whole test
+   suite and every demo works:
+
+   ```bash
+   SB=$(mktemp -d)
+   HOME="$SB" XDG_DATA_HOME="$SB/.local/share" XDG_CONFIG_HOME="$SB/.config" \
+     XDG_CACHE_HOME="$SB/.cache" XDG_STATE_HOME="$SB/.local/state" \
+     ./tools/target/release/ways <subcommand>
+   ```
+
+   For migration work specifically, `ways migrate --what-if` and `--execute` honour these
+   env vars, so a fake in-place clone under `$SB/.claude` exercises the full migrator
+   without ever touching `~/.claude`.
+
+2. **Dogfood via reconcile.** Project your dev tree into your live install to run your own
+   code for real:
+
+   ```bash
+   ways reconcile --source ~/src/agent-ways --dest ~/.claude
+   ```
+
+   Revert by reconciling from the released app: `ways reconcile --source $XDG_DATA_HOME/agent-ways --dest ~/.claude`.
+
+3. **Worktree (parallel branches).** `git worktree add` from your **standalone clone** —
+   never from `$XDG_DATA/agent-ways`. The app dir is replaced wholesale on update, which
+   would orphan a worktree hung off it (its gitdir link dies).
+
+## Conventions
+
+- **ADR-driven:** architectural changes get an ADR first (`docs/scripts/adr new …`); reference
+  the ADR number in the branch and commits. Status flips to `Accepted` when the implementation
+  lands, not when the ADR is written.
+- **Branch → PR → review → merge.** Even solo. The `code-reviewer` pass earns its keep — it has
+  caught real "the code claims X but does Y" bugs that green tests didn't.
+- **Releases are tag-driven:** bump `tools/ways-cli/Cargo.toml`, push a `ways-v*` tag, CI builds
+  the per-platform artifacts. See the release way / `docs/architecture` for the pipeline.
+- **The transition fallbacks are load-bearing, not legacy cruft.** `paths::cache_root()` and
+  `events_log()` prefer the new XDG location but fall back to the pre-1.0 one so an un-migrated
+  install keeps working. When you touch cache/state paths, preserve the fallback — and use
+  `cache_root_canonical()` (no fallback) only where you must *target* the new location (the
+  migrator's rename destination).
+
+## See also
+
+- [ADR-142](architecture/system/ADR-142-agent-ways-1-0-xdg-application-distribution.md) — the XDG application distribution (why dev changed)
+- [ADR-143](architecture/system/ADR-143-three-root-way-runtime-core-user-project.md) — core / user / project way roots
+- [ADR-144](architecture/system/ADR-144-install-repair-migrate-as-one-manifest-reconciler.md) — the reconciler, migrator, and deprecation lifecycle
+- `CONTRIBUTING.md` — contribution norms and the security bar for changes

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "ways"
-version = "0.9.1"
+version = "1.0.0"
 dependencies = [
  "agent-fmt",
  "anyhow",

--- a/tools/ways-cli/Cargo.toml
+++ b/tools/ways-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ways"
-version = "0.9.1"
+version = "1.0.0"
 edition = "2021"
 description = "Unified CLI for ways — knowledge guidance for Claude Code"
 license = "MIT"


### PR DESCRIPTION
Completes the 1.0.0 milestone (no code-logic change — version, ADR statuses, docs).

## Changes
- **Version** 0.9.1 → 1.0.0
- **ADR-142/143/144 → Accepted** — implementation landed across #204/#205/#206
- **ADR-144 §5 deprecation schedule** made concrete: 1.0.0 ships the migrator **dormant** (available, no SessionStart pressure) → 1.0.1–1.0.5 **escalating** pressure → 1.1.0 **removes** it, with the immutable `ways-v1.0.5` tag as the forever escape hatch (`git clone --branch ways-v1.0.5 … && ways migrate`) and the transition fallbacks turning the cliff into a ramp
- **`docs/development.md`** — the post-1.0 dev pattern: your install ≠ your dev checkout; sandbox / reconcile / worktree testing; why a worktree must hang off a standalone clone, not `$XDG_DATA`
- **CONTRIBUTING** — dev-setup pointer + corrected the now-false "this repo **is** `~/.claude`" to "**controls** `~/.claude` (in-place or via projection)"

## Idempotency gate (the release bar)
1.0.0 behaves identically to 0.9.x on an in-place install until the operator runs `ways migrate` — verified live: 115 ways, identical match hits, cache via the `claude-ways` fallback. Safe to land.

## Test plan
- `cargo test -p ways` — 184 unit + integration green (1 ignored); `adr lint` clean (1 pre-existing warning)