### PR TITLE
fix(ways): embedding-unavailable errors point at the app dir, not ~/.claude

### DIFF
--- a/tools/ways-cli/src/cmd/corpus.rs
+++ b/tools/ways-cli/src/cmd/corpus.rs
@@ -472,7 +472,10 @@ fn auto_embed(out_dir: &Path, engine_dir: &Path, corpus: &Path, log: &dyn Fn(&st
     let bin = match embed_bin {
         Some(b) => b,
         None => {
-            log("ERROR: embedding engine required (ADR-125). Run: cd ~/.claude && make setup");
+            log(&format!(
+                "ERROR: embedding engine required (ADR-125). Run: cd {} && make setup",
+                crate::paths::data_root().display()
+            ));
             return Ok(());
         }
     };

--- a/tools/ways-cli/src/cmd/match_cmd.rs
+++ b/tools/ways-cli/src/cmd/match_cmd.rs
@@ -21,7 +21,10 @@ pub fn run(query: String, _corpus: Option<String>) -> Result<()> {
 
     if !scores.any_ran() {
         eprintln!("ERROR: embedding engine unavailable.");
-        eprintln!("       Run: cd ~/.claude && make setup");
+        eprintln!(
+            "       Run: cd {} && make setup",
+            crate::paths::data_root().display()
+        );
         std::process::exit(1);
     }
 


### PR DESCRIPTION
`match_cmd.rs` and `corpus.rs` printed `Run: cd ~/.claude && make setup` on embedding-unavailable — broken under the projection (no Makefile in `~/.claude`). These fire for any topology, so they now use `crate::paths::data_root()` (`$XDG_DATA_HOME/agent-ways`), matching the A3 check-setup fix.

`metrics.rs`'s update nudges are intentionally left: they fire only for `check-config-updates.sh`'s legacy detections (in-place clone / subdirectory) where `~/.claude` genuinely is the repo — a native-projection nudge is task #7. Part of #10; `cargo build -p ways` clean.