### PR TITLE
feat(install): ADR-146 launch-verify + halt-and-instruct recovery card

### DIFF
--- a/docs/finish-install.md
+++ b/docs/finish-install.md
@@ -1,0 +1,75 @@
+# Finishing an agent-ways install (semantic matching)
+
+You're reading this because the installer got everything in place **except** the
+semantic-matching engine — `way-embed` (the embedding binary) or its model isn't
+working on this machine, so ways currently fall back to keyword/pattern matching
+only. This is the guide to finish the job. It's written so **Claude Code can follow
+it** — if a human pasted the installer's recovery prompt, that's you; do the steps
+below and report back.
+
+> This is a **discoverable** doc, not a way or a skill — it does nothing until
+> someone opens it. It won't load into any session on its own.
+
+## The situation
+
+- The app source (with the Makefile and the `way-embed` source) is at
+  **`$XDG_DATA_HOME/agent-ways`** (default `~/.local/share/agent-ways`).
+- `way-embed` builds from a bundled `llama.cpp`, which needs a **C++ toolchain**
+  (cmake + a C++ compiler). The likely reason semantic matching is off: no prebuilt
+  binary exists for this platform *and* the toolchain isn't installed, so the
+  source build couldn't run.
+
+## Steps
+
+Resolve the app dir once:
+
+```bash
+APP="${XDG_DATA_HOME:-$HOME/.local/share}/agent-ways"
+```
+
+**1. Check whether the toolchain is present.**
+
+```bash
+command -v cmake && command -v c++ 2>/dev/null || command -v g++ || command -v clang++
+```
+
+**2a. If cmake / a compiler is MISSING — install the toolchain.**
+
+`make deps` auto-detects the package manager (pacman/apt/dnf/zypper/brew) and
+installs cmake + a compiler + git. **It uses `sudo`.** If you're an agent: *ask the
+human before running it* — installing system packages is their call.
+
+```bash
+cd "$APP" && make deps          # asks for sudo; confirm with the human first
+```
+
+**2b. If the toolchain is already present**, skip straight to build.
+
+**3. Build + regenerate the corpus.**
+
+```bash
+cd "$APP" && make setup
+```
+
+This downloads/builds `way-embed`, fetches the model (~21MB), and regenerates the
+corpus with embeddings.
+
+**4. Verify.**
+
+```bash
+"$APP/bin/ways" status
+```
+
+Success looks like `Engine: embedding`, a `Model: … (OK)` line, and a non-zero
+`Corpus:` count. If it still says `Engine: none`, read the `make setup` output for
+the first error (usually a missing build tool) and resolve that.
+
+**5. Restart Claude Code** so the freshly-built engine is picked up.
+
+## If a prebuilt binary *should* have worked
+
+If your platform is one of linux-x86_64 / linux-aarch64 / darwin-x86_64 /
+darwin-arm64 and the download still failed, the binary may have downloaded but not
+launched (a libc/toolchain mismatch). `make setup` falls back to a source build in
+that case, so steps 2–4 still apply. You can also re-run the installer one-liner —
+it's idempotent.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -203,6 +203,47 @@ link_path_binaries() {
   return 0
 }
 
