### PR TITLE
fix(ways): rewrite injected install doctrine to the 1.0 projection model

### DIFF
--- a/hooks/ways/check-setup.sh
+++ b/hooks/ways/check-setup.sh
@@ -6,6 +6,9 @@
 # Checks: ways binary → corpus → embedding engine (functional probe)
 
 WAYS_BIN="${HOME}/.claude/bin/ways"
+# The app source (with the Makefile) lives in $XDG_DATA, not in the ~/.claude
+# projection — repairs run there, not in ~/.claude (ADR-142).
+APP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/agent-ways"
 # Prefer the 1.0 cache name; fall back to the legacy one for un-migrated installs
 # (must match paths::cache_root() in the binary so the probe checks where the
 # binary actually reads).
@@ -18,17 +21,19 @@ else XDG_WAY="${_CACHE}/agent-ways/user"; fi
 [[ ! -d "${HOME}/.claude/hooks/ways" ]] && exit 0
 
 if [[ ! -x "$WAYS_BIN" ]]; then
-  cat <<'MSG'
+  cat <<MSG
 
-⚠️  Ways setup incomplete — the `ways` binary is not installed.
+⚠️  Ways setup incomplete — the \`ways\` binary is not installed.
 
-Hooks will be inactive until setup completes. Run:
+Hooks will be inactive until setup completes. Build the app source and
+reproject (the Makefile lives in the app dir, not in ~/.claude):
 
-    cd ~/.claude && make setup
+    cd "$APP_DIR" && make setup && ways reconcile
 
-This downloads the ways binary, embedding model, and generates
-the matching corpus. If you don't have a Rust toolchain, pre-built
-binaries are downloaded automatically.
+If the app dir doesn't exist, re-run the installer one-liner. Setup
+downloads the ways binary, embedding model, and generates the matching
+corpus; if you don't have a Rust toolchain, pre-built binaries are
+downloaded automatically.
 
 MSG
   exit 0
@@ -37,13 +42,13 @@ fi
 # Binary exists — check corpus
 CORPUS="${XDG_WAY}/ways-corpus.jsonl"
 if [[ ! -f "$CORPUS" ]]; then
-  cat <<'MSG'
+  cat <<MSG
 
 ⚠️  Ways corpus not generated — semantic matching is inactive.
 
-Run:
+Rebuild it from the app source:
 
-    cd ~/.claude && make setup
+    cd "$APP_DIR" && make setup
 
 MSG
   exit 0
@@ -54,11 +59,11 @@ fi
 #   1. Path checks go stale. The old check looked for way-embed at $XDG_WAY/way-embed,
 #      but it actually lives at ~/.claude/bin/way-embed — so on a healthy install it
 #      false-positived "not installed" (masked by a once-a-day marker).
-#   2. ADR-140 symlink projection makes ~/.claude/{bin,hooks,...} symlinks into a
-#      subdir repo. Asking the binary to actually embed a query resolves identically
-#      across all topologies (in-place / copy-subdir / symlink-subdir) and also
-#      catches a corrupt model or a binary that loads-but-errors — which existence
-#      checks miss entirely.
+#   2. The ADR-142 projection makes ~/.claude/{bin,hooks,...} symlinks into the app
+#      dir in $XDG_DATA. Asking the binary to actually embed a query resolves
+#      identically whether the projection is fresh, repaired, or a legacy in-place
+#      clone, and also catches a corrupt model or a binary that loads-but-errors —
+#      which existence checks miss entirely.
 # Loud EVERY session while broken (no per-day suppression): a degraded engine means
 # only coarse pattern:/commands:/files: triggers fire, and that must not be skimmable.
 # Silent when it works.
@@ -70,15 +75,14 @@ probe_embed() {
   fi
 }
 if ! probe_embed "embedding engine health probe" | grep -qE '[0-9]\.[0-9]'; then
-  cat <<'MSG'
+  cat <<MSG
 
 ⚠  Embedding engine is NOT functional — semantic way matching is OFF.
    Only explicit pattern:/commands:/files: triggers will fire (coarse — expect ways
    to over- and under-fire until this is fixed). It is a hard dependency (ADR-125).
 
-   Repair:
-     in-place install:      cd ~/.claude && make setup
-     subdirectory install:  cd <repo-subdir> && make setup && make sync-to-home
+   Repair (rebuild the binary, model, and corpus from the app source, then reproject):
+     cd "$APP_DIR" && make setup && ways reconcile
 
 MSG
 fi

--- a/hooks/ways/check-setup.sh
+++ b/hooks/ways/check-setup.sh
@@ -26,9 +26,10 @@ if [[ ! -x "$WAYS_BIN" ]]; then
 ⚠️  Ways setup incomplete — the \`ways\` binary is not installed.
 
 Hooks will be inactive until setup completes. Build the app source and
-reproject (the Makefile lives in the app dir, not in ~/.claude):
+reproject (the Makefile lives in the app dir, not in ~/.claude; call the
+binary by full path since it isn't on PATH yet):
 
-    cd "$APP_DIR" && make setup && ways reconcile
+    cd "$APP_DIR" && make setup && "$APP_DIR/bin/ways" reconcile
 
 If the app dir doesn't exist, re-run the installer one-liner. Setup
 downloads the ways binary, embedding model, and generates the matching
@@ -82,7 +83,7 @@ if ! probe_embed "embedding engine health probe" | grep -qE '[0-9]\.[0-9]'; then
    to over- and under-fire until this is fixed). It is a hard dependency (ADR-125).
 
    Repair (rebuild the binary, model, and corpus from the app source, then reproject):
-     cd "$APP_DIR" && make setup && ways reconcile
+     cd "$APP_DIR" && make setup && "$APP_DIR/bin/ways" reconcile
 
 MSG
 fi

--- a/hooks/ways/meta/deployment/deployment.md
+++ b/hooks/ways/meta/deployment/deployment.md
@@ -1,58 +1,67 @@
 ---
-description: Choosing how agent-ways is deployed into the home config dir — in-place repo topology versus subdirectory projection topology, and copy versus symlink — the why behind each path, surfaced when install, update, or an existing ~/.claude conflict comes up
-vocabulary: install setup deploy deployment topology update ~/.claude existing config clobber subdirectory in-place copy symlink sync-to-home projection upgrade reinstall fresh greenfield brownfield
-pattern: install|sync-to-home|clobber|topology|~/\.claude|existing \.?claude|make update|deploy
+description: How agent-ways 1.0 deploys into the home config dir — ~/.claude as a thin projection of an XDG application (source in $XDG_DATA_HOME/agent-ways), how install and update work under it, and how to spot a legacy pre-1.0 in-place clone that must migrate instead of pull — surfaced when install, update, or an existing ~/.claude conflict comes up
+vocabulary: install setup deploy deployment update ~/.claude existing config clobber projection xdg reconcile migrate legacy in-place upgrade reinstall fresh greenfield brownfield sync-to-home
+pattern: install|reconcile|migrate|clobber|topology|~/\.claude|existing \.?claude|make update|deploy|projection
 refire: 0.15
 scope: agent, subagent
 ---
 <!-- epistemic: convention -->
 # Deployment
 
-agent-ways supports **two install topologies** (ADR-140). Which one a user is on
-determines how they update — so when install, update, or an existing `~/.claude`
-comes up, establish the topology *before* giving a command. The decision is real:
-giving `make update` to a subdirectory install does nothing useful, and giving
-`--dangerously-clobber` to someone with a config they value destroys it.
+In 1.0, `~/.claude` is a **thin projection** of an XDG application, not the app
+itself (ADR-142). The source lives in `$XDG_DATA_HOME/agent-ways`; `~/.claude` gets
+symlinks to the projected roots (`skills/`, `agents/`, `commands/`, `hooks/ways/`,
+built binaries) plus a three-way merge into `settings.json`. Everything else the
+app ships — `scripts/`, `tools/`, `docs/`, `governance/` — **stays in `$XDG_DATA`**
+and is deliberately *not* projected. So `~/.claude` remains the user's own directory
+(their sessions, credentials, and settings survive); agent-ways just adds its links.
 
-## The two topologies
+This supersedes the pre-1.0 world where `~/.claude` *was* the git clone. That
+"in-place" topology (and the `sync-to-home` subdirectory variant, ADR-140) is now
+**legacy**: an install still on it needs to **migrate**, not update in place.
 
-**In-place** — `~/.claude` *is* the git clone. This is the default and the simplest
-mental model: `git pull` / `make update` *is* the update, `git status` tells the
-truth, there is zero drift. Choose it for a greenfield machine or anyone who wants
-the least to reason about.
+## How install and update work now
 
-**Subdirectory** — the repo lives in `~/.claude/<dir>` and is *projected* into
-`~/.claude` by `make sync-to-home`; `~/.claude` stays the user's own directory.
-Choose it when the user **already has a `~/.claude` they value** (sessions,
-credentials, their own settings) and won't turn it into someone else's repo. The
-cost is a two-step update (`git pull` *then* `make sync-to-home`) and the risk of
-drift if the sync step is skipped — which the `.claude-source` synced-HEAD stamp
-makes detectable.
+- **Fresh install** — the `curl … | bash` one-liner stages the app into
+  `$XDG_DATA_HOME/agent-ways`, builds it, links the binaries onto `PATH`, and runs
+  `ways reconcile` to materialize the projection and merge `settings.json`. An
+  existing `~/.claude` is **preserved**, not clobbered — reconcile only adds/repairs
+  the projected roots. There is no "clobber vs. keep" menu to reason about anymore.
+- **Update** — pull the app source (or re-run the installer) in
+  `$XDG_DATA_HOME/agent-ways`, then `ways reconcile` reprojects. Because the roots
+  are symlinks into the app dir, a symlink projection is *live* the moment the source
+  updates; reconcile is idempotent and silent when nothing changed.
+- **Repair** — `ways reconcile` alone re-materializes any missing or stale projected
+  root. It refuses to run against a legacy in-place clone (that would strand the
+  user's checkout) — that case routes to the migrator.
 
-## Copy vs symlink (subdirectory only)
+## The one decision left: is this a legacy in-place clone?
 
-- **Copy** is the default and the right call for Windows / low-privilege /
-  non-technical adopters — "it copied files in" is a model that survives. Re-run
-  `make sync-to-home` after each pull.
-- **Symlink** (`make sync-to-home-link`) is the advanced opt-in: `~/.claude/{hooks,
-  bin,…}` point at the repo, so `git pull` becomes the whole update with zero drift —
-  but symlinks are fragile where they need admin/developer-mode (Windows).
+The only fork worth establishing before giving a command is whether `~/.claude` is
+a **pre-1.0 in-place clone** (it has its own `.git` *and* ships the app source —
+`~/.claude/tools/`, `~/.claude/docs/`). If so, **do not `git pull` it** and do not
+reconcile it — point the user at migration:
+
+```
+ways migrate --what-if     # preview: what moves where
+ways migrate --execute     # relocate the clone to $XDG_DATA, build the projection
+```
+
+Migration is gated and backs up first. See `docs/migration-1.0.md` for the full
+walkthrough and the deprecation window (the migrator ships through 1.0.x and is
+removed at 1.1; an un-migrated install then bases on a pre-1.1 `ways-v1.0.x` tag).
 
 ## Why this way exists
 
 The first touch for many adopters is `curl … | bash`, often with *a Claude reading
-the errors and guiding them*. That Claude is you. Arm yourself with the reasoning
-behind the choice, not just a command to paste — an existing-config user steered to
-clobber is a lost adopter.
-
-## Decision tree
-
-- Existing `~/.claude` you value → **subdirectory** (offered in the installer's
-  conflict menu). Greenfield / want simplicity → **in-place**.
-- Subdirectory on Windows / unsure → **copy**. Want `git pull` to be the whole
-  update and symlinks work → **symlink**.
+the errors and guiding them*. That Claude is you. The pre-1.0 hazard was steering an
+existing-config user into a clobber; the 1.0 hazard is telling a legacy in-place user
+to `git pull` (which drifts them) instead of to migrate. Establish the projection
+model first, then give the command.
 
 ## See Also
 
 - localize(meta) — sibling adopter deployment-time choice (output language)
-- skills(meta) — `/sync-to-home` is the skill that drives `make sync-to-home`
+- skills(meta) — skills are one of the projected roots
+- `docs/development.md` — the same projection model, from a contributor's seat (install vs dev checkout vs sandbox)
+- `docs/migration-1.0.md` — the `ways migrate` walkthrough and deprecation lifecycle

--- a/hooks/ways/meta/deployment/deployment.md
+++ b/hooks/ways/meta/deployment/deployment.md
@@ -43,7 +43,7 @@ a **pre-1.0 in-place clone** (it has its own `.git` *and* ships the app source â
 reconcile it â€” point the user at migration:
 
 ```
