### PR TITLE
feat(claims): seed satisfied_when criteria across the corpus (ADR-201, task #9)

### DIFF
--- a/hooks/ways/documentation/adr/migration/provenance.yaml
+++ b/hooks/ways/documentation/adr/migration/provenance.yaml
@@ -6,6 +6,11 @@ controls:
     justifications:
       - Migration workflow preserves decision history during tooling adoption
       - Legacy range in adr.yaml maintains traceability for pre-domain ADRs
+    satisfied_when: >
+      Pre-existing ADRs were moved into the tooling with git mv (preserving file
+      history) rather than recreated, and adr.yaml carries a legacy range covering
+      their original numbers, verifiable by docs/scripts/adr list --group showing
+      them grouped under the legacy band.
 verified: 2026-02-17
 rationale: >
   Migration guidance ensures existing architectural decisions survive tooling adoption

--- a/hooks/ways/documentation/adr/provenance.yaml
+++ b/hooks/ways/documentation/adr/provenance.yaml
@@ -7,14 +7,28 @@ controls:
       - ADR format captures Context/Decision/Consequences for each architectural change
       - Alternatives Considered section documents rejected options and rejection rationale
       - Status lifecycle (Proposed → Accepted → Deprecated → Superseded) tracks decision currency
+    satisfied_when: >
+      An ADR file was created via docs/scripts/adr carrying populated Context,
+      Decision, and Consequences sections and an Alternatives Considered section
+      naming rejected options, with a status drawn from the lifecycle, before the
+      architectural change it records was implemented.
   - id: ISO/IEC 27001:2022 A.5.1 (Policies for Information Security)
     justifications:
       - Structured decision records create traceable architectural policy documentation
       - Deciders field establishes accountability for each architectural decision
+    satisfied_when: >
+      The ADR created for the decision carries a populated deciders frontmatter
+      field naming who owns it, and the record is stored under docs/architecture/
+      where docs/scripts/adr list surfaces it as standing architectural policy.
   - id: NIST SP 800-53 PL-2 (System Security and Privacy Plans)
     justifications:
       - ADR workflow (debate → draft → PR → review → merge) implements documented planning process
       - Consequences section (positive/negative/neutral) documents risk acceptance for each decision
+    satisfied_when: >
+      The decision moved through the documented workflow — drafted with
+      docs/scripts/adr new, opened as a PR for review, then merged — and its
+      Consequences section records positive, negative, and neutral outcomes rather
+      than being left as an unfilled template stub.
 verified: 2026-02-09
 rationale: >
   ADR format with Context/Decision/Consequences implements CM-3 change documentation for

--- a/hooks/ways/meta/knowledge/authoring/provenance.yaml
+++ b/hooks/ways/meta/knowledge/authoring/provenance.yaml
@@ -7,6 +7,12 @@ controls:
       - Way file format specification ensures documented information is appropriate and suitable
       - Frontmatter schema (match, pattern, files, commands) standardizes trigger documentation
       - Writing voice guidance ensures guidance is readable by context-free readers
+    satisfied_when: >
+      A way authored or edited in the session followed the documented format — a
+      {domain}/{wayname}/{wayname}.md file with valid single-line frontmatter
+      fields (description/vocabulary or pattern/files/commands, plus refire on a
+      fire-bearing way) — and was validated with ways lint (corpus rebuilt) rather
+      than hand-shaped ad hoc.
 verified: 2026-02-05
 rationale: >
   Format spec and authoring guidance for writing effective ways.

--- a/hooks/ways/meta/knowledge/optimization/provenance.yaml
+++ b/hooks/ways/meta/knowledge/optimization/provenance.yaml
@@ -6,6 +6,12 @@ controls:
     justifications:
       - Systematic vocabulary analysis ensures ways fire accurately
       - Gap/coverage metrics provide evidence-based improvement decisions
+    satisfied_when: >
+      Vocabulary or threshold changes in the session were driven by the built-in
+      tooling — /ways-tests suggest output read against gap/coverage/unused
+      metrics, applied, then re-tested with score-all and make test-sim holding
+      zero false positives — rather than by ad-hoc edits or hand-written scoring
+      scripts.
 verified: 2026-02-16
 rationale: >
   Optimization workflow for tuning way vocabulary and matching quality.

--- a/hooks/ways/meta/knowledge/provenance.yaml
+++ b/hooks/ways/meta/knowledge/provenance.yaml
@@ -8,10 +8,20 @@ controls:
     justifications:
       - Domain organization (global vs project-local) establishes policy hierarchy
       - Enable/disable mechanism via ways.json provides controlled policy application
+    satisfied_when: >
+      In a session that acted on way placement or activation, the agent respected
+      the global-vs-project-local hierarchy — authoring or overriding a way at the
+      correct root, or disabling a domain via the config mechanism — rather than
+      editing the read-only framework projection under ~/.claude.
   - id: NIST SP 800-53 PL-2 (System Security and Privacy Plans)
     justifications:
       - Ways index at session start documents active security and privacy guidance
       - State machine ensures each policy is delivered exactly once per session
+    satisfied_when: >
+      The session's firing log records this way's guidance being disclosed on
+      trigger and held below its refire threshold rather than re-injected verbatim,
+      and the agent relied on that contextual delivery instead of asking the
+      operator to restate the ways-system guidance.
 verified: 2026-02-05
 rationale: >
   Overview of the ways system for orientation when ways are mentioned

--- a/hooks/ways/softwaredev/architecture/threat-modeling/provenance.yaml
+++ b/hooks/ways/softwaredev/architecture/threat-modeling/provenance.yaml
@@ -6,10 +6,18 @@ controls:
     justifications:
       - STRIDE framework applied at design phase before code review
       - Trust boundaries identified between components and external systems
+    satisfied_when: >
+      Before implementation, the session performed a STRIDE pass over the design
+      and enumerated the trust boundaries where data crosses trust levels — the
+      threat analysis preceded writing the code rather than following it.
   - id: NIST SP 800-30 (Risk Assessment)
     justifications:
       - Risk register documents accepted risks with expiration dates
       - Likelihood and impact assessed for each identified threat
+    satisfied_when: >
+      Identified threats were recorded in a risk register with likelihood and
+      impact assessed for each, and any risk marked accepted carries an expiration
+      date rather than being accepted indefinitely.
 verified: 2026-02-17
 rationale: >
   Security Way covers code-level detection (SQL injection, XSS, secrets).

--- a/hooks/ways/softwaredev/code/errors/provenance.yaml
+++ b/hooks/ways/softwaredev/code/errors/provenance.yaml
@@ -7,14 +7,31 @@ controls:
       - Boundary-only catch pattern ensures errors are logged once at system edges, not swallowed internally
       - Prohibition on silent catch blocks prevents monitoring blind spots
       - Log-once-at-boundary rule prevents log noise that obscures real failures
+    satisfied_when: >
+      Catch blocks added or modified in the session sit at system boundaries (API
+      endpoint, CLI entry, message handler) rather than inside business logic, contain
+      no silent/empty handlers, and log each error at most once; a session that
+      introduces an empty catch or logs the same error at multiple levels is
+      distinguishable in the diff.
   - id: NIST SP 800-53 SI-11 (Error Handling)
     justifications:
       - Generic error responses to clients (code + safe message) prevent information disclosure
       - Programmer vs operational error distinction prevents exposing internal state through bug-triggered messages
+    satisfied_when: >
+      Client- or user-facing error responses produced in the session return a generic
+      code plus a safe message rather than raw exception text or stack traces, and
+      programmer errors (bugs) are allowed to fail fast instead of being caught and
+      surfaced; a response that leaks internal state or an exception message is the
+      failure case.
   - id: NIST SP 800-53 AU-3 (Content of Audit Records)
     justifications:
       - Error wrapping with context (module boundary, identifiers) creates traceable audit records
       - Cause chaining preserves full error provenance for forensic analysis
+    satisfied_when: >
+      Errors re-thrown across module boundaries in the session are wrapped with
+      contextual identifiers and preserve the originating error via cause chaining,
+      visible in the diff; a bare re-throw that drops context or the cause is the
+      failure case.
 verified: 2026-02-09
 rationale: >
   Boundary-only catching with log-once semantics implements OWASP A09 monitoring requirements.

--- a/hooks/ways/softwaredev/code/quality/provenance.yaml
+++ b/hooks/ways/softwaredev/code/quality/provenance.yaml
@@ -7,14 +7,30 @@ controls:
       - File length thresholds (500/800 lines) enforce analyzability through size limits
       - Nesting depth limit (3 levels) maintains modifiability by controlling complexity
       - Method count limit (7 public methods) enforces single responsibility
+    satisfied_when: >
+      When the file-length scan reports a file over the 500/800-line threshold, the
+      session calls it out explicitly before proceeding; and code added in the session
+      stays within the nesting-depth (3), public-method (7), and function-size (30-50
+      line) limits, or a concrete split/extraction is proposed where it would cross
+      them. Adding to a flagged file without acknowledging it is the failure case.
   - id: NIST SP 800-53 SA-15 (Development Process, Standards, and Tools)
     justifications:
       - Ecosystem convention enforcement reduces security-relevant coding errors
       - Anti-pattern detection (foreign patterns, unnecessary abstractions) prevents tool misuse
+    satisfied_when: >
+      Code introduced in the session follows the language/ecosystem's idioms — no
+      foreign patterns (e.g. Result/Option monads in TypeScript) and no reimplementation
+      of what a standard library already provides — and any such pattern encountered in
+      reviewed code is flagged rather than left or copied.
   - id: IEEE 730-2014 (Software Quality Assurance Processes)
     justifications:
       - Measurable quality signals with specific action thresholds
       - Function size limits (30-50 lines) enforce decomposition practices
+    satisfied_when: >
+      Where a quality signal is exceeded, the session names the specific measurable
+      threshold crossed (line count, nesting depth, method count, function length) and
+      pairs it with a concrete remediation such as a named split boundary or extracted
+      helper, rather than proceeding silently or citing quality in the abstract.
 verified: 2026-02-05
 rationale: >
   Measurable thresholds (file length, nesting depth, method count) operationalize

--- a/hooks/ways/softwaredev/code/quality/versioning/provenance.yaml
+++ b/hooks/ways/softwaredev/code/quality/versioning/provenance.yaml
@@ -6,10 +6,21 @@ controls:
     justifications:
       - Version-numbered identifiers create parallel implementations that degrade modifiability — callers split across revisions nobody consolidates
       - Names describing what a symbol is (not which revision) preserve analyzability; VCS carries the timeline
+    satisfied_when: >
+      Identifiers introduced or renamed in the session carry no authoring-revision
+      version suffix (process_v2, _FOO_V0, "v0 seed"); a contract that changed is
+      expressed by editing the existing name or by a behavioral name (parse_strict), and
+      any genuine overlap window marks the old name deprecated with a removal condition
+      rather than leaving a versioned twin. A committed _vN twin is the failure case.
   - id: NIST SP 800-53 SA-15 (Development Process, Standards, and Tools)
     justifications:
       - Anti-pattern detection on the authored diff catches versioned twins at the moment they would become permanent
       - Distinguishes code-owned identifiers from legitimate external version references to avoid false enforcement
+    satisfied_when: >
+      When a version-bearing identifier appears in the diff, the session distinguishes
+      code-owned names (flagged and reworked) from legitimate external version references
+      (/v1/ paths, __version__, schema_version, migration filenames, apiVersion), acting
+      only on the former; flagging a legitimate external reference is the failure case.
 verified: 2026-05-18
 rationale: >
   Versioned identifiers (process_v2, _FOO_V0, "v0 seed") freeze authoring-time

--- a/hooks/ways/softwaredev/code/security/contributions/provenance.yaml
+++ b/hooks/ways/softwaredev/code/security/contributions/provenance.yaml
@@ -6,22 +6,54 @@ controls:
     justifications:
       - Treats external contributions as untrusted input requiring an adversarial review pass before acceptance
       - Dependency/lockfile and install-script inspection applies supply-chain provenance checks at merge time
+    satisfied_when: >
+      Before an external contribution is accepted, the session runs an adversarial pass
+      that is distinct from the correctness review and includes inspection of any
+      manifest/lockfile changes and install/postinstall scripts. A contribution accepted
+      on the strength of a correctness review and green CI alone is the failure case.
   - id: NIST SP 800-53 SA-15 (Development Process, Standards, and Tools)
     justifications:
       - Defines a repeatable adversarial-review checklist applied to incoming changes
       - Separates intent review from correctness review so both gates run before merge
+    satisfied_when: >
+      The session works through the adversarial checklist against the incoming diff and
+      records a security verdict kept separate from the correctness review, so both
+      gates are visible as distinct passes. Folding the security judgment into style
+      notes or omitting the checklist is the failure case.
   - id: NIST SP 800-53 CM-3 (Configuration Change Control)
     justifications:
       - Scope-of-touch check flags changes to CI, build, and security-sensitive files that the change request does not justify
+    satisfied_when: >
+      The session enumerates the touched files (e.g. `git diff --stat`) and flags any
+      CI/workflow, manifest/lockfile, build-script, install-hook, or security-sensitive
+      file that the PR description does not justify. Reviewing the diff without noting an
+      unjustified change to one of these files is the failure case.
   - id: CWE-506 (Embedded Malicious Code)
     justifications:
       - Hunts exfiltration primitives, obfuscation, and weakened guards introduced under cover of a benign-looking diff
+    satisfied_when: >
+      Added lines are scanned for exfiltration primitives (fetch/http/net, fs writes,
+      child_process/exec, eval/new Function, dynamic require/import) and for obfuscation
+      (base64/hex blobs, string-built identifiers, indirected calls) and for removed or
+      loosened existing assertions, with any hit reported. Passing a diff that adds such
+      a primitive without remark is the failure case.
   - id: CWE-1007 (Insufficient Visual Distinction of Homoglyphs)
     justifications:
       - Hidden-character scan detects bidi-override (Trojan Source / CVE-2021-42574), zero-width, and homoglyph attacks in source
+    satisfied_when: >
+      Added lines are scanned for bidi-override, zero-width, and other hidden control
+      characters and for non-ASCII characters in identifiers, and any match is reported
+      as a Trojan-Source finding. Accepting a diff containing such characters without
+      detecting them is the failure case.
   - id: OWASP Top 10 2021 A08 (Software and Data Integrity Failures)
     justifications:
       - Verifies incoming code and its dependencies for integrity before they enter the trusted build
+    satisfied_when: >
+      The session states an explicit go/no-go verdict as its own line ("no malicious
+      patterns found" or "flagging X") before the contribution merges, and raises
+      anything suspect for the contributor to explain rather than silently fixing and
+      absorbing it. Merging without a stated verdict, or quietly patching a finding, is
+      the failure case.
 verified: 2026-06-09
 rationale: >
   Operationalizes supply-chain and development-process controls at the

--- a/hooks/ways/softwaredev/code/security/provenance.yaml
+++ b/hooks/ways/softwaredev/code/security/provenance.yaml
@@ -7,19 +7,40 @@ controls:
       - Detection table maps SQL concatenation, innerHTML, and shell interpolation to remediation actions
       - Parameterized queries required as default for all database access
       - Input validation enforced at system boundaries
+    satisfied_when: >
+      Database access written in the session uses parameterized queries rather than
+      string-concatenated SQL, output is escaped for its rendering context, input is
+      validated at boundaries, and any SQL concatenation or unsanitized user input in
+      reviewed code is flagged. Introducing or leaving a concatenated query unremarked
+      is the failure case.
   - id: NIST SP 800-53 IA-5 (Authenticator Management)
     justifications:
       - Never-commit list explicitly prohibits API keys, tokens, passwords, and private keys
       - Hardcoded secrets flagged for extraction to environment variables
       - .env hygiene enforced with .env.example and .gitignore verification
+    satisfied_when: >
+      No API keys, tokens, passwords, or private keys are committed in the session; any
+      hardcoded secret encountered is flagged for extraction to an environment variable;
+      and changes touching a .env file verify it is gitignored and mirrored by a
+      secret-free .env.example. A committed credential is the failure case.
   - id: CIS Controls v8 16.12 (Implementation of Application-Level Access)
     justifications:
       - Missing auth check on endpoints flagged as security issue
       - Principle of least privilege stated as default for permissions
+    satisfied_when: >
+      Permissions or access grants added or changed in the session are scoped to the
+      minimum needed rather than broad defaults, and any endpoint reachable without an
+      authentication/authorization check is flagged. Granting broader access than the
+      task requires is the failure case.
   - id: SOC 2 CC6.1 (Logical and Physical Access Controls)
     justifications:
       - Authentication/authorization gap detection in code review checklist
       - Endpoint access control enforcement via middleware/guard guidance
+    satisfied_when: >
+      A review pass in the session inspects endpoints for authentication/authorization
+      coverage and reports any access-control gap before merge, rather than the gap
+      passing through unexamined. Reviewing changed endpoints without checking their
+      access control is the failure case.
 verified: 2026-02-05
 rationale: >
   Detection table operationalizes OWASP injection prevention and NIST credential

--- a/hooks/ways/softwaredev/code/testing/provenance.yaml
+++ b/hooks/ways/softwaredev/code/testing/provenance.yaml
@@ -7,15 +7,32 @@ controls:
       - Four coverage categories (happy path, empty/null, boundary, error) implement structured developer test evaluation
       - Framework auto-detection ensures tests follow project conventions rather than ad-hoc patterns
       - One logical assertion per test enforces precise, evaluable test cases
+    satisfied_when: >
+      Tests written in the session cover the four categories for the function under test
+      (happy path, empty/null input, boundary values, error conditions) with one logical
+      assertion each, and the test framework is detected from project files
+      (package.json, requirements.txt, Cargo.toml, go.mod) rather than assumed. Tests
+      covering only the happy path, or written against the wrong framework, is the
+      failure case.
   - id: IEEE 829-2008 (Test Documentation Standard)
     justifications:
       - Arrange-Act-Assert structure standardizes test documentation format
       - Naming convention (should [behavior] when [condition]) creates self-documenting test specifications
       - Test independence requirement (no shared mutable state) ensures repeatable test execution
+    satisfied_when: >
+      Tests written in the session follow Arrange-Act-Assert structure and the
+      "should [behavior] when [condition]" naming, and share no mutable state across
+      tests, all visible in the test files. Tests with vague names, tangled setup, or
+      order-dependent shared state are the failure case.
   - id: ISO/IEC 25010:2011 (Reliability - Maturity, Fault Tolerance)
     justifications:
       - Boundary value testing (min, max, off-by-one, empty collections) verifies fault tolerance
       - Error condition coverage (invalid input, dependency failures) validates graceful degradation
+    satisfied_when: >
+      Tests written in the session include boundary-value cases (min, max, off-by-one,
+      empty collections) and error-condition cases (invalid input, dependency failure),
+      asserting on observable outputs and side effects rather than internal state. A
+      suite that exercises only nominal inputs is the failure case.
 verified: 2026-02-09
 rationale: >
   Structured coverage categories implement SA-11 developer testing evaluation. AAA format

--- a/hooks/ways/softwaredev/delivery/commits/provenance.yaml
+++ b/hooks/ways/softwaredev/delivery/commits/provenance.yaml
@@ -7,14 +7,27 @@ controls:
       - Conventional commit types (feat/fix/refactor) classify changes by nature
       - Atomic single-concern commits make each change independently reviewable
       - Commit message body captures rationale, satisfying change documentation requirements
+    satisfied_when: >
+      Commits created in the session carry a conventional-commit type prefix
+      (feat/fix/refactor/docs/test/chore), each covers a single logical change
+      rather than bundling unrelated edits, and the message body states the
+      rationale for the change.
   - id: SOC 2 CC8.1 (Change Management)
     justifications:
       - Type prefix and scope field create structured change records for audit trail
       - Branch naming convention (adr-NNN, feature/, fix/) categorizes change intent
+    satisfied_when: >
+      Session commits carry a type(scope) prefix and the work was done on a branch
+      named per convention (adr-NNN, feature/, fix/, refactor/) rather than
+      committed directly to main with unstructured messages.
   - id: ISO/IEC 27001:2022 A.8.32 (Change Management)
     justifications:
       - Git commit history provides immutable timestamped change log
       - Conventional format enables automated changelog generation
+    satisfied_when: >
+      Changes were landed as git commits (recorded in timestamped history) rather
+      than left as uncommitted edits, and their subjects follow the conventional
+      format such that a changelog generator could classify them by type.
 verified: 2026-02-05
 rationale: >
   Conventional commits create structured change records with type classification

--- a/hooks/ways/softwaredev/delivery/github/provenance.yaml
+++ b/hooks/ways/softwaredev/delivery/github/provenance.yaml
@@ -7,15 +7,27 @@ controls:
       - PR-always stance ensures all changes pass through a reviewable change management gate
       - Solo PRs still serve as decision records and CI gates even without reviewers
       - Tiered PR depth (lightweight for solo, thorough for teams) scales change management to context
+    satisfied_when: >
+      Changes in the session were routed through a pull request (a PR was opened
+      via gh pr create) rather than pushed or merged directly to main, including
+      for solo work.
   - id: NIST SP 800-53 CM-3 (Configuration Change Control)
     justifications:
       - PR as change record creates immutable audit trail of what changed and why
       - CI checks on PRs implement automated configuration change verification
       - Repo health macro detects missing configuration controls (branch protection, templates)
+    satisfied_when: >
+      A PR was opened describing what changed and why, and its CI check status was
+      consulted (e.g. gh pr checks) before merge rather than merging without
+      confirming checks passed.
   - id: ISO/IEC 27001:2022 A.8.32 (Change Management)
     justifications:
       - PR workflow (create → review → merge) implements formal change management process
       - Issue tracking provides requirements traceability for changes
+    satisfied_when: >
+      The change followed the create → review → merge sequence — a review pass
+      (code-reviewer offered or run) occurred between opening the PR and merging —
+      rather than the PR being merged immediately with no review step.
 verified: 2026-02-09
 rationale: >
   PR-always stance implements CC8.1 change management even for solo projects. PR-as-record

--- a/hooks/ways/softwaredev/delivery/release/provenance.yaml
+++ b/hooks/ways/softwaredev/delivery/release/provenance.yaml
@@ -7,14 +7,28 @@ controls:
       - Keep a Changelog format (Added/Changed/Fixed/Removed) classifies changes by nature for review
       - Git log since last tag captures complete change history between releases
       - Semantic version inference from commit types creates deterministic version progression
+    satisfied_when: >
+      The release session enumerated changes via git log since the last tag and
+      produced changelog entries organized into Keep a Changelog sections
+      (Added/Changed/Fixed/Removed), rather than cutting a release without
+      documenting its changes.
   - id: SOC 2 CC8.1 (Change Management)
     justifications:
       - Changelog generation from commit history produces auditable release documentation
       - Version file detection and update creates traceable release artifacts
+    satisfied_when: >
+      The session both produced changelog documentation and updated the detected
+      version file as part of the release, leaving matching traceable artifacts
+      rather than bumping one without the other.
   - id: NIST SP 800-53 SA-10 (Developer Configuration Management)
     justifications:
       - Semantic versioning (major/minor/patch) from commit message analysis standardizes version identification
       - Version file management across ecosystems (package.json, Cargo.toml, pyproject.toml) ensures consistent version tracking
+    satisfied_when: >
+      The new version number was derived by classifying commits since the last tag
+      (breaking → major, feat → minor, fix/chore → patch) and applied to the
+      ecosystem-appropriate version file (package.json, Cargo.toml, pyproject.toml,
+      version.txt), not chosen arbitrarily.
 verified: 2026-02-09
 rationale: >
   Keep a Changelog format and git-based change enumeration implement CM-3 change documentation.

--- a/hooks/ways/softwaredev/environment/config/provenance.yaml
+++ b/hooks/ways/softwaredev/environment/config/provenance.yaml
@@ -7,14 +7,27 @@ controls:
       - Configuration hierarchy (env vars > config files > defaults) establishes deterministic configuration precedence
       - Fail-fast on missing required config prevents runtime configuration drift
       - Sensible defaults for non-sensitive values reduce misconfiguration risk
+    satisfied_when: >
+      When creating or modifying configuration, the session resolved values in the
+      order env vars over config files over defaults, and added a startup check that
+      fails (throws or exits) on a missing required value rather than reading it
+      lazily at first use.
   - id: CIS Controls v8 4.1 (Establish and Maintain a Secure Configuration Process)
     justifications:
       - Startup validation pattern checks all required configuration before accepting traffic
       - .env.example with placeholder values documents expected configuration shape
+    satisfied_when: >
+      When a .env file was introduced, the session also produced a matching
+      .env.example populated with placeholder (non-real) values, and wired a startup
+      validation enumerating the required configuration keys.
   - id: NIST SP 800-53 IA-5 (Authenticator Management)
     justifications:
       - .env files excluded from version control via .gitignore verification
       - Secrets handling deferred to Security Way for credential separation
+    satisfied_when: >
+      The session confirmed, by reading or editing .gitignore, that .env is ignored
+      when or before creating it, and left real secret values out of any
+      version-controlled file.
 verified: 2026-02-09
 rationale: >
   Configuration hierarchy and startup validation implement CM-6 configuration management.

--- a/hooks/ways/softwaredev/environment/deps/provenance.yaml
+++ b/hooks/ways/softwaredev/environment/deps/provenance.yaml
@@ -6,15 +6,28 @@ controls:
     justifications:
       - Pre-addition checklist evaluates maintenance status, size, and license before adopting third-party components
       - Trivial dependency rejection (is-odd, left-pad) reduces unnecessary supply chain attack surface
+    satisfied_when: >
+      Before adding a third-party dependency, the session checked its maintenance
+      status, size, and license (e.g. npm info, npm pack --dry-run, repository
+      activity) and declined trivial packages that could be written inline, rather
+      than installing on first impulse.
   - id: OWASP Top 10 2021 A06 (Vulnerable and Outdated Components)
     justifications:
       - npm audit / pip-audit / cargo audit required after adding or updating dependencies
       - Dependencies more than 2 major versions behind flagged for remediation
       - Changelog review before updates catches breaking changes and known vulnerabilities
+    satisfied_when: >
+      After adding or updating a dependency the session ran the ecosystem audit
+      command (npm audit / pip-audit / cargo audit), and before an update consulted
+      the changelog and flagged packages more than two major versions behind.
   - id: NIST SP 800-53 RA-5 (Vulnerability Monitoring and Scanning)
     justifications:
       - Post-install audit scanning implements continuous vulnerability monitoring for third-party code
       - Vulnerability warnings must be fixed or explicitly documented as accepted risk
+    satisfied_when: >
+      A vulnerability scan was run after installation, and each reported finding was
+      either remediated or explicitly documented as accepted risk in the session,
+      not left unaddressed without comment.
 verified: 2026-02-09
 rationale: >
   Pre-addition evaluation implements supply chain risk assessment per SA-12. Post-install

--- a/hooks/ways/softwaredev/environment/makefile/provenance.yaml
+++ b/hooks/ways/softwaredev/environment/makefile/provenance.yaml
@@ -3,10 +3,19 @@ controls:
     justifications:
       - Makefile codifies build, test, and release procedures as reproducible targets
       - make help provides discoverable project interface documentation
+    satisfied_when: >
+      When build, test, or release steps were involved, the session routed them
+      through Makefile targets (creating or extending the Makefile) rather than
+      issuing ad-hoc one-off commands, and a self-documenting help target lists the
+      available targets.
   - id: NIST SP 800-53 SA-11 (Developer Testing and Evaluation)
     justifications:
       - Standardized make test / make lint targets ensure consistent test execution
       - CI and local environments run identical commands via Make
+    satisfied_when: >
+      The session invoked tests and linting through standardized make targets
+      (make test / make lint / make check) — the same commands CI would run — and
+      read the existing Makefile or make help before adding new targets.
 verified: 2026-03-13
 rationale: >
   A Makefile provides a language-agnostic, zero-dependency task interface that

--- a/hooks/ways/softwaredev/environment/ssh/provenance.yaml
+++ b/hooks/ways/softwaredev/environment/ssh/provenance.yaml
@@ -7,16 +7,28 @@ controls:
       - BatchMode=yes enforces non-interactive authentication, preventing credential prompt hanging
       - ConnectTimeout prevents indefinite connection attempts to unreachable hosts
       - Tiered scenarios (dev/homelab/enterprise) acknowledge different remote access security postures
+    satisfied_when: >
+      SSH and scp/rsync commands issued in the session carried -o BatchMode=yes and
+      -o ConnectTimeout=..., so an auth or unreachable-host failure returned
+      immediately instead of hanging on a prompt.
   - id: NIST SP 800-53 IA-2 (Identification and Authentication)
     justifications:
       - Key-based authentication preferred over password authentication
       - ssh-agent key verification before connection attempts validates identity infrastructure
       - StrictHostKeyChecking=accept-new prevents MITM while allowing legitimate new hosts
+    satisfied_when: >
+      The session validated key availability before relying on SSH (e.g. ssh-add -l
+      or a BatchMode=yes test connection) and used StrictHostKeyChecking=accept-new
+      rather than blanket-disabling host-key verification.
   - id: NIST SP 800-53 IA-5 (Authenticator Management)
     justifications:
       - Never-hardcode-passwords rule prevents credential exposure in source and process lists
       - sshpass -e (environment variable) preferred over -p (command line) to reduce credential visibility
       - SSH config file patterns centralize credential management per host class
+    satisfied_when: >
+      No password literal appeared in any command or in the transcript; where
+      password auth was unavoidable the session used sshpass -e with the secret
+      sourced from an environment variable (SSHPASS), never -p on the command line.
 verified: 2026-02-09
 rationale: >
   Non-interactive flags implement AC-17 remote access controls for automated sessions.


### PR DESCRIPTION
## Summary

Makes the finding dataset **live**. ADR-201 shipped the assembler that builds classifier-ready finding rows, but every row was **process-tier** (firing-only, inert) because no sidecar carried a `satisfied_when` determination criterion. This seeds them.

All **51 controls across the 19 `provenance.yaml` sidecars** gain a `satisfied_when` — the observable session behavior a classifier could check against the transcript + firing log to decide the control *satisfied* / *other-than-satisfied* (ADR-200 §1).

## What makes a good criterion (the bar these were held to)

- **Observable in a session** — grounded in what leaves a trace: commands run, files inspected, scans performed, artifacts produced.
- **Falsifiable** — each names its failure case (committed to main unstructured, empty `catch`, hardcoded credential, a `_vN` identifier twin, happy-path-only suite, risk accepted with no expiry…) so a not-satisfied session is distinguishable.
- **Not a restatement of the justification** — the justification says what the guidance is *designed* to do; `satisfied_when` says what *observable behavior* demonstrates it.

## Honesty notes

- **Only** `satisfied_when` was added — `id`/`justifications`/`policy`/`verified`/`rationale` untouched.
- The two `meta/knowledge` overview controls carry deliberately **thin-but-honest** criteria (orientation-only ways with genuinely thin session traces) rather than fabricated richer ones — an honest thin criterion beats a confabulated rich one.

## Verification

- All 19 sidecars valid YAML; **51/51 controls** carry a non-empty `satisfied_when`.
- `ways-audit assemble` run against these sidecars yields **51/51 outcome-tier rows** (was 0 — all process-tier before), each with a criterion and an **empty determination** (the assembler still never labels — ADR-201 §1 holds).

Authored by a domain-partitioned fan-out (code / delivery+arch / environment / docs+meta), each criterion reviewed for the bar above.