### PR TITLE
fix(update): document force-rebuild recipe for native updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,17 +287,17 @@ For the attention mechanics: [context-decay.md](docs/hooks-and-ways/context-deca
 In 1.0 the app source lives in `$XDG_DATA_HOME/agent-ways` (not `~/.claude`). Update by refreshing that checkout, then rebuilding and reprojecting — or just re-run the installer one-liner, which is idempotent:
 
 ```bash
-cd "$XDG_DATA_HOME/agent-ways" && git pull && make setup && ways reconcile
+cd "$XDG_DATA_HOME/agent-ways" && make update && ways reconcile
 ```
 
-`make setup` rebuilds the binaries and semantic-matching corpus; `ways reconcile` refreshes the `~/.claude` projection. A fork fetches and merges upstream in the app dir first (`git fetch upstream && git merge upstream/main`), then the same `make setup && ways reconcile`.
+`make update` pulls (robustly — it autostashes around machine-local settings drift), **force-rebuilds** the binaries, regenerates the corpus, and relinks; `ways reconcile` then refreshes the `~/.claude` projection. Use `make update`, not `make setup` — `setup` skips binaries that already exist, so on an update it would leave you on the *old* binary. A fork fetches and merges upstream in the app dir first (`git fetch upstream && git merge upstream/main`), then `make update-binaries && ways reconcile` (force-rebuild without re-pulling origin; the corpus self-heals via the `SessionStart` hook).
 
 At session start, `check-config-updates.sh` flags when you're behind upstream (`aaronsb/agent-ways`), rate-limited to once per hour. It currently recognizes **legacy** git-based layouts — an in-place clone at `~/.claude`, and the ADR-140 subdirectory (`.claude-source` marker). Native-projection update detection is being wired (it reads the app source in `$XDG_DATA`); until then, use the manual command above.
 
 | Scenario | How detected | Sync command |
 |----------|-------------|--------------|
-| **Native projection (1.0)** | app source at `$XDG_DATA_HOME/agent-ways` | `cd "$XDG_DATA_HOME/agent-ways" && git pull && make setup && ways reconcile` |
-| **Fork** | GitHub API reports `parent` is `aaronsb/agent-ways` | fetch/merge upstream in the app dir, then `make setup && ways reconcile` |
+| **Native projection (1.0)** | app source at `$XDG_DATA_HOME/agent-ways` | `cd "$XDG_DATA_HOME/agent-ways" && make update && ways reconcile` |
+| **Fork** | GitHub API reports `parent` is `aaronsb/agent-ways` | fetch/merge upstream in the app dir, then `make update-binaries && ways reconcile` |
 | **Legacy in-place clone** | `~/.claude` is itself the git repo | `ways migrate --execute` first (moves it to the projection model) |
 | **Plugin** | `CLAUDE_PLUGIN_ROOT` set with `plugin.json` | `/plugin update disciplined-methodology` |
 

--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -30,8 +30,10 @@ If `~/.claude/` is your **own** git repo (you version-control your config), that
 **A 1.0 projection install** (the app is in `$XDG_DATA_HOME/agent-ways`, `~/.claude` is not a repo) — update in place:
 
 ```bash
-cd "$XDG_DATA_HOME/agent-ways" && git pull && make setup && ways reconcile
+cd "$XDG_DATA_HOME/agent-ways" && make update && ways reconcile
 ```
+
+`make update` pulls, **force-rebuilds** the binaries, regenerates the corpus, and relinks — use it rather than `make setup`, which skips binaries that already exist and would leave you on the old build.
 
 **A legacy pre-1.0 in-place clone** (`~/.claude` *is* the agent-ways git repo — it has its own `.git/` and ships `~/.claude/tools/`, `~/.claude/docs/`) — do **not** `git pull` it. Migrate it to the 1.0 model with the gated, backup-first migrator:
 
@@ -65,7 +67,7 @@ upstream improvements later:
 ```bash
 cd "$XDG_DATA_HOME/agent-ways"
 git fetch upstream && git merge upstream/main   # resolve conflicts in your custom ways
-make setup && ways reconcile                    # ways is on PATH from the install above
+make update-binaries && ways reconcile          # force-rebuild (make setup would skip existing binaries)
 ```
 
 If you're actively *developing* agent-ways (not just carrying a few custom ways), use a standalone dev checkout instead and dogfood via reconcile — see [development.md](development.md).

--- a/skills/ways-update/SKILL.md
+++ b/skills/ways-update/SKILL.md
@@ -108,8 +108,8 @@ fails (`make -C "$APP" ways-rebuild`, `attend-rebuild`, …).
 
 The embedding corpus regenerates lazily on the next session (`ways corpus --if-stale`
 in the `SessionStart` hook). To refresh it now — e.g. ways changed — run
-`make -C "$APP" setup` (binaries are already fresh, so it only rebuilds way-embed and
-regenerates the corpus) or `"$APP/bin/ways" corpus`.
+`make -C "$APP" setup` (binaries already fresh; this regenerates the corpus) or
+`"$APP/bin/ways" corpus`.
 
 ### 4. Refresh the projection
 

--- a/skills/ways-update/SKILL.md
+++ b/skills/ways-update/SKILL.md
@@ -17,9 +17,16 @@ doesn't do.
 ```
 cd "$XDG_DATA_HOME/agent-ways"
 git pull --ff-only        # (or fetch/merge upstream for a fork — see step 2)
-make setup                # rebuild ways/attend/way-embed + regenerate the corpus
+make update-binaries      # FORCE-rebuild ways/attend/way-embed (make setup skips existing binaries)
 ./bin/ways reconcile      # refresh the ~/.claude projection + re-merge settings.json
 ```
+
+The pull is done here (step 1/2), so this uses `make update-binaries` — a force
+rebuild — rather than `make setup`, which short-circuits any binary that already
+exists and would silently leave you on the old build. (The all-in-one `make update`
+bundles pull + rebuild + relink, but this skill does its own guarded pull first.)
+The embedding corpus self-heals on the next session via the `ways corpus --if-stale`
+`SessionStart` hook; regenerate it eagerly with `make -C "$APP" setup` if you want.
 
 Because the projected roots are symlinks into the app dir, a pull is *live* for
 existing files the moment it lands; `ways reconcile` is what catches **structural**
@@ -87,15 +94,22 @@ git -C "$APP" remote get-url upstream >/dev/null 2>&1 \
 git -C "$APP" fetch upstream && git -C "$APP" merge upstream/main   # resolve conflicts in custom ways
 ```
 
-### 3. Rebuild binaries + corpus
+### 3. Force-rebuild the binaries
 
 ```bash
-make -C "$APP" setup
+make -C "$APP" update-binaries
 ```
 
-`make setup` rebuilds the binaries and regenerates the embedding corpus. If it
-fails partway, the sub-targets are re-runnable (`make -C "$APP" update-binaries`,
-`make -C "$APP" ways-rebuild`).
+`make update-binaries` **force-rebuilds** ways/attend/attend-chat/way-embed. Do
+**not** use `make setup` here: `setup` skips any binary that already exists and runs
+(`ways already installed`), so after a pull it would leave the compiled binary
+**stale** — the whole point of the update. Individual targets are re-runnable if one
+fails (`make -C "$APP" ways-rebuild`, `attend-rebuild`, …).
+
+The embedding corpus regenerates lazily on the next session (`ways corpus --if-stale`
+in the `SessionStart` hook). To refresh it now — e.g. ways changed — run
+`make -C "$APP" setup` (binaries are already fresh, so it only rebuilds way-embed and
+regenerates the corpus) or `"$APP/bin/ways" corpus`.
 
 ### 4. Refresh the projection
 

--- a/tools/ways-cli/src/cmd/show/metrics.rs
+++ b/tools/ways-cli/src/cmd/show/metrics.rs
@@ -224,7 +224,8 @@ pub(crate) fn render_update_status(content: &str) -> String {
             let repo = get("repo").unwrap_or_default();
             let repo_disp = if repo.is_empty() { "$XDG_DATA_HOME/agent-ways" } else { &repo };
             out.push_str(&format!("**⚠ agent-ways is {behind} commit(s) behind upstream.** Update the app source and reproject:\n"));
-            out.push_str(&format!("`cd \"{repo_disp}\" && git pull && make setup && ways reconcile`\n"));
+            out.push_str(&format!("`cd \"{repo_disp}\" && make update && ways reconcile`\n"));
+            out.push_str("`make update` pulls, force-rebuilds the binaries, and relinks; `ways reconcile` reprojects. Don't use `git pull && make setup`: `setup` skips existing binaries (leaving them stale) and a bare `git pull` aborts on machine-local settings.json edits.\n");
         }
         "plugin" => {
             let installed = get("installed").unwrap_or_default();


### PR DESCRIPTION
## Summary

Fixes #13 — the documented native-update recipe left users on a **stale binary**. `make setup` short-circuits any binary that already exists and runs (`ways already installed`), so `git pull && make setup && ways reconcile` pulled new source but never rebuilt the compiled binary. (Confirmed live during a machine update: `make setup` printed *"ways already installed"* / *"attend already built"* and skipped the rebuild.)

The infrastructure already existed — `make update` (pull + `update-binaries` force-rebuild + relink + corpus regen) and `make update-binaries` (force-rebuild standalone). The docs just pointed at the wrong verb.

## Surgical, not a blanket swap
Only genuine **update** recipes change. The many `make setup` references in **acquire/repair** contexts are correct and left alone — fresh install, missing/broken-engine repair (`make setup` rebuilds a binary that doesn't run, and downloads a prebuilt when absent, whereas `update-binaries` forces a source build needing cargo), `finish-install`, the deployment way (already uses `make update`).

## The recipes
- **Direct install:** `make update && ways reconcile` (robust pull that autostashes around machine-local settings.json drift, force-rebuild, corpus regen, then reproject).
- **Fork / surfaces that already pull** (the `ways-update` skill does its own guarded pull): `make update-binaries` + `ways reconcile`. The corpus self-heals on the next session via the `ways corpus --if-stale` `SessionStart` hook.

## Surfaces changed
- `README.md` — update section + the sync-command table (native + fork rows)
- `docs/install-guide.md` — 1.0 update + fork update
- `skills/ways-update/SKILL.md` — the flow block + step 3 (was already naming `update-binaries` as a fallback; now it's the primary)
- `tools/ways-cli/src/cmd/show/metrics.rs` — the `native` branch, matched to the `clone`/`fork` branches that *already* used `make update` / `make update-binaries`

## Test plan
- `cargo build` + `cargo test metrics` green
- Verified no stale `make setup` remains in the update recipes (only intentional "use `make update`, not `make setup`" explanatory prose)