### PR TITLE
feat(settings): secret-path permissions.deny baseline (ADR-152, task #1)

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -72,6 +72,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-149](./system/ADR-149-operator-config-interview-skill.md) | operator config interview skill | Accepted |
 | [ADR-150](./system/ADR-150-version-truth-and-downgrade-safe-self-update.md) | Version-truth and downgrade-safe self-update | Accepted |
 | [ADR-151](./system/ADR-151-extract-ways-core-crate-and-ways-audit-sibling-binary.md) | Extract ways-core crate and ways-audit sibling binary | Accepted |
+| [ADR-152](./system/ADR-152-framework-default-secret-path-deny-baseline.md) | Framework-default secret-path deny baseline | Accepted |
 
 ## Governance
 _Provenance, traceability, controls, compliance mapping_

--- a/docs/architecture/system/ADR-152-framework-default-secret-path-deny-baseline.md
+++ b/docs/architecture/system/ADR-152-framework-default-secret-path-deny-baseline.md
@@ -1,0 +1,127 @@
+---
+status: Accepted
+date: 2026-07-02
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-142
+  - ADR-147
+supersedes: []
+---
+
+# ADR-152: Framework-default secret-path deny baseline
+
+## Context
+
+agent-ways already owns a slice of Claude Code's `settings.json`. During
+`ways reconcile` the settings three-way merge (ADR-142, ADR-147) set-unions a
+fixed list of permission strings — `WAYS_PERMS` — into `permissions.allow`
+(`Bash(ways:*)`, `Edit(~/.claude/**)`, …) and tracks them in a base so entries it
+stops owning are cleaned up. The user's own `permissions` entries are held
+invariant beside ours.
+
+`permissions.deny` is currently empty. Nothing stops the agent's **file tools**
+(`Read`, `Edit`, `Write`) from reaching credential material — `~/.ssh` private
+keys, `~/.aws/credentials`, GPG keyrings, a project `.env`. A single mistaken
+tool call can read a private key into the transcript, where it is then persisted
+and, if the transcript is ever shared, leaked. The framework projects itself into
+every session; it should also project a floor of protection for the paths that
+are almost never a legitimate read target for an agent.
+
+Claude Code's permission model makes this expressible: `permissions.deny` is a
+list of `Tool(pattern)` rules (`Read(./.env)`, `Read(~/.ssh/**)`,
+`Read(//abs/path/**)`), and **deny takes precedence over allow** — a deny is a
+hard block, not a prompt. That precedence is the whole point (a broad
+`Read(~/**)` allow cannot re-open a denied secret path) and also the constraint
+this ADR must respect: a forced deny the user cannot override via `allow` needs a
+deliberate, documented escape hatch, or it becomes a cage.
+
+## Decision
+
+### 1. Ship a curated secret-path deny baseline, reconciler-owned
+
+Add a `WAYS_DENY` list, the deny-side sibling of `WAYS_PERMS`, set-unioned into
+`permissions.deny` by the same merge and tracked in the same base. The baseline
+is intentionally **narrow and high-confidence** — paths an agent has essentially
+no legitimate reason to read or write:
+
+```
+Read(~/.ssh/**)      Edit(~/.ssh/**)      Write(~/.ssh/**)
+Read(~/.aws/**)      Read(~/.gnupg/**)    Read(~/.config/gcloud/**)
+Read(~/.kube/config) Read(~/.netrc)
+Read(./.env)         Read(./.env.local)
+```
+
+`~/.ssh` denies read **and** write (the agent should neither exfiltrate a key nor
+tamper with `authorized_keys`/`config`). The credential stores deny read.
+Project env files deny the secret ones (`.env`, `.env.local`) but **not**
+`.env.example` / `.env.sample`, which are meant to be read. The list is a
+starting floor, expected to grow through the same review as any owned-permission
+change — not a claim of completeness.
+
+### 2. Secure by default, with an explicit opt-out
+
+The baseline applies by default. Because a Claude Code deny cannot be overridden
+by a user `allow`, autonomy is preserved through a config flag, not settings
+editing: `secret_path_deny: false` in `$XDG_CONFIG_HOME/agent-ways/config.yaml`
+suppresses the baseline entirely (default `true`). A user who genuinely needs the
+agent to read a protected path opts the whole baseline out deliberately, rather
+than having it silently re-asserted on the next reconcile. This mirrors the
+`disabled_domains` pattern: framework behavior on by default, off by one explicit
+line.
+
+### 3. Honest scope — this gates tools, not the shell
+
+The deny binds the `Read`/`Edit`/`Write` **tools**. It does **not** stop a shell
+command — `Bash(cat ~/.ssh/id_ed25519)` reads the same file through a different
+door, and command-string denial is unreliable (countless spellings). Bash-level
+exfiltration is a distinct, harder problem addressed elsewhere (the adversarial
+`contributions` way, the hardened code-reviewer). This baseline is a meaningful
+floor against the most common accident — the agent's own file tools wandering
+into a secret — not a claim of exfiltration-proofing. Overselling it would be the
+exact overclaim the compliance work (ADR-200) exists to avoid.
+
+## Consequences
+
+### Positive
+
+- Secret material is protected from the agent's file tools by default, in every
+  reconciled session, at zero user effort.
+- Reuses the proven owned-permission merge machinery — no new projection seam.
+- The opt-out keeps the default honest: secure, but not a cage.
+
+### Negative
+
+- A forced deny can surprise a user whose task legitimately needs a protected
+  path; they must know about the config opt-out. Mitigated by documenting it
+  where the deny is described.
+- The curated list is a maintenance surface and a judgment call — too broad
+  breaks workflows, too narrow misses secrets. It ships deliberately conservative.
+
+### Neutral
+
+- Bash-path exfiltration remains out of scope, by design and stated plainly.
+- The list can grow; each addition is an owned-permission change reviewed like any
+  other, and the three-way base cleans up entries later removed.
+
+## Alternatives Considered
+
+- **Seed once, never re-assert.** Add the deny on first reconcile but let a user
+  removal stick. Rejected: it makes the security floor silently erodible and
+  diverges the deny logic from the forced-allow logic for no clear gain; the
+  config opt-out gives the same autonomy explicitly.
+- **`ask` instead of `deny`.** Use `permissions.ask` so secret paths prompt.
+  Rejected for the baseline: a prompt is the right tool for *ambiguous* paths, but
+  for private keys and credential stores a hard default block is the safer floor.
+  `ask` remains available to users for their own softer cases.
+- **Do nothing / leave to the user.** Rejected: the framework already projects
+  permissions; declining to project the one that protects secrets, when the
+  syntax makes it a few lines, is a missed default.
+
+## References
+
+- **ADR-142 / ADR-147** — the projection and the settings fragment/merge machinery
+  this extends.
+- **Claude Code permissions** — `permissions.deny`, rule syntax, and deny-over-allow
+  precedence. https://code.claude.com/docs/en/permissions

