### PR TITLE
fix(config): canonicalize user config to $XDG_CONFIG/agent-ways/config.yaml (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ For the complete system guide — trigger flow, state machines, the pipeline fro
 
 ## Configuration
 
-User config lives in `$XDG_CONFIG_HOME/ways/config.yaml` (YAML). For example, to disable whole domains:
+User config lives in `$XDG_CONFIG_HOME/agent-ways/config.yaml` (YAML). For example, to disable whole domains:
 
 ```yaml
 disabled_domains:

--- a/docs/hooks-and-ways.md
+++ b/docs/hooks-and-ways.md
@@ -449,7 +449,7 @@ flowchart TD
 
 ## Domain Enable/Disable
 
-`$XDG_CONFIG_HOME/ways/config.yaml` controls which domains are active (a legacy `~/.claude/ways.json` with `{"disabled": [...]}` is still honored):
+`$XDG_CONFIG_HOME/agent-ways/config.yaml` controls which domains are active (a legacy `$XDG_CONFIG_HOME/ways/config.yaml`, and `~/.claude/ways.json` with `{"disabled": [...]}`, are still honored):
 
 ```yaml
 disabled_domains:

--- a/docs/hooks-and-ways/extending.md
+++ b/docs/hooks-and-ways/extending.md
@@ -138,7 +138,7 @@ ways:
 
 ### Disabling an entire domain (global)
 
-Add the domain to `disabled_domains` in `$XDG_CONFIG_HOME/ways/config.yaml`:
+Add the domain to `disabled_domains` in `$XDG_CONFIG_HOME/agent-ways/config.yaml`:
 
 ```yaml
 disabled_domains:

--- a/docs/hooks-and-ways/languages.md
+++ b/docs/hooks-and-ways/languages.md
@@ -24,7 +24,7 @@ There are **two** different language settings; conflating them is the common mis
 
 | Config | Controls | Set by |
 |--------|----------|--------|
-| `language` in `~/.config/ways/config.yaml` (overrides `output_language` in `~/.claude/ways.json`) | the **ways** intl mode + the output-language directive | `ways-localize` |
+| `language` in `~/.config/agent-ways/config.yaml` (overrides `output_language` in `~/.claude/ways.json`) | the **ways** intl mode + the output-language directive | `ways-localize` |
 | `language` in Claude Code `settings.json` (a NAME, e.g. `"spanish"`) | Claude Code's **response** language | the operator (or `ways-localize`) |
 
 `ways.json output_language` (Layer 1) is **overridden** by `config.yaml language`

--- a/docs/hooks-and-ways/matching.md
+++ b/docs/hooks-and-ways/matching.md
@@ -116,7 +116,7 @@ sequenceDiagram
 
 2. **Parent-boost.** Before comparing a candidate way's score to its threshold, the matcher checks the way's ancestor chain for any fired marker. If found, the effective threshold is `base_threshold * parent_threshold_multiplier` (default 0.8). Children within an active parent domain fire on weaker signal; children in cold domains need to clear the full bar.
 
-Configure via `~/.config/ways/config.yaml`:
+Configure via `~/.config/agent-ways/config.yaml`:
 ```yaml
 parent_threshold_multiplier: 0.8   # 1.0 disables the boost
 default_embed_threshold: 0.35      # English base for nodes without explicit override

--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -79,7 +79,7 @@ Pre-1.0, the way to keep an existing `~/.claude` untouched was the **subdirector
 1. **Restart Claude Code** — ways activate on session start.
 2. **Check engine status** — `ways status` shows binary, model, corpus, and project detection.
 3. **Read the ways** — browse `~/.claude/hooks/ways/` (a projected symlink into the app) to see the loaded guidance.
-4. **Config** — user config lives in `$XDG_CONFIG_HOME/ways/config.yaml` (a legacy `~/.claude/ways.json` is still honored). It controls which domains are active.
+4. **Config** — user config lives in `$XDG_CONFIG_HOME/agent-ways/config.yaml` (a legacy `$XDG_CONFIG_HOME/ways/config.yaml` and `~/.claude/ways.json` are still honored). It controls which domains are active.
 
 ## What gets downloaded
 

--- a/hooks/ways/meta/knowledge/knowledge.md
+++ b/hooks/ways/meta/knowledge/knowledge.md
@@ -49,7 +49,7 @@ Three way roots (ADR-143) — don't confuse *reading* one with *authoring* in it
   lost. Change these in a dev checkout and reproject (see `docs/development.md`).
 - **Your own ways (user scope, survives updates):** `$XDG_CONFIG_HOME/agent-ways/ways/{domain}/{wayname}/{wayname}.md`
 - **Project ways:** `$PROJECT/.claude/ways/{domain}/{wayname}/{wayname}.md` — override global ways at the same path
-- Disable domains: `$XDG_CONFIG_HOME/ways/config.yaml` → `disabled_domains: [domain]` (legacy `~/.claude/ways.json` → `{"disabled": [...]}` still honored)
+- Disable domains: `$XDG_CONFIG_HOME/agent-ways/config.yaml` → `disabled_domains: [domain]` (legacy `$XDG_CONFIG_HOME/ways/config.yaml` and `~/.claude/ways.json` → `{"disabled": [...]}` still honored)
 - Ways can nest: `{domain}/{parent}/{child}/{child}.md` for progressive disclosure
 - When a parent way fires, child thresholds are lowered 20% (domain context is established)
 - Tree disclosure metrics are tracked per-session (parent, depth, epoch distance, sibling coverage)

--- a/tools/ways-cli/src/config.rs
+++ b/tools/ways-cli/src/config.rs
@@ -272,9 +272,9 @@ impl Config {
         }
     }
 
