### PR TITLE
docs(adr-150): version-truth and downgrade-safe self-update

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -70,7 +70,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-147](./system/ADR-147-composable-settings-json-config-fragments.md) | Composable settings.json — a store of YAML config fragments | Accepted |
 | [ADR-148](./system/ADR-148-framework-surface-ships-operator-content-dev-harness-in-project-scope.md) | framework surface ships operator content; dev harness in project scope | Draft |
 | [ADR-149](./system/ADR-149-operator-config-interview-skill.md) | operator config interview skill | Accepted |
-| [ADR-150](./system/ADR-150-version-truth-and-downgrade-safe-self-update.md) | Version-truth and downgrade-safe self-update | Draft |
+| [ADR-150](./system/ADR-150-version-truth-and-downgrade-safe-self-update.md) | Version-truth and downgrade-safe self-update | Accepted |
 
 ## Documentation
 _Documentation structure, tooling, coherence_

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -70,6 +70,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-147](./system/ADR-147-composable-settings-json-config-fragments.md) | Composable settings.json — a store of YAML config fragments | Accepted |
 | [ADR-148](./system/ADR-148-framework-surface-ships-operator-content-dev-harness-in-project-scope.md) | framework surface ships operator content; dev harness in project scope | Draft |
 | [ADR-149](./system/ADR-149-operator-config-interview-skill.md) | operator config interview skill | Accepted |
+| [ADR-150](./system/ADR-150-version-truth-and-downgrade-safe-self-update.md) | Version-truth and downgrade-safe self-update | Draft |
 
 ## Documentation
 _Documentation structure, tooling, coherence_

--- a/docs/architecture/system/ADR-150-version-truth-and-downgrade-safe-self-update.md
+++ b/docs/architecture/system/ADR-150-version-truth-and-downgrade-safe-self-update.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-07-01
 deciders:
   - aaronsb