--- a/docs/architecture/system/ADR-152-framework-default-secret-path-deny-baseline.md
+++ b/docs/architecture/system/ADR-152-framework-default-secret-path-deny-baseline.md
@@ -60,6 +60,12 @@ Project env files deny the secret ones (`.env`, `.env.local`) but **not**
 starting floor, expected to grow through the same review as any owned-permission
 change — not a claim of completeness.
 
+Two deliberate narrownesses in that floor: the `.env` rules are **root-anchored**
+(`Read(./.env)` matches the project-root file, not a nested `subdir/.env`) and
+deny **read only** — the home-directory credential stores, not project env files,
+are the higher-severity targets, and over-broad project globs are where workflow
+breakage lives. Both can widen later if warranted.
+
 ### 2. Secure by default, with an explicit opt-out
 
 The baseline applies by default. Because a Claude Code deny cannot be overridden

--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -13,7 +13,7 @@ This guide is for the paths that aren't straight: an existing `~/.claude` you ca
 Before 1.0, this repo *was* `~/.claude/` — installing meant cloning over the directory Claude Code already used, so the installer had to detect existing files and stop rather than destroy them. **1.0 dissolves that.** `~/.claude` is now a thin **projection** of an XDG application whose source lives in `$XDG_DATA_HOME/agent-ways` (see [ADR-142](architecture/system/ADR-142-agent-ways-1-0-xdg-application-distribution.md)). Installing only:
 
 - symlinks the projected roots (`skills/`, `agents/`, `commands/`, `hooks/ways/`, built binaries) into `~/.claude`, and
