### PR TITLE
docs(adr): compliance claims & session-derived findings model

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -30,7 +30,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-107](./system/ADR-107-way-match-corpus-batch-mode-and-locale-support.md) | Corpus, Matching Pipeline, and Locale Support | Accepted |
 | [ADR-108](./system/ADR-108-embedding-based-way-matching-with-all-minilm-l6-v2.md) | Embedding-Based Way Matching with all-MiniLM-L6-v2 | Accepted |
 | [ADR-109](./system/ADR-109-project-scope-way-embedding-with-manifest-based-staleness-detection.md) | Project-Scope Way Embedding with Manifest-Based Staleness Detection | Accepted |
-| [ADR-110](./system/ADR-110-way-file-separation-and-graph-compatible-structure.md) | Way File Separation and Graph-Compatible Structure | Draft |
+| [ADR-110](./system/ADR-110-way-file-separation-and-graph-compatible-structure.md) | Way File Separation and Graph-Compatible Structure | Accepted |
 | [ADR-111](./system/ADR-111-unified-ways-cli-single-binary-tool-consolidation.md) | Unified `ways` CLI — Single Binary Tool Consolidation | Accepted |
 | [ADR-112](./system/ADR-112-session-ledger-and-knowledge-graph-integration.md) | Session Ledger with Optional Knowledge Graph Enhancement | Draft |
 | [ADR-113](./system/ADR-113-attend-active-awareness-module.md) | `attend` — Active Awareness Module | Accepted |
@@ -71,6 +71,14 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-148](./system/ADR-148-framework-surface-ships-operator-content-dev-harness-in-project-scope.md) | framework surface ships operator content; dev harness in project scope | Draft |
 | [ADR-149](./system/ADR-149-operator-config-interview-skill.md) | operator config interview skill | Accepted |
 | [ADR-150](./system/ADR-150-version-truth-and-downgrade-safe-self-update.md) | Version-truth and downgrade-safe self-update | Accepted |
+| [ADR-151](./system/ADR-151-extract-ways-core-crate-and-ways-audit-sibling-binary.md) | Extract ways-core crate and ways-audit sibling binary | Draft |
+
+## Governance
+_Provenance, traceability, controls, compliance mapping_
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-200](./governance/ADR-200-compliance-claims-and-session-derived-findings.md) | Compliance claims and session-derived findings | Draft |
 
 ## Documentation
 _Documentation structure, tooling, coherence_
@@ -86,6 +94,6 @@ _Documentation structure, tooling, coherence_
 | ADR | Title | Status |
 |-----|-------|--------|
 | [ADR-004](./legacy/ADR-004-way-macros.md) | Way Macros for Dynamic Context Injection | Accepted |
-| [ADR-005](./legacy/ADR-005-governance-traceability.md) | Governance Traceability for Ways | Accepted |
+| [ADR-005](./legacy/ADR-005-governance-traceability.md) | Governance Traceability for Ways | Superseded |
 | [ADR-013](./legacy/ADR-013-ways-skills-governance-architecture.md) | Ways, Skills, and Governance Architecture | Accepted |
 | [ADR-014](./legacy/ADR-014-tfidf-semantic-matcher.md) | TF-IDF/BM25 Binary for Semantic Way Matching | Accepted |

--- a/docs/architecture/documentation/ADR-300-documentation-structure.md
+++ b/docs/architecture/documentation/ADR-300-documentation-structure.md
@@ -99,6 +99,12 @@ Policy source docs moved to `governance/policies/` — they're governance chain 
 
 ### 4. Address governance pipeline gap
 
+> *Reconciled (2026-07): the tools named below (`governance.sh`, `provenance-scan.py`,
+> `provenance-verify.sh`) were consolidated into `ways governance` (ADR-111) and now move
+> to the `ways-audit` binary (ADR-151); provenance moved from way frontmatter to a
+> `provenance.yaml` sidecar (ADR-110); and the subsystem is reframed as compliance
+> claims/findings (ADR-200). The "pipeline gap" below is addressed there.*
+
 The governance system has code (governance.sh, provenance-scan.py, provenance-verify.sh) and provenance metadata in way frontmatter, but output artifacts are not generated, tracked, or consumed. The docs explain what governance *is* but not how to *use* it.
 
 Documentation fixes (scoped to this ADR):

