### PR TITLE
docs(adr-146): Draft → Accepted (implemented + validated on cube)

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -66,7 +66,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-143](./system/ADR-143-three-root-way-runtime-core-user-project.md) | Three-root way runtime — core, user, project | Accepted |
 | [ADR-144](./system/ADR-144-install-repair-migrate-as-one-manifest-reconciler.md) | Install / repair / migrate as one manifest reconciler | Accepted |
 | [ADR-145](./system/ADR-145-explicit-three-source-convergence-manifest.md) | Explicit three-source convergence manifest | Draft |
-| [ADR-146](./system/ADR-146-installer-binary-verification-and-guided-build-fallback.md) | installer binary verification and guided build fallback | Draft |
+| [ADR-146](./system/ADR-146-installer-binary-verification-and-guided-build-fallback.md) | installer binary verification and guided build fallback | Accepted |
 
 ## Documentation
 _Documentation structure, tooling, coherence_

--- a/docs/architecture/system/ADR-146-installer-binary-verification-and-guided-build-fallback.md
+++ b/docs/architecture/system/ADR-146-installer-binary-verification-and-guided-build-fallback.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-06-30
 deciders:
   - aaronsb


### PR DESCRIPTION
ADR-146 is implemented — `make deps` (#224) + launch-verify & recovery card (#225) — and validated end-to-end on cube: a forced no-prebuilt + no-cmake state triggered the recovery card (agent handoff + paste-ready prompt + backstop commands, pointing at `docs/finish-install.md`), install exits 0. Flipping status to Accepted. `adr lint` clean; index regenerated.