### PR TITLE
chore(ways): introspection revisions — fix meta/deployment leak + touch-ups

### DIFF
--- a/hooks/ways/meta/deployment/deployment.md
+++ b/hooks/ways/meta/deployment/deployment.md
@@ -1,7 +1,8 @@
 ---
-description: How agent-ways 1.0 deploys into the home config dir — ~/.claude as a thin projection of an XDG application (source in $XDG_DATA_HOME/agent-ways), how install and update work under it, and how to spot a legacy pre-1.0 in-place clone that must migrate instead of pull — surfaced when install, update, or an existing ~/.claude conflict comes up
-vocabulary: install setup deploy deployment update ~/.claude existing config clobber projection xdg reconcile migrate legacy in-place upgrade reinstall fresh greenfield brownfield sync-to-home
-pattern: install|reconcile|migrate|clobber|topology|~/\.claude|existing \.?claude|make update|deploy|projection
+description: How agent-ways itself deploys into the home config dir — ~/.claude as a thin projection of an XDG application (source in $XDG_DATA_HOME/agent-ways), how the agent-ways installer/update/`ways reconcile` work under it, and how to spot a legacy pre-1.0 in-place agent-ways clone that must `ways migrate` instead of pull — surfaced only when installing, updating, migrating, or reconciling agent-ways itself, or resolving an existing ~/.claude conflict during agent-ways setup
+vocabulary: agent-ways ~/.claude thin projection XDG application $XDG_DATA_HOME/agent-ways ways reconcile ways migrate reproject legacy in-place clone pre-1.0 agent-ways projected roots settings.json merge curl bash agent-ways installer existing .claude clobber sync-to-home topology ADR-142
+pattern: agent-ways|~/\.claude|existing \.?claude|ways (reconcile|migrate)|make update|in-place clone|thin projection|xdg.?data
+embed_threshold: 0.45
 refire: 0.15
 scope: agent, subagent
 ---

--- a/hooks/ways/softwaredev/freshness/groundtruth/groundtruth.md
+++ b/hooks/ways/softwaredev/freshness/groundtruth/groundtruth.md
@@ -18,6 +18,8 @@ When you need to state how a system *actually* behaves — and especially when y
 
 Treat the prose layer — ADRs, design notes, specs, READMEs, docstrings — as **claims to verify**, not as truth. Read it, but confirm each load-bearing assertion against the executable side before you rely on it.
 
+The same holds for what you *write out*: a citation, an attribution, or a named term is itself a claim. Verify it against the cited artifact — the ADR you're quoting, the standard you're naming, the API you're describing — not your memory of it. An unchecked citation is an assertion in costume.
+
 This inverts the usual reflex ("the ADR says X, so X"). The failure mode it prevents is the one that compounds: a wrong premise adopted early mis-shapes everything built on it. If the yardstick is stale, every measurement taken with it is off.
 
 ## Each divergence is a finding

--- a/hooks/ways/writing/writing.md
+++ b/hooks/ways/writing/writing.md
@@ -42,6 +42,7 @@ Write prose, not bullet points wearing a trenchcoat. Let ideas develop across se
 - Avoid staccato sentence fragments for rhetorical impact. Let the substance carry the weight.
 - Lead with the conclusion when the audience is busy. Lead with context when the audience needs persuading.
 - Cut filler on revision. "In order to" → "To". "It should be noted that" → delete.
+- Name the real term, then gloss it. For domain vocabulary, give the precise term *and* a plain-language gloss on first use — neither a jargon wall nor analogy-mush. Analogies illustrate; they don't carry the argument.
 
 **Ask the user** about style preferences early. Use literary terms when discussing: register (formal/informal), diction (word choice), syntax (sentence structure), cadence (rhythm), tone (attitude toward subject). These terms are precise and help the user articulate what they want.
 

--- a/skills/ways-tests/SKILL.md
+++ b/skills/ways-tests/SKILL.md
@@ -49,8 +49,8 @@ After editing any `description`/`vocabulary`, regenerate so scores reflect it:
 `ways corpus`. Then rank the whole corpus in one batch:
 
 ```bash
-ways embed --query "$prompt"                  # ranked by cosine
-ways embed --query "$prompt" --threshold 0.1  # full landscape — debugging a miss
+ways embed "$prompt"    # full corpus ranking by cosine — read down the list to debug a miss
+                        # QUERY is positional; embed takes no --threshold (that's the per-way embed_threshold frontmatter field, not a CLI flag)
 ```
 
 For a single way, grep its id (path relative to the ways root, e.g.


### PR DESCRIPTION
## Summary

Output of a test-first introspection pass. The guiding decision: **revise existing ways, mint none** — the session's lessons already had homes, so this bundles small revisions plus one real bug fix.

## Changes

- **`meta/deployment` — leak fix (the real one).** The way's `pattern`/`vocabulary` carried bare `install`/`deploy`/`migrate`/`projection` with no `agent-ways` anchor, so it fired on generic deployment/migration talk in *unrelated* projects (observed leaking agent-ways deploy guidance into a Python data-pipeline session). Anchored the matching surface to agent-ways, dropped the generic verbs, added `embed_threshold: 0.45`.
- **`groundtruth`** — generalize "source of truth": a citation/attribution/named term is a *claim*; verify it against the cited artifact, not memory. Closes a fabricated-citation defect (caught in the prior ADR review).
- **`writing`** — the name-the-term-then-gloss register note.
- **`ways-tests` SKILL** — fix stale `ways embed` docs (`QUERY` is positional; no `--threshold` CLI flag).

## Test plan

Verified with the `ways-tests` harness (`ways embed`) after `ways corpus`:
- Generic queries — "install in a venv", "deploy the pipeline", "run the database migration" — no longer surface `meta/deployment` (they route to supplychain / `delivery` / `delivery/migrations`).
- Real agent-ways queries — "install agent-ways into ~/.claude", "update agent-ways … ways reconcile" — still fire `meta/deployment` at ~0.5 (above the 0.45 threshold).
- `ways lint` clean on the changed ways.