--- a/docs/architecture/governance/ADR-200-compliance-claims-and-session-derived-findings.md
+++ b/docs/architecture/governance/ADR-200-compliance-claims-and-session-derived-findings.md
@@ -1,0 +1,315 @@
+---
+status: Accepted
+date: 2026-07-02
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-005
+  - ADR-013
+  - ADR-110
+  - ADR-111
+  - ADR-151
+supersedes:
+  - ADR-005
+---
+
+# ADR-200: Compliance claims and session-derived findings
+
+## Context
+
+The framework carries a provenance subsystem (ADR-005) and a rationale for it
+(ADR-013): a way can carry metadata mapping its guidance to regulatory controls
+(NIST 800-53, OWASP, ISO 27001, SOC 2, CIS, IEEE), stored today as a `provenance.yaml`
+sidecar beside the way (ADR-110) and queried by a `ways governance` CLI (ADR-111).
+
+In use, three problems surfaced — each worse than the last.
+
+**It is misnamed.** Mapping practices to external standards and reporting on that
+mapping is **compliance** work — demonstrating conformance to an outside rule — not
+**governance**, which is the steering discipline (ADRs, ways, review gates) the
+framework is already saturated with. Calling a narrow control-mapping tool
+"governance" oversells it as the steering layer *and* strands the real governance
+without the word. That category error is much of why the subsystem reads as bolted on.
+
+**Nothing consumes it.** No CI job, hook, or reviewer runs it. The `governance-cite`
+guidance tells the model to cite controls when recommending practices, but that is
+advisory and manual. The machinery is a library with no callers.
+
+**Its claims were never assessed** — the decisive problem. Each provenance sidecar is
+hand-authored: the control IDs, the justifications, the `verified` date are all typed
+by a person. Nothing ever assessed whether a way *actually* meets a control. In audit
+vocabulary the distinction is exact and we collapsed it:
+
+- An **implementation claim** is a statement that a control is *designed* to do its
+  job. That is all the sidecars are. Auditors call this posture **SOC 2 Type I** —
+  *suitably designed as of a point in time.*
+- An **assessment finding** is what an assessor produces after examining real
+  operation. NIST's assessment standard (SP 800-53A) records a finding with a
+  determination of **satisfied** or **other than satisfied**. The richer report,
+  **SOC 2 Type II**, covers *design **and** operating effectiveness over a period.*
+
+A hand-written citation is an implementation claim (Type I) wearing the costume of a
+finding (Type II). ADR-013 made this exact error out loud — it called provenance
+"auditability … pull real control citations" and said it "turns Claude from a hack
+into a professional." A claim on demand is not proof; it is an assertion awaiting an
+assessment.
+
+### The reframe
+
+Separate the two epistemic statuses ADR-005/013 conflated, using the field's real
+names, and state honestly what the subsystem is a *foundation for*:
+
+- A **claim** is a control-design assertion (SOC 2 Type I; in NIST's OSCAL data model,
+  a *Component Definition* — "here is how this component can satisfy the control").
+- A **finding** is a session-derived assessment finding (SOC 2 Type II; OSCAL
+  *Assessment Results*): evidence that the claimed guidance actually shaped real work.
+
+The connective tissue between them is an **assurance case** — a spelled-out argument
+tying a claim to its evidence so a reader can check the *reasoning*, not just the
+proof. The notation whose vocabulary we use literally is **CAE (Claims–Arguments–
+Evidence)**; its graphical sibling GSN is the same idea (GSN confusingly names the
+evidence node a "Solution"). This is also, recursively, the model OSCAL itself uses —
+a compliance-claim system built this way follows the standard shape of compliance
+systems.
+
+### The formation thesis
+
+Agent-ways operates at the **first line** — in the Three Lines Model (the Institute of
+Internal Auditors' 2020 update of the old "three lines of defense"), the roles that
+own and manage risk *in the actual doing of the work*, distinct from second-line
+functions that monitor them and third-line auditors who independently check them.
+
+A first-line developer does not recite NIST 800-53 while committing. Through repeated
+exposure to a way of working, the control's expectations become **tacit knowledge** —
+Polanyi's "we can know more than we can tell," the expertise the hands hold that words
+can't fully capture. A way is the **externalization** of that shape (in Nonaka's SECI
+model, the tacit→explicit step; more generally, **codification**) delivered at the
+point of work. That shaped habit is the expensive precondition every audit assumes but
+none create: when the work already has the standard's shape, evidence can be *gathered*
+later instead of *manufactured*.
+
+So the compliance stack, top to bottom:
+
+```
+   certify   → independent attestation (SOC 2, SSAE 18) or an OSCAL SSP   ← third line / GRC toolchain — NOT us
+   finding   → "the shaped work actually happened" (Type II)       ← ways-audit (ADR-151)
+   claim     → "this way is designed to steer toward control X" (Type I)   ← provenance sidecars
+ ──────────────────────────────────────────────────────────────────
+   way       → externalized guidance that shapes the work           ← agent-ways  ★ first line, we live here
+   work      → the actual activity
+```
+
+We own the bottom two natively. The compliance subsystem reaches up into claim and
+finding and deliberately **stops below certify** — we are a first-line formation aid,
+not a third-line assurance function. The honest top-level statement is therefore:
+**foundation for, not implementation of, a GRC/OSCAL toolchain.** And that statement is
+itself a claim awaiting its own findings — the system is an instance of its own thesis.
+
+## Decision
+
+Reframe the subsystem from asserted "governance traceability" into an
+**operator-invoked compliance formation layer** with an honest claim/finding split.
+This supersedes ADR-005 and refines (does not discard) ADR-013.
+
+### 1. Claims are claims, not evidence
+
+The provenance sidecars are **compliance claims** — control-*design* assertions (SOC 2
+Type I; OSCAL Component Definition). They carry no weight beyond assertion. ADR-013's
+framing of them as auditability or proof is retracted. A claim is a hypothesis awaiting
+a finding.
+
+**A claim must be assessable.** To seed claims across the corpus without recreating the
+overclaim at scale, each claim carries a **determination criterion** — a plain
+statement of what observable behavior in a session would let an assessor mark it
+*satisfied* or *other than satisfied* (NIST 800-53A). A claim with no such criterion is
+unfalsifiable: it can never graduate into a finding, and coverage of such claims is not
+evidence of anything. Claim-authoring may be **agent-assisted** — `ways-audit` can
+propose candidate controls for a way so the author is not hand-researching every way —
+but it stays **human-grounded**: what a control *means*, and whether a way honestly
+addresses it, is the author's epistemic call (ADR-013's collaborative authorship model).
+
+### 2. Findings are session-derived
+
+Evidence is produced, not authored:
+
+```
+claim (sidecar)  →  way fires → logged event  →  auditor reads (claim + firing + transcript)  →  finding
+```
+
+The firing-event log and session transcripts already exist. A **finding** records
+`(claim-id, session-id, timestamp, determination, evidence-pointers)`, its
+determination **satisfied** / **other than satisfied** in NIST 800-53A's own terms, the
+pointer being the transcript and firing event so every finding is auditable back to its
+source. Findings accumulate in an append-only ledger; each *other than satisfied*
+finding becomes a **POA&M** (plan of action & milestones) entry — a tracked gap, not a
+vague fail.
+
+### 3. Two evidence tiers, honestly separated
+
+Audit-evidence practice distinguishes **process evidence** (a step was performed) from
+**outcome evidence** (the intended result was achieved). We adopt both, separately:
+
+- **Process tier** — "control-aligned guidance was surfaced at the point of work." The
+  firing log *alone* substantiates this: timestamped, deterministic, no model judgment.
+  Defensible today; this is the MVP.
+- **Outcome tier** — "and the work actually took that shape." This needs an auditor
+  reading the transcript, is model-judged, is fallible, and carries a credibility
+  problem: a model grading whether a model followed model-injected guidance. It is the
+  stretch tier and must be labeled opinion, never proof.
+
+Outcome-finding credibility rests on auditor trustworthiness — independence,
+deterministic checks where possible, optional human counter-sign. This is the central
+unsolved problem and is named as such, not hidden.
+
+### 4. Operator-invoked, never forced
+
+There is **no mandatory claim → finding → certify traversal.** Compliance review is a
+station the operator pulls into deliberately, like `/ship` or `/wrap` — not a gate
+anyone is dragged through. Concretely: a `compliance-reviewer` agent (sibling of
+`code-reviewer`) plus skills that let the main agent direct it and do the loop-closing
+work. It slots into delivery as an *optional* stage — `code-review → compliance-review
+→ fix → ship` — where findings become labeled issues (the POA&M). The tooling that
+backs it is `ways-audit` (ADR-151), not the core binary.
+
+### 5. Borrow the vocabulary; do not implement the standard
+
+Use OSCAL and assurance-case nouns (claim, finding, POA&M, assessment) for precision
+and to shape output a real toolchain could ingest. We do **not** implement the OSCAL
+schema, validate against it, or produce a System Security Plan (SSP). Using the
+vocabulary must never read as a conformance claim to the standard itself.
+
+Reference standards by ID and authoritative URL; never reproduce normative text. NIST
+800-53/OSCAL/800-53A and OWASP are public; CIS is free-with-registration; **ISO 27001
+and ISO 25010 are copyrighted** — cite the clause ID only.
+
+### 6. Evidence is shaped to be handed up
+
+Findings must be legible to the layer above (OSCAL Assessment-Results-shaped, control
+IDs that resolve to real catalogs). Our job is to *feed* a certifier we are not — never
+to terminate the chain with an attestation of our own.
+
+### 7. The progressive-ways loop
+
+Reframe `gaps` from "ways without provenance" to **"claimed controls with no
+influencing way."** The claim set then *drives the ways backlog*: every control we
+claim but do not yet steer toward is authoring work. This is what makes the subsystem a
+living formation layer rather than a static bibliography — the claim creates the
+obligation to build the way.
+
+### 8. Rename on the operator surface
+
+"Governance" leaves the operator-facing surface: the toolkit is `ways-audit`, its
+domain concept is **compliance**, its artifacts are **claim / finding / POA&M**.
+Storage stays the `provenance.yaml` sidecar (ADR-110), consumed by `ways-audit` rather
+than the core binary. "Governance" survives only as the name of this ADR topic band
+(200–299), whose `adr.yaml` description already reads "compliance mapping."
+
+## Non-Goals
+
+This section is load-bearing — the fence that stops a future session from growing this
+into the thing it is not. **The system is incapable of overclaiming by construction:**
+every artifact says "we *claim* X" or "we found *evidence* that guidance for X was
+present/followed," never "you *conform to* X." It is a first-line formation aid, not a
+third-line assurance function.
+
+This is **not**:
+
+- a GRC platform or compliance-management product;
+- an OSCAL implementation, validator, or SSP generator;
+- audit-grade evidence, an attestation, or an independent assessment;
+- a continuous, automated, or enforced control;
+- a certification, or any claim of conformance.
+
+It **is**: an opinionated, operator-invoked lens that helps consider compliance-shaped
+concerns at the point of work, curate ways toward controls the operator chooses to
+claim, and keep a modest, honestly-labeled claims-and-findings trail — *a way of
+working that leans compliance-shaped, not a compliance framework.*
+
+## Relationship to prior ADRs
+
+- **Supersedes ADR-005** (Governance Traceability for Ways). The mechanism — sidecar
+  claims, generated manifest, reporting-not-enforcing — is retained and renamed; the
+  framing of provenance as "auditability / proof" is replaced by the claim/finding
+  split.
+- **Refines ADR-013**, does not discard it. Kept: the activation-cue thesis (ways prime
+  latent knowledge rather than inject it), the Type 1–4 way classification, the
+  author-as-compiler model, and the formation intuition latent in its "Shift Lead
+  Wisdom" type. Corrected: the epistemic overclaim that a citation on demand
+  constitutes evidence or professional proof. Under this ADR, ADR-013's Type 1 ways
+  carry *claims*; findings are what a session produces.
+- **Relates to ADR-110** (provenance moved to a `provenance.yaml` sidecar) for storage,
+  and **ADR-111** (CLI consolidation) for the command surface that becomes `ways-audit`.
+- **Requires ADR-151** for packaging: the `ways-core` library crate and the `ways-audit`
+  sibling binary.
+
+## Consequences
+
+### Positive
+
+- The subsystem stops overclaiming and starts being true: claims are claims, findings
+  are earned and carry a real determination.
+- A defensible MVP exists immediately (process evidence from the firing log) without
+  waiting on the hard outcome-audit problem.
+- The formation-layer framing gives every downstream decision a coherent "why," and
+  positions agent-ways to *feed* enterprise GRC toolchains rather than compete with them.
+- The progressive-ways loop turns claims into an authoring backlog — the subsystem
+  becomes generative.
+- Operator-invoked design keeps zero forced ceremony; users who never touch it pay
+  nothing.
+
+### Negative
+
+- Real work to realize: rename, de-assertion of existing sidecars, the `ways-audit`
+  toolkit (ADR-151), the auditor agent + skills, and the finding-ledger format.
+- The outcome-tier credibility problem is genuine and unsolved; that tier ships labeled
+  as opinion or not at all.
+- Borrowing OSCAL/assurance vocabulary invites the very "are you OSCAL-conformant?"
+  overclaim the Non-Goals forbid; the honesty framing must be maintained vigilantly.
+
+### Neutral
+
+- The ADR domain folder stays "governance" (topic band); only the operator surface
+  renames to "compliance."
+- Existing provenance sidecars remain valid data — reclassified as claims, not rewritten.
+- Whether the outcome tier ever ships is left open; the process tier stands on its own.
+
+## Alternatives Considered
+
+- **Keep it as "governance traceability" (status quo).** Rejected: misnamed,
+  unconsumed, and epistemically overclaiming — the problems that motivated this ADR.
+- **Delete it entirely.** Rejected: the data, policy docs, and CLI are a real
+  foundation, and the formation-layer idea is valuable and rare. Deleting discards a
+  good foundation to avoid fixing a label and an epistemic error.
+- **Promote to a full compliance/GRC platform.** Rejected: that is the third line, not
+  ours. Certification, SSPs, and independent assessment belong to tools built for them;
+  we produce foundation-grade inputs for those tools.
+- **Bake in a mandatory claim → finding → certify loop.** Rejected: forced traversal is
+  exactly the bolt-on failure mode. The value is *availability* to the operator, like
+  any session-defining skill.
+- **Keep provenance framed as evidence (ADR-013 as written).** Rejected: it is the
+  overclaim this ADR exists to correct.
+
+## References
+
+Cited by identifier; normative text of copyrighted standards (ISO) is not reproduced.
+
+- **The Three Lines Model** — IIA, 2020 update of the "three lines of defense"
+  (governance roles; "first line" = risk-owning roles in the work).
+  https://www.theiia.org/en/content/communications/2020/july/20-july-2020-iia-issues-important-update-to-three-lines-model/
+- **SOC 2 Type I vs Type II** — AICPA attestation under SSAE 18 / Trust Services
+  Criteria (design at a point in time vs design *and* operating effectiveness over a
+  period).
+- **Assurance cases — CAE (Claims–Arguments–Evidence)** and **GSN** — ISO/IEC 15026-2;
+  the claim → argument → evidence structure this ADR mirrors.
+- **OSCAL** (NIST) — Catalog / Profile / Component Definition / Assessment Results /
+  POA&M layered model. https://pages.nist.gov/OSCAL/learn/concepts/layer/
+- **NIST SP 800-53A Rev. 5** — assessment findings; determinations "satisfied" /
+  "other than satisfied." https://csrc.nist.gov/glossary/term/assessment_findings
+- **PCAOB AS 1105** — *Audit Evidence* (the general standard; the process-vs-outcome
+  framing is our application of it).
+- **Tacit knowledge** — Polanyi, *The Tacit Dimension* (1966): "we can know more than we
+  can tell." **Externalization / codification** — Nonaka & Takeuchi, SECI model.
+- **Procedural vs declarative knowledge** — Ryle, *The Concept of Mind* (1949):
+  knowing-how vs knowing-that.
+- **ADR-005, ADR-013** — the prior decisions this ADR supersedes and refines.