-ways migrate --what-if     # preview: what moves where
+ways migrate --what-if     # preview (read-only dry-run)
 ways migrate --execute     # relocate the clone to $XDG_DATA, build the projection
 ```
 

--- a/hooks/ways/meta/skills/skills.md
+++ b/hooks/ways/meta/skills/skills.md
@@ -31,11 +31,12 @@ These three overlap, and reaching for the wrong one is the most common mistake.
 
 Rule of thumb: **a way teaches Claude how to behave; a skill gives Claude something to run.** If the answer is "inject advice when X happens," it's a way — and most of *this repo's* value is ways, so default there and only reach for a skill when there's a concrete procedure to execute. (`ways-update`, `ways-tests`, `ship`, `attend` are skills because each *runs a procedure*; `meta/knowledge`, `softwaredev/code/quality` are ways because they *shape behavior*.)
 
-## The scope caveat — this repo IS `~/.claude`
+## The scope caveat — `skills/` here projects into personal scope
 
-`skills/` here is the **live personal scope** (`~/.claude/skills/`). A skill added
-to this repo is available in **every** project on this machine the moment it lands.
-Two consequences:
+`skills/` in this repo is **projected into `~/.claude/skills/`** (ADR-142) — the
+live personal scope. Once a skill here reaches your install (via `ways reconcile` /
+update, or immediately if you're editing the symlinked projection), it is available
+in **every** project on this machine. Two consequences:
 
 - **Triggers must be tight.** A loose `description` on a global skill hijacks
   unrelated requests everywhere. Name the specific task and the words a user would


### PR DESCRIPTION
## Summary

- The **session-injected** deployment doctrine still asserted the pre-1.0 identity (`~/.claude *is* the clone`, "this repo IS `~/.claude`") and gave repair commands (`cd ~/.claude && make setup`) that **break** under the 1.0 native projection — there's no Makefile in the projection.
- Per doc-sweep decision **D1 = supersede** (native projection is THE 1.0 model; in-place/subdirectory are legacy), rewrites the three highest-stakes surfaces:
  - `hooks/ways/meta/deployment/deployment.md` — no longer a two-topology chooser; teaches the projection model (source in `$XDG_DATA`, `~/.claude` as thin symlink projection) and the one real fork: a legacy in-place clone that must `ways migrate`, not `git pull`.
  - `hooks/ways/meta/skills/skills.md` — "this repo IS `~/.claude`" → "`skills/` projects into `~/.claude/skills/`"; the tight-triggers lesson is unchanged.
  - `hooks/ways/check-setup.sh` — the three repair messages point at `$XDG_DATA_HOME/agent-ways` + `ways reconcile`, not `cd ~/.claude && make setup`.

This is **Category A (A1/A2/A3)** of the 1.0 `~/.claude` path & doctrine audit — the injected-every-session doctrine + one broken command. Model matched to the known-correct `docs/development.md`.

## Test plan

- `bash -n hooks/ways/check-setup.sh` — clean; heredocs render the resolved app path with literal backticks (verified).
- `deployment.md` frontmatter is well-formed; `pattern`/`vocabulary` still match install/update/`~/.claude`/reconcile/migrate so the way still fires.
- Prose only elsewhere — no runtime behavior change.

https://claude.ai/code/session_01TFyiQNDZ8RTMHX4Tnmp1wY