### PR TITLE
docs(adr-147): mark Accepted

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -67,7 +67,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-144](./system/ADR-144-install-repair-migrate-as-one-manifest-reconciler.md) | Install / repair / migrate as one manifest reconciler | Accepted |
 | [ADR-145](./system/ADR-145-explicit-three-source-convergence-manifest.md) | Explicit three-source convergence manifest | Draft |
 | [ADR-146](./system/ADR-146-installer-binary-verification-and-guided-build-fallback.md) | installer binary verification and guided build fallback | Accepted |
-| [ADR-147](./system/ADR-147-composable-settings-json-config-fragments.md) | Composable settings.json — a store of YAML config fragments | Draft |
+| [ADR-147](./system/ADR-147-composable-settings-json-config-fragments.md) | Composable settings.json — a store of YAML config fragments | Accepted |
 | [ADR-148](./system/ADR-148-framework-surface-ships-operator-content-dev-harness-in-project-scope.md) | framework surface ships operator content; dev harness in project scope | Draft |
 
 ## Documentation

--- a/docs/architecture/system/ADR-147-composable-settings-json-config-fragments.md
+++ b/docs/architecture/system/ADR-147-composable-settings-json-config-fragments.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-07-01
 deciders:
   - aaronsb


### PR DESCRIPTION
## Summary
- Flips ADR-147 status Draft → Accepted (+ INDEX regen). This was missed from #237 — the Managed-scope interop edit landed, but the accept flip was never committed.
- ADR-147 is accepted; config-linter implementation begins on a follow-up branch.

## Test plan
- `docs/scripts/adr lint --check` → 0 errors.