--- a/docs/architecture/legacy/ADR-005-governance-traceability.md
+++ b/docs/architecture/legacy/ADR-005-governance-traceability.md
@@ -1,13 +1,23 @@
 ---
-status: Accepted
+status: Superseded
 date: 2026-02-05
 deciders:
   - aaronsb
   - claude
-related: []
+related:
+  - ADR-013
+  - ADR-200
 ---
 
 # ADR-005: Governance Traceability for Ways
+
+> **Superseded by [ADR-200](../governance/ADR-200-compliance-claims-and-session-derived-findings.md).**
+> This ADR established provenance traceability but framed the hand-authored mappings as
+> "auditability" and "proof." ADR-200 corrects the epistemics: the mappings are compliance
+> **claims** (control-*design* assertions — SOC 2 Type I), not **findings** (assessed
+> evidence). The sidecar mechanism described here is retained and renamed; its framing as
+> proof is replaced. Storage later moved from way frontmatter to a `provenance.yaml`
+> sidecar (ADR-110). Kept unedited below as the historical record.
 
 ## Context
 

--- a/docs/architecture/legacy/ADR-013-ways-skills-governance-architecture.md
+++ b/docs/architecture/legacy/ADR-013-ways-skills-governance-architecture.md
@@ -7,9 +7,23 @@ deciders:
 related:
   - ADR-004
   - ADR-005
