### PR TITLE
fix: align remaining cache-name refs claude-ways → agent-ways (docs + mmaid)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ ways lint --global
 ways suggest --file ~/.claude/hooks/ways/softwaredev/code/security/security.md
 
 # Embedding similarity scores
-way-embed match --corpus ~/.cache/claude-ways/user/ways-corpus.jsonl \
-  --model ~/.cache/claude-ways/user/minilm-l6-v2.gguf \
+way-embed match --corpus ~/.cache/agent-ways/user/ways-corpus.jsonl \
+  --model ~/.cache/agent-ways/user/minilm-l6-v2.gguf \
   --query "pin lockfile versions"
 
 # Sibling vocabulary overlap (Jaccard)

--- a/docs/hooks-and-ways.md
+++ b/docs/hooks-and-ways.md
@@ -199,8 +199,8 @@ make test-sim   # 8 integration scenarios
 ways status
 ```
 
-Model location: `${XDG_CACHE_HOME:-~/.cache}/claude-ways/user/minilm-l6-v2.gguf`
-Corpus: `${XDG_CACHE_HOME:-~/.cache}/claude-ways/user/ways-corpus.jsonl`
+Model location: `${XDG_CACHE_HOME:-~/.cache}/agent-ways/user/minilm-l6-v2.gguf`
+Corpus: `${XDG_CACHE_HOME:-~/.cache}/agent-ways/user/ways-corpus.jsonl`
 
 Both user-scope (`~/.claude/hooks/ways/`) and project-scope (`.claude/ways/`) corpora are scanned. They share the same model file.
 

--- a/hooks/ways/softwaredev/visualization/diagrams/diagrams.md
+++ b/hooks/ways/softwaredev/visualization/diagrams/diagrams.md
@@ -14,12 +14,12 @@ refire: 0.15
 Resolution order — use the first one found:
 
 1. **System PATH**: `mmaid` (installed via AUR, brew, `go install`)
-2. **XDG cache**: `~/.cache/claude-ways/user/mmaid` (downloaded by our tooling)
+2. **XDG cache**: `~/.cache/agent-ways/user/mmaid` (downloaded by our tooling)
 3. **Not found**: suggest installation
 
 ```bash
 # Check if available
-command -v mmaid || ~/.cache/claude-ways/user/mmaid --version
+command -v mmaid || ~/.cache/agent-ways/user/mmaid --version
 ```
 
 If not installed:
@@ -35,7 +35,7 @@ Pipe Mermaid syntax via stdin:
 echo 'flowchart LR
     A[Start] --> B{Decision}
     B -->|yes| C[Done]
-    B -->|no| D[Retry]' | ~/.cache/claude-ways/user/mmaid -t blueprint
+    B -->|no| D[Retry]' | ~/.cache/agent-ways/user/mmaid -t blueprint
 ```
 
 Or render a file: `mmaid diagram.mmd -t slate`

--- a/tools/mmaid/download-mmaid.sh
+++ b/tools/mmaid/download-mmaid.sh
@@ -2,7 +2,7 @@
 # Download the pre-built mmaid binary for the current platform
 #
 # Detects OS/arch, downloads from GitHub Releases, verifies it runs.
-# Binary is placed at: ${XDG_CACHE_HOME:-~/.cache}/claude-ways/user/mmaid
+# Binary is placed at: ${XDG_CACHE_HOME:-~/.cache}/agent-ways/user/mmaid
 #
 # Usage:
 #   download-mmaid.sh [--release TAG]
@@ -27,7 +27,7 @@ BIN_NAME="mmaid-${PLATFORM}"
 [[ "$OS" == "windows" ]] && BIN_NAME="${BIN_NAME}.exe"
 
 XDG_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}"
-OUTPUT_DIR="${XDG_CACHE}/claude-ways/user"
+OUTPUT_DIR="${XDG_CACHE}/agent-ways/user"
 OUTPUT_FILE="${OUTPUT_DIR}/mmaid"
 
 # Parse args


### PR DESCRIPTION
Closes the deferred cache-name flips now that the downloaders write `agent-ways`:
- `tools/mmaid/download-mmaid.sh` installed mmaid to `claude-ways/user` → now `agent-ways/user` (diagrams.md refs flip in lockstep).
- `diagrams.md` (mmaid cache paths, 17/22/38), `README.md` (way-embed example, 182-183), `docs/hooks-and-ways.md` (model/corpus, 202-203).

All now match the ways binary's `cache_root` and the fixed download scripts (#222/#223). Completes fix-C-DOCS + the mmaid slice of #10. `bash -n` clean; grep confirms no residual `claude-ways` in the touched files. Trivial mechanical rename.