--- a/docs/architecture/system/ADR-150-version-truth-and-downgrade-safe-self-update.md
+++ b/docs/architecture/system/ADR-150-version-truth-and-downgrade-safe-self-update.md
@@ -1,0 +1,160 @@
+---
+status: Draft
+date: 2026-07-01
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-142
+---
+
+# ADR-150: Version-truth and downgrade-safe self-update
+
+## Context
+
+`ways update` (the self-update command, ADR-142's projection lifecycle) refreshes
+the app source and its binaries "pre-built first": it downloads the latest
+GitHub Release binary and only falls back to building from source when no
+toolchain is present. This is correct for an end user pinned to a release — but
+it **silently downgraded a live install** in practice:
+
+- The app checkout tracks `main`. At the time of the failure `main` was **78
+  commits ahead of the `ways-v1.0.0` tag** — those 78 commits included the
+  entire `settings` command and `ways update` itself.
+- `tools/ways-cli/Cargo.toml` had stayed at `version = "1.0.0"` across all 78
+  commits, and the newest published release was also `ways-v1.0.0`. So the
+  pre-built binary and the source **reported the same version string while being
+  78 commits apart**.
+- `ways update` downloaded the stale `ways-v1.0.0` binary over the current one.
+  `ways update` and `ways settings` vanished (`unrecognized subcommand`), and a
+  second `ways update` was impossible — the command that would fix it had been
+  removed by the update.
+
+The machinery to *avoid* this already exists; the gap is **version-truth**, not
+tooling:
+
+- **The release pipeline is complete.** `.github/workflows/build-ways.yml` (and
+  the sibling `build-attend`/`build-way-embed` workflows) trigger on `ways-v*`
+  tags, build all four platforms, and the tag-gated `release` job runs
+  `gh release create`. Cutting a release is `bump + tag + push`; CI does the
+  rest.
+- **The binary already bakes provenance.** `build.rs` sets `WAYS_COMMIT` from
+  `git rev-parse --short HEAD`, and `banner.rs` shows `v1.0.0 (c595437)`.
+
+But that provenance never reaches the surfaces that decide anything:
+
+- `ways --version` is wired to clap's `version` = `CARGO_PKG_VERSION` alone
+  (`1.0.0`), with **no commit**. `download-ways.sh`'s "already installed" check
+  and every human sanity-check see only the frozen string. The one place the
+  commit appears — the bare-invocation banner — is human-only and unread by
+  tooling.
+- **Nothing compares versions before replacing a binary.** `ways update`'s
+  `refresh_component` renames-then-reverts on *build failure*, but a *successful*
+  download of an older binary is treated as success. There is no "is this
+  candidate actually newer than what I'm replacing?" gate.
+
+The result: staleness is invisible where it counts, and the self-updater will
+downgrade whenever the tracked source is ahead of the latest cut release — which,
+for a checkout that follows `main`, is the *normal* state between releases.
+
+## Decision
+
+Make the version *truthful and staleness-detectable*, and make self-update
+*refuse to move backward* — leveraging the existing tag→CI→release pipeline
+rather than adding a new one. Four changes:
+
+1. **Bake `git describe`, not just the short hash.** Extend `build.rs` to emit
+   `WAYS_BUILD = git describe --tags --always --dirty` (e.g.
+   `ways-v1.0.0-78-gc595437`) alongside `WAYS_COMMIT`. This single string
+   encodes the nearest release tag, the commits-ahead count, the commit, and a
+   dirty flag — everything needed to order two builds.
+
+2. **Surface it in `ways --version`.** Set clap's `long_version` so
+   `ways --version` prints the full provenance
+   (`ways 1.0.0 (ways-v1.0.0-78-gc595437)`), making a dev build visibly distinct
+   from a release build to both humans and scripts. The banner is unaffected.
+
+3. **A downgrade guard in `ways update`.** Before installing a candidate
+   pre-built binary, compare its embedded `WAYS_BUILD` against the pulled
+   source's `git describe`. Install the pre-built **only if it is at least as new
+   as the source** (same commit, or the source is an ancestor of the release).
+   Otherwise:
+   - **toolchain present →** build from source (the checkout is the authority
+     and can't be behind itself);
+   - **no toolchain →** keep the current binary and warn loudly ("a pre-built
+     matching this source hasn't been published yet; install a toolchain or wait
+     for the release"). **Never replace a binary with an older one.** This is the
+     belt-and-suspenders that keeps `ways update` safe *between* releases,
+     independent of whether anyone remembered to cut one.
+
+4. **A release-cut helper so the version bump can't be forgotten.** The root
+   cause was human: 78 commits merged with no bump and no tag. Add a single
+   entry point — `scripts/release.sh <component> <patch|minor|major>` (surfaced
+   as `make cut-release COMPONENT=ways LEVEL=patch`) — that bumps the component
+   `Cargo.toml` version, commits it, creates the `<component>-vX.Y.Z` tag, and
+   pushes. CI takes it from there. The policy: **a release is cut from `main`
+   whenever a user-affecting change to a shipped binary lands** (not every PR,
+   but no long silent runs). Between releases, `git describe` — now surfaced and
+   guarded — carries the truth, so a missed release degrades to "build from
+   source / keep current," never to a downgrade.
+
+Semver stays per-component (`ways-vX.Y.Z`, `attend-vX.Y.Z`, …), matching the
+existing tag scheme and independent CI workflows.
+
+## Consequences
+
+### Positive
+
+- The self-updater can never silently downgrade: the worst case between releases
+  is "built from source" or "kept current with a warning," both of which leave a
+  working, current-or-newer binary.
+- Staleness is legible everywhere — `ways --version`, `download-ways.sh`, CI logs,
+  bug reports — because the build string names its exact provenance.
+- The release pipeline that already exists gets *used* on a discipline, closing
+  the gap that let 78 commits sit unpublished.
+- `git describe` ordering is free and reliable — no version-string parsing games,
+  no dependence on anyone bumping Cargo.toml for *correctness* (the bump is for
+  human-facing semver; the guard keys on commit ancestry).
+
+### Negative
+
+- `build.rs` now depends on `git describe` succeeding in the build environment;
+  a tarball build with no `.git` yields `WAYS_BUILD = unknown` (handled: the
+  guard treats `unknown` as "cannot prove newer" → build/keep-current, never
+  downgrade).
+- The downgrade guard needs the source checkout's `git describe` at update time —
+  fine for the app checkout (always a git clone per ADR-142), and the guard
+  degrades safely when it can't be computed.
+- One more release step to remember — mitigated by the `make cut-release` helper,
+  which makes the correct path the easy path.
+
+### Neutral
+
+- Requires touching `build.rs`, `main.rs` (clap `long_version`),
+  `update.rs` (`refresh_component` gains the version comparison), and a new
+  `scripts/release.sh` + `make cut-release` target — the build slice tracked
+  separately from this ADR.
+- The `attend`/`attend-chat` binaries still have no published pre-builts; the
+  guard's "no candidate newer than source → build/keep" path already covers them
+  (they are toolchain-gated today), so nothing regresses.
+
+## Alternatives Considered
+
+- **Always build from source when a toolchain is present (drop pre-built-first).**
+  Rejected: it discards the explicit "not everyone has build tools" requirement
+  that motivated pre-built-first, and it's slower for the common case where the
+  source *is* a released tag. The downgrade guard achieves the same safety while
+  keeping download-first for users on releases.
+- **Compare `CARGO_PKG_VERSION` strings only (bump-per-PR discipline).** Rejected
+  as the *primary* mechanism: it's exactly what failed — a human forgot to bump,
+  and string equality can't see commit ancestry. Version bumps remain for
+  human-facing semver, but *correctness* rides on `git describe`, which can't be
+  forgotten.
+- **Auto-cut a release on every merge to `main` (CI bumps + tags).** Rejected as
+  over-complex for now ("only complexify to the amount necessary"): it turns
+  every merge into a published release with version churn and 4-platform builds.
+  The `make cut-release` helper keeps cutting cheap and deliberate; auto-cut can
+  be revisited if the cadence proves too manual.
+- **Embed a monotonic build number instead of `git describe`.** Rejected: it
+  needs external state (a counter), where `git describe` derives ordering from
+  the repo itself for free and is human-legible.


### PR DESCRIPTION
## Summary

Draft ADR capturing the root cause of the `ways update` self-downgrade you hit, and the fix — **on the release pipeline that already exists**, not a new one.

**Root cause:** `Cargo.toml` frozen at `1.0.0` across 78 commits past the `ways-v1.0.0` tag → the pre-built release binary and `main` report the same version string while being 78 commits apart. `ways update` downloaded the stale pre-built over the current binary, erasing `update`/`settings`. Staleness was invisible (`ways --version` shows only `1.0.0`) and nothing compared versions before replacing a binary.

**Decision (4 parts):**
1. Bake `git describe --tags --always --dirty` in `build.rs` (`WAYS_BUILD`).
2. Surface it in `ways --version` via clap `long_version`.
3. **Downgrade guard** in `ways update`: install a pre-built only if ≥ the pulled source; else build (toolchain) or keep-current + warn. Never move backward.
4. `make cut-release COMPONENT=ways LEVEL=patch` helper so the bump/tag/push can't be forgotten; CI (existing `build-ways.yml` tag trigger) does the platforms + release.

Correctness rides on `git describe` ancestry (can't be forgotten); the Cargo bump is for human-facing semver.

## Notes for review
- Leverages existing infra: `build.rs` already bakes `WAYS_COMMIT`; `build-ways.yml:115` already cuts releases on `ways-v*` tags. This ADR wires the provenance to the surfaces that decide, and adds the guard + helper.
- Related: ADR-142 (projection/update lifecycle).
- Lints clean; INDEX regenerated.

If you agree, I'll flip it to Accepted and build task #3 (the guard + `build.rs` + `--version` + `cut-release` helper).