### PR TITLE
fix(way-embed): resolve cache dir in test/calibrate scripts (prefer agent-ways)

### DIFF
--- a/tools/way-embed/calibrate.sh
+++ b/tools/way-embed/calibrate.sh
@@ -6,7 +6,10 @@
 
 set -euo pipefail
 
-XDG_WAY="${XDG_CACHE_HOME:-$HOME/.cache}/claude-ways/user"
+_C="${XDG_CACHE_HOME:-$HOME/.cache}"
+if [[ -d "$_C/agent-ways/user" ]]; then XDG_WAY="$_C/agent-ways/user"
+elif [[ -d "$_C/claude-ways/user" ]]; then XDG_WAY="$_C/claude-ways/user"
+else XDG_WAY="$_C/agent-ways/user"; fi
 WAY_EMBED="${XDG_WAY}/way-embed"
 [[ ! -x "$WAY_EMBED" ]] && WAY_EMBED="${HOME}/.claude/bin/way-embed"
 CORPUS="${XDG_WAY}/ways-corpus.jsonl"

--- a/tools/way-embed/compare-engines.sh
+++ b/tools/way-embed/compare-engines.sh
@@ -4,7 +4,10 @@
 
 set -euo pipefail
 
-XDG_WAY="${XDG_CACHE_HOME:-$HOME/.cache}/claude-ways/user"
+_C="${XDG_CACHE_HOME:-$HOME/.cache}"
+if [[ -d "$_C/agent-ways/user" ]]; then XDG_WAY="$_C/agent-ways/user"
+elif [[ -d "$_C/claude-ways/user" ]]; then XDG_WAY="$_C/claude-ways/user"
+else XDG_WAY="$_C/agent-ways/user"; fi
 WAY_EMBED="${XDG_WAY}/way-embed"
 [[ ! -x "$WAY_EMBED" ]] && WAY_EMBED="${HOME}/.claude/bin/way-embed"
 WAY_MATCH="${HOME}/.claude/bin/way-match"

--- a/tools/way-embed/test-embedding.sh
+++ b/tools/way-embed/test-embedding.sh
@@ -4,7 +4,10 @@
 
 set -euo pipefail
 
-XDG_WAY="${XDG_CACHE_HOME:-$HOME/.cache}/claude-ways/user"
+_C="${XDG_CACHE_HOME:-$HOME/.cache}"
+if [[ -d "$_C/agent-ways/user" ]]; then XDG_WAY="$_C/agent-ways/user"
+elif [[ -d "$_C/claude-ways/user" ]]; then XDG_WAY="$_C/claude-ways/user"
+else XDG_WAY="$_C/agent-ways/user"; fi
 if [[ -x "${XDG_WAY}/way-embed" ]]; then
   WAY_EMBED="${XDG_WAY}/way-embed"
 elif [[ -x "${HOME}/.claude/bin/way-embed" ]]; then

--- a/tools/way-embed/test-multilingual.sh
+++ b/tools/way-embed/test-multilingual.sh
@@ -8,7 +8,10 @@
 
 set -euo pipefail
 
-XDG_WAY="${XDG_CACHE_HOME:-$HOME/.cache}/claude-ways/user"
+_C="${XDG_CACHE_HOME:-$HOME/.cache}"
+if [[ -d "$_C/agent-ways/user" ]]; then XDG_WAY="$_C/agent-ways/user"
+elif [[ -d "$_C/claude-ways/user" ]]; then XDG_WAY="$_C/claude-ways/user"
+else XDG_WAY="$_C/agent-ways/user"; fi
 EMBED="${XDG_WAY}/way-embed"
 [[ ! -x "$EMBED" ]] && EMBED="${HOME}/.claude/bin/way-embed"
 EN_MODEL="${XDG_WAY}/minilm-l6-v2.gguf"


### PR DESCRIPTION
Completes fix-C. The 4 dev/test helpers (test-embedding, compare-engines, calibrate, test-multilingual) still hardcoded `XDG_WAY=$XDG_CACHE/claude-ways/user`, so on an `agent-ways` install they looked at the wrong (empty) dir and created a stray empty `~/.cache/claude-ways/user` (observed on cube). Now they use the same prefer-agent-ways-fallback resolution the binary (`paths.rs cache_root`) and Makefile (`MODEL_DIR`) already use. `bash -n` clean on all four. Trivial mechanical change.