+# Platform triple for messages (linux-x86_64, darwin-arm64, …).
+PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)"
+
+# Did setup produce a functional semantic-matching engine? (ADR-146 verify step.)
+# A binary that downloaded/built but won't actually embed is treated as "not
+# acquired" — `ways status` reports Engine: embedding only when it truly works.
+embedding_engine_ok() {
+  [[ -x "$APP_DIR/bin/ways" ]] || return 1
+  "$APP_DIR/bin/ways" status 2>/dev/null | grep -qiE '^Engine:[[:space:]]*embedding'
+}
+
+# ADR-146 recovery card: shown when the projection is up but semantic matching is
+# off (no prebuilt way-embed for this platform / it won't launch / toolchain
+# missing). Leads with an agent handoff — Claude Code is, by definition, installed,
+# since this is being set up *for* it — including a paste-ready prompt; the exact
+# commands are the backstop. This function never builds or installs anything.
+print_recovery_card() {
+  cat <<CARD
+
+${YELLOW}⚠ Semantic (meaning-based) way-matching is OFF${RESET} — keyword/pattern ways still fire,
+  but the embedding engine (way-embed) isn't working on this platform (${PLATFORM}).
+
+  ${BOLD}Easiest fix — let the agent you're installing this for finish it.${RESET}
+  Open Claude Code in ${CYAN}${APP_DIR}${RESET} and paste this:
+  ${DIM}────────────────────────────────────────────────────────────────${RESET}
+  agent-ways installed but semantic way-matching is off — way-embed isn't
+  working on this machine (${PLATFORM}). The app source is at ${APP_DIR}.
+  Please finish setup per docs/finish-install.md: check for a C++ toolchain
+  (cmake + compiler); if it's missing run \`make deps\` (it uses sudo — ask me
+  first); then \`make setup\`; then verify \`ways status\` shows Engine: embedding.
+  ${DIM}────────────────────────────────────────────────────────────────${RESET}
+
+  ${BOLD}Or finish it yourself:${RESET}
+    cd ${APP_DIR}
+    make deps      # only if cmake/compiler is missing — installs the toolchain (sudo)
+    make setup     # build way-embed + fetch model + regenerate corpus
+  Details: ${CYAN}${APP_DIR}/docs/finish-install.md${RESET}
+
+CARD
+}
+
 # --- Clobber: remove the app dir AND ~/.claude (backs ~/.claude up first) ---
 
 if [[ "$CLOBBER" == "true" ]]; then
@@ -254,6 +295,7 @@ if is_agent_ways_repo "$APP_DIR"; then
     "$APP_DIR/bin/ways" reconcile --source "$APP_DIR" --dest "$DEST" || true
     echo ""
     echo -e "${GREEN}Updated.${RESET} Restart Claude Code for changes to take effect."
+    embedding_engine_ok || print_recovery_card
   else
     echo -e "${YELLOW}ways binary not built — projection was NOT reconciled.${RESET}"
     echo "  Fix the build (cd $APP_DIR && make setup), then run: ways reconcile"
@@ -330,6 +372,9 @@ if [[ -x "$APP_DIR/bin/ways" ]]; then
   echo "  Restart Claude Code for ways to take effect."
   echo -e "  If ${CYAN}${XDG_BIN}${RESET} isn't on your PATH, add it to your shell rc."
   echo ""
+  # ADR-146 verify: the projection is up, but if semantic matching didn't come
+  # up (no prebuilt way-embed for this platform / toolchain missing), guide recovery.
+  embedding_engine_ok || print_recovery_card
 else
   # No binary → don't create an empty ~/.claude. The app is staged; finish by hand.
   echo -e "${YELLOW}ways binary not built — projection not created.${RESET}"


### PR DESCRIPTION
## Summary

Second slice of **ADR-146**: the installer now **verifies** semantic matching actually came up (not just "the binary downloaded") and, if it didn't, prints a **recovery card** instead of leaving a silently-degraded install.

- `embedding_engine_ok()` — checks `ways status` reports `Engine: embedding`. A binary that downloaded/built but won't embed is treated as *not acquired*.
- `print_recovery_card()` (ADR-146 halt-and-instruct) — leads with an **agent handoff**: Claude Code is by definition installed (this is being set up *for* it), so it prints a **paste-ready prompt** with the app-dir path + platform substituted — recovery is one copy-paste. Exact `make deps`/`make setup` commands are the backstop. The installer never builds or installs anything itself.
- Wired into **both** the fresh-install and update paths (after each reconcile).
- Adds **`docs/finish-install.md`** — a *discoverable* context doc (explicitly **not** a way or skill, so it never loads into a session on its own) that the card + paste-prompt reference.

Completes ADR-146's runtime behavior (the `make deps` target landed in #224). Local compilation stays a consented last resort; the happy path (prebuilt binary) is unaffected.

## Test plan

- `bash -n scripts/install.sh` clean.
- The recovery card's heredoc is unquoted (so `$APP_DIR`/`$PLATFORM`/colors expand) but all backticks are **escaped** — render test confirms no command substitution fires and the paths substitute correctly.
- `embedding_engine_ok` uses the same `ways status` "Engine:" line validated on cube.
- Happy path unchanged (card only prints when the engine is down).