+  - ADR-200
 ---
 
 # ADR-013: Ways, Skills, and Governance Architecture
+
+> **Refined by [ADR-200](../governance/ADR-200-compliance-claims-and-session-derived-findings.md).**
+> This ADR's core insights stand — ways as *activation cues* for latent knowledge, the
+> Type 1–4 way classification, the author-as-compiler model, and the formation intuition
+> in its "Shift Lead Wisdom" type. But its **epistemics are corrected**: wherever it calls
+> provenance "evidence," "auditability," "proof," or what "turns Claude from a hack into a
+> professional," read **claim**. A hand-authored mapping is a control-*design* assertion
+> (SOC 2 Type I), not an assessed **finding** (SOC 2 Type II); a citation on demand is an
+> assertion awaiting a finding, not proof. Its analogies (kitchen poster, shift lead, FAA
+> tool) are illustration; the grounded vocabulary — *first line*, *tacit knowledge*,
+> *claim/finding* — lives in ADR-200. Mechanism has also moved on: `governance.sh` is now
+> `ways governance`/`ways-audit` (ADR-111), and provenance lives in a `provenance.yaml`
+> sidecar, not way frontmatter (ADR-110).
 
 ## Context
 
@@ -75,10 +89,10 @@ Provenance is the evidence chain from repeated failure → institutional learnin
 - Maps specific way directives to specific control requirements with justifications
 - Creates a self-supporting network: multiple controls cross-referencing the same practice
 
