### PR TITLE
feat(settings): ways settings compile — merge engine + baked output (ADR-147 slice 3)

### DIFF
--- a/tools/ways-cli/src/cmd/settings/compile.rs
+++ b/tools/ways-cli/src/cmd/settings/compile.rs
@@ -1,0 +1,193 @@
+//! Compile a fragment store into baked `settings.json` (ADR-147).
+//!
+//! Each scope's fragments are deep-merged in filename order into one baked
+//! object, following Claude Code's documented merge law. The law is small — a
+//! path-keyed strategy, not a merge engine:
+//!
+//! - **objects deep-merge** (recurse key by key);
+//! - the documented **concat** paths (`permissions.allow/deny/ask`,
+//!   `deniedMcpServers`) union their arrays with de-duplication;
+//! - **everything else overrides** — the last fragment in filename order wins,
+//!   which is exactly the case the duplicate-scalar lint warns about.
+//!
+//! Merging also yields a **provenance** map (`dotted path → contributing
+//! fragment(s)`): the effective (last) source for an overridden key, every
+//! contributor for a concatenated list. That is both `git blame`-for-config and
+//! the future reconciler's merge base.
+
+use super::fragment::Fragment;
+use serde_json::{Map, Value};
+use std::collections::BTreeMap;
+
+/// `dotted path → fragment file name(s)` that produced the effective value.
+pub type Provenance = BTreeMap<String, Vec<String>>;
+
+/// The documented concat-and-dedupe paths. Everything else overrides (objects
+/// deep-merge). Kept explicit and minimal; extend as Claude Code's edge cases
+/// surface (see ADR-147 Q3 — the merge law is a spec to mirror, not invent).
+fn is_concat(path: &str) -> bool {
+    matches!(
+        path,
+        "permissions.allow" | "permissions.deny" | "permissions.ask" | "deniedMcpServers"
+    )
+}
+
+/// Deep-merge a scope's fragments (already filename-ordered) into one baked
+/// settings object, plus the provenance of every leaf.
+pub fn merge_scope(frags: &[&Fragment]) -> (Value, Provenance) {
+    let mut acc = Value::Object(Map::new());
+    let mut prov = Provenance::new();
+    for frag in frags {
+        let name = frag
+            .path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("<fragment>")
+            .to_string();
+        if let Some(obj) = frag.settings.as_object() {
+            merge_object(&mut acc, obj, "", &name, &mut prov);
+        }
+    }
+    (acc, prov)
+}
+
+/// Merge `incoming` into `acc` (both objects) at `prefix`, recording provenance.
+fn merge_object(
+    acc: &mut Value,
+    incoming: &Map<String, Value>,
+    prefix: &str,
+    frag: &str,
+    prov: &mut Provenance,
+) {
+    let acc_obj = acc.as_object_mut().expect("merge target must be an object");
+    for (key, val) in incoming {
+        let path = if prefix.is_empty() {
+            key.clone()
+        } else {
+            format!("{prefix}.{key}")
+        };
+
+        if is_concat(&path) && val.is_array() {
+            // Concat + dedupe (order-preserving) into the accumulated array.
+            let entry = acc_obj
+                .entry(key.clone())
+                .or_insert_with(|| Value::Array(Vec::new()));
+            if let Some(arr) = entry.as_array_mut() {
+                for item in val.as_array().expect("checked is_array") {
+                    if !arr.contains(item) {
+                        arr.push(item.clone());
+                    }
+                }
+            } else {
+                *entry = val.clone(); // prior value wasn't an array — replace
+            }
+            prov.entry(path).or_default().push(frag.to_string());
+        } else if val.is_object() {
+            // Deep-merge: ensure the slot is an object, then recurse.
+            let entry = acc_obj
+                .entry(key.clone())
+                .or_insert_with(|| Value::Object(Map::new()));
+            if !entry.is_object() {
+                *entry = Value::Object(Map::new());
+            }
+            merge_object(entry, val.as_object().expect("checked is_object"), &path, frag, prov);
+        } else {
+            // Override — last fragment wins; provenance is the effective source.
+            acc_obj.insert(key.clone(), val.clone());
+            prov.insert(path, vec![frag.to_string()]);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::fragment::Scope;
+    use super::*;
+    use serde_json::json;
+    use std::path::PathBuf;
+
+    fn frag(name: &str, settings: Value) -> Fragment {
+        Fragment {
+            path: PathBuf::from(name),
+            order_prefix: None,
+            scope: Scope::User,
+            mandatory: false,
+            settings,
+            body: String::new(),
+        }
+    }
+
+    fn merge(frags: &[Fragment]) -> (Value, Provenance) {
+        let refs: Vec<&Fragment> = frags.iter().collect();
+        merge_scope(&refs)
+    }
+
+    #[test]
+    fn scalar_override_last_wins() {
+        let (baked, prov) = merge(&[
+            frag("10-a.md", json!({ "model": "sonnet" })),
+            frag("20-b.md", json!({ "model": "opus" })),
+        ]);
+        assert_eq!(baked["model"], json!("opus"));
+        assert_eq!(prov["model"], vec!["20-b.md"]);
+    }
+
+    #[test]
+    fn permission_lists_concat_and_dedupe() {
+        let (baked, prov) = merge(&[
+            frag("10-a.md", json!({ "permissions": { "allow": ["Bash(git:*)", "Bash(gh:*)"] } })),
+            frag("20-b.md", json!({ "permissions": { "allow": ["Bash(gh:*)", "Bash(ls:*)"] } })),
+        ]);
+        assert_eq!(
+            baked["permissions"]["allow"],
+            json!(["Bash(git:*)", "Bash(gh:*)", "Bash(ls:*)"]),
+            "union, de-duplicated, order-preserving"
+        );
+        assert_eq!(prov["permissions.allow"], vec!["10-a.md", "20-b.md"]);
+    }
+
+    #[test]
+    fn objects_deep_merge_union_and_leaf_override() {
+        let (baked, _) = merge(&[
+            frag("10-a.md", json!({ "env": { "X": "1", "Y": "keep" } })),
+            frag("20-b.md", json!({ "env": { "Y": "override", "Z": "2" } })),
+        ]);
+        assert_eq!(baked["env"], json!({ "X": "1", "Y": "override", "Z": "2" }));
+    }
+
+    #[test]
+    fn nested_object_mixes_concat_and_override_in_one_merge() {
+        // permissions.allow concatenates while permissions.defaultMode overrides,
+        // in the same deep-merge of the `permissions` object.
+        let (baked, prov) = merge(&[
+            frag("10-a.md", json!({ "permissions": { "allow": ["a"], "defaultMode": "acceptEdits" } })),
+            frag("20-b.md", json!({ "permissions": { "allow": ["b"], "defaultMode": "plan" } })),
+        ]);
+        assert_eq!(baked["permissions"]["allow"], json!(["a", "b"]));
+        assert_eq!(baked["permissions"]["defaultMode"], json!("plan"));
+        assert_eq!(prov["permissions.defaultMode"], vec!["20-b.md"]);
+        assert_eq!(prov["permissions.allow"], vec!["10-a.md", "20-b.md"]);
+    }
+
+    #[test]
+    fn plain_arrays_override_not_concat() {
+        // A non-permission array (availableModels) overrides — most arrays do.
+        let (baked, _) = merge(&[
+            frag("10-a.md", json!({ "availableModels": ["opus"] })),
+            frag("20-b.md", json!({ "availableModels": ["sonnet", "haiku"] })),
+        ]);
+        assert_eq!(baked["availableModels"], json!(["sonnet", "haiku"]));
+    }
+
+    #[test]
+    fn single_fragment_passes_through_with_provenance() {
+        let (baked, prov) = merge(&[frag(
+            "10-a.md",
+            json!({ "model": "opus", "permissions": { "allow": ["x"] } }),
+        )]);
+        assert_eq!(baked["model"], json!("opus"));
+        assert_eq!(baked["permissions"]["allow"], json!(["x"]));
+        assert_eq!(prov["model"], vec!["10-a.md"]);
+        assert_eq!(prov["permissions.allow"], vec!["10-a.md"]);
+    }
+}

--- a/tools/ways-cli/src/cmd/settings/compile.rs
+++ b/tools/ways-cli/src/cmd/settings/compile.rs
@@ -15,12 +15,97 @@
 //! contributor for a concatenated list. That is both `git blame`-for-config and
 //! the future reconciler's merge base.
 
-use super::fragment::Fragment;
+use super::fragment::{load_dir, Fragment, Scope};
+use super::{lint, schema_doc};
+use anyhow::{bail, Context, Result};
 use serde_json::{Map, Value};
 use std::collections::BTreeMap;
+use std::path::Path;
 
 /// `dotted path → fragment file name(s)` that produced the effective value.
 pub type Provenance = BTreeMap<String, Vec<String>>;
+
+/// Compile a store: lint-gate, then merge each scope into a baked settings
+/// object + provenance. Returns `true` if the lint gate failed (caller exits
+/// non-zero). With `out`, writes `<scope>.settings.json` + `provenance.json`;
+/// otherwise prints a single scope's baked blob to stdout.
+pub fn run(store: &Path, scope_filter: Option<Scope>, out: Option<&Path>) -> Result<bool> {
+    let frags = load_dir(store)?;
+
+    // Lint gate — refuse to bake a store with errors (warnings are fine).
+    let findings = lint::check(&frags, schema_doc::active());
+    let errors: Vec<_> = findings
+        .iter()
+        .filter(|f| f.severity == lint::Severity::Error)
+        .collect();
+    if !errors.is_empty() {
+        eprintln!(
+            "compile refused: {} lint error(s) — fix first (`ways settings lint {}`):",
+            errors.len(),
+            store.display()
+        );
+        for e in &errors {
+            eprintln!("  {}: {}", e.file, e.message);
+        }
+        return Ok(true);
+    }
+
+    // Merge each scope present (or the requested one), in filename order.
+    let mut baked: BTreeMap<&str, Value> = BTreeMap::new();
+    let mut provenance: BTreeMap<&str, Provenance> = BTreeMap::new();
+    for scope in [Scope::User, Scope::Project, Scope::Managed] {
+        if scope_filter.is_some_and(|f| f != scope) {
+            continue;
+        }
+        let scoped: Vec<&Fragment> = frags.iter().filter(|fr| fr.scope == scope).collect();
+        if scoped.is_empty() {
+            continue;
+        }
+        let (obj, prov) = merge_scope(&scoped);
+        baked.insert(scope.as_str(), obj);
+        provenance.insert(scope.as_str(), prov);
+    }
+
+    if baked.is_empty() {
+        bail!(
+            "no fragments to compile in {}{}",
+            store.display(),
+            scope_filter
+                .map(|s| format!(" at {} scope", s.as_str()))
+                .unwrap_or_default()
+        );
+    }
+
+    match out {
+        Some(dir) => {
+            std::fs::create_dir_all(dir)
+                .with_context(|| format!("creating {}", dir.display()))?;
+            for (scope, obj) in &baked {
+                let path = dir.join(format!("{scope}.settings.json"));
+                std::fs::write(&path, format!("{}\n", serde_json::to_string_pretty(obj)?))
+                    .with_context(|| format!("writing {}", path.display()))?;
+                println!("Wrote {}", path.display());
+            }
+            let prov_path = dir.join("provenance.json");
+            std::fs::write(
+                &prov_path,
+                format!("{}\n", serde_json::to_string_pretty(&provenance)?),
+            )?;
+            println!("Wrote {}", prov_path.display());
+        }
+        None => {
+            if baked.len() > 1 {
+                bail!(
+                    "store has multiple scopes ({}); pass --scope or --out",
+                    baked.keys().copied().collect::<Vec<_>>().join(", ")
+                );
+            }
+            let obj = baked.values().next().expect("non-empty");
+            println!("{}", serde_json::to_string_pretty(obj)?);
+        }
+    }
+    Ok(false)
+}
 
 /// The documented concat-and-dedupe paths. Everything else overrides (objects
 /// deep-merge). Kept explicit and minimal; extend as Claude Code's edge cases

--- a/tools/ways-cli/src/cmd/settings/compile.rs
+++ b/tools/ways-cli/src/cmd/settings/compile.rs
@@ -34,11 +34,11 @@ pub fn run(store: &Path, scope_filter: Option<Scope>, out: Option<&Path>) -> Res
 
     // Lint gate — refuse to bake a store with errors (warnings are fine).
     let findings = lint::check(&frags, schema_doc::active());
-    let errors: Vec<_> = findings
-        .iter()
-        .filter(|f| f.severity == lint::Severity::Error)
-        .collect();
-    if !errors.is_empty() {
+    if lint::has_errors(&findings) {
+        let errors: Vec<_> = findings
+            .iter()
+            .filter(|f| f.severity == lint::Severity::Error)
+            .collect();
         eprintln!(
             "compile refused: {} lint error(s) — fix first (`ways settings lint {}`):",
             errors.len(),
@@ -109,12 +109,28 @@ pub fn run(store: &Path, scope_filter: Option<Scope>, out: Option<&Path>) -> Res
 
 /// The documented concat-and-dedupe paths. Everything else overrides (objects
 /// deep-merge). Kept explicit and minimal; extend as Claude Code's edge cases
-/// surface (see ADR-147 Q3 — the merge law is a spec to mirror, not invent).
-fn is_concat(path: &str) -> bool {
+/// surface (ADR-147 Q3 — the merge law is a spec to mirror, not invent).
+///
+/// This is the **single source of the concat law**: the linter's duplicate-scalar
+/// check consults it too (a repeat of a non-concat list is lossy under override
+/// and must be warned), so the two components cannot diverge.
+pub fn is_concat_path(path: &str) -> bool {
     matches!(
         path,
-        "permissions.allow" | "permissions.deny" | "permissions.ask" | "deniedMcpServers"
+        "permissions.allow"
+            | "permissions.deny"
+            | "permissions.ask"
+            | "permissions.additionalDirectories"
+            | "allowedMcpServers"
+            | "deniedMcpServers"
     )
+}
+
+/// Drop provenance for `path` and everything nested under it — used when a value
+/// is replaced by a differently-shaped one, so stale leaf entries don't linger.
+fn prune_provenance(prov: &mut Provenance, path: &str) {
+    let prefix = format!("{path}.");
+    prov.retain(|k, _| k != path && !k.starts_with(&prefix));
 }
 
 /// Deep-merge a scope's fragments (already filename-ordered) into one baked
@@ -152,21 +168,30 @@ fn merge_object(
             format!("{prefix}.{key}")
         };
 
-        if is_concat(&path) && val.is_array() {
-            // Concat + dedupe (order-preserving) into the accumulated array.
+        if is_concat_path(&path) && val.is_array() {
             let entry = acc_obj
                 .entry(key.clone())
                 .or_insert_with(|| Value::Array(Vec::new()));
             if let Some(arr) = entry.as_array_mut() {
+                // Concat + dedupe (order-preserving). Credit this fragment only if
+                // it actually contributed a new entry (net-zero adds don't count).
+                let mut added = false;
                 for item in val.as_array().expect("checked is_array") {
                     if !arr.contains(item) {
                         arr.push(item.clone());
+                        added = true;
                     }
                 }
+                if added {
+                    prov.entry(path).or_default().push(frag.to_string());
+                }
             } else {
-                *entry = val.clone(); // prior value wasn't an array — replace
+                // Prior value wasn't an array (shape change) — replace, and reset
+                // provenance (the discarded value's source no longer applies).
+                *entry = val.clone();
+                prune_provenance(prov, &path);
+                prov.insert(path, vec![frag.to_string()]);
             }
-            prov.entry(path).or_default().push(frag.to_string());
         } else if val.is_object() {
             // Deep-merge: ensure the slot is an object, then recurse.
             let entry = acc_obj
@@ -174,10 +199,13 @@ fn merge_object(
                 .or_insert_with(|| Value::Object(Map::new()));
             if !entry.is_object() {
                 *entry = Value::Object(Map::new());
+                prune_provenance(prov, &path); // was a leaf, now an object
             }
             merge_object(entry, val.as_object().expect("checked is_object"), &path, frag, prov);
         } else {
             // Override — last fragment wins; provenance is the effective source.
+            // Prune any stale nested entries if we're replacing an object.
+            prune_provenance(prov, &path);
             acc_obj.insert(key.clone(), val.clone());
             prov.insert(path, vec![frag.to_string()]);
         }
@@ -252,6 +280,30 @@ mod tests {
         assert_eq!(baked["permissions"]["defaultMode"], json!("plan"));
         assert_eq!(prov["permissions.defaultMode"], vec!["20-b.md"]);
         assert_eq!(prov["permissions.allow"], vec!["10-a.md", "20-b.md"]);
+    }
+
+    #[test]
+    fn additional_directories_concatenate() {
+        // Regression (PR #242 review H1): permissions.additionalDirectories merges
+        // in CC, so it must concat — not silently drop an entry.
+        let (baked, _) = merge(&[
+            frag("10-a.md", json!({ "permissions": { "additionalDirectories": ["/a"] } })),
+            frag("20-b.md", json!({ "permissions": { "additionalDirectories": ["/b"] } })),
+        ]);
+        assert_eq!(baked["permissions"]["additionalDirectories"], json!(["/a", "/b"]));
+    }
+
+    #[test]
+    fn provenance_is_pruned_on_shape_change() {
+        // Regression (review M1): a later fragment replacing an object with a
+        // scalar must drop the stale nested-leaf provenance.
+        let (baked, prov) = merge(&[
+            frag("10-a.md", json!({ "env": { "A": "1" } })),
+            frag("20-b.md", json!({ "env": "off" })),
+        ]);
+        assert_eq!(baked["env"], json!("off"));
+        assert!(prov.get("env.A").is_none(), "stale nested provenance must be pruned");
+        assert_eq!(prov["env"], vec!["20-b.md"]);
     }
 
     #[test]

--- a/tools/ways-cli/src/cmd/settings/lint.rs
+++ b/tools/ways-cli/src/cmd/settings/lint.rs
@@ -132,7 +132,13 @@ pub fn check(frags: &[Fragment], schema: Option<&schema_doc::SettingsSchema>) ->
     for frag in frags {
         let Some(obj) = frag.settings.as_object() else { continue };
         for (key, value) in obj {
-            if !is_scalar(value) {
+            // A repeat is lossy exactly when compile would *override* it: scalars,
+            // and arrays that aren't concat paths. Objects deep-merge and concat
+            // lists union — those are not lossy, so they aren't flagged. The
+            // concat law is shared with compile so the two can't disagree.
+            let lossy = is_scalar(value)
+                || (value.is_array() && !super::compile::is_concat_path(key));
+            if !lossy {
                 continue;
             }
             let slot = (frag.scope, key.as_str());
@@ -144,8 +150,8 @@ pub fn check(frags: &[Fragment], schema: Option<&schema_doc::SettingsSchema>) ->
                     file: frag.path.display().to_string(),
                     key: key.clone(),
                     message: format!(
-                        "scalar `{key}` is also set in {prev} at {} scope — last \
-                         wins by filename order, the earlier value is dropped",
+                        "`{key}` is also set in {prev} at {} scope — last wins by \
+                         filename order, the earlier value is dropped",
                         frag.scope.as_str()
                     ),
                 });
@@ -220,7 +226,13 @@ pub fn run(dir: &Path, json: bool) -> Result<bool> {
     let frags = super::fragment::load_dir(dir)?;
     let findings = check(&frags, schema_doc::active());
     report(&findings, json);
-    Ok(findings.iter().any(|f| f.severity == Severity::Error))
+    Ok(has_errors(&findings))
+}
+
+/// Whether any finding is an error — the shared "should this gate fail?" predicate
+/// (used by lint's own exit code and by `compile`'s lint gate).
+pub fn has_errors(findings: &[Finding]) -> bool {
+    findings.iter().any(|f| f.severity == Severity::Error)
 }
 
 #[cfg(test)]
@@ -370,12 +382,22 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_ignores_objects_and_arrays() {
-        // permissions (object) and an array key set twice — deep-merge/concat,
-        // not lossy, so no duplicate finding.
-        let a = frag("10.md", Scope::User, json!({ "permissions": { "allow": ["a"] }, "enabledMcpjsonServers": ["x"] }));
-        let b = frag("20.md", Scope::User, json!({ "permissions": { "allow": ["b"] }, "enabledMcpjsonServers": ["y"] }));
+    fn duplicate_ignores_objects_and_concat_arrays() {
+        // permissions (object, deep-merges) and deniedMcpServers (a concat path,
+        // unions) set twice are not lossy, so no duplicate finding.
+        let a = frag("10.md", Scope::User, json!({ "permissions": { "allow": ["a"] }, "deniedMcpServers": ["x"] }));
+        let b = frag("20.md", Scope::User, json!({ "permissions": { "allow": ["b"] }, "deniedMcpServers": ["y"] }));
         assert!(of(&checked(&[a, b]), "duplicate").is_empty());
+    }
+
+    #[test]
+    fn duplicate_warns_on_overriding_array() {
+        // A non-concat array (enabledMcpjsonServers) set twice IS lossy — compile
+        // overrides it (last wins), so lint must warn. Closes the lint/compile
+        // divergence (PR #242 review H2).
+        let a = frag("10.md", Scope::User, json!({ "enabledMcpjsonServers": ["x"] }));
+        let b = frag("20.md", Scope::User, json!({ "enabledMcpjsonServers": ["y"] }));
+        assert_eq!(of(&checked(&[a, b]), "duplicate").len(), 1);
     }
 
     #[test]

--- a/tools/ways-cli/src/cmd/settings/mod.rs
+++ b/tools/ways-cli/src/cmd/settings/mod.rs
@@ -12,9 +12,6 @@
 //! This module is the *authoring* side that produces it. Distinct, too, from
 //! `crate::config`, the ways runtime config behind `ways config`.
 
-// Wired into the CLI in the `ways settings compile` slice; the merge engine
-// lands ahead of its orchestration/command callers.
-#[allow(dead_code)]
 pub mod compile;
 pub mod fragment;
 pub mod lint;

--- a/tools/ways-cli/src/cmd/settings/mod.rs
+++ b/tools/ways-cli/src/cmd/settings/mod.rs
@@ -12,6 +12,10 @@
 //! This module is the *authoring* side that produces it. Distinct, too, from
 //! `crate::config`, the ways runtime config behind `ways config`.
 
+// Wired into the CLI in the `ways settings compile` slice; the merge engine
+// lands ahead of its orchestration/command callers.
+#[allow(dead_code)]
+pub mod compile;
 pub mod fragment;
 pub mod lint;
 pub mod scaffold;

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -609,6 +609,29 @@ enum SettingsCommand {
         #[arg(long)]
         dir: Option<PathBuf>,
     },
+    /// Compile a fragment store into baked settings.json (+ provenance)
+    Compile {
+        /// Store directory (default: $XDG_CONFIG_HOME/agent-ways/settings)
+        path: Option<PathBuf>,
+        /// Only compile this scope
+        #[arg(long)]
+        scope: Option<String>,
+        /// Write <scope>.settings.json + provenance.json here (else print one scope to stdout)
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+}
+
+/// Parse an optional `--scope` string into a settings scope.
+fn parse_settings_scope(scope: Option<String>) -> Result<Option<cmd::settings::fragment::Scope>> {
+    use cmd::settings::fragment::Scope;
+    match scope.as_deref() {
+        None => Ok(None),
+        Some("user") => Ok(Some(Scope::User)),
+        Some("project") => Ok(Some(Scope::Project)),
+        Some("managed") => Ok(Some(Scope::Managed)),
+        Some(other) => anyhow::bail!("invalid --scope `{other}` (want user|project|managed)"),
+    }
 }
 
 fn main() -> Result<()> {
@@ -803,17 +826,18 @@ fn main() -> Result<()> {
                 }
             }
             SettingsCommand::New { key, scope, dir } => {
-                let scope = match scope.as_deref() {
-                    None => None,
-                    Some("user") => Some(cmd::settings::fragment::Scope::User),
-                    Some("project") => Some(cmd::settings::fragment::Scope::Project),
-                    Some("managed") => Some(cmd::settings::fragment::Scope::Managed),
-                    Some(other) => {
-                        anyhow::bail!("invalid --scope `{other}` (want user|project|managed)")
-                    }
-                };
+                let scope = parse_settings_scope(scope)?;
                 let dir = dir.unwrap_or_else(|| paths::config_root().join("settings"));
                 cmd::settings::scaffold::run(&key, scope, &dir)
+            }
+            SettingsCommand::Compile { path, scope, out } => {
+                let scope = parse_settings_scope(scope)?;
+                let dir = path.unwrap_or_else(|| paths::config_root().join("settings"));
+                let had_error = cmd::settings::compile::run(&dir, scope, out.as_deref())?;
+                if had_error {
+                    std::process::exit(1);
+                }
+                Ok(())
             }
         },
     }

--- a/tools/ways-cli/tests/fixtures/settings-store/mergeable/10-perms.md
+++ b/tools/ways-cli/tests/fixtures/settings-store/mergeable/10-perms.md
@@ -1,0 +1,10 @@
+---
+scope: user
+settings:
+  permissions:
+    allow: ["Bash(git:*)"]
+  model: sonnet
+---
+# Base permissions + model
+First fragment: git allowed, model sonnet. The next fragment adds to the allow
+list (concat) and overrides the model (last wins).

--- a/tools/ways-cli/tests/fixtures/settings-store/mergeable/20-more.md
+++ b/tools/ways-cli/tests/fixtures/settings-store/mergeable/20-more.md
@@ -1,0 +1,12 @@
+---
+scope: user
+settings:
+  permissions:
+    allow: ["Bash(gh:*)"]
+  model: opus
+  env:
+    FOO: bar
+---
+# More permissions + overrides
+Adds gh to the allow list (concatenates with 10), overrides model to opus, and
+introduces an env block (deep-merge).

--- a/tools/ways-cli/tests/settings_lint.rs
+++ b/tools/ways-cli/tests/settings_lint.rs
@@ -201,6 +201,59 @@ fn schema_refresh_writes_the_user_copy() {
 }
 
 #[test]
+fn compile_merges_to_out_dir_with_provenance() {
+    let out = tmp_store();
+    let run = ways()
+        .args(["settings", "compile"])
+        .arg(store("mergeable"))
+        .arg("--out")
+        .arg(&out)
+        .output()
+        .unwrap();
+    assert!(run.status.success(), "compile failed: {}", String::from_utf8_lossy(&run.stderr));
+
+    let baked = out.join("user.settings.json");
+    let prov = out.join("provenance.json");
+    assert!(baked.exists() && prov.exists(), "compile must write baked + provenance");
+
+    let s = std::fs::read_to_string(&baked).unwrap();
+    // concat: both allow entries present; override: opus wins; deep-merge: env present.
+    assert!(s.contains("Bash(git:*)") && s.contains("Bash(gh:*)"), "allow concatenated; got:\n{s}");
+    assert!(s.contains("\"opus\""), "model overridden to opus; got:\n{s}");
+    assert!(s.contains("FOO"), "env deep-merged; got:\n{s}");
+
+    let p = std::fs::read_to_string(&prov).unwrap();
+    assert!(p.contains("permissions.allow") && p.contains("20-more.md"), "provenance records sources; got:\n{p}");
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+#[test]
+fn compile_prints_single_scope_to_stdout() {
+    let out = ways()
+        .args(["settings", "compile"])
+        .arg(store("mergeable"))
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let s = String::from_utf8_lossy(&out.stdout);
+    assert!(s.trim_start().starts_with('{'), "expected a JSON object; got:\n{s}");
+    assert!(s.contains("Bash(gh:*)"), "merged content on stdout; got:\n{s}");
+}
+
+#[test]
+fn compile_refuses_a_store_with_lint_errors() {
+    // The dirty fixture has schema/scope errors -> compile must refuse.
+    let out = ways()
+        .args(["settings", "compile"])
+        .arg(store("dirty"))
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "compile must refuse an erroring store");
+    let s = String::from_utf8_lossy(&out.stderr);
+    assert!(s.contains("refused"), "expected a refusal message; got:\n{s}");
+}
+
+#[test]
 fn scaffold_fails_when_schema_absent() {
     let dir = tmp_store();
     let out = Command::new(ways_bin())


### PR DESCRIPTION
## Summary
Third ADR-147 slice: compile a fragment store into baked `settings.json`.

- **Merge engine** (`compile.rs`): `merge_scope()` deep-merges a scope's fragments in filename order per CC's documented law — objects deep-merge, the documented concat paths (`permissions.allow/deny/ask`, `deniedMcpServers`) union+dedupe, everything else overrides (last wins). Yields a **provenance** map (dotted path → contributing fragments). Minimal-correct 3-strategy law (decided); extend as CC edge cases surface.
- **Orchestration**: lint-gates (refuses to bake a store with errors), groups by scope, merges each. `--out <dir>` writes `<scope>.settings.json` + `provenance.json`; else prints a single scope's baked blob to stdout. Managed scope = single pre-merged blob (decided).
- **CLI**: `ways settings compile <store> [--scope] [--out]`.

The baked user blob is what the reconciler will project (next slice); the managed blob is what you paste into the enterprise console.

## Test plan
- `cargo test --manifest-path tools/ways-cli/Cargo.toml` — 231 unit (incl. 6 merge-law conformance) + 13 settings integration (compile: --out+provenance, stdout, lint-gate refusal), clippy clean.
- Pre-existing `session_sim` failures are environment-only (embedding corpus), unchanged.