### PR TITLE
fix: migrator aborts mid-migration on reconcile's in-place guard

### DIFF
--- a/tools/ways-cli/src/cmd/migrate_exec.rs
+++ b/tools/ways-cli/src/cmd/migrate_exec.rs
@@ -283,6 +283,7 @@ fn phase_projection(ctx: &Ctx) -> Result<Vec<String>> {
         None,
         false,
         true,
+        true, // allow_in_place: migrator is the legitimate mid-migration reconcile
     )?;
     // Postcondition gate before the destructive removal: a projection root must
     // now resolve as a symlink. If it doesn't, abort BEFORE deleting anything.
@@ -480,7 +481,11 @@ mod tests {
         };
         g(&["init", "-q"]);
         g(&["remote", "add", "origin", "https://github.com/aaronsb/agent-ways"]);
-        for f in ["hooks/ways/meta/a.md", "skills/wrap/SKILL.md", "docs/x.md", "settings.json"] {
+        // Include tools/ AND docs/ so the clone fully matches is_legacy_in_place
+        // (.git + tools + docs) — the real ~/.claude shape. Without tools/, the
+        // reconcile guard never fired in the sandbox and masked the mid-migration
+        // abort bug.
+        for f in ["hooks/ways/meta/a.md", "skills/wrap/SKILL.md", "docs/x.md", "tools/x.rs", "settings.json"] {
             let p = root.join(f);
             std::fs::create_dir_all(p.parent().unwrap()).unwrap();
             std::fs::write(&p, if f == "settings.json" { "{\"hooks\":{}}" } else { "---\nx\n" }).unwrap();

--- a/tools/ways-cli/src/cmd/reconcile.rs
+++ b/tools/ways-cli/src/cmd/reconcile.rs
@@ -46,12 +46,19 @@ struct Outcome {
 }
 
 /// `ways reconcile` entrypoint.
+///
+/// `allow_in_place` bypasses the legacy-in-place guard. It is `false` for the
+/// CLI (a manual `ways reconcile` must never clobber an in-place clone) and
+/// `true` only for the migrator, which calls reconcile mid-migration when the
+/// dest still *looks* in-place (its `.git`/`tools`/`docs` aren't removed until
+/// after this step) but has already been backed up and relocated.
 pub fn run(
     source: Option<String>,
     dest: Option<String>,
     mode: Option<String>,
     dry_run: bool,
     quiet: bool,
+    allow_in_place: bool,
 ) -> Result<()> {
     let source_root: PathBuf = source.map(PathBuf::from).unwrap_or_else(paths::data_root);
     let dest_root: PathBuf = dest.map(PathBuf::from).unwrap_or_else(paths::projection_root);
@@ -68,8 +75,10 @@ pub fn run(
 
     // Refuse to reconcile a live in-place clone — that path needs the migrator,
     // not the repair posture. An in-place clone is a dest that is itself the
-    // agent-ways git repo (has a .git AND ships the app source).
-    if is_legacy_in_place(&dest_root) {
+    // agent-ways git repo (has a .git AND ships the app source). The migrator
+    // sets allow_in_place: it is *mid-migration* over a backed-up, relocated
+    // tree, so the dest still looks in-place but reconciling it is correct.
+    if !allow_in_place && is_legacy_in_place(&dest_root) {
         bail!(
             "{} looks like a legacy in-place agent-ways clone — reconcile won't \
              clobber it. Migration (ADR-144 §5) is the path off in-place; it is \
@@ -273,7 +282,7 @@ mod tests {
         std::fs::create_dir_all(&dst).unwrap();
         fake_source(&src);
 
-        run(Some(src.to_string_lossy().into()), Some(dst.to_string_lossy().into()), None, false, true).unwrap();
+        run(Some(src.to_string_lossy().into()), Some(dst.to_string_lossy().into()), None, false, true, false).unwrap();
 
         // A file reached through the projection must be the source file.
         let via_projection = std::fs::read_to_string(dst.join("skills/wrap/SKILL.md")).unwrap();
@@ -293,7 +302,7 @@ mod tests {
 
         let s = |p: &Path| Some(p.to_string_lossy().into_owned());
         // First run creates; second run must find everything already correct.
-        run(s(&src), s(&dst), None, false, true).unwrap();
+        run(s(&src), s(&dst), None, false, true, false).unwrap();
 
         // Re-run in dry-run: zero roots should want changing.
         let roots = projection_roots(&src);
@@ -317,8 +326,14 @@ mod tests {
         std::fs::create_dir_all(dst.join("docs")).unwrap();
 
         let s = |p: &Path| Some(p.to_string_lossy().into_owned());
-        let err = run(s(&src), s(&dst), None, false, true).unwrap_err();
+        // CLI posture (allow_in_place=false): refuses.
+        let err = run(s(&src), s(&dst), None, false, true, false).unwrap_err();
         assert!(err.to_string().contains("in-place"), "should refuse: {err}");
+        // Migrator posture (allow_in_place=true): bypasses the guard and reconciles
+        // the still-in-place-looking tree. This is the bug the real migration hit —
+        // the guard fired mid-migration because dest still has .git/tools/docs.
+        run(s(&src), s(&dst), None, false, true, true).expect("migrator bypass must reconcile");
+        assert!(std::fs::symlink_metadata(dst.join("skills")).unwrap().file_type().is_symlink());
         let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -621,7 +621,7 @@ fn main() -> Result<()> {
             cmd::migrate::run(execute, what_if, dest)
         }
         Commands::Reconcile { source, dest, mode, dry_run, quiet } => {
-            cmd::reconcile::run(source, dest, mode, dry_run, quiet)
+            cmd::reconcile::run(source, dest, mode, dry_run, quiet, false)
         }
         Commands::Rethink { session, project, speed, list, json } => {
             if json {


### PR DESCRIPTION
Real bug from running `ways migrate --execute` on an actual in-place machine — aborts at phase 05 because the migrator's own `reconcile` call trips the legacy-in-place guard (mid-migration, `~/.claude` still has `.git`/`tools`/`docs`, removed only *after* reconcile per the reorder).

**Fix:** `allow_in_place` param on `reconcile::run` — CLI passes `false` (never clobber an in-place clone), migrator passes `true` (already backed up + relocated).

**Why the test missed it:** `fake_clone` had `docs/` but no `tools/`; the guard needs all of `.git`+`tools`+`docs`. Fixture now includes `tools/` and reproduces it; `refuses_legacy_in_place_clone` now asserts both postures.

Verified: full `--execute` against a sandbox with the real shape completes. The abort itself was safe-by-design (backup intact, no gutting). 184 tests, clippy clean.