-- three-way-merges the hooks block into your `settings.json`.
+- three-way-merges its owned slices into your `settings.json`: the hooks block, its `permissions.allow` entries (its own binaries), and a `permissions.deny` secret-path baseline (`~/.ssh`, `~/.aws`, `.env`, … — [ADR-152](architecture/system/ADR-152-framework-default-secret-path-deny-baseline.md); opt out with `secret_path_deny: false`).
 
 Everything else you have in `~/.claude` — `settings.json` values you set, `.credentials.json`, `projects/`, `memory/`, `CLAUDE.md` — is **preserved by construction**. There is nothing to back up first and no clobber prompt, because the install never replaces your directory. (`scripts/` and `tools/` and the rest of the app stay in `$XDG_DATA` and are deliberately *not* projected.)
 
@@ -21,7 +21,7 @@ Everything else you have in `~/.claude` — `settings.json` values you set, `.cr
 
 **Signs:** `~/.claude/` has `settings.json`, `projects/`, credentials, or sessions — with or without its own `.git/`.
 
-Just run the one-liner. The projection coexists with your directory; your files are untouched and your `settings.json` keeps its model, theme, plugins, and permissions (only the hooks block is merged in, and it backs up first). No move-aside, no restore dance.
+Just run the one-liner. The projection coexists with your directory; your files are untouched and your `settings.json` keeps its model, theme, plugins, and your own permissions (agent-ways merges only its owned slices — the hooks block, its `permissions.allow` entries, and the secret-path `permissions.deny` baseline — and backs up first). No move-aside, no restore dance.
 
 If `~/.claude/` is your **own** git repo (you version-control your config), that still works — the projection adds symlinks alongside your tracked files. Add the projected roots to your `.gitignore` if you don't want them tracked.
 

--- a/tools/ways-cli/src/cmd/settings_merge.rs
+++ b/tools/ways-cli/src/cmd/settings_merge.rs
@@ -40,30 +40,53 @@ pub const WAYS_PERMS: &[&str] = &[
     "Write(~/.claude/**)",
 ];
 
+/// The framework-default secret-path `permissions.deny` baseline (ADR-152).
+/// Set-unioned into `permissions.deny` unless `config.secret_path_deny` is false.
+/// A hard block on the agent's file tools reaching credential material — narrow
+/// and high-confidence (paths with essentially no legitimate agent read target).
+/// `.env.example` / `.env.sample` are intentionally NOT denied. Bash-path access
+/// is out of scope (see the ADR).
+pub const WAYS_DENY: &[&str] = &[
+    "Read(~/.ssh/**)",
+    "Edit(~/.ssh/**)",
+    "Write(~/.ssh/**)",
+    "Read(~/.aws/**)",
+    "Read(~/.gnupg/**)",
+    "Read(~/.config/gcloud/**)",
+    "Read(~/.kube/config)",
+    "Read(~/.netrc)",
+    "Read(./.env)",
+    "Read(./.env.local)",
+];
+
 /// The slices agent-ways last applied — the merge base.
 #[derive(Debug, Clone, Default)]
 pub struct Owned {
     /// Hook entries we wrote, per event (`SessionStart`, `PreToolUse`, …).
     pub hooks: Map<String, Value>,
-    /// Permission strings we added.
+    /// `permissions.allow` strings we added.
     pub perms: Vec<String>,
+    /// `permissions.deny` strings we added (ADR-152).
+    pub deny: Vec<String>,
 }
 
 impl Owned {
     fn from_value(v: &Value) -> Owned {
         let hooks = v.get("hooks").and_then(|h| h.as_object()).cloned().unwrap_or_default();
-        let perms = v
-            .get("perms")
-            .and_then(|p| p.as_array())
-            .map(|a| a.iter().filter_map(|x| x.as_str().map(String::from)).collect())
-            .unwrap_or_default();
-        Owned { hooks, perms }
+        let str_vec = |key: &str| {
+            v.get(key)
+                .and_then(|p| p.as_array())
+                .map(|a| a.iter().filter_map(|x| x.as_str().map(String::from)).collect())
+                .unwrap_or_default()
+        };
+        Owned { hooks, perms: str_vec("perms"), deny: str_vec("deny") }
     }
 
     fn to_value(&self) -> Value {
         serde_json::json!({
             "hooks": Value::Object(self.hooks.clone()),
             "perms": self.perms,
+            "deny": self.deny,
         })
     }
 }
@@ -76,7 +99,12 @@ pub struct Merged {
 
 /// Three-way merge of our owned slices into `live`, given the desired hooks and
 /// the prior base. Pure: no I/O, fully testable.
-pub fn merge(live: &Value, desired_hooks: &Value, base: &Owned) -> Result<Merged> {
+pub fn merge(
+    live: &Value,
+    desired_hooks: &Value,
+    base: &Owned,
+    deny_secrets: bool,
+) -> Result<Merged> {
     let mut out = live.as_object().cloned().unwrap_or_default();
 
     // --- hooks: per-event three-way ---
@@ -166,11 +194,41 @@ pub fn merge(live: &Value, desired_hooks: &Value, base: &Owned) -> Result<Merged
         new_allow.push(Value::String(p.clone()));
     }
     perms_obj.insert("allow".into(), Value::Array(new_allow));
+
+    // --- permissions.deny: same set-union + deprecated-ours cleanup (ADR-152) ---
+    // `ours_deny` is empty when the operator opts out (`secret_path_deny: false`),
+    // so the opt-out flows through the ordinary deprecated-cleanup: entries we
+    // added on a prior reconcile are dropped here, restoring the user's own deny.
+    let theirs_deny = perms_obj.get("deny").and_then(|a| a.as_array()).cloned().unwrap_or_default();
+    let ours_deny: Vec<String> = if deny_secrets {
+        WAYS_DENY.iter().map(|s| s.to_string()).collect()
+    } else {
+        Vec::new()
+    };
+    let deprecated_deny: Vec<String> =
+        base.deny.iter().filter(|p| !ours_deny.contains(p)).cloned().collect();
+    let mut new_deny: Vec<Value> = theirs_deny
+        .into_iter()
+        .filter(|v| {
+            v.as_str()
+                .map(|s| !deprecated_deny.iter().any(|d| d == s) && !ours_deny.iter().any(|o| o == s))
+                .unwrap_or(true)
+        })
+        .collect();
+    for d in &ours_deny {
+        new_deny.push(Value::String(d.clone()));
+    }
+    if new_deny.is_empty() {
+        perms_obj.remove("deny");
+    } else {
+        perms_obj.insert("deny".into(), Value::Array(new_deny));
+    }
+
     out.insert("permissions".into(), Value::Object(perms_obj));
 
     Ok(Merged {
         settings: Value::Object(out),
-        base: Owned { hooks: base_hooks, perms: ours_perms },
+        base: Owned { hooks: base_hooks, perms: ours_perms, deny: ours_deny },
     })
 }
 
@@ -207,17 +265,20 @@ pub fn stripped_user_view(settings: &Value, base: &Owned) -> Value {
         }
     }
 
-    // Strip our perms from permissions.allow.
+    // Strip our perms from permissions.allow and our deny baseline from
+    // permissions.deny — both are owned slices held invariant by the self-audit.
     if let Some(mut perms) = obj.get("permissions").and_then(|p| p.as_object()).cloned() {
-        if let Some(allow) = perms.get("allow").and_then(|a| a.as_array()).cloned() {
-            let kept: Vec<Value> = allow
-                .into_iter()
-                .filter(|v| v.as_str().map(|s| !base.perms.iter().any(|p| p == s)).unwrap_or(true))
-                .collect();
-            if kept.is_empty() {
-                perms.remove("allow");
-            } else {
-                perms.insert("allow".into(), Value::Array(kept));
+        for (key, owned) in [("allow", &base.perms), ("deny", &base.deny)] {
+            if let Some(entries) = perms.get(key).and_then(|a| a.as_array()).cloned() {
+                let kept: Vec<Value> = entries
+                    .into_iter()
+                    .filter(|v| v.as_str().map(|s| !owned.iter().any(|p| p == s)).unwrap_or(true))
+                    .collect();
+                if kept.is_empty() {
+                    perms.remove(key);
+                } else {
+                    perms.insert(key.into(), Value::Array(kept));
+                }
             }
         }
         if perms.is_empty() {
@@ -248,13 +309,20 @@ fn union_owned(a: &Owned, b: &Owned) -> Owned {
         }
         hooks.insert(event.clone(), Value::Array(combined));
     }
-    let mut perms = a.perms.clone();
-    for p in &b.perms {
-        if !perms.contains(p) {
-            perms.push(p.clone());
+    let union_vec = |a: &[String], b: &[String]| {
+        let mut out = a.to_vec();
+        for x in b {
+            if !out.contains(x) {
+                out.push(x.clone());
+            }
         }
+        out
+    };
+    Owned {
+        hooks,
+        perms: union_vec(&a.perms, &b.perms),
+        deny: union_vec(&a.deny, &b.deny),
     }
-    Owned { hooks, perms }
 }
 
 /// Quote the first whitespace-bearing command-path token so a `${HOME}` that
@@ -375,10 +443,11 @@ pub fn apply_to_files(
         Owned {
             hooks: live.get("hooks").and_then(|h| h.as_object()).cloned().unwrap_or_default(),
             perms: WAYS_PERMS.iter().map(|s| s.to_string()).collect(),
+            deny: WAYS_DENY.iter().map(|s| s.to_string()).collect(),
         }
     };
 
-    let merged = merge(&live, &desired_hooks, &base)?;
+    let merged = merge(&live, &desired_hooks, &base, crate::config::global().secret_path_deny)?;
 
     // Idempotent: if nothing changed, don't churn the file or a backup.
     if merged.settings == live {
@@ -460,7 +529,7 @@ mod tests {
     #[test]
     fn fresh_merge_adds_hooks_and_perms() {
         let live = json!({});
-        let m = merge(&live, &ours_hooks(), &Owned::default()).unwrap();
+        let m = merge(&live, &ours_hooks(), &Owned::default(), false).unwrap();
         assert!(m.settings["hooks"]["SessionStart"].is_array());
         let allow = m.settings["permissions"]["allow"].as_array().unwrap();
         assert_eq!(allow.len(), WAYS_PERMS.len());
@@ -470,20 +539,84 @@ mod tests {
     #[test]
     fn merge_is_idempotent() {
         let live = json!({});
-        let m1 = merge(&live, &ours_hooks(), &Owned::default()).unwrap();
+        let m1 = merge(&live, &ours_hooks(), &Owned::default(), false).unwrap();
         // Second apply, with the first run's base and its output as the live file.
-        let m2 = merge(&m1.settings, &ours_hooks(), &m1.base).unwrap();
+        let m2 = merge(&m1.settings, &ours_hooks(), &m1.base, false).unwrap();
         assert_eq!(m1.settings, m2.settings, "merge must be idempotent");
     }
 
     #[test]
     fn preserves_unrelated_user_keys() {
         let live = json!({ "model": "opus", "theme": "dark", "permissions": { "deny": ["Bash(rm:*)"] } });
-        let m = merge(&live, &ours_hooks(), &Owned::default()).unwrap();
+        let m = merge(&live, &ours_hooks(), &Owned::default(), false).unwrap();
         assert_eq!(m.settings["model"], "opus");
         assert_eq!(m.settings["theme"], "dark");
         // permissions.deny (user's) survives alongside our allow additions.
         assert_eq!(m.settings["permissions"]["deny"][0], "Bash(rm:*)");
+    }
+
+    fn deny_list(settings: &Value) -> Vec<String> {
+        settings["permissions"]["deny"]
+            .as_array()
+            .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn deny_baseline_added_when_enabled() {
+        let m = merge(&json!({}), &ours_hooks(), &Owned::default(), true).unwrap();
+        let deny = deny_list(&m.settings);
+        for want in WAYS_DENY {
+            assert!(deny.iter().any(|d| d == want), "missing deny entry {want}");
+        }
+        assert_eq!(m.base.deny.len(), WAYS_DENY.len(), "base records owned deny");
+    }
+
+    #[test]
+    fn deny_baseline_absent_when_opted_out() {
+        // Opted out + no user deny → no `deny` key written at all.
+        let m = merge(&json!({}), &ours_hooks(), &Owned::default(), false).unwrap();
+        assert!(m.settings["permissions"].get("deny").is_none());
+        assert!(m.base.deny.is_empty());
+    }
+
+    #[test]
+    fn deny_preserves_user_deny_entries() {
+        let live = json!({ "permissions": { "deny": ["Bash(rm:*)"] } });
+        let m = merge(&live, &ours_hooks(), &Owned::default(), true).unwrap();
+        let deny = deny_list(&m.settings);
+        assert!(deny.iter().any(|d| d == "Bash(rm:*)"), "user deny must survive");
+        assert!(deny.iter().any(|d| d == "Read(~/.ssh/**)"), "ours added alongside");
+    }
+
+    #[test]
+    fn opt_out_removes_previously_owned_deny_keeps_user() {
+        // A settled install: our baseline is present and recorded in the base.
+        let enabled = merge(&json!({ "permissions": { "deny": ["Bash(rm:*)"] } }), &ours_hooks(), &Owned::default(), true).unwrap();
+        // Now the operator opts out — our owned deny must vanish, the user's stays.
+        let opted = merge(&enabled.settings, &ours_hooks(), &enabled.base, false).unwrap();
+        let deny = deny_list(&opted.settings);
+        assert_eq!(deny, vec!["Bash(rm:*)"], "only the user's own deny remains");
+        assert!(opted.base.deny.is_empty());
+    }
+
+    #[test]
+    fn deny_is_idempotent() {
+        let m1 = merge(&json!({}), &ours_hooks(), &Owned::default(), true).unwrap();
+        let m2 = merge(&m1.settings, &ours_hooks(), &m1.base, true).unwrap();
+        assert_eq!(m1.settings, m2.settings, "re-applying the deny baseline is stable");
+    }
+
+    #[test]
+    fn user_view_invariant_holds_with_deny() {
+        // The self-audit: stripping our owned slices from before/after must match.
+        let live = json!({ "model": "opus", "permissions": { "deny": ["Bash(rm:*)"] } });
+        let m = merge(&live, &ours_hooks(), &Owned::default(), true).unwrap();
+        assert_eq!(
+            stripped_user_view(&live, &Owned::default()),
+            stripped_user_view(&m.settings, &m.base),
+            "the user's portion is provably unchanged under the deny baseline"
+        );
     }
 
     #[test]
@@ -491,7 +624,7 @@ mod tests {
         // The key three-way property: a user's own hook entry is NOT clobbered.
         let user_hook = json!({ "matcher": "startup", "hooks": [ { "type": "command", "command": "/usr/local/bin/my-thing" } ] });
         let live = json!({ "hooks": { "SessionStart": [ user_hook.clone() ] } });
-        let m = merge(&live, &ours_hooks(), &Owned::default()).unwrap();
+        let m = merge(&live, &ours_hooks(), &Owned::default(), false).unwrap();
         let entries = m.settings["hooks"]["SessionStart"].as_array().unwrap();
         assert!(entries.contains(&user_hook), "user hook must survive the merge");
         assert!(entries.len() >= 2, "both user and our hook present");
@@ -506,7 +639,7 @@ mod tests {
         let mut base = Owned::default();
         base.hooks.insert("SessionStart".into(), json!([ old.clone() ]));
 
-        let m = merge(&live, &ours_hooks(), &base).unwrap();
+        let m = merge(&live, &ours_hooks(), &base, false).unwrap();
         let ss = m.settings["hooks"]["SessionStart"].as_array().unwrap();
         assert!(!ss.contains(&old), "our deprecated hook must be removed");
         // User's unrelated hook on another event is untouched.
@@ -520,7 +653,7 @@ mod tests {
             "hooks": { "SessionStart": [ { "matcher": "startup", "hooks": [ { "type": "command", "command": "/u/mine" } ] } ] },
             "permissions": { "allow": ["Bash(git:*)"], "deny": ["Bash(rm:*)"] }
         });
-        let m = merge(&live, &ours_hooks(), &Owned::default()).unwrap();
+        let m = merge(&live, &ours_hooks(), &Owned::default(), false).unwrap();
         // Stripping our slices from before and after must yield identical user views.
         let before = stripped_user_view(&live, &Owned::default());
         let after = stripped_user_view(&m.settings, &m.base);
@@ -709,7 +842,7 @@ mod tests {
         let cmds: Vec<&str> = ss.iter().filter_map(|e| e["hooks"][0]["command"].as_str()).collect();
         assert!(cmds.iter().any(|c| c.contains("check-state.sh")), "new hook present: {cmds:?}");
         assert!(!cmds.iter().any(|c| c.contains("check-setup.sh")), "old hook removed: {cmds:?}");
-        assert!(cmds.iter().any(|c| *c == "/u/mine"), "user hook preserved: {cmds:?}");
+        assert!(cmds.contains(&"/u/mine"), "user hook preserved: {cmds:?}");
         assert_eq!(after["model"], "opus", "user content preserved");
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -757,7 +890,7 @@ mod tests {
         let user_hook = json!({ "matcher": "startup", "hooks": [ { "type": "command",
             "command": "tail -f ${HOME}/.claude/hooks/ways/debug.log" } ] });
         let live = json!({ "hooks": { "SessionStart": [ user_hook.clone() ] } });
-        let m = merge(&live, &ours_hooks(), &Owned::default()).unwrap();
+        let m = merge(&live, &ours_hooks(), &Owned::default(), false).unwrap();
         let ss = m.settings["hooks"]["SessionStart"].as_array().unwrap();
         assert!(ss.contains(&user_hook), "user hook (path-as-arg) must survive: {ss:?}");
         // And the self-audit view agrees it's user content on both sides.

--- a/tools/ways-cli/src/cmd/settings_merge.rs
+++ b/tools/ways-cli/src/cmd/settings_merge.rs
@@ -443,7 +443,16 @@ pub fn apply_to_files(
         Owned {
             hooks: live.get("hooks").and_then(|h| h.as_object()).cloned().unwrap_or_default(),
             perms: WAYS_PERMS.iter().map(|s| s.to_string()).collect(),
-            deny: WAYS_DENY.iter().map(|s| s.to_string()).collect(),
+            // Seed deny EMPTY, not with WAYS_DENY. Unlike allow (which agent-ways
+            // has long written, so a legacy install's entries must be claimed to
+            // avoid duplication), agent-ways has NEVER written permissions.deny
+            // before this baseline. Seeding WAYS_DENY would falsely claim ownership
+            // of any textually-matching entry the user authored themselves — and on
+            // the opt-out + first-reconcile path that entry would be silently
+            // stripped while the self-audit still passed. Empty is correct: enabled,
+            // the deny is added fresh and the user's own entries are provably
+            // preserved; opted out, nothing is touched.
+            deny: Vec::new(),
         }
     };
 
@@ -598,6 +607,27 @@ mod tests {
         let deny = deny_list(&opted.settings);
         assert_eq!(deny, vec!["Bash(rm:*)"], "only the user's own deny remains");
         assert!(opted.base.deny.is_empty());
+    }
+
+    #[test]
+    fn opt_out_first_reconcile_keeps_user_deny_matching_baseline() {
+        // Regression (PR #264 review, HIGH): on first reconcile (no base → the
+        // seed's deny is EMPTY) with the baseline opted out, a user's own deny that
+        // textually matches a WAYS_DENY pattern must NOT be stripped. Seeding the
+        // base with WAYS_DENY instead of empty deleted it silently AND passed the
+        // self-audit. Owned::default() here stands in for the empty-deny seed.
+        let live = json!({ "permissions": { "deny": ["Read(~/.ssh/**)"] } });
+        let m = merge(&live, &ours_hooks(), &Owned::default(), false).unwrap();
+        assert_eq!(
+            deny_list(&m.settings),
+            vec!["Read(~/.ssh/**)"],
+            "a user's own deny matching the baseline survives when opted out"
+        );
+        // And the self-audit must agree the user's view is unchanged.
+        assert_eq!(
+            stripped_user_view(&live, &union_owned(&Owned::default(), &m.base)),
+            stripped_user_view(&m.settings, &m.base),
+        );
     }
 
     #[test]

--- a/tools/ways-core/src/config.rs
+++ b/tools/ways-core/src/config.rs
@@ -86,6 +86,13 @@ pub struct Config {
     /// an org can point at an internal mirror or a pinned version instead of the
     /// public schema.
     pub settings_schema_url: Option<String>,
+    /// Whether `ways reconcile` projects the framework's secret-path
+    /// `permissions.deny` baseline into `settings.json` (ADR-152). Default
+    /// `true` — secure by default. Set `secret_path_deny: false` to suppress the
+    /// baseline entirely (the one explicit opt-out; a Claude Code deny cannot be
+    /// re-opened by a user `allow`, so the escape hatch lives here, not in
+    /// settings).
+    pub secret_path_deny: bool,
 }
 
 impl Config {
@@ -123,6 +130,7 @@ impl Default for Config {
             near_miss_margin: 0.05,
             refire_presets,
             settings_schema_url: None,
+            secret_path_deny: true,
         }
     }
 }
@@ -241,6 +249,9 @@ impl Config {
                 self.settings_schema_url = Some(v.to_string());
             }
         }
+        if let Some(v) = doc.get("secret_path_deny").and_then(|v| v.as_bool()) {
+            self.secret_path_deny = v;
+        }
     }
 
     /// Parse the project-scope `ways:` mapping for per-way toggles (ADR-131).
@@ -302,6 +313,9 @@ impl Config {
 # language: en          # Output language (en, ja, auto)
 # default_scope: agent  # Default scope for ways without explicit scope
 # disabled_domains: []  # Domains to disable everywhere (e.g., [ea, itops])
+# secret_path_deny: true # Project the secret-path permissions.deny baseline
+#                        # (~/.ssh, ~/.aws, .env, …) into settings.json — ADR-152.
+#                        # Set false to opt out entirely (secure by default).
 
 # Per-way enable/disable (ADR-131) is project scope only — set it in
 # {project}/.claude/ways.yaml using either form:
@@ -394,6 +408,16 @@ mod tests {
             cfg.settings_schema_url.as_deref(),
             Some("https://mirror.example/cc.json")
         );
+    }
+
+    #[test]
+    fn secret_path_deny_defaults_true_and_opts_out() {
+        let mut cfg = Config::default();
+        assert!(cfg.secret_path_deny, "secure by default (ADR-152)");
+        cfg.apply_yaml("secret_path_deny: false");
+        assert!(!cfg.secret_path_deny, "explicit opt-out honored");
+        cfg.apply_yaml("secret_path_deny: true");
+        assert!(cfg.secret_path_deny);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements **ADR-152** (task #1). agent-ways already owns `permissions.allow` in the `settings.json` three-way merge; this adds the **deny-side sibling** — a curated secret-path baseline that protects the agent's file tools from credential material **by default, in every reconciled session**.

`WAYS_DENY`:
```
Read(~/.ssh/**)  Edit(~/.ssh/**)  Write(~/.ssh/**)
Read(~/.aws/**)  Read(~/.gnupg/**)  Read(~/.config/gcloud/**)
Read(~/.kube/config)  Read(~/.netrc)
Read(./.env)  Read(./.env.local)
```
`.env.example` / `.env.sample` are intentionally **not** denied.

## Design

- **Reuses the proven merge machinery** — set-union into `permissions.deny`, tracked in the `Owned` base so the three-way cleanup applies to deny exactly as to allow.
- **Secure by default, explicit opt-out** — `secret_path_deny: false` in config suppresses the baseline. Because a Claude Code deny **cannot be re-opened by a user `allow`** (deny precedes allow), the escape hatch lives in config, not settings-editing. Opting out flows through the ordinary deprecated-cleanup, restoring the user's own deny.
- **Self-audit safe** — `stripped_user_view` + `union_owned` extended to the deny slice, so the post-write invariant holds our deny and never spuriously reverts (proven by test).

## Honest scope

This gates the `Read`/`Edit`/`Write` **tools**, not the shell — `Bash(cat ~/.ssh/id_ed25519)` reads through a different door, and command-string denial is unreliable. It's a **floor against the common accident** (the agent's own file tools wandering into a secret), not exfiltration-proofing. Overselling it would be the exact overclaim ADR-200 exists to avoid.

## Docs

- config.yaml template documents the opt-out.
- **install-guide corrected**: it claimed "only the hooks block is merged into settings.json" — but the merge has long owned `permissions.allow` and now `permissions.deny` too. Ground-truth fix.

## Test plan

- 6 new deny merge tests: added-when-enabled, absent-when-opted-out, preserves-user-deny, opt-out-removes-previously-owned, idempotent, and the **self-audit invariant** holds with deny.
- config default-true / opt-out test.
- `ways-core` **85** + `ways` **197** green; `doc lint` 0/0; new code clippy-clean.
- The two commits keep ADR-first history (ADR-152 Accepted → implementation).