### PR TITLE
docs: config-path refs → canonical XDG config.yaml + knowledge.md three-root nuance

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,17 +123,18 @@ For the complete system guide — trigger flow, state machines, the pipeline fro
 
 ## Configuration
 
-Ways config lives in `~/.claude/ways.json`:
+User config lives in `$XDG_CONFIG_HOME/ways/config.yaml` (YAML). For example, to disable whole domains:
 
-```json
-{
-  "disabled": []
-}
+```yaml
+disabled_domains:
+  - itops
 ```
 
-| Field | Purpose |
+A legacy `~/.claude/ways.json` (`{"disabled": [...]}`) is still honored as a lower-precedence layer for un-migrated installs.
+
+| Key | Purpose |
 |-------|---------|
-| `disabled` | Array of domain names to skip (e.g., `["itops", "softwaredev"]`) |
+| `disabled_domains` | List of domain names to skip (e.g., `[itops, softwaredev]`) — in legacy `ways.json` this key is `disabled` |
 
 Disabled domains are completely ignored — no pattern matching, no output.
 

--- a/docs/hooks-and-ways.md
+++ b/docs/hooks-and-ways.md
@@ -449,12 +449,11 @@ flowchart TD
 
 ## Domain Enable/Disable
 
-`~/.claude/ways.json` controls which domains are active:
+`$XDG_CONFIG_HOME/ways/config.yaml` controls which domains are active (a legacy `~/.claude/ways.json` with `{"disabled": [...]}` is still honored):
 
-```json
-{
-  "disabled": ["itops"]
-}
+```yaml
+disabled_domains:
+  - itops
 ```
 
 Checked by `ways scan` before outputting any way.

--- a/docs/hooks-and-ways/extending.md
+++ b/docs/hooks-and-ways/extending.md
@@ -138,13 +138,15 @@ ways:
 
 ### Disabling an entire domain (global)
 
-Add the domain name to `~/.claude/ways.json`:
+Add the domain to `disabled_domains` in `$XDG_CONFIG_HOME/ways/config.yaml`:
 
-```json
-{
-  "disabled": ["itops", "experimental"]
-}
+```yaml
+disabled_domains:
+  - itops
+  - experimental
 ```
+
+(A legacy `~/.claude/ways.json` with `{"disabled": [...]}` is still honored for un-migrated installs.)
 
 All ways in disabled domains are silently skipped everywhere. The domain still appears in the Available Ways table but its ways won't fire. Domain-level disable is the right tool for "never anywhere"; project-scope per-way disable is the right tool for "not in this project."
 

--- a/hooks/ways/meta/knowledge/knowledge.md
+++ b/hooks/ways/meta/knowledge/knowledge.md
@@ -41,9 +41,15 @@ Disclosure isn't once-and-done. Each (way, session) pair stamps the epoch it fir
 
 ## Locations
 
-- Global: `~/.claude/hooks/ways/{domain}/{wayname}/{wayname}.md`
-- Project: `$PROJECT/.claude/ways/{domain}/{wayname}/{wayname}.md`
-- Disable domains: `~/.claude/ways.json` → `{"disabled": ["domain"]}`
+Three way roots (ADR-143) — don't confuse *reading* one with *authoring* in it:
+
+- **Framework ways (read-only projection):** `~/.claude/hooks/ways/{domain}/{wayname}/{wayname}.md`
+  — a symlink into the app source at `$XDG_DATA_HOME/agent-ways`. Readable here, but
+  **don't author durably in it**: the app dir is replaced wholesale on update, so edits are
+  lost. Change these in a dev checkout and reproject (see `docs/development.md`).
+- **Your own ways (user scope, survives updates):** `$XDG_CONFIG_HOME/agent-ways/ways/{domain}/{wayname}/{wayname}.md`
+- **Project ways:** `$PROJECT/.claude/ways/{domain}/{wayname}/{wayname}.md` — override global ways at the same path
+- Disable domains: `$XDG_CONFIG_HOME/ways/config.yaml` → `disabled_domains: [domain]` (legacy `~/.claude/ways.json` → `{"disabled": [...]}` still honored)
 - Ways can nest: `{domain}/{parent}/{child}/{child}.md` for progressive disclosure
 - When a parent way fires, child thresholds are lowered 20% (domain context is established)
 - Tree disclosure metrics are tracked per-session (parent, depth, epoch distance, sibling coverage)


### PR DESCRIPTION
## Summary

**Category C + D** — the final, low-urgency chunk of the 1.0 `~/.claude` path & doctrine audit. Nothing here was *broken* (D3: `~/.claude/ways.json` is still read as a legacy layer — `config.rs:131-135`), so this is a correctness/canonicalization pass.

**Category C (config-path):** the refs that presented `~/.claude/ways.json` as *the* config location now point at the canonical **`$XDG_CONFIG_HOME/ways/config.yaml`** (YAML; disable via `disabled_domains:`, vs the legacy JSON key `disabled`), each noting the legacy file is still honored:
- README "Configuration", `docs/hooks-and-ways.md`, `docs/hooks-and-ways/extending.md`, and the `knowledge.md` disable line.
- **Left intentionally:** the localization docs (`languages.md`, mode-gate, adopter-lifecycle) already describe `ways.json` correctly — as the legacy *Layer 1* overridden by `config.yaml`.

**Category D (authoring nuance):** `knowledge.md` Locations rewritten to the three-root model (ADR-143) — distinguishing the **read-only `~/.claude` projection** (a symlink into `$XDG_DATA`, wiped on update → don't author there) from **user-scope ways** at `$XDG_CONFIG/agent-ways/ways/` (survives updates; verified scanned by `corpus.rs`/`scan/candidates.rs`) and project ways.

The config-file path cited is the **functional loader path** (`config.rs:138`); the `config.rs`-vs-`paths.rs` location disagreement is a separate latent bug, tracked.

## Test plan

- `docs/scripts/doc lint` → 0 errors, 0 warnings.
- User-scope ways path + `disabled_domains` YAML key verified against `paths.rs`/`config.rs`/`corpus.rs` (not aspirational).
- Docs/way prose only.

## Follow-up tasks surfaced across the whole sweep (code, not docs)

- Native-projection update detection missing from `check-config-updates.sh`.
- Subagent domain-disable (`inject-subagent.sh`) reads only legacy `ways.json`, not `config.yaml`.
- Canonicalize the user config-file path (`config.rs` vs `paths.rs` disagree; one is dead).

https://claude.ai/code/session_01TFyiQNDZ8RTMHX4Tnmp1wY