### PR TITLE
fix(security): least-privilege the agent fleet (lock Task)

### DIFF
--- a/agents/requirements-analyst.md
+++ b/agents/requirements-analyst.md
@@ -1,6 +1,9 @@
 ---
 name: requirements-analyst
 description: Captures user needs as GitHub issues or in ADR context. Creates simple requirement statements with acceptance criteria. Focuses on understanding the problem to solve, not prescribing solutions.
+# Hardened: keeps its full working + research toolset; locks only Task — this role
+# authors issues/ADR context, it doesn't spawn subagents.
+tools: Read, Grep, Glob, Bash, Edit, Write, WebFetch, WebSearch
 ---
 
 You translate user needs into documented requirements that serve as the foundation for all implementation work.

--- a/agents/system-architect.md
+++ b/agents/system-architect.md
@@ -1,6 +1,9 @@
 ---
 name: system-architect
 description: Drafts Architecture Decision Records (ADRs) documenting design choices. Evaluates against SOLID principles. Guides ADR workflow from draft to PR to merge. Never implements - only designs and documents.
+# Hardened: keeps its full working + research toolset; locks only Task — this role
+# drafts ADRs, it doesn't spawn subagents.
+tools: Read, Grep, Glob, Bash, Edit, Write, WebFetch, WebSearch
 ---
 
 You create and maintain architectural decisions through the ADR workflow pattern.

--- a/agents/task-planner.md
+++ b/agents/task-planner.md
@@ -1,6 +1,9 @@
 ---
 name: task-planner
 description: Plans implementation work using branches and TodoWrite. Thinks in git workflow, not tracking files. Helps break down complex work into manageable pieces with clear dependencies.
+# Hardened: keeps TodoWrite + full working + research toolset; locks only Task —
+# it plans work, it doesn't spawn subagents.
+tools: Read, Grep, Glob, Bash, Edit, Write, WebFetch, WebSearch, TodoWrite
 ---
 
 You help plan and organize implementation work using branches and session-scoped todos.

--- a/agents/workflow-orchestrator.md
+++ b/agents/workflow-orchestrator.md
@@ -1,6 +1,9 @@
 ---
 name: workflow-orchestrator
 description: Coordinates ADR-driven development workflow. Ensures work has declared intent and proper tracking. Guides users through debate → ADR → branch → implement → PR pattern. Maintains process integrity without being rigid.
+# Hardened: the coordinator KEEPS Task (it delegates to the other agents) plus the
+# full working + research toolset; only NotebookEdit and unused surfaces drop off.
+tools: Read, Grep, Glob, Bash, Edit, Write, WebFetch, WebSearch, TodoWrite, Task
 ---
 
 You coordinate the development lifecycle following the ADR-driven workflow pattern.

--- a/agents/workspace-curator.md
+++ b/agents/workspace-curator.md
@@ -1,6 +1,9 @@
 ---
 name: workspace-curator
 description: Organizes docs/ directory and manages .claude/ structure. Recommends ADR numbering and file placement. Prevents documentation sprawl through simple, consistent organization.
+# Hardened: keeps read/search + Bash (ls/mv/mkdir) + edit + research; locks only
+# Task — it organizes files, it doesn't spawn subagents.
+tools: Read, Grep, Glob, Bash, Edit, Write, WebFetch, WebSearch
 ---
 
 You maintain organized project workspaces and prevent documentation sprawl.


### PR DESCRIPTION
## Summary

Extends the code-reviewer hardening (#251) to the other five shipped agents — as a **blend**, not a lockdown.

Each agent now declares an explicit `tools:` allowlist that **keeps its full working + research toolset** (`Read/Grep/Glob/Bash/Edit/Write/WebFetch/WebSearch`, plus `TodoWrite` for the planners) and **locks the one cabinet that's both unused and a real amplifier: `Task`** (spawning further subagents). WebFetch stays — it's genuinely useful for research.

| Agent | Task | TodoWrite | Rationale |
|---|---|---|---|
| requirements-analyst | ❌ | ❌ | authors issues/ADR context |
| system-architect | ❌ | ❌ | drafts ADRs |
| task-planner | ❌ | ✅ | plans via branches + todos |
| workspace-curator | ❌ | ❌ | organizes files |
| workflow-orchestrator | ✅ | ✅ | the coordinator — it delegates |

## Not in scope (by design)
- **Path blocking** (e.g. `~/.ssh`) is orthogonal — that's the global `permissions.deny` in settings.json, which already covers every agent/subagent. A tool allowlist can't express paths.
- These agents run on the *user's own intent*, not untrusted external input (that's what made code-reviewer the priority) — so this is modest defense-in-depth: cap the capability surface, remove the subagent-spawn amplifier.

## Test plan
- All five frontmatters validated as YAML; the `#` rationale comments are legal and the parsed `tools` list is clean.
- Each keeps the tools its own instructions actually use (Bash for git/gh, Edit/Write for docs, TodoWrite for planners).