-**What provenance provides**:
-- The difference between "Claude follows good practices because it was trained on good code" (hack) and "Claude follows good practices because specific regulations require them, and here's the evidence chain" (professional)
-- Auditability: when someone asks "prove it," the governance-cite skill can pull real control citations
-- Authority: a way without provenance is a rule without authority; with provenance, it's a traceable policy implementation
+**What a claim provides** *(epistemics corrected by ADR-200 — this section originally read "What provenance provides")*:
+- A statement that a way is *designed* to address specific controls — a control-design **claim** (SOC 2 Type I), not proof that it does.
+- Traceability of intent: the lookup can surface which controls a way *claims* to address. This is an asserted mapping, not evidence — a citation on demand is a claim awaiting a **finding**, not a satisfied "prove it."
+- Explicitness: a way with a claim states its intended control alignment, which makes that alignment *assessable*; substantiating it requires a session-derived finding (ADR-200).
 
 #### The Authorship Model: Provenance as Design-Time Artifact
 
@@ -215,14 +229,14 @@ The overlap zone is "inject contextual guidance." But the ways that justify the 
 - Scope-filtered team coordination
 - Macro-based dynamic context (repo health checks, file scanning)
 
-### The professional distinction
+### First-line formation, not proof
 
-The difference between a professional and a hack isn't skill — it's awareness of the policy network. Both might write the same code. The professional knows WHY (the regulation, the safety standard, the certification requirement) and can PROVE IT (traceability, test evidence, documentation). The hack just knows "don't break it."
+*(Reframed per ADR-200.)* A way carrying a claim knows *which control shape* it steers toward — but citing that claim is an assertion, not proof. In audit terms this is **first-line** work (the Three Lines Model): shaping how risk is managed *in the doing of the work*, distinct from the third-line assurance that independently proves conformance.
 
-- A hack agent: follows good practices because the LLM was trained on good code
-- A professional agent: follows good practices because specific policies require them, and can cite those policies on demand
+- Without claims: guidance is followed because the model was trained on good practice.
+- With claims: guidance also *states* the control shape it intends — so a later **finding** can test whether the work actually took that shape.
 
-The governance provenance layer is what turns Claude from a very capable hack into a professional.
+The claim layer makes intended alignment explicit and assessable. It does not, by itself, turn assertion into evidence — that is precisely the correction ADR-200 exists to make.
 
 ## The Governance Control Surface
 
@@ -300,42 +314,16 @@ Rejected: skills cannot fire on tool use, cannot session-gate, cannot carry prov
 ### Replace ways with raw hooks
 Possible but rejected: ways provide an abstraction (session-gating, multi-mode matching, macros, governance provenance, scope filtering, domain organization) that would need to be rebuilt in every hook script. The abstraction layer is the value.
 
-## Traceability Gap: Current State
+## Traceability: a live query, not a frozen table
 
