### PR TITLE
fix(way-embed): correct model repo, align cache name, fix stale ~/.claude strings

### DIFF
--- a/tools/way-embed/Makefile
+++ b/tools/way-embed/Makefile
@@ -75,21 +75,21 @@ MODEL_MULTI = $(MODEL_DIR)/multilingual-minilm-l12-v2-q8.gguf
 SRCDIR     = $(CURDIR)/
 
 model:
-	@[ -f "$(MODEL_EN)" ] || bash "$(SRCDIR)download-model.sh"
+	@[ -f "$(MODEL_EN)" ] || bash "$(SRCDIR)download-model.sh" "$(MODEL_DIR)"
 
 model-multilingual:
-	@[ -f "$(MODEL_MULTI)" ] || bash "$(SRCDIR)download-model.sh" --multilingual
+	@[ -f "$(MODEL_MULTI)" ] || bash "$(SRCDIR)download-model.sh" --multilingual "$(MODEL_DIR)"
 
 # Download directly from HuggingFace (for provenance verification)
 model-upstream:
-	bash $(SRCDIR)download-model.sh --upstream
+	bash $(SRCDIR)download-model.sh --upstream "$(MODEL_DIR)"
 
 # Full setup: download (or build) binary + English model, regenerate corpus.
 # Tries pre-built binary from GitHub Releases first, builds from source if unavailable.
 # The multilingual model (127MB) is on-demand per ADR-139 — fetched via
 # `make model-multilingual` by the ways-localize skill, not at default setup.
 setup: setup-binary
-	@[ -f "$(MODEL_EN)" ] || bash "$(SRCDIR)download-model.sh"
+	@[ -f "$(MODEL_EN)" ] || bash "$(SRCDIR)download-model.sh" "$(MODEL_DIR)"
 	@echo "Regenerating corpus with embeddings..."
 	../../bin/ways corpus --quiet
 	@echo ""
@@ -101,7 +101,7 @@ setup: setup-binary
 
 # Try download, fall back to build
 setup-binary:
-	@if bash "$(SRCDIR)download-binary.sh"; then \
+	@if bash "$(SRCDIR)download-binary.sh" "$(MODEL_DIR)"; then \
 		echo "Pre-built binary installed."; \
 	else \
 		echo "No pre-built binary available, building from source..."; \

--- a/tools/way-embed/RELEASE.md
+++ b/tools/way-embed/RELEASE.md
@@ -5,7 +5,7 @@ Pre-built binaries and model for ADR-108 embedding-based way matching.
 One command — downloads the right binary for your platform + model, generates corpus:
 
 ```bash
-cd ~/.claude && make setup
+cd "${XDG_DATA_HOME:-$HOME/.local/share}/agent-ways" && make setup
 ```
 
 This will:
@@ -20,14 +20,14 @@ If no pre-built binary exists for your platform, it builds from source automatic
 
 ```bash
 # Download binary + model separately
-bash ~/.claude/tools/way-embed/download-binary.sh
-bash ~/.claude/tools/way-embed/download-model.sh
+bash ${XDG_DATA_HOME:-$HOME/.local/share}/agent-ways/tools/way-embed/download-binary.sh
+bash ${XDG_DATA_HOME:-$HOME/.local/share}/agent-ways/tools/way-embed/download-model.sh
 
 # Regenerate corpus
 ways corpus
 
 # Verify
-bash ~/.claude/tools/way-embed/test-embedding.sh
+bash ${XDG_DATA_HOME:-$HOME/.local/share}/agent-ways/tools/way-embed/test-embedding.sh
 ```
 
 ## Available platforms
@@ -44,7 +44,7 @@ bash ~/.claude/tools/way-embed/test-embedding.sh
 If your platform isn't listed:
 
 ```bash
-cd ~/.claude && make setup
+cd "${XDG_DATA_HOME:-$HOME/.local/share}/agent-ways" && make setup
 ```
 
 Requires: cmake, C++ compiler, git (for submodule).
@@ -54,7 +54,7 @@ Requires: cmake, C++ compiler, git (for submodule).
 Download the model directly from HuggingFace instead of the release:
 
 ```bash
-bash ~/.claude/tools/way-embed/download-model.sh --upstream
+bash ${XDG_DATA_HOME:-$HOME/.local/share}/agent-ways/tools/way-embed/download-model.sh --upstream
 ```
 
 Both paths verify against the same SHA-256 checksum.

--- a/tools/way-embed/download-binary.sh
+++ b/tools/way-embed/download-binary.sh
@@ -7,7 +7,7 @@
 # Usage:
 #   download-binary.sh [--release TAG] [output-dir]
 #
-# The binary is placed at: ${XDG_CACHE_HOME:-~/.cache}/claude-ways/user/way-embed
+# The binary is placed at: ${XDG_CACHE_HOME:-~/.cache}/agent-ways/user/way-embed
 
 set -euo pipefail
 
@@ -20,7 +20,9 @@ GH_REPO="aaronsb/agent-ways"
 RELEASE_TAG="${WAY_EMBED_RELEASE:-latest}"
 BIN_NAME="way-embed-${PLATFORM}"
 XDG_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}"