-    /// Initialize user config at XDG path.
+    /// Initialize user config at the canonical XDG path.
     pub fn init_user_config() -> PathBuf {
-        let path = xdg_config_dir().join("ways/config.yaml");
+        let path = crate::paths::user_config();
         if path.exists() {
             return path;
         }
@@ -282,7 +282,7 @@ impl Config {
             std::fs::create_dir_all(parent).ok();
         }
         let content = "# ways configuration
-# User scope: $XDG_CONFIG_HOME/ways/config.yaml
+# User scope: $XDG_CONFIG_HOME/agent-ways/config.yaml
 # Project scope: {project}/.claude/ways.yaml (layered on top)
 
 # language: en          # Output language (en, ja, auto)
@@ -301,12 +301,14 @@ impl Config {
         path
     }
 
-    /// Show the config file path.
+    /// Show the config file paths (canonical first, then honored legacy fallbacks).
     pub fn config_path() -> String {
-        let xdg = xdg_config_dir().join("ways/config.yaml");
-        format!("user:    {}\nlegacy:  {}\nproject: $PROJECT/.claude/ways.yaml",
-            xdg.display(),
-            home_dir().join(".claude/ways.json").display())
+        format!(
+            "user:    {}\nlegacy:  {}\nlegacy:  {}\nproject: $PROJECT/.claude/ways.yaml",
+            crate::paths::user_config().display(),
+            xdg_config_dir().join("ways/config.yaml").display(),
+            home_dir().join(".claude/ways.json").display()
+        )
     }
 }
 

--- a/tools/ways-cli/src/config.rs
+++ b/tools/ways-cli/src/config.rs
@@ -2,9 +2,10 @@
 //!
 //! Resolution order (later overrides earlier):
 //!   1. Built-in defaults
-//!   2. ~/.claude/ways.json (legacy, backward compat)
-//!   3. $XDG_CONFIG_HOME/ways/config.yaml (user scope)
-//!   4. $PROJECT/.claude/ways.yaml (project scope)
+//!   2. ~/.claude/ways.json (legacy JSON, pre-1.0 backward compat)
+//!   3. $XDG_CONFIG_HOME/ways/config.yaml (legacy XDG path)
+//!   4. $XDG_CONFIG_HOME/agent-ways/config.yaml (canonical user scope)
+//!   5. $PROJECT/.claude/ways.yaml (project scope)
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -134,13 +135,25 @@ impl Config {
             cfg.apply_ways_json(&content);
         }
 
-        // Layer 2: XDG user config
-        let xdg_config = xdg_config_dir().join("ways/config.yaml");
-        if let Ok(content) = std::fs::read_to_string(&xdg_config) {
+        // Layer 2: legacy XDG user config ($XDG_CONFIG_HOME/ways/config.yaml).
+        // Kept as a fallback for installs written before the app-namespaced path.
+        let legacy_xdg = xdg_config_dir().join("ways/config.yaml");
+        if let Ok(content) = std::fs::read_to_string(&legacy_xdg) {
             cfg.apply_yaml(&content);
         }
 
-        // Layer 3: project overlay — only this layer may populate `disabled_ways`
+        // Layer 3: canonical user config ($XDG_CONFIG_HOME/agent-ways/config.yaml) —
+        // the app-namespaced location, matching user_ways_root's parent. This is the
+        // single source of truth for the path (paths::user_config); it overrides
+        // the legacy `ways/config.yaml` above when both exist.
+        let user_config = crate::paths::user_config();
+        if user_config != legacy_xdg {
+            if let Ok(content) = std::fs::read_to_string(&user_config) {
+                cfg.apply_yaml(&content);
+            }
+        }
+
+        // Layer 4: project overlay — only this layer may populate `disabled_ways`
         // (ADR-131: per-way disable is project-scope only).
         let project_config = Path::new(project_dir).join(".claude/ways.yaml");
         if let Ok(content) = std::fs::read_to_string(&project_config) {


### PR DESCRIPTION
`config.rs` read user config from `$XDG_CONFIG_HOME/ways/config.yaml`, but `paths::user_config()` returned `$XDG_CONFIG_HOME/agent-ways/config.yaml` — **dead code nothing read** (flagged in the #219 review). User *ways* live under `agent-ways/` (`user_ways_root`), so the config file sat under a different parent — a latent trap.

**Fix:** add the canonical layer. Order is now defaults → `~/.claude/ways.json` → `$XDG_CONFIG/ways/config.yaml` (legacy) → **`$XDG_CONFIG/agent-ways/config.yaml`** (canonical, via now-live `paths::user_config()`) → project. Both legacy locations stay honored fallbacks — no existing config breaks. Docs updated in lockstep; immutable ADRs left historical.

## Test plan
- `cargo build -p ways` clean; 15 config unit tests pass.
- `apply_ways_json` (legacy `disabled`) and `apply_yaml` (`disabled_domains`) unchanged; only the file-resolution layer added.