-*Updated 2026-02-09 after provenance gap-fill (37 controls, 93 justifications across 12 ways)*
-
-| Way | Has Provenance | Type | Status |
-|-----|---------------|------|--------|
-| softwaredev/commits | YES | Kitchen Poster | Complete |
-| softwaredev/security | YES | Kitchen Poster | Complete |
-| softwaredev/quality | YES | Kitchen Poster | Complete |
-| meta/knowledge | YES | HQ Policy Manual | Complete |
-| softwaredev/deps | YES | Kitchen Poster | **Added** — SA-12, OWASP A06, RA-5 |
-| softwaredev/testing | YES | Kitchen Poster | **Added** — SA-11, IEEE 829, ISO 25010 |
-| softwaredev/config | YES | Kitchen Poster | **Added** — CM-6, CIS 4.1, IA-5 |
-| softwaredev/errors | YES | Kitchen Poster | **Added** — OWASP A09, SI-11, AU-3 |
-| softwaredev/ssh | YES | Kitchen Poster | **Added** — AC-17, IA-2, IA-5 |
-| softwaredev/release | YES | Kitchen Poster | **Added** — CM-3, CC8.1, SA-10 |
-| softwaredev/adr | YES | Kitchen Poster | **Added** — CM-3, A.5.1, PL-2 |
-| softwaredev/github | YES | Kitchen Poster | **Added** — CC8.1, CM-3, A.8.32 |
-| softwaredev/debugging | NO | Shift Lead Wisdom | None needed |
-| softwaredev/patches | NO | Shift Lead Wisdom | None needed |
-| softwaredev/performance | NO | Shift Lead Wisdom | None needed |
-| softwaredev/api | NO | Shift Lead Wisdom | None needed |
-| softwaredev/design | NO | Shift Lead Wisdom | None needed |
-| softwaredev/migrations | NO | Shift Lead Wisdom | None needed |
-| softwaredev/docs | NO | Shift Lead Wisdom | None needed |
-| meta/memory | NO | Plumbing | None needed |
-| meta/subagents | NO | Plumbing | None needed |
-| meta/teams | NO | Plumbing | None needed |
-| meta/todos | NO | Plumbing | None needed |
-| meta/tracking | NO | Plumbing | None needed |
-| meta/introspection | NO | HQ Policy Manual | None needed |
-| meta/skills | NO | HQ Policy Manual | None needed |
-| itops/incident | NO | Kitchen Poster (disabled) | Future work |
-| itops/policy | NO | HQ Policy Manual (disabled) | Future work |
-| itops/proposals | NO | Kitchen Poster (disabled) | Future work |
-| itops/runbooks | NO | Kitchen Poster (disabled) | Future work |
+*(Reframed per ADR-200.)* This ADR originally carried a point-in-time table marking each
+way's provenance as "Complete." That is retired on two counts. Coverage is a **live
+query** now (`ways governance`, moving to the `ways-audit` binary) — not a snapshot
+frozen into a decision record. And under ADR-200 a way with a hand-authored mapping
+carries a **claim**, not a completed control; "Complete" was the
+coverage-equals-compliance overclaim. A claim is complete only once a session-derived
+**finding** substantiates it. Run the tool for current coverage, and read any count it
+reports as *claims made*, not *conformance achieved*.
 
 ## References
 

--- a/docs/architecture/system/ADR-110-way-file-separation-and-graph-compatible-structure.md
+++ b/docs/architecture/system/ADR-110-way-file-separation-and-graph-compatible-structure.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-03-29
 deciders:
   - aaronsb
@@ -8,9 +8,19 @@ related:
   - ADR-107
   - ADR-108
   - ADR-005
+  - ADR-111
+  - ADR-151
+  - ADR-200
 ---
 
 # ADR-110: Way File Separation and Graph-Compatible Structure
+
+> **Accepted as implemented; reconciled with later ADRs.** The `provenance.yaml` sidecar
+> defined here is the storage for what **ADR-200** reframes as a compliance **claim** (a
+> control-*design* assertion, not evidence). Its consumers named below — `governance.sh`
+> and `provenance-scan.py` — predate the single-binary consolidation (**ADR-111**); the
+> sidecar is now read by `ways governance`, moving to the `ways-audit` binary
+> (**ADR-151**). Read those tool names accordingly.
 
 ## Context
 
@@ -31,7 +41,7 @@ Meanwhile, the ways system is approaching a point where humans other than the or
 
 Three observations converged:
 
-1. **Anthropic's harness design research** (March 2028) found that "every component in a harness encodes an assumption about what the model can't do on its own." Ways are exactly this — each one encodes an assumption. As models improve, some assumptions become stale. There's no mechanism to signal which assumptions a way is making or how firm they are.
+1. **Anthropic's harness design research** (2025) found that "every component in a harness encodes an assumption about what the model can't do on its own." Ways are exactly this — each one encodes an assumption. As models improve, some assumptions become stale. There's no mechanism to signal which assumptions a way is making or how firm they are.
 
 2. **Man page architecture** has solved the "many structured documents, navigable by humans and machines" problem for 40 years with a clear separation: minimal metadata (one line), conventional body sections (`NAME`, `SEE ALSO`), derived indexes (`mandb`/`whatis`), and locale as a directory concern. Ways could follow the same pattern.
 
