### PR TITLE
ci(way-embed): publish prebuilt binaries as a release (the #6 linchpin)

### DIFF
--- a/.github/workflows/build-way-embed.yml
+++ b/.github/workflows/build-way-embed.yml
@@ -3,6 +3,7 @@ name: Build way-embed
 on:
   push:
     branches: [main]
+    tags: ['way-embed-v*']
     paths:
       - 'tools/way-embed/**'
       - '.github/workflows/build-way-embed.yml'
@@ -88,3 +89,30 @@ jobs:
         with:
           name: way-embed-all-platforms
           path: binaries/
+
+  release:
+    needs: collect
+    if: startsWith(github.ref, 'refs/tags/way-embed-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          name: way-embed-all-platforms
+          path: binaries
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "way-embed ${TAG#way-embed-}" \
+            --notes "Pre-built way-embed (semantic matcher) binaries for 4 platforms.
+
+          Downloaded automatically by \`make setup\` / the installer, so semantic
+          matching works with no C++ toolchain. To build from source instead,
+          install a C++ toolchain (cmake + compiler), then \`make setup\`." \
+            binaries/*


### PR DESCRIPTION
## Summary

Fresh installs land with **semantic matching down** because `way-embed` (the embedding engine) has no prebuilt binary to download — reproduced on cube (stock Arch, no cmake): source build fails → model never downloads → `ways status` shows Engine: none, Model MISSING, 107/115 ways can't fire.

Root cause: `build-way-embed.yml` builds all 4 platform binaries but **only uploads them as ephemeral CI artifacts** — it has no `tags:` trigger and no `release:` job, so `gh release create` never runs. `download-binary.sh` resolves the latest **`way-embed-v*` release** (line 69-70), which never exists → always falls through to source build → needs cmake.

`build-ways.yml` and `build-attend.yml` both publish (tags + release job → `ways-v1.0.0`, `attend-v0.7.1`); `build-way-embed` was the lone workflow missing both. This adds them, mirroring `build-attend.yml:114-133`:
- `tags: ['way-embed-v*']` push trigger
- a `release:` job (`needs: collect`, gated on the tag) that downloads `way-embed-all-platforms` + `gh release create`s it

## Effect

Once merged and a `way-embed-v1.0.0` tag is cut → CI publishes the release → `download-binary.sh` finds it → the installer downloads the platform binary → `setup-binary` succeeds → model download proceeds → **semantic matching works with no C++ toolchain**, exactly like `ways`. This is **fix A** of the embedding-acquisition task; fixes B (a `make deps` toolchain-installer fallback) and C (cache-name align) follow.

## Test plan

- `python3 -c "import yaml; yaml.safe_load(...)"` → valid; jobs = build/collect/**release**, trigger includes `way-embed-v*`.
- Release job structurally identical to the proven `build-attend.yml` release job (same `download-artifact` + `gh release create` shape).
- Full end-to-end validation is the tag cut + a fresh cube install (no cmake) — to be done after merge.

https://claude.ai/code/session_01TFyiQNDZ8RTMHX4Tnmp1wY