### PR TITLE
fix(skills): rewrite ways-update for the 1.0 projection update flow

### DIFF
--- a/skills/ways-update/SKILL.md
+++ b/skills/ways-update/SKILL.md
@@ -1,85 +1,110 @@
 ---
 name: ways-update
-description: Update the agent-ways installation to the latest version — pull, rebuild the Rust binaries (ways/attend/way-embed), re-install symlinks, and rebuild the corpus. Use when the user wants to update agent-ways, pull the latest ways/hooks, run "make update", or refresh their ways framework install. Not for editing or authoring individual ways (that is the ways skill) or upgrading project dependencies.
+description: Update the agent-ways installation to the latest version — pull the app source in $XDG_DATA, rebuild the Rust binaries (ways/attend/way-embed) and corpus, and refresh the ~/.claude projection with `ways reconcile`. Use when the user wants to update agent-ways, pull the latest ways/hooks, or refresh their ways framework install. Not for editing or authoring individual ways (that is the ways skill) or upgrading project dependencies.
 allowed-tools: Bash, Read
 ---
 
 # ways-update: Update the agent-ways install
 
-Brings the local **agent-ways** checkout (the repo that backs `~/.claude`) up to
-the latest version and rebuilds everything that depends on it. The canonical
-entry point is `make update`; this skill wraps it with the pre-flight checks
-`make` itself doesn't do.
+In 1.0, `~/.claude` is a thin **projection** of an XDG application whose source
+lives in `$XDG_DATA_HOME/agent-ways` (ADR-142). Updating means refreshing *that*
+checkout, rebuilding what depends on it, and reprojecting — not touching `~/.claude`
+directly. This skill wraps the flow with the pre-flight checks a bare `git pull`
+doesn't do.
 
-## What `make update` does
+## The update flow
 
 ```
-make update
-  ├─ git pull --ff-only          # fast-forward to latest; refuses if history diverged
-  ├─ make update-binaries        # force-rebuild ways, attend, attend-chat, way-embed
-  └─ make install                # re-symlink binaries into ~/.local/bin, mark hooks executable
+cd "$XDG_DATA_HOME/agent-ways"
+git pull --ff-only        # (or fetch/merge upstream for a fork — see step 2)
+make setup                # rebuild ways/attend/way-embed + regenerate the corpus
+ways reconcile            # refresh the ~/.claude projection + re-merge settings.json
 ```
 
-Binaries are symlinked, so a rebuild takes effect immediately for *new* shells —
-but a **running Claude Code session keeps the old hooks and ways in memory.**
-Always finish by telling the user to restart Claude Code.
+Because the projected roots are symlinks into the app dir, a pull is *live* for
+existing files the moment it lands; `ways reconcile` is what catches **structural**
+changes (a new skill/way directory to link) and re-runs the `settings.json`
+three-way merge. A **running Claude Code session keeps the old hooks and ways in
+memory** — always finish by telling the user to restart.
 
 ## Steps
 
-Run from the install root. Resolve it once and reuse it — the skill is global, so
-the working directory is unknown at invocation:
+Resolve the app dir once — the skill is global, so the working directory is
+unknown at invocation:
 
 ```bash
-ROOT="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
-# Confirm this is actually the agent-ways repo before touching anything
-grep -q 'agent-ways' "$ROOT/Makefile" 2>/dev/null && git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1 \
-  || { echo "Not an agent-ways checkout: $ROOT"; exit 1; }
+APP="${XDG_DATA_HOME:-$HOME/.local/share}/agent-ways"
 ```
 
-### 1. Pre-flight: check the working tree
-
-`git pull --ff-only` will **abort** if tracked files have uncommitted changes that
-the incoming update also touches — and this repo commonly carries a modified
-`settings.json` / `settings.local.json`. Surface the state before pulling:
+### 0. Guard: is this actually a projection install?
 
 ```bash
-git -C "$ROOT" fetch origin --quiet
-git -C "$ROOT" status --short --branch
+# Legacy pre-1.0 in-place clone? ~/.claude is itself the agent-ways repo.
+if git -C "$HOME/.claude" rev-parse --git-dir >/dev/null 2>&1 \
+   && [ -d "$HOME/.claude/tools" ] && [ -d "$HOME/.claude/docs" ]; then
+  echo "~/.claude looks like a pre-1.0 in-place clone. Don't update it in place —"
+  echo "migrate to the 1.0 projection first:  ways migrate --what-if  then  --execute"
+  exit 1
+fi
+
+# The app source must exist and be a git checkout.
+grep -q 'agent-ways' "$APP/Makefile" 2>/dev/null && git -C "$APP" rev-parse --git-dir >/dev/null 2>&1 \
+  || { echo "No agent-ways app source at $APP. (Re-run the installer to (re)stage it.)"; exit 1; }
+```
+
+### 1. Pre-flight: check the app checkout
+
+`git pull --ff-only` **aborts** if tracked files have uncommitted changes or the
+history diverged. Surface the state before pulling:
+
+```bash
+git -C "$APP" fetch origin --quiet
+git -C "$APP" status --short --branch
 ```
 
 - **Clean tree, behind remote** → safe to proceed to step 2.
