### PR TITLE
fix(skills,ways): resolve app-internal script refs via XDG, not ~/.claude

### DIFF
--- a/hooks/ways/softwaredev/visualization/diagrams/diagrams.md
+++ b/hooks/ways/softwaredev/visualization/diagrams/diagrams.md
@@ -25,7 +25,7 @@ command -v mmaid || ~/.cache/claude-ways/user/mmaid --version
 If not installed:
 - **Arch Linux**: `yay -S mmaid` (AUR, when published)
 - **Go**: `go install github.com/aaronsb/mmaid-go/cmd/mmaid@latest`
-- **Download**: `bash ~/.claude/tools/mmaid/download-mmaid.sh`
+- **Download**: `bash "${XDG_DATA_HOME:-$HOME/.local/share}/agent-ways/tools/mmaid/download-mmaid.sh"` (the `tools/` tree is app-internal, not projected into `~/.claude` — ADR-142)
 
 ## Usage
 

--- a/skills/gh-monitor/SKILL.md
+++ b/skills/gh-monitor/SKILL.md
@@ -39,9 +39,10 @@ to leave running afterward.
 
 Launch with the **Monitor tool** (not Bash):
 
-- **command**: `bash ~/.claude/scripts/gh-monitor-ci-watch.sh` — append a PR
-  number/branch/URL only if watching something other than the current branch,
-  e.g. `bash ~/.claude/scripts/gh-monitor-ci-watch.sh 142`
+- **command**: `bash "${XDG_DATA_HOME:-$HOME/.local/share}/agent-ways/scripts/gh-monitor-ci-watch.sh"` —
+  append a PR number/branch/URL only if watching something other than the current
+  branch, e.g. `bash "${XDG_DATA_HOME:-$HOME/.local/share}/agent-ways/scripts/gh-monitor-ci-watch.sh" 142`
+  (the `scripts/` helpers live in the app dir, not the `~/.claude` projection — ADR-142)
 - **description**: `gh-monitor ci: <repo>#<pr>` (fill in the PR you're watching)
 - **persistent**: `false`
 - **timeout_ms**: `1800000` (30 min — a generous cap so a wedged/never-running
@@ -59,7 +60,7 @@ work it was supporting is done.
 
 Launch with the **Monitor tool**:
 
-- **command**: `bash ~/.claude/scripts/gh-monitor-inbox-watch.sh`
+- **command**: `bash "${XDG_DATA_HOME:-$HOME/.local/share}/agent-ways/scripts/gh-monitor-inbox-watch.sh"`
 - **description**: `gh-monitor: GitHub notifications`
 - **persistent**: `true`
 - **timeout_ms**: `3600000` (ignored when persistent, but pass it anyway)

--- a/skills/project-pulse/SKILL.md
+++ b/skills/project-pulse/SKILL.md
@@ -22,10 +22,11 @@ Compare this project against Claude Code upstream releases, or reconcile ADR sta
 
 ## How to Run
 
-Execute the script and capture its output:
+Execute the script and capture its output. The helper lives in the app dir
+(`scripts/` is not projected into `~/.claude` — ADR-142), so resolve it via XDG:
 
 ```bash
-bash ~/.claude/scripts/project-pulse [flags]
+bash "${XDG_DATA_HOME:-$HOME/.local/share}/agent-ways/scripts/project-pulse" [flags]
 ```
 
 The script outputs structured markdown. Your job is to interpret it.


### PR DESCRIPTION
## Summary

Three skills/ways invoked helper scripts at `~/.claude/scripts/…` and `~/.claude/tools/…`. Under the 1.0 projection, **only** `skills/ agents/ commands/ hooks/ways/ bin/` are projected into `~/.claude`; `scripts/` and `tools/` deliberately stay in `$XDG_DATA` (`manifest.rs`). So these commands **fail when run today** — the paths don't exist in the projection.

Per doc-sweep decision **B-form = resolve at app location**, they now point at `"${XDG_DATA_HOME:-$HOME/.local/share}/agent-ways/{scripts,tools}/…"`:

- `skills/project-pulse/SKILL.md` — the run command
- `skills/gh-monitor/SKILL.md` — ci-watch (×2) + inbox-watch Monitor commands (quoted)
- `hooks/ways/softwaredev/visualization/diagrams/diagrams.md` — the mmaid downloader

**Deferred (task #6):** diagrams.md's `~/.cache/claude-ways/user/mmaid` cache-name refs are left as-is — they're still *functional* (the download tooling writes `claude-ways` today). Flipping them to `agent-ways` now would break the fallback until the downloader is fixed; both move in lockstep in the embedding/tooling chunk.

This is **Category B (B1/B2/B3)** — the real runtime breakage — of the 1.0 `~/.claude` path & doctrine audit.

## Test plan

- `grep` confirms no `~/.claude/scripts` or `~/.claude/tools` refs remain in the three files.
- Path form matches `scripts/install.sh` and `docs/development.md` (`${XDG_DATA_HOME:-$HOME/.local/share}/agent-ways`).
- Prose/instruction change only — no code behavior change; the referenced scripts are unmodified.

https://claude.ai/code/session_01TFyiQNDZ8RTMHX4Tnmp1wY