@@ -63,7 +73,7 @@ controls:
       - Nesting depth limit maintains modifiability by controlling complexity
 ```
 
-`governance.sh` reads `provenance.yaml` files instead of parsing way frontmatter. The governance pipeline never needs to parse markdown again.
+The governance CLI (`ways governance`, later the `ways-audit` binary — ADR-111/151) reads `provenance.yaml` files instead of parsing way frontmatter. The pipeline never needs to parse markdown again.
 
 Way files that have no governance mapping simply don't have a `provenance.yaml`. Absence is the default, not an empty block.
 
@@ -256,7 +266,7 @@ This simplifies ADR-107's scope: locale support only touches way files, not the 
 - ADR-107: Way-Match Corpus, Batch Mode, and Locale Support
 - ADR-108: Embedding-Based Way Matching with all-MiniLM-L6-v2
 - ADR-005: Governance Traceability for Ways
-- Anthropic Engineering: "Harness Design for Long-Running Application Development" (2028)
+- Anthropic Engineering: "Harness Design for Long-Running Application Development" (2025)
 - `hooks/ways/frontmatter-schema.yaml`: Current field definitions
-- `governance/governance.sh`: Current provenance consumer
+- Provenance consumer: `ways governance` (consolidated from the former `governance/governance.sh` per ADR-111; moving to the `ways-audit` binary per ADR-151)
 - Unix man pages: `man(7)`, `mandb(8)` — prior art for structured document corpora

--- a/docs/architecture/system/ADR-151-extract-ways-core-crate-and-ways-audit-sibling-binary.md
+++ b/docs/architecture/system/ADR-151-extract-ways-core-crate-and-ways-audit-sibling-binary.md
@@ -1,0 +1,154 @@
+---
+status: Accepted
+date: 2026-07-02
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-110
+  - ADR-111
+  - ADR-142
+  - ADR-200
+supersedes: []
+---
+
+# ADR-151: Extract ways-core crate and ways-audit sibling binary
+
+## Context
+
+ADR-200 reframes the compliance subsystem into an operator-invoked claim/finding
+formation layer, backed by a purpose-built toolkit rather than the core `ways` binary.
+This ADR decides how that toolkit is packaged.
+
+The relevant facts about the current code:
+
+- `tools/` is a Cargo **workspace** (a set of crates built together), and shared
+  library crates are already the house style here — `sensor-trait`, `agent-fmt`, and
+  `agent-identity` are exactly that pattern: small libraries several binaries depend on.
+- `ways-cli` is a **binary-only crate** (it produces the `ways` executable and has no
+  `[lib]` target). The compliance logic — the `governance`/`provenance` modules, ~1,100
+  lines — lives *inside* that binary crate and reaches into its private siblings
+  (`crate::util`, `crate::cmd`). It is not a reusable library; it is trapped in the
+  executable.
+- That ~1,100-line engine has **zero tests**, including the integrity linter that is
+  supposed to audit the claims. Being buried in a binary with no library boundary is
+  part of why: there is no clean seam to unit-test against.
+- ADR-111 consolidated a sprawl of shell scripts (`governance.sh`, `provenance-scan.py`,
+  …) into the single `ways` binary. That was the right call for *script sprawl*. The
+  question here is different: the compliance concern is a **distinct operator surface**,
+  invoked deliberately (like `/ship` or `/wrap`), which the subsystem's own `governance/README.md` already sketches as
+  separable (its "Making This Its Own Repo" section — a "perforated pop-out"). It should
+  not be re-scattered — but it also
+  should not bloat the core tool everyone runs.
+
+So the packaging question: how does `ways-audit` reuse the engine without rewriting it,
+keep the core binary lean, and give the untested engine a home worth testing?
+
+## Decision
+
+### 1. Extract a `ways-core` library crate
+
+Pull the reusable engine out of the `ways` binary into a new **`ways-core`** library
+crate in the workspace: way discovery and scanning, frontmatter parsing, path and
+projection resolution, the firing-event log reader, and the claim (`provenance.yaml`)
+sidecar model and manifest builder. Both `ways` (binary) and `ways-audit` (binary)
+depend on it. This is the established house pattern (`sensor-trait` et al.), not a new
+paradigm.
+
+The extraction pays for itself independently of the compliance work: a library boundary
+is exactly what makes the previously-untested engine unit-testable. `ways-core` ships
+with tests; the core tool gets healthier whether or not anyone ever runs `ways-audit`.
+
+### 2. Add `ways-audit` as a sibling binary
+
+A new **`ways-audit`** binary crate, depending on `ways-core`, owns the whole compliance
+surface:
+
+- The reporting commands presently under `ways governance` (report, trace, control,
+  gaps, matrix, lint), migrated and renamed to the compliance vocabulary of ADR-200
+  (claim / finding / POA&M).
+- The **finding pipeline**: read a claim + its firing events + the session transcript,
+  produce an assessment finding with a determination, and append it to the finding
+  ledger.
+- The **claim-authoring assist**: propose candidate control mappings for a way
+  (agent-assisted, human-grounded per ADR-200 §1).
+
+The core `ways` binary **sheds** the `governance` subcommand. It goes back to being the
+runtime — matching, hooks, session lifecycle — with the compliance concern living next
+to it, not inside it.
+
+### 3. The claim schema lives in `ways-core`, built for scale and assessability
+
+`ways-core` defines the claim type stored in the `provenance.yaml` sidecar (ADR-110).
+Per ADR-200 §1 the schema carries a **determination criterion** — the observable
+behavior that would let an assessor mark the claim *satisfied* / *other than satisfied*
+— so a claim is assessable rather than a bare assertion. `ways-audit` consumes that
+type both to *assess* (produce findings) and to *suggest* (candidate mappings). Defining
+it in the shared crate keeps the format single-sourced as claims are seeded across the
+corpus at scale (ADR-200 §7).
+
+### 4. Distribution reuses the per-component release machinery
+
+`ways-audit` slots into the existing component-parameterized release flow: a
+`ways-audit-v*` tag series, its own CI build job, and a download entry, exactly as
+`ways` has. The marginal cost is one CI job and one download path — the same
+prebuilt-binary machinery already planned for the other app binaries (ADR-142/ADR-146).
+
+## Relationship to ADR-111
+
+ADR-111 folded shell-script sprawl into one binary because the *abstraction layer* — one
+tool, consistent surface — was the value. This ADR does not reverse that: it introduces
+**one** additional binary for **one** cohesive, separable concern, and the two binaries
+share a real library (`ways-core`) rather than duplicating logic. The distinction is
+concern-separation with a shared abstraction, not a return to sprawl. ADR-111's own
+"the abstraction layer is the value" argument is what `ways-core` embodies.
+
+## Consequences
+
+### Positive
+
+- The core `ways` binary stays lean — the compliance concern is isolated and optional.
+- `ways-core` gives the previously-untested engine a testable boundary; the extraction
+  improves the main tool on its own merits.
+- The claim schema is single-sourced and scale-ready, with assessability built in.
+- Extraction to a standalone repo later (already sketched in `governance/README.md`) becomes a small
+  move — the library seam is already drawn — without paying that cost now.
+- Distribution is nearly free: the release/CI machinery already handles N components.
+
+### Negative
+
+- A real refactor: extract `ways-core`, move the modules off `crate::util`/`crate::cmd`
+  onto the library API, and fix imports across the workspace.
+- A second binary to build, ship, and version.
+- `ways-core` now has a public API surface to keep stable for two consumers.
+
+### Neutral
+
+- `ways-audit` can version independently of `ways` (different cadence, own tag series).
+- The `ways governance` command path is retired from the core binary; a one-release
+  deprecation pointer to `ways-audit` can be kept if any operator scripted against it,
+  though it was never a consumed surface.
+- Repo extraction remains an available future option, deliberately not taken now.
+
+## Alternatives Considered
+
+- **Keep compliance inside the `ways` binary (status quo / strict ADR-111).** Rejected:
+  it bloats the core runtime with an optional, deliberately-invoked concern, offers no
+  separation seam, and couples the compliance release cadence to the core tool.
+- **A new binary that copies the engine (no shared crate).** Rejected: duplication and
+  drift. The workspace already solves this with shared library crates; not using one
+  here would be the anomaly.
+- **Extract the whole subsystem to a separate repository now.** Rejected as premature:
+  a same-workspace sibling is cheaper, keeps the `ways-core` refactor in one place, and
+  still leaves repo extraction open once the toolkit proves itself. Drawing the library
+  seam now is the reversible half of that decision.
+
+## References
+
+- **ADR-200** — the compliance claim/finding model this toolkit backs.
+- **ADR-110** — the `provenance.yaml` sidecar storage the claim schema extends.
+- **ADR-111** — the single-binary consolidation this refines (one sibling, shared lib).
+- **ADR-142 / ADR-146** — XDG application distribution and installer binary handling the
+  new binary plugs into.
+- **The Cargo Book — Workspaces** — the shared-crate mechanism used here.
+  https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html


### PR DESCRIPTION
## Summary

Reframes the governance/provenance subsystem into an **operator-invoked compliance formation layer** with an honest **claim → finding** split, grounded in verified domain vocabulary (SOC 2 Type I/II, OSCAL, the Three Lines Model, NIST 800-53A, assurance cases). This is the **decision layer** — a docs-only PR. The docs-corpus rewrite and the `ways-core`/`ways-audit` implementation are follow-on PRs.

## What changed

- **ADR-200** (new, governance) — claims (control-design assertions) vs findings (session-derived, assessed); process/outcome evidence tiers; operator-invoked, never forced; foundation-for-not-implementation-of; assessable claim schema.
- **ADR-151** (new, system) — extract a `ways-core` library crate; add `ways-audit` as a sibling binary reusing it.
- **ADR-005** — superseded by ADR-200.
- **ADR-013** — refined: epistemic overclaims corrected (a citation is a claim, not evidence); insights kept; stale "coverage = complete" table retired.
- **ADR-110** — accepted; `provenance.yaml` sidecar reconciled to `ways governance`/`ways-audit`; future-dated references fixed.
- **ADR-300 §4** — reconciled stale `governance.sh`/`provenance-scan.py` references.

## Register

Name-the-shape-then-teach-it: real domain terms as the spine, each glossed in plain language on first use, analogies demoted to marked illustration. Terminology verified against authoritative sources before use.

## Test plan

- `docs/scripts/adr lint` — clean (0 errors; 1 pre-existing unrelated warning).
- ADR index regenerated.
- Decision records only; no code changes in this PR.