### PR TITLE
feat(audit): assemble classifier-ready finding dataset (ADR-201, ADR-151 §3)

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -71,14 +71,15 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-148](./system/ADR-148-framework-surface-ships-operator-content-dev-harness-in-project-scope.md) | framework surface ships operator content; dev harness in project scope | Draft |
 | [ADR-149](./system/ADR-149-operator-config-interview-skill.md) | operator config interview skill | Accepted |
 | [ADR-150](./system/ADR-150-version-truth-and-downgrade-safe-self-update.md) | Version-truth and downgrade-safe self-update | Accepted |
-| [ADR-151](./system/ADR-151-extract-ways-core-crate-and-ways-audit-sibling-binary.md) | Extract ways-core crate and ways-audit sibling binary | Draft |
+| [ADR-151](./system/ADR-151-extract-ways-core-crate-and-ways-audit-sibling-binary.md) | Extract ways-core crate and ways-audit sibling binary | Accepted |
 
 ## Governance
 _Provenance, traceability, controls, compliance mapping_
 
 | ADR | Title | Status |
 |-----|-------|--------|
-| [ADR-200](./governance/ADR-200-compliance-claims-and-session-derived-findings.md) | Compliance claims and session-derived findings | Draft |
+| [ADR-200](./governance/ADR-200-compliance-claims-and-session-derived-findings.md) | Compliance claims and session-derived findings | Accepted |
+| [ADR-201](./governance/ADR-201-findings-assembled-as-classifier-ready-assessment-records.md) | Findings assembled as classifier-ready assessment records | Accepted |
 
 ## Documentation
 _Documentation structure, tooling, coherence_

--- a/docs/architecture/governance/ADR-200-compliance-claims-and-session-derived-findings.md
+++ b/docs/architecture/governance/ADR-200-compliance-claims-and-session-derived-findings.md
@@ -10,6 +10,7 @@ related:
   - ADR-110
   - ADR-111
   - ADR-151
+  - ADR-201
 supersedes:
   - ADR-005
 ---

