### PR TITLE
docs(compliance): reconcile governance/provenance corpus to the claim/finding model

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,29 +244,29 @@ This matters because of how attention works in transformers. Rules loaded at fil
 | **Dynamic content** | No | No | Yes (shell macros) |
 | **Survives refactoring** | No (`src/` → `lib/` breaks paths) | Yes | Yes |
 | **Non-file triggers** | No | No | Yes (`git commit`, context threshold, subagent spawn) |
-| **Governance provenance** | No | No | Yes (NIST, OWASP, ISO, SOC 2 traceability) |
+| **Compliance claims** | No | No | Yes (design claims → NIST, OWASP, ISO, SOC 2) |
 | **Org-level scope** | Yes (`/etc/claude-code/`) | No | No |
 | **Zero-config simplicity** | Yes (drop a `.md` file) | Yes | No (requires hook infrastructure) |
 
 **Rules** are best for static, always-on preferences ("use TypeScript strict mode", "tabs not spaces"). **Skills** are best for specific capabilities invoked by intent ("ship this PR", "rotate AWS keys"). **Ways** are best for context-sensitive guidance that fires on events, cuts across the file tree, and needs to stay fresh in long sessions.
 
-They compose well: rules set baseline preferences, ways inject governance at tool boundaries, skills provide specific workflows. The [full comparison](docs/hooks-and-ways/README.md#ways-rules-and-skills) covers the architectural details.
+They compose well: rules set baseline preferences, ways inject guidance at tool boundaries, skills provide specific workflows. The [full comparison](docs/hooks-and-ways/README.md#ways-rules-and-skills) covers the architectural details.
 
 > **Is this just RAG?** Ways and RAG solve the same fundamental problem — getting the right context into the window at the right time — but through different architectures. RAG retrieves by semantic similarity; Ways retrieve by event. RAG is stateless; Ways track session state. The [full comparison](docs/hooks-and-ways/ways-vs-rag.md) explores what's shared, what's different, and when each approach wins.
 
 ## Governance
 
-Ways are compiled from policy. Every way can carry `provenance:` metadata linking it to policy documents and regulatory controls — the runtime strips it (zero tokens), but the [governance operator](governance/README.md) walks the chain:
+A way can carry a compliance **claim**: a `provenance.yaml` sidecar linking it to policy documents and the regulatory controls its guidance is *designed* to address. The runtime never reads it (zero tokens), but the [governance operator](governance/README.md) walks the chain:
 
 ```
-Regulatory Framework → Policy Document → Way File → Agent Context
+Control Framework → Policy Document → Way + claim → Agent Context
 ```
 
-The [`governance/`](governance/) directory contains reporting tools and [policy source documents](governance/policies/) — coverage queries, control traces, traceability matrices. Designed to be separable. The built-in ways carry justifications across controls from NIST, OWASP, ISO, SOC 2, CIS, and IEEE.
+The [`governance/`](governance/) directory contains reporting tools and [policy source documents](governance/policies/) — claim-coverage queries, control traces, matrices. Designed to be separable. The built-in ways carry justification *claims* across controls from NIST, OWASP, ISO, SOC 2, CIS, and IEEE — assertions about how the guidance is *designed*, not evidence that any control operates.
 
-Most users don't need governance. It's an additive layer that emerges when compliance asks *"can you prove your agents follow policy?"* See [docs/governance.md](docs/governance.md) for the full reference.
+Most users don't need it. It's an additive layer that helps work take a control-aligned shape at the point of work: a first-line aid, not an assessment or attestation. Read any coverage number as *claims made*, not *conformance achieved*. See [docs/governance.md](docs/governance.md) for the full reference.
 
-For adding provenance: [provenance.md](docs/hooks-and-ways/provenance.md) | Design rationale: [ADR-005](docs/architecture/legacy/ADR-005-governance-traceability.md)
+For adding a claim: [provenance.md](docs/hooks-and-ways/provenance.md) | Design rationale: [ADR-200](docs/architecture/governance/ADR-200-compliance-claims-and-session-derived-findings.md)
 
 ## Philosophy
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ Same pattern: guide, reference, implementation.
 
 - **[../governance/README.md](../governance/README.md)** — guide. Getting started, operator commands.
 - **[governance.md](governance.md)** — reference. Compilation chain, data flow, tool mechanics.
-- **[../governance/](../governance/)** — implementation. Scripts, policies, manifests.
+- **[../governance/](../governance/)** — implementation. Policy source documents and reporting tooling (the `ways governance` CLI).
 
 | Path | What's there |
 |------|-------------|

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,52 +1,64 @@
-# Governance System
+# Governance & Compliance Traceability
 
-How policy traceability works for ways. This is the reference layer — for getting started, see [governance/README.md](../governance/README.md). For adding provenance to a way, see [provenance.md](hooks-and-ways/provenance.md).
+How agent-ways links its guidance to external control frameworks — and, plainly, what
+that link is and is not. This is the reference layer; for the model and its rationale
+see **[ADR-200](architecture/governance/ADR-200-compliance-claims-and-session-derived-findings.md)**
+(compliance claims and session-derived findings).
 
-## The Compilation Chain
+> **Read this first.** A way can carry a **claim** that its guidance is *designed* to
+> steer work toward a specific control (NIST 800-53, OWASP, ISO 27001, SOC 2, CIS,
+> IEEE). A claim is a control-*design* assertion — in audit terms the **SOC 2 Type I**
+> posture (suitably designed at a point in time) — **not** evidence that the control
+> operates. Evidence is a **finding**, produced later from real sessions (SOC 2 Type II;
+> the `ways-audit` direction in ADR-151). Today the tooling reports on **claims**, so
+> read any coverage number as *claims made*, not *conformance achieved*.
 
-Ways are compiled policy. A human reads a policy document, interprets it for the agent context, and writes a way file — compressed, directive, stripped of rationale. The governance system makes that compilation traceable.
+## The chain
+
+A way is authored guidance: a person (often Claude) reads a control or policy and writes
+compact, directive guidance that steers work into the shape the control expects. The
+claim records which control that guidance is *designed* to address, so the link is
+walkable in either direction:
 
 ```
-Regulatory Framework    (NIST, ISO, OWASP, SOC 2, CIS, IEEE...)
-       ↓
-Control Requirement     (NIST SP 800-53 CM-3, OWASP A03:Injection...)
-       ↓
-Policy Document         (governance/policies/*.md — human prose)
-       ↓
-Way File                (hooks/ways/*/{name}.md — compiled guidance)
-       ↓
-Agent Context           (injected at runtime when triggers match)
+Control framework   (NIST 800-53, OWASP, ISO 27001, SOC 2, CIS, IEEE…)
+       ↓  cited by
+Policy document     (governance/policies/*.md — human prose)
+       ↓  claimed by
+Way + claim         (hooks/ways/**/{name}.md  +  provenance.yaml sidecar)
+       ↓  injected at runtime (claim metadata stripped — zero tokens)
+Agent context       (the guidance fires when its triggers match)
 ```
 
-Each layer compresses the one above it. The regulatory framework is hundreds of pages. The control is a paragraph. The policy is a few pages. The way is 30 lines. The agent sees only the directives — but the full chain is walkable.
+Each layer compresses the one above it. But the link is a *design* claim — that the
+guidance was written to address the control — not proof the work conformed. Only a
+session-derived finding can show that.
 
-## Provenance Metadata
+## Where a claim lives: the `provenance.yaml` sidecar
 
-Ways carry optional `provenance:` blocks in their YAML frontmatter:
+A claim lives in a **`provenance.yaml` sidecar** beside the way (ADR-110), not in the
+way's own frontmatter. The runtime never reads the sidecar; way frontmatter is stripped
+before injection anyway, so a claim reaches the agent's context **never** — zero tokens,
+zero latency. It exists for the compliance tooling and for humans, not for the model.
 
 ```yaml
----
-pattern: commit|push
-provenance:
-  policy:
-    - uri: governance/policies/code-lifecycle.md
-      type: governance-doc
-  controls:
-    - id: NIST SP 800-53 CM-3 (Configuration Change Control)
-      justifications:
-        - Conventional commit types classify changes by nature
-        - Atomic commits make each change independently reviewable
-    - id: SOC 2 CC8.1 (Change Management)
-      justifications:
-        - Type prefix and scope create structured change records
-  verified: 2026-02-05
-  rationale: >
-    Conventional commits create structured change records with type
-    classification and justification.
----
+# hooks/ways/softwaredev/delivery/commits/provenance.yaml
+policy:
+  - uri: governance/policies/code-lifecycle.md
+    type: governance-doc
+controls:
+  - id: NIST SP 800-53 CM-3 (Configuration Change Control)
+    justifications:
+      - Conventional commit types classify changes by nature
+      - Atomic commits make each change independently reviewable
+  - id: SOC 2 CC8.1 (Change Management)
+    justifications:
+      - Type prefix and scope create structured change records
+verified: 2026-02-05
+rationale: >
+  Conventional commits create structured change records with type classification,
+  implementing auditable change control.
 ```
-
-**The runtime strips all frontmatter before injection.** Provenance metadata never reaches the agent's context window. Zero tokens. Zero latency. It exists purely for governance — the debug symbols of compiled policy.
 
 ### Fields
 
@@ -54,12 +66,38 @@ provenance:
 |-------|---------|
 | `policy[].uri` | Source policy document — relative path or `github://org/repo/path` |
 | `policy[].type` | Classification: `adr`, `governance-doc`, `regulatory-framework`, `control-spec` |
-| `controls[].id` | Regulatory control this way addresses |
-| `controls[].justifications[]` | Specific claims about how guidance satisfies the control |
-| `verified` | Date provenance was last confirmed accurate |
-| `rationale` | How policy intent became way guidance — the compilation commentary |
+| `controls[].id` | The control this way *claims* to be designed for |
+| `controls[].justifications[]` | How the guidance is meant to address the control (assertions, not evidence) |
+| `verified` | Date the claim's *authoring* was last reviewed (not an assessment date) |
+| `rationale` | Summary of how the way's guidance compiles the cited controls into practice |
 
-## Data Flow
+> **Proposed (ADR-200 §1), not yet in the schema:** a per-control *determination
+> criterion* — the observable session behavior that would move a claim from an assertion
+> to a *satisfied* / *other-than-satisfied* finding. It is what makes a claim assessable;
+> the current sidecars don't carry it yet.
+
+## What the tooling does today
+
+Compliance queries run through the `ways` CLI (`ways governance <mode>`). The command
+keeps the `governance` name for now; the claim/finding model and a dedicated `ways-audit`
+binary are the direction set in ADR-151, not yet shipped. The CLI scans the
+`provenance.yaml` sidecars directly and builds the manifest **in memory** — there is no
+persisted `provenance-manifest.json`, and no separate shell scripts (the former
+`governance.sh` / `provenance-scan.py` were consolidated into the binary, ADR-111).
+
+| Mode | Command | Output |
+|------|---------|--------|
+| **Coverage** | `ways governance report` | Which ways carry a claim, which don't |
+| **Trace** | `ways governance trace softwaredev/commits` | The full chain for one way |
+| **Control query** | `ways governance control OWASP` | Which ways *claim* a control |
+| **Policy query** | `ways governance policy code-lifecycle` | Which ways derive from a policy |
+| **Gaps** | `ways governance gaps` | Ways without a claim |
+| **Stale** | `ways governance stale 90` | Claims with old `verified` dates |
+| **Active** | `ways governance active` | Cross-reference claims with way firing stats |
+| **Matrix** | `ways governance matrix` | Flat sheet: way / control / justification |
+| **Lint** | `ways governance lint` | Validate claim integrity (URIs resolve, fields present) |
+
+All modes support `--json`.
 
 ```mermaid
 flowchart LR
@@ -67,75 +105,72 @@ flowchart LR
     classDef data fill:#FF9800,stroke:#E65100,color:#fff
     classDef output fill:#4CAF50,stroke:#2E7D32,color:#fff
 
-    W["way files<br/>(provenance frontmatter)"]:::data
+    W["way + provenance.yaml<br/>(claims)"]:::data
     P["governance/policies/<br/>(policy source docs)"]:::data
     CLI["ways governance"]:::tool
-    R["Reports<br/>(coverage, traces,<br/>matrices, lint)"]:::output
+    R["Reports<br/>(claim coverage, traces,<br/>matrix, lint)"]:::output
 
     W --> CLI
     P --> CLI
     CLI --> R
 ```
 
-## Tools
+## Honest scope
 
-All governance queries are handled by the `ways` CLI (`ways governance <mode>`). The CLI scans way files directly, generates the provenance manifest in memory, and runs queries against it.
+- A claim is a **design** assertion (SOC 2 Type I; in NIST's OSCAL model, a *Component
+  Definition*), **not** a finding.
+- The reports show **claim coverage**, not conformance. "Complete" is not a state a claim
+  can reach — it awaits a session-derived finding.
+- This is a **first-line** aid — in the Three Lines Model (the IIA's framework for
+  governance roles), the first line is the roles that own risk *in the doing of the
+  work*. It helps the work take a control-aligned shape at the point of work. It is
+  **not** an assessment, an attestation, or a certification — that is the third line,
+  and agent-ways is built to *feed* it, not to be it.
 
-| Mode | Command | Output |
-|------|---------|--------|
-| **Coverage** | `ways governance report` | Which ways have provenance, which don't |
-| **Trace** | `ways governance trace softwaredev/commits` | End-to-end chain for one way |
-| **Control query** | `ways governance control OWASP` | Which ways implement a control |
-| **Policy query** | `ways governance policy code-lifecycle` | Which ways derive from a policy |
-| **Gaps** | `ways governance gaps` | Ways without provenance |
-| **Stale** | `ways governance stale 90` | Ways with old verified dates |
-| **Active** | `ways governance active` | Cross-reference with way firing stats |
-| **Matrix** | `ways governance matrix` | Flat spreadsheet: way / control / justification |
-| **Lint** | `ways governance lint` | Validate provenance integrity |
+See ADR-200 for the full model and its non-goals.
 
-All modes support `--json` for machine-readable output.
+## Policy source documents
 
-## Policy Source Documents
+Policy documents live in `governance/policies/`. They are the human-readable
+interpretation layer — why a way exists, what principle it implements, where the
+boundaries are. `ways governance lint` validates that every `policy.uri` in a claim
+resolves to a real file; the chain breaks silently if policies move without the claims
+following.
 
-Policy documents live in `governance/policies/`. These are the human-readable interpretation layer — they explain why a way exists, what principle it implements, what the boundaries are. They're the "source code" that ways compile from.
+## Growth pattern
 
-The governance scanner validates that every `policy.uri` in way frontmatter points to a real file. The provenance chain breaks if policies are moved without updating URIs.
+Compliance claiming is optional and additive. Most users never touch it.
 
-## The Growth Pattern
+1. **Ways** — encode how you work. Everyone starts here.
+2. **Policies** — write down *why* (`governance/policies/`).
+3. **Claims** — link a way to the controls it's *designed* to address (`provenance.yaml`).
+4. **Reporting** — `ways governance` surfaces claim coverage and gaps.
+5. **Findings** — *(direction, ADR-151 / `ways-audit`)* session-derived evidence that the
+   claimed guidance actually shaped the work. Not yet built.
 
-Governance is optional and additive. Most users never need it. The progression:
+Each step builds on the previous without requiring it. A way without a claim runs
+identically at runtime. The system doesn't penalize partial adoption.
 
-1. **Ways** — encode how you do things. Everyone starts here.
-2. **Policies** — write down why. Emerges when ways need rationale or when new team members ask "why do we do it this way?"
-3. **Provenance** — link ways to policies and controls. Emerges when compliance asks "can you prove your agents follow policy?"
-4. **Reporting** — run the governance operator. Emerges when auditors need evidence.
+## Cross-repo pattern
 
-Each step builds on the previous without requiring it. A way without provenance works exactly the same at runtime. Provenance without reporting still documents intent. The system doesn't penalize partial adoption.
-
-## Cross-Repo Pattern
-
-In an enterprise, policy documents and way implementations typically live in separate repositories:
+In an enterprise, policy documents and way implementations typically live in separate
+repositories:
 
 ```
 compliance-repo/              your-claude-config/
 ├── docs/architecture/        ├── hooks/ways/
-│   ├── ADR-150.md           │   ├── softwaredev/delivery/commits/commits.md
-│   └── ADR-200.md           │   │   (provenance: → ADR-150)
-├── audit-ledger.json        │   └── softwaredev/code/security/security.md
-└── controls.xlsx            └── governance/
-                                 ├── policies/
-                                 └── provenance-manifest.json
+│   ├── ADR-150.md            │   └── softwaredev/delivery/commits/
+│   └── ADR-200.md            │       ├── commits.md
+├── controls-catalog.md       │       └── provenance.yaml   (claim → ADR-150)
+└── …                         └── governance/policies/
 ```
 
-The provenance frontmatter references policies by URI. The manifest bridges repos at verification time. The verify script supports `--ledger` for cross-referencing external control inventories.
+A claim references its policy by URI. `ways governance` resolves those URIs and builds
+the cross-repo view in memory at query time — nothing is persisted between repos, so the
+two sides stay decoupled.
 
-## Analogy
+---
 
-| Concept | Software Build | Governance System |
-|---------|---------------|-------------------|
-| Source code | `.c` files | `governance/policies/*.md` |
-| Compiler | `gcc` | Human authoring process |
-| Object code | `.o` files | `hooks/ways/*/{name}.md` |
-| Debug symbols | DWARF / PDB | `provenance:` frontmatter block |
-| Symbol table | `.map` file | `provenance-manifest.json` |
-| Build system | `make` | `ways governance` |
+*Informally:* a way is compiled guidance and a claim is the note saying which standard it
+was compiled to address — useful shorthand, but the note is an assertion, and only a
+finding turns an assertion into evidence.

--- a/docs/hooks-and-ways/README.md
+++ b/docs/hooks-and-ways/README.md
@@ -14,7 +14,7 @@ flowchart LR
     classDef impl fill:#4CAF50,stroke:#2E7D32,color:#fff
 
     P["1. Principle"]:::principle
-    G["2. Governance<br/>Interpretation"]:::governance
+    G["2. Interpretation"]:::governance
     D["3. Documentation"]:::docs
     I["4. Implementation"]:::impl
 
@@ -29,7 +29,7 @@ An opinion about how things should work. This might come from experience, organi
 
 Principles are the raw input. They don't need to be formalized - they just need to be articulated clearly enough to act on.
 
-### 2. Governance Interpretation
+### 2. Interpretation
 
 How that principle applies in practice. This is where the principle meets the real world: what does it mean for this team, this stack, this workflow? What are the boundaries, exceptions, and trade-offs?
 
@@ -142,7 +142,7 @@ flowchart LR
 | **Dynamic content** | No | Yes (shell macros) | No |
 | **Session-gating** | No (always loaded when matched) | Yes (once per session, marker-gated) | No (always available) |
 | **Scope filtering** | No | Yes (agent/teammate/subagent) | No |
-| **Governance provenance** | No | Yes (zero-token provenance metadata) | No |
+| **Compliance claims** | No | Yes (zero-token provenance.yaml sidecars) | No |
 | **Tool restrictions** | No | No | Yes (`allowed-tools`) |
 | **Org-level scope** | Yes (`/etc/claude-code/`) | No | No |
 | **Zero-config** | Yes (drop a `.md` file) | No (requires hook infrastructure) | Yes (drop a `SKILL.md` file) |
@@ -174,7 +174,7 @@ A skill for rotating an AWS key works better when the security way has already e
 - **Cross-cutting concern** (security, testing, commit standards) → **way**
 - **Specific capability** invoked by intent → **skill**
 - Need **tool restrictions** → **skill** (`allowed-tools`)
-- Need **governance traceability** → **way** (provenance metadata)
+- Need to **claim a control** → **way** (`provenance.yaml` sidecar)
 
 <sub>Always, hallways, byways, pathways, crossways, doorways, sideways, stairways, airways, fairways, gateways, getaways. 12 dimensions in the comparison table. 12 ways. Coincidence? There are no coincidences — only ways.</sub>
 
@@ -186,7 +186,7 @@ Don't start by writing the way file. Start at stage 1.
 
 What's the opinion? Why does it matter? Write it down plainly. If you can't explain it in a paragraph, it's not clear enough to implement.
 
-### Step 2: Interpret for governance
+### Step 2: Interpret the principle
 
 How does this apply in practice? Write the prose doc (or add a section to an existing one under `docs/hooks-and-ways/`). Cover:
 
@@ -217,9 +217,9 @@ Test by triggering it and verifying the guidance is actionable.
 
 ### Step 5: Connect the layers
 
-Add a `provenance:` block to the way's frontmatter referencing the policy document, relevant control standards, and a rationale connecting policy intent to compiled guidance. The runtime strips all frontmatter before injection, so provenance metadata costs zero tokens.
+Add a `provenance.yaml` sidecar beside the way referencing the policy document, the controls its guidance *claims* to address, and a rationale connecting policy intent to the compiled guidance. The runtime never reads the sidecar (and way frontmatter is stripped before injection anyway), so the claim costs zero tokens.
 
-See [provenance.md](provenance.md) for the full traceability system — manifest generation, coverage reports, and cross-repo verification.
+See [provenance.md](provenance.md) for the full chain — claim coverage, control traces, and cross-repo resolution.
 
 ## Reading Order
 
@@ -243,6 +243,6 @@ If you're running agent teams:
 2. **[stats.md](stats.md)** — observability, interpreting the telemetry
 3. **[meta.md](meta.md)** — the meta ways (teams, memory, todos, tracking)
 
-If you care about governance traceability:
-1. **[provenance.md](provenance.md)** — the full chain from regulatory framework to agent context
-2. **[ADR-005: Governance Traceability](../architecture/legacy/ADR-005-governance-traceability.md)** — the design decision
+If you care about compliance claims:
+1. **[provenance.md](provenance.md)** — the full chain from control framework to agent context
+2. **[ADR-200: Compliance Claims and Session-Derived Findings](../architecture/governance/ADR-200-compliance-claims-and-session-derived-findings.md)** — the design decision

--- a/docs/hooks-and-ways/extending.md
+++ b/docs/hooks-and-ways/extending.md
@@ -7,7 +7,7 @@ How to create new ways, override existing ones, and manage domains. Writing a wa
 1. Create a directory: `~/.claude/hooks/ways/{domain}/{wayname}/`
 2. Add `{wayname}.md` with YAML frontmatter and guidance content
 3. Optionally add `macro.sh` for dynamic content
-4. Optionally add `provenance:` to frontmatter linking to policy sources (see [provenance.md](provenance.md))
+4. Optionally add a `provenance.yaml` sidecar claiming the controls the way is designed for (see [provenance.md](provenance.md))
 
 No configuration files to update. No registration step. The discovery scripts scan for `{wayname}.md` files automatically.
 

--- a/docs/hooks-and-ways/provenance.md
+++ b/docs/hooks-and-ways/provenance.md
@@ -1,87 +1,46 @@
-# Provenance and Governance Traceability
+# Adding a compliance claim to a way
 
-Ways are compiled policy. A human reads a policy document, interprets it for the agent context, and writes a way file — compressed, directive, stripped of rationale. The guidance that reaches the agent is the object code. The policy document is the source.
+A way can carry a **claim** that its guidance is *designed* to address a specific control
+(NIST 800-53, OWASP, ISO 27001, SOC 2, CIS, IEEE). A claim is a control-*design*
+assertion — not evidence the control operates. For the model and its honest scope, see
+[governance.md](../governance.md) and
+[ADR-200](../architecture/governance/ADR-200-compliance-claims-and-session-derived-findings.md).
+This page is the how-to: author a claim and check it.
 
-This page documents how to make that compilation traceable. For running governance reports, see [governance/README.md](../../governance/README.md).
+## Where a claim lives
 
-## Quick Start: Add Provenance to a Way
+A claim is a **`provenance.yaml` sidecar** in the way's own directory, beside `{name}.md`
+(ADR-110). The runtime never reads it — way frontmatter is stripped before injection, so
+a claim reaches the agent's context **never**: zero tokens, zero latency. It exists for
+the compliance tooling and for humans.
 
-Add a `provenance:` block to your way's YAML frontmatter. The runtime strips it before injection — zero tokens, zero latency:
+```
+hooks/ways/softwaredev/delivery/commits/
+├── commits.md            # the way (guidance + matching frontmatter)
+├── commits.check.md      # optional re-fire check
+└── provenance.yaml       # the compliance claim  ← add this
+```
+
+## Write the sidecar
 
 ```yaml
----
-match: regex
-pattern: commit|push
-provenance:
-  policy:
-    - uri: governance/policies/code-lifecycle.md
-      type: governance-doc
-  controls:
-    - id: NIST SP 800-53 CM-3
-      justifications:
-        - Conventional commits create structured change records
-  verified: 2026-02-17
----
+# hooks/ways/softwaredev/delivery/commits/provenance.yaml
+policy:
+  - uri: governance/policies/code-lifecycle.md
+    type: governance-doc
+controls:
+  - id: NIST SP 800-53 CM-3 (Configuration Change Control)
+    justifications:
+      - Conventional commit types classify changes by nature
+      - Atomic commits make each change independently reviewable
+  - id: SOC 2 CC8.1 (Change Management)
+    justifications:
+      - Type prefix and scope create structured change records
+verified: 2026-02-05
+rationale: >
+  Conventional commits create structured change records with type classification,
+  implementing auditable change control.
 ```
-
-Then verify it's picked up: `ways governance trace softwaredev/commits`
-
-## The Full Chain
-
-```
-Regulatory Framework    (NIST, ISO, OWASP, SOC 2, CIS...)
-       ↓
-Control Requirement     (NIST SP 800-53 CM-3, OWASP A03:Injection...)
-       ↓
-Policy Document         (ADR, governance doc, internal standard)
-       ↓
-Way File                ({name}.md — compiled guidance, context-optimized)
-       ↓
-Agent Context           (injected at runtime when triggers match)
-```
-
-Each layer compresses the one above it. The regulatory framework is hundreds of pages. The control requirement is a paragraph. The policy document is a few pages of interpretation. The way is 30 lines of directives. The agent sees only the directives — but the full chain is walkable.
-
-## The Compilation Metaphor
-
-| Concept | Software Build | Way System |
-|---------|---------------|------------|
-| Source code | `.c` files | Policy documents |
-| Compiler | `gcc` | Human authoring process |
-| Object code | `.o` files | `{name}.md` way files |
-| Debug symbols | DWARF / PDB | `provenance:` frontmatter block |
-| Symbol table | `.map` file | `provenance-manifest.json` |
-
-Debug symbols don't affect program execution but are essential for debugging. Provenance metadata doesn't affect way injection but is essential for governance auditing.
-
-## Adding Provenance to a Way
-
-Add a `provenance:` block to the YAML frontmatter. The runtime strips all frontmatter before injection — these fields never reach the agent's context window. Zero cost.
-
-```yaml
----
-match: regex
-pattern: commit|push
-provenance:
-  policy:
-    - uri: governance/policies/code-lifecycle.md
-      type: governance-doc
-  controls:
-    - id: NIST SP 800-53 CM-3 (Configuration Change Control)
-      justifications:
-        - Conventional commit types classify changes by nature
-        - Atomic commits make each change independently reviewable
-    - id: SOC 2 CC8.1 (Change Management)
-      justifications:
-        - Type prefix and scope create structured change records
-  verified: 2026-02-05
-  rationale: >
-    Conventional commits create structured change records. Atomic commits
-    ensure each change is independently traceable and reversible.
----
-```
-
-Each control carries its own justifications — specific claims about how the way's guidance satisfies that control's requirements. This enables both graph queries (way → control → justification) and flat reporting (the spreadsheet auditors love).
 
 ### Fields
 
@@ -89,60 +48,57 @@ Each control carries its own justifications — specific claims about how the wa
 |-------|---------|
 | `policy[].uri` | Source policy document — relative path (same repo) or `github://org/repo/path` (cross-repo) |
 | `policy[].type` | Classification: `adr`, `governance-doc`, `regulatory-framework`, `control-spec` |
-| `controls[].id` | Regulatory control reference this way addresses |
-| `controls[].justifications[]` | Specific claims about how guidance satisfies the control |
-| `verified` | Date provenance was last confirmed accurate |
-| `rationale` | How policy intent became way guidance — the "compilation commentary" |
+| `controls[].id` | The control this way *claims* to be designed for |
+| `controls[].justifications[]` | How the guidance is meant to address the control — assertions, not evidence |
+| `verified` | Date the claim's authoring was last reviewed (not an assessment date) |
+| `rationale` | Summary of how the way's guidance compiles the cited controls into practice |
 
-Provenance is optional. Ways without it work exactly as before. Not every way is policy-derived — operational ways like `meta/todos` or `meta/memory` exist for system management, not compliance.
+A way without a `provenance.yaml` runs identically at runtime — claims are optional and
+additive. Operational ways (`meta/todos`, `meta/memory`) aren't policy-derived and
+shouldn't carry one; forcing a claim where none is honest is the anti-pattern.
 
-## Generating the Manifest
+## Check it
 
-```bash
-python3 ~/.claude/governance/provenance-scan.py
-python3 ~/.claude/governance/provenance-scan.py -o provenance-manifest.json
-```
-
-The manifest aggregates provenance across all ways into a single JSON artifact with:
-- Per-way provenance data
-- Inverted index: policy document → implementing ways
-- Inverted index: control reference → addressing ways
-- Coverage statistics
-
-## Running the Coverage Report
+`ways governance` reads the sidecars directly and builds its view **in memory** — there
+is no persisted manifest and no separate scripts (the former `governance.sh` /
+`provenance-scan.py` were consolidated into the `ways` binary, ADR-111):
 
 ```bash
-# Coverage report
-ways governance report
-
-# Full governance lint
-ways governance lint
-
-# Machine-readable
-ways governance report --json
+ways governance trace softwaredev/delivery/commits   # the chain for one way
+ways governance report                               # which ways carry a claim
+ways governance lint                                 # validate: URIs resolve, fields present
+ways governance report --json                        # machine-readable
 ```
 
-The report shows which ways have provenance, which policy documents are referenced, which controls are covered, and where gaps exist.
+## Keep it honest
 
-## Cross-Repo Pattern
+- A `justification` is an **assertion** about how the guidance is *designed* to address
+  the control — not proof it did. Substantiating a claim needs a session-derived
+  **finding** (SOC 2 Type II), which is the `ways-audit` direction
+  ([ADR-151](../architecture/system/ADR-151-extract-ways-core-crate-and-ways-audit-sibling-binary.md)),
+  not yet built.
+- Read `ways governance report` coverage as *claims made*, not *conformance achieved*.
+- Point a claim at a control you can defend by ID — and verify the control means what you
+  think, because an unchecked citation is itself a claim.
 
-In an enterprise, policy documents and way implementations typically live in separate repositories:
+## Cross-repo
+
+Policy documents and ways often live in separate repositories:
 
 ```
 compliance-repo/              your-claude-config/
-├── docs/architecture/        ├── hooks/ways/
-│   ├── ADR-150.md           │   ├── softwaredev/delivery/commits/commits.md
-│   └── ADR-200.md           │   │   (provenance: → ADR-150)
-├── audit-ledger.json        │   └── softwaredev/code/security/security.md
-└── controls.xlsx            └── provenance-manifest.json
+├── docs/architecture/        └── hooks/ways/softwaredev/delivery/commits/
+│   ├── ADR-150.md               ├── commits.md
+│   └── ADR-200.md               └── provenance.yaml   (policy uri → ADR-150)
+└── controls-catalog.md
 ```
 
-The provenance frontmatter in ways references policies by URI. The manifest bridges the repos at verification time. The audit ledger in the compliance repo traces controls to policies. Together, the full chain is walkable from regulatory framework to agent context.
+A claim references its policy by `uri`; `ways governance` resolves those URIs and builds
+the cross-repo view at query time. Nothing is persisted between the repos, so the two
+sides stay decoupled.
 
-## Why This Matters
+---
 
-Governance-as-code means the connection between stated policy and actual agent behavior is verifiable — not by reading two documents side-by-side and trusting that someone maintained the link, but by running a script that walks the chain.
-
-This doesn't require expensive GRC software. It requires frontmatter fields that the runtime ignores, a Python script that reads them, and a bash script that reports on them. The entire traceability system is three files and zero runtime cost.
-
-An auditor can ask: "Show me which agent governance implements NIST CM-3." The answer is a `jq` query against the manifest. The way file contains the compiled guidance. The policy document contains the rationale. The control reference closes the loop to the regulatory framework. All of it is in git, with cryptographic hashes and commit history.
+*Informally:* the way is compiled guidance and the sidecar is the note saying which
+standard it was compiled to address. The note is an assertion — only a finding turns it
+into evidence.

--- a/docs/hooks-and-ways/stats.md
+++ b/docs/hooks-and-ways/stats.md
@@ -1,6 +1,6 @@
 # Stats and Observability
 
-You can't manage what you can't see. The ways system logs every firing event and provides tools to understand how governance is actually being applied across sessions, projects, and teams.
+You can't manage what you can't see. The ways system logs every firing event and provides tools to understand how guidance is actually being applied across sessions, projects, and teams.
 
 ## What Gets Logged
 
@@ -75,11 +75,11 @@ Last 24h: 11 sessions, 458 way fires
 
 ### How to Interpret It
 
-**Top ways** tells you which governance is actually active. If `meta/todos` and `meta/memory` dominate, your sessions are long enough to hit context thresholds regularly — the system is doing its job keeping state persistent. If a domain-specific way never appears, either the trigger patterns don't match your workflow or the domain is disabled.
+**Top ways** tells you which guidance is actually active. If `meta/todos` and `meta/memory` dominate, your sessions are long enough to hit context thresholds regularly — the system is doing its job keeping state persistent. If a domain-specific way never appears, either the trigger patterns don't match your workflow or the domain is disabled.
 
-**By scope** shows who's receiving governance. `agent` is your main sessions. `teammate` means team members got their coordination norms. `subagent` means delegated tasks received relevant ways. `unknown` is from older events logged before scope tracking existed — it ages out naturally.
+**By scope** shows who's receiving guidance. `agent` is your main sessions. `teammate` means team members got their coordination norms. `subagent` means delegated tasks received relevant ways. `unknown` is from older events logged before scope tracking existed — it ages out naturally.
 
-**By team** appears only when teams have been used. It shows which teams triggered the most governance. A team with many fires was doing complex, varied work. A team with few fires was focused on something narrow that only matched a couple of ways.
+**By team** appears only when teams have been used. It shows which teams triggered the most ways. A team with many fires was doing complex, varied work. A team with few fires was focused on something narrow that only matched a couple of ways.
 
 **By trigger** reveals *how* ways are being activated:
 - `state` — context-threshold and session-start triggers (the system managing itself)
@@ -88,7 +88,7 @@ Last 24h: 11 sessions, 458 way fires
 - `file` — file path matching (editing .env, README.md, etc.)
 - `teammate`/`subagent` — injected into spawned agents
 
-**By project** shows governance distribution across your work. A project with many fires is one where the ways are highly relevant. A project with few fires either doesn't trigger many patterns or has a focused workflow.
+**By project** shows guidance distribution across your work. A project with many fires is one where the ways are highly relevant. A project with few fires either doesn't trigger many patterns or has a focused workflow.
 
 ### Filtering
 

--- a/docs/hooks-and-ways/teams.md
+++ b/docs/hooks-and-ways/teams.md
@@ -73,7 +73,7 @@ When a team spawns, the team name propagates through the entire way-firing pipel
 Task tool (team_name param) → stash file → marker file → detect_team() → log events
 ```
 
-Every way that fires for a teammate logs the team name alongside the usual fields (way, domain, trigger, scope). The stats tool can then group activity by team — useful for understanding which teams triggered which governance and how much.
+Every way that fires for a teammate logs the team name alongside the usual fields (way, domain, trigger, scope). The stats tool can then group activity by team — useful for understanding which teams triggered which ways and how much.
 
 ## Working With Teams
 

--- a/docs/reference/ways-cli.md
+++ b/docs/reference/ways-cli.md
@@ -471,7 +471,7 @@ ways permissions audit --global
 | `matrix` | Flat spreadsheet: way → control → justification |
 | `lint` | Provenance integrity check |
 | `trace <id>` | End-to-end provenance trace for a single way |
-| `control <id>` | Which ways implement a given control |
+| `control <id>` | Which ways *claim* a given control |
 | `policy <id>` | Which ways derive from a given policy |
 
 ```

--- a/skills/governance-cite/SKILL.md
+++ b/skills/governance-cite/SKILL.md
@@ -6,9 +6,11 @@ allowed-tools: Bash, Read, Grep, Glob
 
 # Governance Citation Lookup
 
-A governance traceability system maps agent guidance (ways) to real regulatory
-controls with specific justification evidence. This skill is the **lookup** — run
-it to fetch the control IDs and justification text behind a practice. For *when*
+A governance traceability system maps agent guidance (ways) to the regulatory
+controls their guidance *claims* to address, each with asserted justifications —
+control-*design* claims, not evidence the control operates. This skill is the
+**lookup** — run it to fetch the control IDs and justification text behind a
+practice. For *when*
 to cite and *how* to phrase it, see the **governance citation** way.
 
 ## Look up controls


### PR DESCRIPTION
## Summary

Reconciles the documentation corpus to the merged **ADR-200 / ADR-151** decision layer (PR #257). Retires the old "governance traceability" framing — the compiled-policy/debug-symbols analogy, and the epistemic overclaims that treated hand-authored control mappings as *evidence* — and replaces it with the honest **claim → finding** model. Also fixes accumulated mechanism drift.

## Changed (10 files)

**Heavy rewrites:**
- `docs/governance.md` — reference layer: claims (SOC 2 Type I) vs findings (Type II, *direction*); `provenance.yaml` sidecar; `ways governance` builds its manifest in memory; first-line (Three Lines Model) framing; the analogy demoted to a single marked "*Informally:*" line.
- `docs/hooks-and-ways/provenance.md` — how-to: sidecar authoring + `ways governance`; **purged** the dead `provenance-scan.py`/manifest step and the "cryptographic hashes prove behavior" overclaim.

**Light / surgical:** `README.md`, `docs/README.md`, `docs/hooks-and-ways/README.md`, `docs/hooks-and-ways/extending.md` (inline frontmatter → sidecar; ADR-005 → ADR-200; "Governance provenance" feature row → "Compliance claims"); `skills/governance-cite/SKILL.md` ("justification evidence" → asserted claims); `teams.md` + `stats.md` (register normalization); `ways-cli.md` (control subcommand wording).

## Ground-truth discipline

Describes **only what exists today** — `ways governance`, `provenance.yaml` sidecars. `ways-audit`, session-derived findings, and the `satisfied_when` determination criterion are labeled **direction** (ADR-151 / ADR-200 §1), never as shipped. (The verify pass caught two of my own drafts asserting the criterion as current, plus an inventory-missed file — `extending.md` — still teaching inline frontmatter.)

## Test plan

- `docs/scripts/doc lint` — 0 errors, 0 warnings.
- `docs/scripts/adr lint` — clean (1 pre-existing unrelated warning).
- Verified: no stale ADR-005 links, no dead-script/manifest references presented as live, no inline `provenance:` frontmatter taught, all ADR cross-links resolve.