-- **Dirty tracked files** → tell the user what's modified. Offer to commit them
-  (use `/ship` for that), or `git -C "$ROOT" stash` before the update and
-  `git stash pop` after. Do **not** stash or discard their changes without asking.
+- **Dirty tracked files** (common on a fork carrying custom ways) → tell the user
+  what's modified. Offer to commit (`/ship`) or `git -C "$APP" stash` before the
+  update and `git stash pop` after. Do **not** stash or discard without asking.
 - **Diverged history** (local commits not on remote) → `--ff-only` will fail by
   design. Stop and explain; the user decides whether to push, rebase, or merge.
-  Never force anything.
 
-Untracked files (e.g. a new way you haven't committed) are safe — the pull leaves
-them alone — but flag them so nothing is silently left behind.
+Untracked files are safe — the pull leaves them alone — but flag them.
 
-### 2. Run the update
+### 2. Pull the update
 
-```bash
-make -C "$ROOT" update
-```
-
-If it fails partway, the three sub-steps are independent and re-runnable — you can
-invoke `make -C "$ROOT" update-binaries` and `make -C "$ROOT" install` directly to
-finish, or `make -C "$ROOT" ways-rebuild` to force just the ways binary.
-
-### 3. Rebuild the matching corpus
-
-`make update` rebuilds binaries but not the embedding corpus. If the pull changed
-any way's `description`/`vocabulary`, refresh it so matching reflects the update:
+**Direct install** (origin is agent-ways):
 
 ```bash
-ways corpus
+git -C "$APP" pull --ff-only
 ```
 
-(Skip if the pull touched no `.md` frontmatter — `git -C "$ROOT" diff --stat HEAD@{1} -- '*/ways/**/*.md'` shows whether it did.)
+**Fork** (origin is your fork, `upstream` tracks agent-ways):
 
-### 4. Tell the user to restart
+```bash
+git -C "$APP" fetch upstream && git -C "$APP" merge upstream/main   # resolve conflicts in custom ways
+```
+
+### 3. Rebuild binaries + corpus
+
+```bash
+make -C "$APP" setup
+```
+
+`make setup` rebuilds the binaries and regenerates the embedding corpus. If it
+fails partway, the sub-targets are re-runnable (`make -C "$APP" update-binaries`,
+`make -C "$APP" ways-rebuild`).
+
+### 4. Refresh the projection
+
+```bash
+ways reconcile --source "$APP" --dest "$HOME/.claude"
+```
+
+Idempotent and silent when nothing structural changed; relinks any new projected
+root and re-runs the `settings.json` merge.
+
+### 5. Tell the user to restart
 
 The running session won't pick up new hooks or ways until restart. End with an
 explicit: **"Restart Claude Code for the update to take effect."**
@@ -88,15 +113,16 @@ explicit: **"Restart Claude Code for the update to take effect."**
 
 ```bash
 ways --version          # confirm the rebuilt binary is on PATH
-make -C "$ROOT" test    # full suite: lint + smoke + unit + sim + lang (slow)
+ways status             # binary / model / corpus / project detection
+make -C "$APP" test     # full suite: lint + smoke + unit + sim + lang (slow)
 ```
 
 ## Notes
 
-- This skill lives **inside** the repo it updates (`skills/` is the live personal
-  scope). That's intentional — an "update my config" command should be reachable
-  from any project — but it means the skill can update the very file defining it.
-  It only ever runs `git`/`make`; it does not edit repo contents.
-- For a first-time install (not an update), the target is `make install`, and for
-  a from-scratch environment `make setup` first. This skill assumes an existing
-  checkout.
+- This skill is itself a **projected** file (`skills/` links into `~/.claude/skills/`),
+  so it can update the app that defines it — it only ever runs `git`/`make`/`ways`,
+  never edits repo contents.
+- For a first-time install (not an update), run the installer one-liner instead —
+  this skill assumes an existing app checkout at `$XDG_DATA_HOME/agent-ways`.
+- See `docs/development.md` for the install-vs-dev-checkout distinction, and
+  `docs/migration-1.0.md` for moving a legacy in-place clone onto the projection.

--- a/skills/ways-update/SKILL.md
+++ b/skills/ways-update/SKILL.md
@@ -18,7 +18,7 @@ doesn't do.
 cd "$XDG_DATA_HOME/agent-ways"
 git pull --ff-only        # (or fetch/merge upstream for a fork — see step 2)
 make setup                # rebuild ways/attend/way-embed + regenerate the corpus
-ways reconcile            # refresh the ~/.claude projection + re-merge settings.json
+./bin/ways reconcile      # refresh the ~/.claude projection + re-merge settings.json
 ```
 
 Because the projected roots are symlinks into the app dir, a pull is *live* for
@@ -40,8 +40,8 @@ APP="${XDG_DATA_HOME:-$HOME/.local/share}/agent-ways"
 
 ```bash
 # Legacy pre-1.0 in-place clone? ~/.claude is itself the agent-ways repo.
-if git -C "$HOME/.claude" rev-parse --git-dir >/dev/null 2>&1 \
-   && [ -d "$HOME/.claude/tools" ] && [ -d "$HOME/.claude/docs" ]; then
+# (Same triad as reconcile.rs is_legacy_in_place: own .git + ships tools/ + docs/.)
+if [ -d "$HOME/.claude/.git" ] && [ -d "$HOME/.claude/tools" ] && [ -d "$HOME/.claude/docs" ]; then
   echo "~/.claude looks like a pre-1.0 in-place clone. Don't update it in place —"
   echo "migrate to the 1.0 projection first:  ways migrate --what-if  then  --execute"
   exit 1
@@ -82,6 +82,8 @@ git -C "$APP" pull --ff-only
 **Fork** (origin is your fork, `upstream` tracks agent-ways):
 
 ```bash
+git -C "$APP" remote get-url upstream >/dev/null 2>&1 \
+  || { echo "No 'upstream' remote. Add it: git -C \"$APP\" remote add upstream https://github.com/aaronsb/agent-ways"; exit 1; }
 git -C "$APP" fetch upstream && git -C "$APP" merge upstream/main   # resolve conflicts in custom ways
 ```
 
@@ -98,11 +100,12 @@ fails partway, the sub-targets are re-runnable (`make -C "$APP" update-binaries`
 ### 4. Refresh the projection
 
 ```bash
-ways reconcile --source "$APP" --dest "$HOME/.claude"
+"$APP/bin/ways" reconcile --source "$APP" --dest "$HOME/.claude"
 ```
 
 Idempotent and silent when nothing structural changed; relinks any new projected
-root and re-runs the `settings.json` merge.
+root and re-runs the `settings.json` merge. (Called by absolute path — like
+`install.sh` does — so it works even if `~/.local/bin` isn't on `PATH`.)
 
 ### 5. Tell the user to restart
 


### PR DESCRIPTION
## Summary

`ways-update` was **broken on every 1.0 install**: its pre-flight resolved `ROOT="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"` and required a Makefile + `.git` *there*. Under native projection `~/.claude` is not a repo and has no Makefile, so the skill aborted with "Not an agent-ways checkout" before doing anything.

Rewritten to the projection model (ADR-142):
- Resolves the app source at **`$XDG_DATA_HOME/agent-ways`** (where the checkout + Makefile actually live), not `~/.claude`.
- **Legacy guard:** if `~/.claude` *is* a pre-1.0 in-place clone (own `.git` + ships `tools/`+`docs/`), routes to `ways migrate` instead of updating in place.
- **Flow:** `git pull` (or fetch/merge `upstream` for a fork) → `make setup` → `ways reconcile` to refresh the projection + re-merge `settings.json`.
- Preserves the pre-flight discipline (ff-only, dirty/diverged handling, never stash/discard without asking).

This is **Category A (A7)** of the audit — upgraded from a one-line fix to a full rewrite once it was clear the skill was non-functional under projection.

## Test plan

- `grep` confirms no residual `CLAUDE_CONFIG_DIR` / `$ROOT` / in-place `make update` / "repo that backs" refs.
- Frontmatter `name: ways-update` matches the directory; description keeps the trigger phrasing ("update agent-ways", "pull the latest ways/hooks", "refresh their ways framework install").
- Commands align with the reconcile/migrate/XDG conventions used by `scripts/install.sh`, `docs/development.md`, and the just-rewritten `install-guide.md`.

https://claude.ai/code/session_01TFyiQNDZ8RTMHX4Tnmp1wY