--- a/docs/architecture/governance/ADR-201-findings-assembled-as-classifier-ready-assessment-records.md
+++ b/docs/architecture/governance/ADR-201-findings-assembled-as-classifier-ready-assessment-records.md
@@ -1,0 +1,137 @@
+---
+status: Accepted
+date: 2026-07-02
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-110
+  - ADR-151
+  - ADR-200
+---
+
+# ADR-201: Findings assembled as classifier-ready assessment records
+
+## Context
+
+ADR-200 separated a **compliance claim** (a control-*design* assertion; SOC 2 Type I;
+OSCAL Component Definition) from an **assessment finding** (session-derived evidence
+with a determination of *satisfied* / *other than satisfied*; NIST SP 800-53A; OSCAL
+Assessment Results). It also required, in §1, that every claim carry a **determination
+criterion** — the observable session behavior that would let an assessor decide the
+finding. ADR-151 packages the tool that produces findings: `ways-audit`.
+
+ADR-200 left one thing unresolved: **who fills the determination, and when.** Two
+tempting answers are both wrong.
+
+- **The tool determines inline.** If `ways-audit` reads a claim and its firing evidence
+  and writes `satisfied` itself, it manufactures the very evidence ADR-200 forbids — a
+  model grading whether a model followed model-injected guidance, stamped as fact. This
+  recreates the ADR-013 overclaim at the finding layer.
+- **A human always determines.** If every finding must wait on a person to read the
+  transcript and rule, the assessment surface is an unbounded labor sink. It does not
+  scale past a handful of ways, and the corpus is designed to hold hundreds (ADR-200 §7).
+
+The honest position is neither. The tool should **assemble** the finding — gather the
+inputs and leave the determination *unset* — producing a record that some *other*
+system will classify. That classifying system is deliberately **out of scope**: we do
+not design it, ship it, or constrain what it is. In NIST 800-53A the assessor is a
+*role*, not a person; generalize it to a **classifier** and leave it entirely external.
+`ways-audit`'s whole responsibility is to make the record **cleanly classifiable** —
+well-structured and easily accessible — and then stop.
+
+## Decision
+
+### 1. `ways-audit` assembles findings; it never determines them
+
+The finding pipeline reads `(claim + its determination criterion + firing events +
+transcript pointers)` and writes a finding record with the **determination slot empty**.
+The tool's output is an *assessable record*, not an assessment. No code path in
+`ways-audit` writes a determination value — that boundary is the load-bearing honesty of
+this ADR.
+
+### 2. An assembled finding is a classifier-ready record
+
+Frame the finding record as one row of a supervised-classification dataset — *features*
+(the observable inputs) and a *label* (the determination) filled later:
+
+| Role | Field | Source |
+|------|-------|--------|
+| feature | `criterion` (the claim's `satisfied_when`) | claim sidecar (ADR-110) |
+| feature | `evidence.firing` — counts, sessions, timestamps | firing-event log |
+| feature | `evidence.transcript_refs` — session + pointer | session transcripts |
+| feature | `tier` — `process` or `outcome` (ADR-200 §3) | the criterion's kind |
+| **label** | `determination` — `satisfied` / `other-than-satisfied` / *unset* | a classifier |
+| provenance | `assessed_by`, `assessed_at`, `basis` | the classifier, when it labels |
+
+*Informally:* the ledger is a dataset with an empty label column. The framing is not
+decorative — it is why the record stores the criterion and the raw evidence *beside* the
+empty determination, so a finding is classifiable and auditable, not a bare verdict.
+
+The record also carries empty **provenance** slots — `assessed_by`, `assessed_at`,
+`basis` — so that when something does fill the label, *what* filled it and *on what* are
+recorded next to it. `ways-audit` writes those slots empty and never fills them.
+
+### 3. The classifier is out of scope — a different, undesigned system
+
+We do not design, ship, or constrain the system that classifies these records. It is a
+separate concern for a later day, and possibly a different tool entirely. This ADR fixes
+only the **record** and the **boundary**: `ways-audit` produces clean, accessible,
+classifiable rows and stops. Whatever eventually reads them — a deterministic check for a
+*process-tier* criterion, a human reviewer, a trained model for an *outcome-tier* one
+(ADR-200 §3) — is not our design problem here, and nothing in this decision presumes
+which it will be. The one guarantee we make is structural: the dataset is easy to get at
+and unambiguous to label.
+
+## Consequences
+
+### Positive
+
+- Resolves ADR-200's open question without either overclaim (tool-determines) or an
+  unbounded human labor sink (human-only).
+- The determination boundary is enforced in code, not just prose: `ways-audit` has no
+  path that writes a determination.
+- The scope is small and honest: the tool ships a dataset, not an assessment engine.
+  Classification is someone else's problem, on someone else's schedule.
+- The ledger is dual-purpose at no extra authoring cost — an audit trail *and* a labeled-
+  when-classified dataset — and stays useful even if the classifier is never built.
+
+### Negative
+
+- The finding record carries more structure (criterion + evidence + empty label and
+  provenance slots) than a bare verdict, and the schema must stay stable enough to be a
+  dataset over time.
+- A dataset with a perpetually-empty label column is inert until *something* classifies
+  it; this ADR deliberately does not deliver that something, so findings have no
+  determinations until a separate effort supplies a classifier.
+
+### Neutral
+
+- The classifying system is entirely out of scope — not designed, not stubbed, not
+  constrained here. This ADR fixes only the record shape and the assemble-never-determine
+  boundary.
+- `satisfied_when` moves from ADR-200 §1's "proposed, not yet in schema" note into the
+  actual claim schema (ADR-151 §3) as part of realizing this ADR.
+
+## Alternatives Considered
+
+- **Tool writes the determination inline.** Rejected: manufactures evidence; the exact
+  error ADR-200 was written to stop, relocated one layer down.
+- **Determinations are human-only.** Rejected: an unbounded labor sink that cannot cover
+  a corpus of hundreds; also forecloses the deterministic process-tier check that needs
+  no human at all.
+- **No stored criterion/evidence — store only the verdict.** Rejected: a bare verdict is
+  neither auditable back to its basis nor usable as classifier training data, discarding
+  the record's second purpose for nothing saved.
+
+## References
+
+- **ADR-200** — the claim/finding model this refines (§1 assessability, §2 findings, §3
+  the two evidence tiers).
+- **ADR-151** — the `ways-core` claim schema and the `ways-audit` binary that assembles
+  findings.
+- **ADR-110** — the `provenance.yaml` claim sidecar the criterion is stored in.
+- **NIST SP 800-53A** — assessment findings and the *satisfied* / *other than satisfied*
+  determination; the assessor as a role.
+- **OSCAL Assessment Results** — the machine-readable finding layer this record shape
+  anticipates.

--- a/docs/architecture/governance/ADR-201-findings-assembled-as-classifier-ready-assessment-records.md
+++ b/docs/architecture/governance/ADR-201-findings-assembled-as-classifier-ready-assessment-records.md
@@ -57,12 +57,13 @@ Frame the finding record as one row of a supervised-classification dataset — *
 
 | Role | Field | Source |
 |------|-------|--------|
-| feature | `criterion` (the claim's `satisfied_when`) | claim sidecar (ADR-110) |
-| feature | `evidence.firing` — counts, sessions, timestamps | firing-event log |
-| feature | `evidence.transcript_refs` — session + pointer | session transcripts |
-| feature | `tier` — `process` or `outcome` (ADR-200 §3) | the criterion's kind |
-| **label** | `determination` — `satisfied` / `other-than-satisfied` / *unset* | a classifier |
-| provenance | `assessed_by`, `assessed_at`, `basis` | the classifier, when it labels |
+| `way`, `control` | the claimed `(way, control)` this row assesses | claim sidecar (ADR-110) |
+| feature | `criterion` — the claim's `satisfied_when` (`null` if none) | claim sidecar |
+| feature | `evidence` — `total` fire count, `sessions` (each id is a transcript pointer), `first_seen` / `last_seen` | firing-event log |
+| feature | `tier` — `process` when there is no criterion, `outcome` when there is (ADR-200 §3) | criterion presence |
+| **label** | `determination` — `satisfied` / `other-than-satisfied`, `null` until labeled | a classifier |
+| provenance | `assessed_by`, `assessed_at`, `basis` — `null` until labeled | the classifier, when it labels |
+| provenance | `assembled_at`, `assembled_by` — who built the row, when | the assembler |
 
 *Informally:* the ledger is a dataset with an empty label column. The framing is not
 decorative — it is why the record stores the criterion and the raw evidence *beside* the
@@ -112,6 +113,13 @@ and unambiguous to label.
   boundary.
 - `satisfied_when` moves from ADR-200 §1's "proposed, not yet in schema" note into the
   actual claim schema (ADR-151 §3) as part of realizing this ADR.
+- The ledger is **append-only**, like the firing-event log it is built from: each
+  `assemble --write` appends a fresh *snapshot* of the rows (their `assembled_at` and
+  evolving firing evidence distinguish them), rather than mutating prior rows in place. It
+  is therefore a time series of assemblies, not a unique-keyed table; a consumer that wants
+  current state reduces by `(way, control)` to the latest `assembled_at`. This keeps the
+  writer a trivial, honest append and defers any compaction policy to the — out of scope —
+  consumer.
 
 ## Alternatives Considered
 

--- a/docs/architecture/system/ADR-151-extract-ways-core-crate-and-ways-audit-sibling-binary.md
+++ b/docs/architecture/system/ADR-151-extract-ways-core-crate-and-ways-audit-sibling-binary.md
@@ -9,6 +9,7 @@ related:
   - ADR-111
   - ADR-142
   - ADR-200
+  - ADR-201
 supersedes: []
 ---
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -69,22 +69,22 @@ rationale: >
 | `policy[].type` | Classification: `adr`, `governance-doc`, `regulatory-framework`, `control-spec` |
 | `controls[].id` | The control this way *claims* to be designed for |
 | `controls[].justifications[]` | How the guidance is meant to address the control (assertions, not evidence) |
+| `controls[].satisfied_when` | The *determination criterion* — what observable session behavior would let a classifier mark this control *satisfied* / *other-than-satisfied* (ADR-200 §1, ADR-201). Optional; without it a control carries only a process-tier finding, never an outcome one |
 | `verified` | Date the claim's *authoring* was last reviewed (not an assessment date) |
 | `rationale` | Summary of how the way's guidance compiles the cited controls into practice |
 
-> **Proposed (ADR-200 §1), not yet in the schema:** a per-control *determination
-> criterion* — the observable session behavior that would move a claim from an assertion
-> to a *satisfied* / *other-than-satisfied* finding. It is what makes a claim assessable;
-> the current sidecars don't carry it yet.
+> **The criterion is what makes a claim assessable.** A control with no `satisfied_when`
+> is unfalsifiable — it can never graduate into an outcome finding. Most existing sidecars
+> don't carry one yet; adding them is the seeding work that turns coverage into something a
+> classifier can eventually assess.
 
 ## What the tooling does today
 
 Compliance queries run through the `ways-audit` binary (`ways-audit <mode>`), a sibling of
-the `ways` binary (ADR-151). Session-derived findings — the claim/finding model's second
-half — remain the direction set in ADR-151, not yet built. The tool scans the
-`provenance.yaml` sidecars directly and builds the manifest **in memory** — there is no
-persisted `provenance-manifest.json`, and no separate shell scripts (the former
-`governance.sh` / `provenance-scan.py` were consolidated into the binary, ADR-111).
+the `ways` binary (ADR-151). The tool scans the `provenance.yaml` sidecars directly and
+builds the manifest **in memory** — there is no persisted `provenance-manifest.json`, and
+no separate shell scripts (the former `governance.sh` / `provenance-scan.py` were
+consolidated into the binary, ADR-111).
 
 | Mode | Command | Output |
 |------|---------|--------|
@@ -97,8 +97,22 @@ persisted `provenance-manifest.json`, and no separate shell scripts (the former
 | **Active** | `ways-audit active` | Cross-reference claims with way firing stats |
 | **Matrix** | `ways-audit matrix` | Flat sheet: way / control / justification |
 | **Lint** | `ways-audit lint` | Validate claim integrity (URIs resolve, fields present) |
+| **Assemble** | `ways-audit assemble [--write]` | Build the classifier-ready **finding dataset** from claims + firing evidence (ADR-201) |
+| **Findings** | `ways-audit findings` | Show the assembled finding ledger |
 
 All modes support `--json`.
+
+### Findings: assembled, not determined
+
+`ways-audit assemble` produces the finding dataset described in **ADR-201**: one row per
+claimed `(way, control)`, carrying the `satisfied_when` criterion and the firing evidence
+(counts, sessions as transcript pointers, first/last seen) **beside an empty
+`determination`**. The tool never writes a determination — that would manufacture the
+evidence the claim/finding split exists to keep honest. Each row is a classifier-ready
+dataset entry with a uniform column set; the label is filled later by a **classifier**
+(human, deterministic check, or model) that is **deliberately out of scope** — a separate,
+undesigned system. `ways-audit`'s guarantee ends at producing a clean, accessible,
+unambiguous-to-label record.
 
 ```mermaid
 flowchart LR
@@ -107,13 +121,17 @@ flowchart LR
     classDef output fill:#4CAF50,stroke:#2E7D32,color:#fff
 
     W["way + provenance.yaml<br/>(claims)"]:::data
+    F["firing-event log<br/>(observed evidence)"]:::data
     P["governance/policies/<br/>(policy source docs)"]:::data
     CLI["ways-audit"]:::tool
     R["Reports<br/>(claim coverage, traces,<br/>matrix, lint)"]:::output
+    D["Finding dataset<br/>(rows w/ empty label,<br/>for an external classifier)"]:::output
 
     W --> CLI
     P --> CLI
+    F --> CLI
     CLI --> R
+    CLI --> D
 ```
 
 ## Honest scope
@@ -146,8 +164,10 @@ Compliance claiming is optional and additive. Most users never touch it.
 2. **Policies** — write down *why* (`governance/policies/`).
 3. **Claims** — link a way to the controls it's *designed* to address (`provenance.yaml`).
 4. **Reporting** — `ways-audit` surfaces claim coverage and gaps.
-5. **Findings** — *(direction, ADR-151)* session-derived evidence that the
-   claimed guidance actually shaped the work. Not yet built.
+5. **Criteria** — give a control a `satisfied_when` so it becomes assessable (ADR-200 §1).
+6. **Findings** — `ways-audit assemble` builds the classifier-ready dataset (ADR-201):
+   session-derived evidence rows with an empty determination. The classifier that labels
+   them is a separate, out-of-scope system — assembly is what agent-ways ships.
 
 Each step builds on the previous without requiring it. A way without a claim runs
 identically at runtime. The system doesn't penalize partial adoption.

--- a/docs/hooks-and-ways/provenance.md
+++ b/docs/hooks-and-ways/provenance.md
@@ -33,6 +33,9 @@ controls:
     justifications:
       - Conventional commit types classify changes by nature
       - Atomic commits make each change independently reviewable
+    satisfied_when: >
+      Commits in the session follow the conventional-commit format with a type
+      prefix and are scoped to a single logical change.
   - id: SOC 2 CC8.1 (Change Management)
     justifications:
       - Type prefix and scope create structured change records
@@ -50,6 +53,7 @@ rationale: >
 | `policy[].type` | Classification: `adr`, `governance-doc`, `regulatory-framework`, `control-spec` |
 | `controls[].id` | The control this way *claims* to be designed for |
 | `controls[].justifications[]` | How the guidance is meant to address the control — assertions, not evidence |
+| `controls[].satisfied_when` | *(optional)* the **determination criterion** — what observable session behavior would let a classifier mark this control *satisfied* / *other-than-satisfied* (ADR-200 §1, ADR-201). A control with one can carry an outcome-tier finding; without one, only a process-tier finding (that the way fired) |
 | `verified` | Date the claim's authoring was last reviewed (not an assessment date) |
 | `rationale` | Summary of how the way's guidance compiles the cited controls into practice |
 
@@ -68,15 +72,18 @@ ways-audit trace softwaredev/delivery/commits   # the chain for one way
 ways-audit report                               # which ways carry a claim
 ways-audit lint                                 # validate: URIs resolve, fields present
 ways-audit report --json                        # machine-readable
+ways-audit assemble --json                      # the finding dataset for these claims
 ```
 
 ## Keep it honest
 
 - A `justification` is an **assertion** about how the guidance is *designed* to address
   the control — not proof it did. Substantiating a claim needs a session-derived
-  **finding** (SOC 2 Type II), which is the direction set in
-  [ADR-151](../architecture/system/ADR-151-extract-ways-core-crate-and-ways-audit-sibling-binary.md),
-  not yet built.
+  **finding** (SOC 2 Type II). `ways-audit assemble` builds the finding *record* — the
+  claim's `satisfied_when` criterion beside the firing evidence — but leaves the
+  determination **empty**: whether the control is *satisfied* is a classifier's call
+  ([ADR-201](../architecture/governance/ADR-201-findings-assembled-as-classifier-ready-assessment-records.md)),
+  and that classifier is a separate, out-of-scope system. Assembly is not assessment.
 - Read `ways-audit report` coverage as *claims made*, not *conformance achieved*.
 - Point a claim at a control you can defend by ID — and verify the control means what you
   think, because an unchecked citation is itself a claim.

--- a/docs/reference/ways-cli.md
+++ b/docs/reference/ways-cli.md
@@ -473,13 +473,19 @@ ways permissions audit --global
 | `trace <id>` | End-to-end provenance trace for a single way |
 | `control <id>` | Which ways *claim* a given control |
 | `policy <id>` | Which ways derive from a given policy |
+| `assemble [--way <id>] [--write]` | Build the classifier-ready **finding dataset** (ADR-201) — one row per `(way, control)` with firing evidence and an *empty* determination. `--write` appends to the finding ledger |
+| `findings` | Show the assembled finding ledger |
 
 ```
 ways-audit report
 ways-audit gaps
 ways-audit trace meta/knowledge
 ways-audit matrix --json > coverage.jsonl
+ways-audit assemble --json > findings.json   # dataset for an external classifier
 ```
+
+`assemble` never writes a determination — it leaves the label empty for a separate,
+out-of-scope classifier (ADR-201). Assembly is not assessment.
 
 ---
 

--- a/tools/ways-audit/src/findings.rs
+++ b/tools/ways-audit/src/findings.rs
@@ -13,6 +13,11 @@ use ways_core::{firing, paths, util};
 
 /// Assemble finding rows from the claim manifest + firing events, print them, and
 /// optionally append them to the ledger. `way` filters to a single way id.
+///
+/// `--write` **appends** a fresh snapshot; the ledger is append-only (like the
+/// firing-event log), so repeated writes accumulate timestamped snapshots rather
+/// than replacing prior rows. A consumer that wants current state reduces by
+/// `(way, control)` to the latest `assembled_at` (ADR-201).
 pub fn assemble(manifest: &Value, way: Option<&str>, write: bool, json_out: bool) -> Result<()> {
     let events = firing::load_events();
     let mut findings = assemble_findings(manifest, &events, &util::now_utc());

--- a/tools/ways-audit/src/findings.rs
+++ b/tools/ways-audit/src/findings.rs
@@ -1,0 +1,122 @@
+//! `ways-audit assemble` and `ways-audit findings` — the finding dataset (ADR-201).
+//!
+//! `assemble` builds the classifier-ready dataset from the current claims and the
+//! firing log; `findings` reads the ledger back. Neither writes a determination —
+//! that boundary is enforced here by simply having no code that does.
+
+use anyhow::Result;
+use serde_json::Value;
+use std::io::Write;
+
+use ways_core::finding::{assemble as assemble_findings, Finding};
+use ways_core::{firing, paths, util};
+
+/// Assemble finding rows from the claim manifest + firing events, print them, and
+/// optionally append them to the ledger. `way` filters to a single way id.
+pub fn assemble(manifest: &Value, way: Option<&str>, write: bool, json_out: bool) -> Result<()> {
+    let events = firing::load_events();
+    let mut findings = assemble_findings(manifest, &events, &util::now_utc());
+    if let Some(w) = way {
+        findings.retain(|f| f.way == w);
+    }
+
+    if write {
+        append_to_ledger(&findings)?;
+    }
+
+    if json_out {
+        println!("{}", serde_json::to_string_pretty(&findings)?);
+        return Ok(());
+    }
+
+    render_table(&findings, "Assembled Findings");
+    let outcome = findings.iter().filter(|f| f.criterion.is_some()).count();
+    println!();
+    println!(
+        "  \x1b[2m{} finding(s): {} outcome-tier (assessable), {} process-tier. \
+         Determination is unset — a classifier labels it (ADR-201).\x1b[0m",
+        findings.len(),
+        outcome,
+        findings.len() - outcome,
+    );
+    if write {
+        println!("  \x1b[2mAppended to {}\x1b[0m", paths::findings_ledger().display());
+    }
+    Ok(())
+}
+
+/// Read the finding ledger back and display it.
+pub fn list(json_out: bool) -> Result<()> {
+    let path = paths::findings_ledger();
+    let content = std::fs::read_to_string(&path).unwrap_or_default();
+    let findings: Vec<Finding> = content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect();
+
+    if json_out {
+        println!("{}", serde_json::to_string_pretty(&findings)?);
+        return Ok(());
+    }
+
+    if findings.is_empty() {
+        println!();
+        println!("  \x1b[2mNo findings assembled yet. Run `ways-audit assemble --write`.\x1b[0m");
+        return Ok(());
+    }
+    render_table(&findings, "Finding Ledger");
+    let labeled = findings.iter().filter(|f| f.determination.is_some()).count();
+    println!();
+    println!(
+        "  \x1b[2m{} finding(s), {} labeled by a classifier, {} awaiting classification.\x1b[0m",
+        findings.len(),
+        labeled,
+        findings.len() - labeled,
+    );
+    Ok(())
+}
+
+fn render_table(findings: &[Finding], title: &str) {
+    println!();
+    println!("\x1b[1m{title}\x1b[0m");
+    println!();
+    println!(
+        "  \x1b[1m{:<26} {:<26} {:<8} {:>5}  DETERMINATION\x1b[0m",
+        "WAY", "CONTROL", "TIER", "FIRES"
+    );
+    println!(
+        "  \x1b[2m{:<26} {:<26} {:<8} {:>5}  -------------\x1b[0m",
+        "---", "-------", "----", "-----"
+    );
+    for f in findings {
+        let control = if f.control.len() > 26 { &f.control[..26] } else { &f.control };
+        let tier = match f.tier {
+            ways_core::finding::Tier::Process => "process",
+            ways_core::finding::Tier::Outcome => "outcome",
+        };
+        let det = match &f.determination {
+            Some(d) => d.as_str(),
+            None => "\x1b[2m(unset)\x1b[0m",
+        };
+        println!(
+            "  {:<26} {:<26} {:<8} {:>5}  {}",
+            f.way, control, tier, f.evidence.total, det
+        );
+    }
+}
+
+fn append_to_ledger(findings: &[Finding]) -> Result<()> {
+    let path = paths::findings_ledger();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)?;
+    for f in findings {
+        writeln!(file, "{}", serde_json::to_string(f)?)?;
+    }
+    Ok(())
+}

--- a/tools/ways-audit/src/main.rs
+++ b/tools/ways-audit/src/main.rs
@@ -10,6 +10,7 @@
 //! the same `ways-core` engine this binary already depends on.
 
 mod audit;
+mod findings;
 mod helpers;
 mod lint;
 mod matrix;
@@ -74,6 +75,17 @@ enum Command {
     Matrix,
     /// Validate claim integrity
     Lint,
+    /// Assemble the classifier-ready finding dataset from claims + firing (ADR-201)
+    Assemble {
+        /// Restrict to a single way ID
+        #[arg(long)]
+        way: Option<String>,
+        /// Append the assembled findings to the ledger
+        #[arg(long)]
+        write: bool,
+    },
+    /// Show the assembled finding ledger
+    Findings,
 }
 
 fn main() -> Result<()> {
@@ -99,5 +111,9 @@ fn main() -> Result<()> {
         Command::Active => audit::active(&manifest, json),
         Command::Matrix => matrix::run(&manifest, json),
         Command::Lint => lint::run(&manifest, json),
+        Command::Assemble { way, write } => {
+            findings::assemble(&manifest, way.as_deref(), write, json)
+        }
+        Command::Findings => findings::list(json),
     }
 }

--- a/tools/ways-core/src/finding.rs
+++ b/tools/ways-core/src/finding.rs
@@ -1,0 +1,218 @@
+//! Assembled compliance findings — the classifier-ready dataset (ADR-201).
+//!
+//! A **finding** is one row of a would-be supervised-classification dataset: the
+//! *features* (a claim's `satisfied_when` criterion + the firing evidence) sit
+//! beside an **empty label** (the `determination`) and empty provenance slots for
+//! whatever eventually fills them. This module only *assembles* rows; it never
+//! writes a determination. The classifying system is deliberately out of scope
+//! (ADR-201 §3) — the guarantee here is purely structural: a clean, accessible,
+//! unambiguous-to-label record.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+use crate::provenance::Claim;
+
+/// The evidence tier a finding sits in (ADR-200 §3). Set by whether the claim
+/// carries an assessable criterion — never a determination of anything.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Tier {
+    /// "Control-aligned guidance surfaced at the point of work." The firing log
+    /// alone speaks to this; no criterion needed.
+    Process,
+    /// "And the work actually took the claimed shape." Needs the criterion judged
+    /// against the transcript — the harder, model-judged label.
+    Outcome,
+}
+
+/// The firing evidence for a way — the observable, deterministic feature column.
+/// `sessions` are transcript pointers (a session id names its transcript).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FiringEvidence {
+    pub total: u64,
+    pub sessions: Vec<String>,
+    pub first_seen: Option<String>,
+    pub last_seen: Option<String>,
+}
+
+/// One assembled finding — a dataset row with an empty label.
+///
+/// Every `Option` field serializes explicitly (as `null` when empty) rather than
+/// being omitted, so every row carries an identical column set — a uniform,
+/// unambiguous-to-label dataset (ADR-201 §2), not a ragged one.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Finding {
+    pub way: String,
+    pub control: String,
+    /// The determination criterion (feature). `null` → not yet assessable.
+    pub criterion: Option<String>,
+    pub tier: Tier,
+    pub evidence: FiringEvidence,
+
+    // --- the empty label + its provenance slots (ADR-201 §1–2) ---
+    // ways-audit writes these `null` and never fills them; a classifier does.
+    /// `satisfied` / `other-than-satisfied` — the label. Always `null` at assembly.
+    pub determination: Option<String>,
+    pub assessed_by: Option<String>,
+    pub assessed_at: Option<String>,
+    pub basis: Option<String>,
+
+    // --- assembly provenance (who built the row, when) ---
+    pub assembled_at: String,
+    pub assembled_by: String,
+}
+
+/// Per-way firing aggregate, folded from the raw event stream once.
+#[derive(Default)]
+struct WayFiring {
+    total: u64,
+    sessions: Vec<String>,
+    first_seen: Option<String>,
+    last_seen: Option<String>,
+}
+
+fn index_firing(events: &[Value]) -> BTreeMap<String, WayFiring> {
+    let mut idx: BTreeMap<String, WayFiring> = BTreeMap::new();
+    for ev in events {
+        if ev["event"].as_str() != Some("way_fired") {
+            continue;
+        }
+        let Some(way) = ev["way"].as_str() else { continue };
+        let entry = idx.entry(way.to_string()).or_default();
+        entry.total += 1;
+        if let Some(sess) = ev["session"].as_str() {
+            if !entry.sessions.iter().any(|s| s == sess) {
+                entry.sessions.push(sess.to_string());
+            }
+        }
+        if let Some(ts) = ev["ts"].as_str() {
+            if entry.first_seen.as_deref().map(|f| ts < f).unwrap_or(true) {
+                entry.first_seen = Some(ts.to_string());
+            }
+            if entry.last_seen.as_deref().map(|l| ts > l).unwrap_or(true) {
+                entry.last_seen = Some(ts.to_string());
+            }
+        }
+    }
+    idx
+}
+
+/// Assemble the finding dataset from the claim manifest and the firing events.
+///
+/// One row per (claimed way, control). The determination and its provenance are
+/// left empty — assembly never labels (ADR-201 §1). `assembled_at` is injected so
+/// this stays a pure function (the binary supplies `util::now_utc()`).
+pub fn assemble(manifest: &Value, events: &[Value], assembled_at: &str) -> Vec<Finding> {
+    let firing = index_firing(events);
+    let mut findings = Vec::new();
+
+    let Some(ways) = manifest["ways"].as_object() else {
+        return findings;
+    };
+
+    for (way, entry) in ways {
+        let Some(claim) = Claim::from_provenance_value(&entry["provenance"]) else {
+            continue; // no claim → no finding
+        };
+        let ev = firing.get(way);
+        let evidence = FiringEvidence {
+            total: ev.map(|f| f.total).unwrap_or(0),
+            sessions: ev.map(|f| f.sessions.clone()).unwrap_or_default(),
+            first_seen: ev.and_then(|f| f.first_seen.clone()),
+            last_seen: ev.and_then(|f| f.last_seen.clone()),
+        };
+
+        for control in claim.controls {
+            let tier = if control.satisfied_when.is_some() {
+                Tier::Outcome
+            } else {
+                Tier::Process
+            };
+            findings.push(Finding {
+                way: way.clone(),
+                control: control.id,
+                criterion: control.satisfied_when,
+                tier,
+                evidence: evidence.clone(),
+                determination: None,
+                assessed_by: None,
+                assessed_at: None,
+                basis: None,
+                assembled_at: assembled_at.to_string(),
+                assembled_by: "ways-audit".to_string(),
+            });
+        }
+    }
+
+    findings.sort_by(|a, b| (&a.way, &a.control).cmp(&(&b.way, &b.control)));
+    findings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn manifest() -> Value {
+        json!({
+            "ways": {
+                "sd/commits": {"provenance": {
+                    "controls": [
+                        {"id": "NIST CM-3", "justifications": ["x"],
+                         "satisfied_when": "commits follow conventional format"},
+                        {"id": "SOC 2 CC8.1", "justifications": ["y"]}
+                    ]
+                }},
+                "meta/todos": {"provenance": null}
+            }
+        })
+    }
+
+    fn events() -> Vec<Value> {
+        vec![
+            json!({"event": "way_fired", "way": "sd/commits", "session": "s1", "ts": "2026-06-01T10:00:00Z"}),
+            json!({"event": "way_fired", "way": "sd/commits", "session": "s1", "ts": "2026-06-02T10:00:00Z"}),
+            json!({"event": "way_fired", "way": "sd/commits", "session": "s2", "ts": "2026-05-30T10:00:00Z"}),
+        ]
+    }
+
+    #[test]
+    fn assembles_one_row_per_control_with_empty_label() {
+        let f = assemble(&manifest(), &events(), "2026-07-02T00:00:00Z");
+        assert_eq!(f.len(), 2); // two controls on the one claimed way
+        for row in &f {
+            assert!(row.determination.is_none(), "assembler must never label");
+            assert!(row.assessed_by.is_none());
+            assert_eq!(row.assembled_by, "ways-audit");
+        }
+    }
+
+    #[test]
+    fn tier_follows_criterion_presence() {
+        let f = assemble(&manifest(), &events(), "t");
+        let cm3 = f.iter().find(|r| r.control == "NIST CM-3").unwrap();
+        let cc81 = f.iter().find(|r| r.control == "SOC 2 CC8.1").unwrap();
+        assert_eq!(cm3.tier, Tier::Outcome);
+        assert_eq!(cm3.criterion.as_deref(), Some("commits follow conventional format"));
+        assert_eq!(cc81.tier, Tier::Process);
+        assert!(cc81.criterion.is_none());
+    }
+
+    #[test]
+    fn firing_evidence_aggregates_sessions_and_range() {
+        let f = assemble(&manifest(), &events(), "t");
+        let row = &f[0];
+        assert_eq!(row.evidence.total, 3);
+        assert_eq!(row.evidence.sessions, vec!["s1", "s2"]);
+        assert_eq!(row.evidence.first_seen.as_deref(), Some("2026-05-30T10:00:00Z"));
+        assert_eq!(row.evidence.last_seen.as_deref(), Some("2026-06-02T10:00:00Z"));
+    }
+
+    #[test]
+    fn ways_without_claims_produce_no_rows() {
+        let empty = json!({"ways": {"meta/todos": {"provenance": null}}});
+        assert!(assemble(&empty, &[], "t").is_empty());
+    }
+}

--- a/tools/ways-core/src/finding.rs
+++ b/tools/ways-core/src/finding.rs
@@ -88,6 +88,8 @@ fn index_firing(events: &[Value]) -> BTreeMap<String, WayFiring> {
             }
         }
         if let Some(ts) = ev["ts"].as_str() {
+            // Lexicographic compare is chronological here: every event timestamp is
+            // written by the same RFC3339 `…Z` writer, so string order == time order.
             if entry.first_seen.as_deref().map(|f| ts < f).unwrap_or(true) {
                 entry.first_seen = Some(ts.to_string());
             }

--- a/tools/ways-core/src/lib.rs
+++ b/tools/ways-core/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod agents;
 pub mod config;
+pub mod finding;
 pub mod firing;
 pub mod frontmatter;
 pub mod paths;

--- a/tools/ways-core/src/paths.rs
+++ b/tools/ways-core/src/paths.rs
@@ -221,6 +221,14 @@ pub fn events_log() -> PathBuf {
     resolve_events(&state_root(), &projection_root())
 }
 
+/// Append-only ledger of assembled compliance findings (ADR-201):
+/// `$XDG_STATE/agent-ways/findings.jsonl`. agent-ways owns this — findings are
+/// session-derived records, not Claude-Code state — so it sits beside the event
+/// log in `$XDG_STATE`, never in the `~/.claude` projection.
+pub fn findings_ledger() -> PathBuf {
+    state_root().join("findings.jsonl")
+}
+
 /// Pure fallback resolution for the event log, factored out for testing without
 /// touching `$XDG_STATE`/`$HOME`.
 fn resolve_events(state: &Path, projection: &Path) -> PathBuf {

--- a/tools/ways-core/src/provenance.rs
+++ b/tools/ways-core/src/provenance.rs
@@ -11,12 +11,109 @@
 //! ADR-200 §1 direction, layered on in a later change.
 
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
 use crate::util::{has_frontmatter, home_dir};
+
+/// The typed compliance-claim schema stored in a `provenance.yaml` sidecar
+/// (ADR-110, ADR-151 §3). The manifest builder above stays `Value`-based for the
+/// query layer; this type is the single-sourced, documented schema and the lens
+/// the finding assembler reads through (ADR-201).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Claim {
+    #[serde(default)]
+    pub policy: Vec<Policy>,
+    #[serde(default)]
+    pub controls: Vec<Control>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verified: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rationale: Option<String>,
+}
+
+/// A source policy document a claim derives from.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Policy {
+    pub uri: String,
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+}
+
+/// A control the way *claims* to be designed for.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Control {
+    pub id: String,
+    #[serde(default)]
+    pub justifications: Vec<String>,
+    /// The determination criterion (ADR-200 §1, ADR-201): the observable session
+    /// behavior that would let a classifier decide this control *satisfied* or
+    /// *other than satisfied*. Absent → the control is not yet assessable; it can
+    /// carry only a process-tier finding (that the way fired), never an outcome one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub satisfied_when: Option<String>,
+}
+
+impl Claim {
+    /// Build a typed claim from a manifest way-entry's `provenance` object,
+    /// tolerating the legacy bare-string control form (`- OWASP A01`) alongside
+    /// the structured form. Returns `None` when the entry carries no claim.
+    pub fn from_provenance_value(prov: &Value) -> Option<Claim> {
+        let obj = prov.as_object()?;
+        let policy = obj
+            .get("policy")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|p| {
+                        let uri = p.get("uri")?.as_str()?.to_string();
+                        let kind = p.get("type").and_then(|v| v.as_str()).map(str::to_string);
+                        Some(Policy { uri, kind })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let controls = obj
+            .get("controls")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|c| {
+                        if let Some(s) = c.as_str() {
+                            return Some(Control {
+                                id: s.to_string(),
+                                justifications: Vec::new(),
+                                satisfied_when: None,
+                            });
+                        }
+                        let o = c.as_object()?;
+                        Some(Control {
+                            id: o.get("id")?.as_str()?.to_string(),
+                            justifications: o
+                                .get("justifications")
+                                .and_then(|v| v.as_array())
+                                .map(|a| a.iter().filter_map(|j| j.as_str().map(str::to_string)).collect())
+                                .unwrap_or_default(),
+                            satisfied_when: o
+                                .get("satisfied_when")
+                                .and_then(|v| v.as_str())
+                                .map(str::to_string),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        Some(Claim {
+            policy,
+            controls,
+            verified: obj.get("verified").and_then(|v| v.as_str()).map(str::to_string),
+            rationale: obj.get("rationale").and_then(|v| v.as_str()).map(str::to_string),
+        })
+    }
+}
 
 /// Build the full compliance-claim manifest as a JSON value.
 ///

--- a/tools/ways-core/src/util.rs
+++ b/tools/ways-core/src/util.rs
@@ -181,6 +181,18 @@ pub fn is_excluded_path(path: &Path, excluded_segments: &[String]) -> bool {
     false
 }
 
+/// Current UTC timestamp as `YYYY-MM-DDThh:mm:ssZ`, chrono-free.
+pub fn now_utc() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let time_of_day = secs % 86400;
+    let (y, m, d) = days_to_ymd(secs / 86400);
+    let (hh, mm, ss) = (time_of_day / 3600, (time_of_day % 3600) / 60, time_of_day % 60);
+    format!("{y:04}-{m:02}-{d:02}T{hh:02}:{mm:02}:{ss:02}Z")
+}
+
 /// Convert days-since-Unix-epoch to a `(year, month, day)` civil date (UTC).
 ///
 /// A dependency-free calendar conversion (Howard Hinnant's `civil_from_days`).


### PR DESCRIPTION
## Summary

The **net-new assessability layer** — the third and final ADR-151 PR (PR-A #260, PR-B #261 merged). It closes the question ADR-200 §1 left open: *who fills a finding's determination, and when.*

Introduces **ADR-201** (new, Accepted): `ways-audit` **assembles** findings; it **never determines** them. A finding is one row of a classifier-ready dataset — the `satisfied_when` criterion + firing evidence (*features*) beside an **empty** `determination` (*label*) and empty provenance slots. The classifier that labels it is a **separate, undesigned, out-of-scope system** (human, deterministic check, or model). The tool's guarantee is purely structural: a clean, uniform, unambiguous-to-label record. **No code path in `ways-audit` writes a determination** — the honesty boundary that keeps this from manufacturing the evidence the claim/finding split exists to protect.

## `ways-core`

- **`provenance`** — typed `Claim`/`Policy`/`Control` schema (ADR-151 §3). `Control` carries the new **`satisfied_when`** determination criterion. `from_provenance_value` tolerates the legacy bare-string control form.
- **`finding`** — `Finding`/`FiringEvidence`/`Tier` + `assemble()`, a **pure function** (`manifest + events + timestamp → rows`). Every `Option` serializes explicitly so the dataset has a **uniform column set**. Process vs. outcome tier follows criterion presence — never a determination.
- `util::now_utc` (chrono-free RFC3339); `paths::findings_ledger` (`$XDG_STATE`).

## `ways-audit`

- **`assemble [--way <id>] [--write]`** — build the dataset, print it (`--json` = the machine dataset), optionally append to the ledger.
- **`findings`** — read the ledger back.

## Docs

`satisfied_when` graduates from ADR-200 §1's "proposed, not yet in schema" note into the actual schema (`governance.md`, `provenance.md`, `ways-cli.md`). Findings reframed from "not yet built" → "assembled; classification out of scope." ADR-200/151 gain reciprocal ADR-201 graph edges.

## Honest scope

- The tool ships a **dataset, not an assessment engine**. Classification is a separate effort on a separate schedule — deliberately not designed here (ADR-201 §3).
- All 51 rows assembled from the real corpus are **process-tier**, because no sidecar carries `satisfied_when` yet. That's correct: existing claims aren't outcome-assessable until authors seed criteria (task #9).
- A dataset with a perpetually-empty label column is **inert until something classifies it** — this PR does not deliver that something, by design.

## Test plan

- `ways-core` **84** (+5) + `ways-audit` **3** tests green; the assembler logic (in `ways-core::finding`) has 4 tests, incl. an assertion that assembly **never** produces a determination.
- `cargo clippy -D warnings` clean on both crates; `doc lint` 0/0; `adr lint` clean (pre-existing `Rejected`-status warning only).
- `ways-audit assemble` exercised end-to-end against the real 109-way corpus (51 rows, uniform null-label schema); ledger `--write` → `findings` round-trips.