-OUTPUT_DIR="${XDG_CACHE}/claude-ways/user"
+OUTPUT_DIR="${XDG_CACHE}/agent-ways/user"
+# App source dir (has the Makefile + way-embed source) — for build-from-source hints.
+APP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/agent-ways"
 
 # Parse args
 while [[ $# -gt 0 ]]; do
@@ -32,7 +34,7 @@ while [[ $# -gt 0 ]]; do
       echo "Usage: $0 [--release TAG] [output-dir]"
       echo ""
       echo "  --release TAG  GitHub Release tag (default: latest way-embed-* release)"
-      echo "  output-dir     Override output directory (default: \$XDG_CACHE_HOME/claude-ways/user/)"
+      echo "  output-dir     Override output directory (default: \$XDG_CACHE_HOME/agent-ways/user/)"
       echo ""
       echo "Platform: ${PLATFORM}"
       echo "Available: linux-x86_64, linux-aarch64, darwin-x86_64, darwin-arm64"
@@ -57,7 +59,7 @@ fi
 # Need gh CLI
 if ! command -v gh >/dev/null 2>&1; then
   echo "error: gh CLI not found — install it or build from source:" >&2
-  echo "  cd ~/.claude/tools/way-embed && make" >&2
+  echo "  cd $APP_DIR/tools/way-embed && make" >&2
   exit 1
 fi
 
@@ -70,7 +72,7 @@ if [[ "$RELEASE_TAG" == "latest" ]]; then
     | grep '^way-embed-v' | head -1)
   if [[ -z "$RELEASE_TAG" ]]; then
     echo "No way-embed release found. Build from source:" >&2
-    echo "  cd ~/.claude && make setup" >&2
+    echo "  cd $APP_DIR && make setup" >&2
     exit 1
   fi
 fi
@@ -85,7 +87,7 @@ if ! gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.asset
   gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep "way-embed-" | sed 's/^/  /' >&2
   echo "" >&2
   echo "Build from source instead:" >&2
-  echo "  cd ~/.claude && make setup" >&2
+  echo "  cd $APP_DIR && make setup" >&2
   exit 1
 fi
 
@@ -132,7 +134,7 @@ if "$OUTPUT_FILE" --version >/dev/null 2>&1; then
 else
   echo "WARNING: binary downloaded but won't execute on this platform" >&2
   echo "Build from source instead:" >&2
-  echo "  cd ~/.claude/tools/way-embed && make" >&2
+  echo "  cd $APP_DIR/tools/way-embed && make" >&2
   rm -f "$OUTPUT_FILE" "$PLATFORM_FILE"
   exit 1
 fi

--- a/tools/way-embed/download-model.sh
+++ b/tools/way-embed/download-model.sh
@@ -9,7 +9,7 @@
 #   download-model.sh [--upstream] [--f16] [--multilingual] [output-dir]
 #
 # Models are placed in the XDG cache directory by default:
-#   ${XDG_CACHE_HOME:-$HOME/.cache}/claude-ways/user/
+#   ${XDG_CACHE_HOME:-$HOME/.cache}/agent-ways/user/
 
 set -euo pipefail
 
@@ -23,13 +23,13 @@ MODEL_SIZE="21MB"
 # Source URLs
 HF_BASE="https://huggingface.co/second-state/All-MiniLM-L6-v2-Embedding-GGUF/resolve/main"
 MULTI_HF_BASE="https://huggingface.co/mykor/paraphrase-multilingual-MiniLM-L12-v2.gguf/resolve/main"
-GH_REPO="aaronsb/claude"
+GH_REPO="aaronsb/agent-ways"
 GH_RELEASE_TAG="v0.1.0-model"
 
 # Defaults
 SOURCE="github"
 XDG_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}"
-OUTPUT_DIR="${XDG_CACHE}/claude-ways/user"
+OUTPUT_DIR="${XDG_CACHE}/agent-ways/user"
 
 # Parse args
 while [[ $# -gt 0 ]]; do
@@ -59,7 +59,7 @@ while [[ $# -gt 0 ]]; do
       echo "  --upstream      Download directly from HuggingFace (verify provenance)"
       echo "  --f16           Download full-precision F16 (44MB) instead of Q5_K_M (21MB)"
       echo "  --multilingual  Download multilingual model (127MB, 52 languages)"
-      echo "  output-dir      Override output directory (default: \$XDG_CACHE_HOME/claude-ways/user/)"
+      echo "  output-dir      Override output directory (default: \$XDG_CACHE_HOME/agent-ways/user/)"
       echo ""
       echo "Models:"
       echo "  English:      all-MiniLM-L6-v2 Q5_K_M (21MB)"


### PR DESCRIPTION
## Summary

Three fixes to the `way-embed` acquisition scripts — covers the `GH_REPO` bug (#3), the cache-name align (#2/fix C), and the way-embed slice of the stale-string sweep (#10):

- **Repo bug (headline):** `download-model.sh:26` had `GH_REPO="aaronsb/claude"` (the pre-rename name), so the GitHub-release model fetch always 404'd and silently fell back to HuggingFace. Corrected to `aaronsb/agent-ways` (matches `download-binary.sh`). The release path now works once a `v0.1.0-model` release exists.
- **Cache name:** both scripts defaulted to `$XDG_CACHE/claude-ways/user`; the `ways` binary reads `$XDG_CACHE/agent-ways/user` (prefer) with a `claude-ways` fallback. Default to **agent-ways**, and pass the Makefile's `MODEL_DIR` (already computes prefer-agent-ways-fallback-claude-ways) into both scripts so binary/scripts/Makefile resolve the **same** dir. The intentional legacy fallback in `MODEL_DIR` stays for un-migrated installs.
- **Stale strings:** build-from-source hints (`cd ~/.claude && make setup`, `~/.claude/tools/way-embed/…`) were broken under the projection (`tools/` isn't projected). Point them at `$XDG_DATA_HOME/agent-ways`. Same in `RELEASE.md`.

## Test plan

- `grep` confirms no stray `~/.claude` / `claude-ways` remain except the deliberate `MODEL_DIR` fallback.
- `bash -n` clean on both scripts; `download-model.sh` arg parsing handles the positional dir after `--multilingual`/`--upstream`.
- Validates end-to-end on the next cube `make setup` (should write/read a consistent cache dir; model fetch prefers the GitHub release once bundled).