### PR TITLE
feat(settings): ways settings project — install compiled config into live settings.json (ADR-147)

### DIFF
--- a/tools/ways-cli/src/cmd/settings/compile.rs
+++ b/tools/ways-cli/src/cmd/settings/compile.rs
@@ -25,34 +25,30 @@ use std::path::Path;
 /// `dotted path → fragment file name(s)` that produced the effective value.
 pub type Provenance = BTreeMap<String, Vec<String>>;
 
-/// Compile a store: lint-gate, then merge each scope into a baked settings
-/// object + provenance. Returns `true` if the lint gate failed (caller exits
-/// non-zero). With `out`, writes `<scope>.settings.json` + `provenance.json`;
-/// otherwise prints a single scope's baked blob to stdout.
-pub fn run(store: &Path, scope_filter: Option<Scope>, out: Option<&Path>) -> Result<bool> {
+/// The result of compiling a store: either the lint gate refused, or a baked
+/// object + provenance per scope present.
+pub enum Outcome {
+    /// Lint errors blocked the bake (the error findings, for reporting).
+    Refused(Vec<lint::Finding>),
+    /// One `(scope, baked settings, provenance)` per scope that had fragments.
+    Baked(Vec<(Scope, Value, Provenance)>),
+}
+
+/// Lint-gate a store, then merge each scope into a baked object + provenance.
+/// Pure (no output) — shared by `compile` and `project`.
+pub fn compile_store(store: &Path, scope_filter: Option<Scope>) -> Result<Outcome> {
     let frags = load_dir(store)?;
 
-    // Lint gate — refuse to bake a store with errors (warnings are fine).
     let findings = lint::check(&frags, schema_doc::active());
     if lint::has_errors(&findings) {
-        let errors: Vec<_> = findings
-            .iter()
+        let errors = findings
+            .into_iter()
             .filter(|f| f.severity == lint::Severity::Error)
             .collect();
-        eprintln!(
-            "compile refused: {} lint error(s) — fix first (`ways settings lint {}`):",
-            errors.len(),
-            store.display()
-        );
-        for e in &errors {
-            eprintln!("  {}: {}", e.file, e.message);
-        }
-        return Ok(true);
+        return Ok(Outcome::Refused(errors));
     }
 
-    // Merge each scope present (or the requested one), in filename order.
-    let mut baked: BTreeMap<&str, Value> = BTreeMap::new();
-    let mut provenance: BTreeMap<&str, Provenance> = BTreeMap::new();
+    let mut scopes = Vec::new();
     for scope in [Scope::User, Scope::Project, Scope::Managed] {
         if scope_filter.is_some_and(|f| f != scope) {
             continue;
@@ -62,8 +58,41 @@ pub fn run(store: &Path, scope_filter: Option<Scope>, out: Option<&Path>) -> Res
             continue;
         }
         let (obj, prov) = merge_scope(&scoped);
-        baked.insert(scope.as_str(), obj);
-        provenance.insert(scope.as_str(), prov);
+        scopes.push((scope, obj, prov));
+    }
+    Ok(Outcome::Baked(scopes))
+}
+
+/// Print lint-gate errors to stderr. Shared by `compile`/`project`.
+pub fn report_refusal(store: &Path, errors: &[lint::Finding]) {
+    eprintln!(
+        "refused: {} lint error(s) — fix first (`ways settings lint {}`):",
+        errors.len(),
+        store.display()
+    );
+    for e in errors {
+        eprintln!("  {}: {}", e.file, e.message);
+    }
+}
+
+/// Compile a store: lint-gate, then merge each scope into a baked settings
+/// object + provenance. Returns `true` if the lint gate failed (caller exits
+/// non-zero). With `out`, writes `<scope>.settings.json` + `provenance.json`;
+/// otherwise prints a single scope's baked blob to stdout.
+pub fn run(store: &Path, scope_filter: Option<Scope>, out: Option<&Path>) -> Result<bool> {
+    let scopes = match compile_store(store, scope_filter)? {
+        Outcome::Refused(errors) => {
+            report_refusal(store, &errors);
+            return Ok(true);
+        }
+        Outcome::Baked(scopes) => scopes,
+    };
+
+    let mut baked: BTreeMap<&str, Value> = BTreeMap::new();
+    let mut provenance: BTreeMap<&str, Provenance> = BTreeMap::new();
+    for (scope, obj, prov) in &scopes {
+        baked.insert(scope.as_str(), obj.clone());
+        provenance.insert(scope.as_str(), prov.clone());
     }
 
     if baked.is_empty() {

--- a/tools/ways-cli/src/cmd/settings/mod.rs
+++ b/tools/ways-cli/src/cmd/settings/mod.rs
@@ -15,6 +15,7 @@
 pub mod compile;
 pub mod fragment;
 pub mod lint;
+pub mod project;
 pub mod scaffold;
 pub mod schema;
 pub mod schema_doc;

--- a/tools/ways-cli/src/cmd/settings/project.rs
+++ b/tools/ways-cli/src/cmd/settings/project.rs
@@ -1,0 +1,264 @@
+//! `ways settings project` — install a compiled store into the live
+//! `settings.json` (ADR-147, the pipeline's final stage).
+//!
+//! This is a **second, disjoint writer** alongside the reconciler
+//! ([`crate::cmd::settings_merge`]). The reconciler co-owns `{hooks, ways-perms}`;
+//! `project` owns *the fragment store's keys* (`model`, `env`, `statusLine`, …).
+//! Both preserve keys they don't own, so they coexist — the `kubectl apply`
+//! field-ownership model with two controllers over disjoint fields. `project`
+//! keeps its own last-applied base (`$XDG_STATE/agent-ways/settings-fragments-
+//! <scope>.json`) so it can remove a key it stops setting without disturbing the
+//! user's — or the reconciler's — fields.
+//!
+//! MVP scope: top-level keys only, override + cleanup. `hooks` and `permissions`
+//! are **skipped with a warning** — the reconciler co-owns them, and recursively
+//! co-merging the `permissions` object is deferred. Managed scope is never
+//! auto-written to a system path; it prints the blob for the console.
+
+use super::compile::{self, Outcome};
+use super::fragment::Scope;
+use anyhow::{bail, Context, Result};
+use serde_json::{Map, Value};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// Keys the reconciler co-owns — `project` must not touch them (MVP).
+fn reconciler_owned(key: &str) -> bool {
+    matches!(key, "hooks" | "permissions")
+}
+
+pub fn run(store: &Path, scope_filter: Option<Scope>, dry_run: bool) -> Result<bool> {
+    let scopes = match compile::compile_store(store, scope_filter)? {
+        Outcome::Refused(errors) => {
+            compile::report_refusal(store, &errors);
+            return Ok(true);
+        }
+        Outcome::Baked(scopes) => scopes,
+    };
+    if scopes.is_empty() {
+        bail!("nothing to project in {}", store.display());
+    }
+
+    for (scope, baked, _prov) in scopes {
+        match scope {
+            Scope::User => project_into(scope, &crate::paths::settings_json(), &baked, dry_run)?,
+            Scope::Project => project_into(scope, &project_settings_path(), &baked, dry_run)?,
+            Scope::Managed => {
+                println!("# managed scope — paste into the enterprise console (not auto-written):");
+                println!("{}", serde_json::to_string_pretty(&baked)?);
+            }
+        }
+    }
+    Ok(false)
+}
+
+/// `$CLAUDE_PROJECT_DIR` (or cwd) `/.claude/settings.json`.
+fn project_settings_path() -> PathBuf {
+    let root = std::env::var("CLAUDE_PROJECT_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+    root.join(".claude").join("settings.json")
+}
+
+/// The last-applied base for a scope: `$XDG_STATE/agent-ways/settings-fragments-<scope>.json`.
+fn base_path(scope: Scope) -> PathBuf {
+    crate::paths::state_root().join(format!("settings-fragments-{}.json", scope.as_str()))
+}
+
+fn read_json(path: &Path) -> Result<Value> {
+    match std::fs::read_to_string(path) {
+        Ok(text) => serde_json::from_str(&text)
+            .with_context(|| format!("parsing {}", path.display())),
+        Err(_) => Ok(Value::Object(Map::new())), // absent = empty
+    }
+}
+
+/// Three-way merge the baked object into the live settings for one scope, using
+/// this scope's persisted base.
+fn project_into(scope: Scope, target: &Path, baked: &Value, dry_run: bool) -> Result<()> {
+    project_write(target, baked, dry_run, &base_path(scope), scope.as_str())
+}
+
+/// The merge core, with the base file injected — so tests supply their own base
+/// path rather than mutating the process-global `$XDG_STATE_HOME`.
+fn project_write(
+    target: &Path,
+    baked: &Value,
+    dry_run: bool,
+    base_file: &Path,
+    scope_label: &str,
+) -> Result<()> {
+    let ours = baked.as_object().cloned().unwrap_or_default();
+    let live = read_json(target)?;
+    let base = read_json(base_file)?;
+    let base_obj = base.as_object().cloned().unwrap_or_default();
+
+    let mut result = live.as_object().cloned().unwrap_or_default();
+    let mut applied = Map::new(); // what we end up owning — the next base
+    let mut changes: Vec<String> = Vec::new();
+    let mut skipped: Vec<String> = Vec::new();
+
+    // Keys we currently set or previously set (for cleanup).
+    let keys: BTreeSet<&String> = ours.keys().chain(base_obj.keys()).collect();
+    for key in keys {
+        if reconciler_owned(key) {
+            if ours.contains_key(key) {
+                skipped.push(key.clone());
+            }
+            continue;
+        }
+        match ours.get(key) {
+            Some(val) => {
+                // Own it: override the live value.
+                if result.get(key) != Some(val) {
+                    changes.push(format!("set {key}"));
+                }
+                result.insert(key.clone(), val.clone());
+                applied.insert(key.clone(), val.clone());
+            }
+            None => {
+                // We set it last time but not now — remove, unless the user has
+                // since changed it from what we wrote (then leave it to them).
+                if result.get(key) == base_obj.get(key) {
+                    if result.remove(key).is_some() {
+                        changes.push(format!("remove {key}"));
+                    }
+                } else {
+                    changes.push(format!("keep {key} (changed since we set it)"));
+                }
+            }
+        }
+    }
+
+    // Report.
+    let label = format!("{} scope -> {}", scope_label, target.display());
+    if changes.is_empty() {
+        println!("{label}: already up to date");
+    } else {
+        println!("{label}:");
+        for c in &changes {
+            println!("  {c}");
+        }
+    }
+    if !skipped.is_empty() {
+        eprintln!(
+            "  note: skipped reconciler-owned key(s) {} — the reconciler manages those; \
+             project them via the managed blob or `ways reconcile` instead",
+            skipped.join(", ")
+        );
+    }
+    if dry_run {
+        println!("  (dry-run — nothing written)");
+        return Ok(());
+    }
+
+    // Write the merged settings (with a backup) and persist the new base.
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    if target.exists() {
+        let backup = target.with_extension("json.bak");
+        std::fs::copy(target, &backup).ok();
+    }
+    std::fs::write(
+        target,
+        format!("{}\n", serde_json::to_string_pretty(&Value::Object(result))?),
+    )
+    .with_context(|| format!("writing {}", target.display()))?;
+
+    if let Some(parent) = base_file.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(
+        base_file,
+        format!("{}\n", serde_json::to_string_pretty(&Value::Object(applied))?),
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static SEQ: AtomicU32 = AtomicU32::new(0);
+
+    fn tmpdir() -> PathBuf {
+        let d = std::env::temp_dir().join(format!(
+            "ways-project-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::SeqCst)
+        ));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn write(path: &Path, v: &Value) {
+        std::fs::write(path, serde_json::to_string_pretty(v).unwrap()).unwrap();
+    }
+    fn read(path: &Path) -> Value {
+        serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn overrides_owned_key_and_preserves_others() {
+        let dir = tmpdir();
+        let target = dir.join("settings.json");
+        let base = dir.join("base.json");
+        write(&target, &json!({ "theme": "dark", "model": "sonnet" }));
+        project_write(&target, &json!({ "model": "opus" }), false, &base, "user").unwrap();
+        let after = read(&target);
+        assert_eq!(after["model"], json!("opus"), "our key overridden");
+        assert_eq!(after["theme"], json!("dark"), "user's key preserved");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn removes_a_key_we_stopped_setting() {
+        let dir = tmpdir();
+        let target = dir.join("settings.json");
+        let base = dir.join("base.json");
+        // First projection sets cleanupPeriodDays.
+        project_write(&target, &json!({ "cleanupPeriodDays": 30 }), false, &base, "user").unwrap();
+        assert_eq!(read(&target)["cleanupPeriodDays"], json!(30));
+        // Second projection drops it -> removed (base records we owned it).
+        project_write(&target, &json!({}), false, &base, "user").unwrap();
+        assert!(read(&target).get("cleanupPeriodDays").is_none(), "dropped key removed");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn skips_reconciler_owned_keys() {
+        let dir = tmpdir();
+        let target = dir.join("settings.json");
+        let base = dir.join("base.json");
+        write(&target, &json!({ "hooks": { "SessionStart": [] } }));
+        project_write(
+            &target,
+            &json!({ "permissions": { "allow": ["x"] }, "model": "opus" }),
+            false,
+            &base,
+            "user",
+        )
+        .unwrap();
+        let after = read(&target);
+        assert_eq!(after["model"], json!("opus"), "non-owned key applied");
+        assert!(after.get("permissions").is_none(), "permissions skipped (reconciler-owned)");
+        assert!(after["hooks"].is_object(), "reconciler's hooks preserved");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dry_run_writes_nothing() {
+        let dir = tmpdir();
+        let target = dir.join("settings.json");
+        let base = dir.join("base.json");
+        write(&target, &json!({ "model": "sonnet" }));
+        project_write(&target, &json!({ "model": "opus" }), true, &base, "user").unwrap();
+        assert_eq!(read(&target)["model"], json!("sonnet"), "dry-run left the file untouched");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/tools/ways-cli/src/cmd/settings/project.rs
+++ b/tools/ways-cli/src/cmd/settings/project.rs
@@ -19,7 +19,7 @@ use super::compile::{self, Outcome};
 use super::fragment::Scope;
 use anyhow::{bail, Context, Result};
 use serde_json::{Map, Value};
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 
 /// Keys the reconciler co-owns — `project` must not touch them (MVP).
@@ -28,26 +28,55 @@ fn reconciler_owned(key: &str) -> bool {
 }
 
 pub fn run(store: &Path, scope_filter: Option<Scope>, dry_run: bool) -> Result<bool> {
-    let scopes = match compile::compile_store(store, scope_filter)? {
+    let baked = match compile::compile_store(store, scope_filter)? {
         Outcome::Refused(errors) => {
             compile::report_refusal(store, &errors);
             return Ok(true);
         }
         Outcome::Baked(scopes) => scopes,
     };
-    if scopes.is_empty() {
-        bail!("nothing to project in {}", store.display());
+    let mut baked_map: HashMap<Scope, Value> = HashMap::new();
+    for (scope, obj, _prov) in baked {
+        baked_map.insert(scope, obj);
     }
 
-    for (scope, baked, _prov) in scopes {
-        match scope {
-            Scope::User => project_into(scope, &crate::paths::settings_json(), &baked, dry_run)?,
-            Scope::Project => project_into(scope, &project_settings_path(), &baked, dry_run)?,
-            Scope::Managed => {
-                println!("# managed scope — paste into the enterprise console (not auto-written):");
-                println!("{}", serde_json::to_string_pretty(&baked)?);
-            }
+    // Process a scope if it has fragments now OR a base file to clean up — the
+    // latter is how deleting all of a scope's fragments GCs its keys from the
+    // live settings. Managed is never auto-written, so it only appears when it
+    // currently has fragments.
+    let mut did = false;
+    for scope in [Scope::User, Scope::Project, Scope::Managed] {
+        if scope_filter.is_some_and(|f| f != scope) {
+            continue;
         }
+        if scope == Scope::Managed {
+            if let Some(obj) = baked_map.get(&scope) {
+                println!("# managed scope — paste into the enterprise console (not auto-written):");
+                println!("{}", serde_json::to_string_pretty(obj)?);
+                did = true;
+            }
+            continue;
+        }
+        let has_base = base_path(scope).exists();
+        if !baked_map.contains_key(&scope) && !has_base {
+            continue;
+        }
+        // An emptied scope (base exists, no fragments) projects an empty object,
+        // which removes everything it previously owned.
+        let ours = baked_map
+            .get(&scope)
+            .cloned()
+            .unwrap_or_else(|| Value::Object(Map::new()));
+        let target = if scope == Scope::User {
+            crate::paths::settings_json()
+        } else {
+            project_settings_path()
+        };
+        project_into(scope, &target, &ours, dry_run)?;
+        did = true;
+    }
+    if !did {
+        bail!("nothing to project in {}", store.display());
     }
     Ok(false)
 }
@@ -69,9 +98,13 @@ fn base_path(scope: Scope) -> PathBuf {
 
 fn read_json(path: &Path) -> Result<Value> {
     match std::fs::read_to_string(path) {
-        Ok(text) => serde_json::from_str(&text)
-            .with_context(|| format!("parsing {}", path.display())),
-        Err(_) => Ok(Value::Object(Map::new())), // absent = empty
+        Ok(text) if text.trim().is_empty() => Ok(Value::Object(Map::new())),
+        Ok(text) => serde_json::from_str(&text).with_context(|| format!("parsing {}", path.display())),
+        // Only a genuinely-absent file is treated as empty; a real I/O error
+        // (permissions, transient) must propagate — never rewrite a file we
+        // couldn't read as if it held nothing.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Value::Object(Map::new())),
+        Err(e) => Err(anyhow::Error::new(e)).with_context(|| format!("reading {}", path.display())),
     }
 }
 
@@ -149,32 +182,45 @@ fn project_write(
             skipped.join(", ")
         );
     }
+    // Self-audit (analogous to the reconciler's stripped_user_view check): every
+    // key we change must be one we own. By construction we only touch owned keys,
+    // so this never fires — it's the net that turns any future bug into a refusal
+    // instead of silent corruption of the user's live config.
+    let owned: BTreeSet<&String> = ours
+        .keys()
+        .chain(base.as_object().map(|o| o.keys()).into_iter().flatten())
+        .filter(|k| !reconciler_owned(k))
+        .collect();
+    let live_obj = live.as_object().cloned().unwrap_or_default();
+    let all: BTreeSet<&String> = live_obj.keys().chain(result.keys()).collect();
+    for key in all {
+        if live_obj.get(key) != result.get(key) && !owned.contains(key) {
+            bail!(
+                "project self-audit: refusing to change unmanaged key `{key}` in {}",
+                target.display()
+            );
+        }
+    }
+
     if dry_run {
         println!("  (dry-run — nothing written)");
         return Ok(());
     }
 
-    // Write the merged settings (with a backup) and persist the new base.
+    // Back up (distinct slot from the reconciler's) and write atomically.
     if let Some(parent) = target.parent() {
         std::fs::create_dir_all(parent)?;
     }
     if target.exists() {
-        let backup = target.with_extension("json.bak");
+        let backup = target.with_extension("json.ways-project.bak");
         std::fs::copy(target, &backup).ok();
     }
-    std::fs::write(
-        target,
-        format!("{}\n", serde_json::to_string_pretty(&Value::Object(result))?),
-    )
-    .with_context(|| format!("writing {}", target.display()))?;
+    crate::cmd::settings_merge::write_json_atomic(target, &Value::Object(result))?;
 
     if let Some(parent) = base_file.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    std::fs::write(
-        base_file,
-        format!("{}\n", serde_json::to_string_pretty(&Value::Object(applied))?),
-    )?;
+    crate::cmd::settings_merge::write_json_atomic(base_file, &Value::Object(applied))?;
     Ok(())
 }
 
@@ -248,6 +294,34 @@ mod tests {
         assert_eq!(after["model"], json!("opus"), "non-owned key applied");
         assert!(after.get("permissions").is_none(), "permissions skipped (reconciler-owned)");
         assert!(after["hooks"].is_object(), "reconciler's hooks preserved");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn coexists_with_reconciler_and_user_keys() {
+        // One write that exercises all three ownership classes at once: our new
+        // key applied, our dropped key removed, reconciler's hooks/perms and the
+        // user's theme all preserved.
+        let dir = tmpdir();
+        let target = dir.join("settings.json");
+        let base = dir.join("base.json");
+        write(&base, &json!({ "oldKey": "x" }));
+        write(
+            &target,
+            &json!({
+                "hooks": { "SessionStart": [] },
+                "permissions": { "allow": ["Bash(ways:*)"] },
+                "theme": "dark",
+                "oldKey": "x"
+            }),
+        );
+        project_write(&target, &json!({ "model": "opus" }), false, &base, "user").unwrap();
+        let after = read(&target);
+        assert_eq!(after["model"], json!("opus"), "our key applied");
+        assert!(after.get("oldKey").is_none(), "our dropped key removed");
+        assert!(after["hooks"].is_object(), "reconciler hooks preserved");
+        assert_eq!(after["permissions"]["allow"][0], json!("Bash(ways:*)"), "reconciler perms preserved");
+        assert_eq!(after["theme"], json!("dark"), "user key preserved");
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/tools/ways-cli/src/cmd/settings_merge.rs
+++ b/tools/ways-cli/src/cmd/settings_merge.rs
@@ -364,7 +364,7 @@ fn read_json_or_empty(p: &Path) -> Result<Value> {
     }
 }
 
-fn write_json_atomic(p: &Path, v: &Value) -> Result<()> {
+pub(crate) fn write_json_atomic(p: &Path, v: &Value) -> Result<()> {
     let tmp = p.with_extension(format!("json.tmp.{}", std::process::id()));
     let body = serde_json::to_string_pretty(v)?;
     std::fs::write(&tmp, body).with_context(|| format!("writing {}", tmp.display()))?;

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -620,6 +620,17 @@ enum SettingsCommand {
         #[arg(long)]
         out: Option<PathBuf>,
     },
+    /// Project a compiled store into the live settings.json (user/project); emits managed as a blob
+    Project {
+        /// Store directory (default: $XDG_CONFIG_HOME/agent-ways/settings)
+        path: Option<PathBuf>,
+        /// Only project this scope
+        #[arg(long)]
+        scope: Option<String>,
+        /// Preview changes without writing
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 /// Parse an optional `--scope` string into a settings scope.
@@ -834,6 +845,15 @@ fn main() -> Result<()> {
                 let scope = parse_settings_scope(scope)?;
                 let dir = path.unwrap_or_else(|| paths::config_root().join("settings"));
                 let had_error = cmd::settings::compile::run(&dir, scope, out.as_deref())?;
+                if had_error {
+                    std::process::exit(1);
+                }
+                Ok(())
+            }
+            SettingsCommand::Project { path, scope, dry_run } => {
+                let scope = parse_settings_scope(scope)?;
+                let dir = path.unwrap_or_else(|| paths::config_root().join("settings"));
+                let had_error = cmd::settings::project::run(&dir, scope, dry_run)?;
                 if had_error {
                     std::process::exit(1);
                 }

--- a/tools/ways-cli/tests/settings_lint.rs
+++ b/tools/ways-cli/tests/settings_lint.rs
@@ -254,6 +254,45 @@ fn compile_refuses_a_store_with_lint_errors() {
 }
 
 #[test]
+fn project_applies_to_project_scope_and_dry_run_does_not() {
+    // A project-scope fragment projects into $CLAUDE_PROJECT_DIR/.claude/settings.json.
+    let store = tmp_store();
+    std::fs::write(
+        store.join("10-a.md"),
+        "---\nscope: project\nsettings:\n  cleanupPeriodDays: 30\n---\nrationale\n",
+    )
+    .unwrap();
+    let proj = tmp_store();
+    let state = tmp_store();
+    let target = proj.join(".claude").join("settings.json");
+
+    let base_args = |args: &[&str]| {
+        let mut c = Command::new(ways_bin());
+        c.env("WAYS_SETTINGS_SCHEMA_FILE", repo_schema())
+            .env("CLAUDE_PROJECT_DIR", &proj)
+            .env("XDG_STATE_HOME", &state)
+            .args(args)
+            .arg(&store);
+        c.output().unwrap()
+    };
+
+    // dry-run writes nothing.
+    let dry = base_args(&["settings", "project", "--scope", "project", "--dry-run"]);
+    assert!(dry.status.success(), "dry-run stderr: {}", String::from_utf8_lossy(&dry.stderr));
+    assert!(!target.exists(), "dry-run must not write the file");
+
+    // real apply writes the projected key.
+    let run = base_args(&["settings", "project", "--scope", "project"]);
+    assert!(run.status.success(), "apply stderr: {}", String::from_utf8_lossy(&run.stderr));
+    let written = std::fs::read_to_string(&target).unwrap();
+    assert!(written.contains("cleanupPeriodDays"), "projected key present; got:\n{written}");
+
+    for d in [&store, &proj, &state] {
+        let _ = std::fs::remove_dir_all(d);
+    }
+}
+
+#[test]
 fn scaffold_fails_when_schema_absent() {
     let dir = tmp_store();
     let out = Command::new(ways_bin())

--- a/tools/ways-cli/tests/settings_lint.rs
+++ b/tools/ways-cli/tests/settings_lint.rs
@@ -293,6 +293,40 @@ fn project_applies_to_project_scope_and_dry_run_does_not() {
 }
 
 #[test]
+fn project_gcs_keys_when_all_fragments_removed() {
+    // Delete a scope's only fragment, re-project -> the key it set is GC'd from
+    // the live settings (drives the cleanup path through compile_store + run).
+    let store = tmp_store();
+    let frag = store.join("10-a.md");
+    std::fs::write(&frag, "---\nscope: project\nsettings:\n  cleanupPeriodDays: 30\n---\nr\n").unwrap();
+    let proj = tmp_store();
+    let state = tmp_store();
+    let target = proj.join(".claude").join("settings.json");
+    let run = |extra: &[&str]| {
+        let mut c = Command::new(ways_bin());
+        c.env("WAYS_SETTINGS_SCHEMA_FILE", repo_schema())
+            .env("CLAUDE_PROJECT_DIR", &proj)
+            .env("XDG_STATE_HOME", &state)
+            .args(["settings", "project", "--scope", "project"])
+            .args(extra)
+            .arg(&store);
+        c.output().unwrap()
+    };
+    assert!(run(&[]).status.success());
+    assert!(std::fs::read_to_string(&target).unwrap().contains("cleanupPeriodDays"));
+
+    std::fs::remove_file(&frag).unwrap(); // scope now has no fragments
+    let out = run(&[]);
+    assert!(out.status.success(), "GC re-project stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let after = std::fs::read_to_string(&target).unwrap();
+    assert!(!after.contains("cleanupPeriodDays"), "dropped key must be GC'd; got:\n{after}");
+
+    for d in [&store, &proj, &state] {
+        let _ = std::fs::remove_dir_all(d);
+    }
+}
+
+#[test]
 fn scaffold_fails_when_schema_absent() {
     let dir = tmp_store();
     let out = Command::new(ways_bin())


### PR DESCRIPTION
## Summary
The pipeline's final stage: project a compiled store into the live `settings.json`.

- `ways settings project <store> [--scope] [--dry-run]`: compiles (lint-gated, via the extracted `compile_store`), then three-way-merges each scope's baked object into the live settings — user → `~/.claude/settings.json`, project → `$CLAUDE_PROJECT_DIR/.claude/settings.json`, managed → printed blob (**never** auto-writes a system path).
- **Coexists with the reconciler** (`settings_merge` co-owns `{hooks, ways-perms}`): project owns the *fragment store's* keys, keeps its own last-applied base (`$XDG_STATE/agent-ways/settings-fragments-<scope>.json`) to clean up keys it stops setting, and preserves everything it doesn't own — the `kubectl apply` field-ownership model with two disjoint controllers.
- **MVP scope:** top-level override + cleanup; `hooks`/`permissions` are skipped with a warning (the reconciler co-owns them; recursive permissions-coexistence deferred). Writes keep a `.bak`; `--dry-run` previews.

This completes author → lint → compile → **project**. The config-authoring skill (next) will drive these primitives.

## Test plan
- `cargo test --manifest-path tools/ways-cli/Cargo.toml` — 238 unit (4 project: override+preserve, cleanup of dropped keys, skip-reconciler-owned, dry-run) + project integration (project-scope apply + dry-run), clippy clean.
- Pre-existing `session_sim` failures are environment-only, unchanged.