### PR TITLE
feat(dist): download-first attend/attend-chat pre-built binaries (task #4)

### DIFF
--- a/.github/workflows/build-attend-chat.yml
+++ b/.github/workflows/build-attend-chat.yml
@@ -1,0 +1,137 @@
+name: Build attend-chat
+
+on:
+  push:
+    branches: [main]
+    tags: ['attend-chat-v*']
+    paths:
+      - 'tools/attend-chat/**'
+      - 'tools/agent-fmt/**'
+      - 'tools/sensor-*/**'
+      - 'tools/Cargo.toml'
+      - 'tools/Cargo.lock'
+      - '.github/workflows/build-attend-chat.yml'
+  pull_request:
+    paths:
+      - 'tools/attend-chat/**'
+      - 'tools/agent-fmt/**'
+      - 'tools/sensor-*/**'
+      - 'tools/Cargo.toml'
+      - 'tools/Cargo.lock'
+      - '.github/workflows/build-attend-chat.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            platform: linux-x86_64
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            platform: linux-aarch64
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            platform: darwin-x86_64
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            platform: darwin-arm64
+            os: macos-latest
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cargo-zigbuild (Linux cross-compile)
+        if: runner.os == 'Linux' && matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          pip3 install ziglang
+          cargo install cargo-zigbuild
+
+      - name: Build (native)
+        if: "!(runner.os == 'Linux' && matrix.target == 'aarch64-unknown-linux-gnu')"
+        run: cargo build --release --manifest-path tools/Cargo.toml -p attend-chat --target ${{ matrix.target }}
+
+      - name: Build (zigbuild cross-compile)
+        if: runner.os == 'Linux' && matrix.target == 'aarch64-unknown-linux-gnu'
+        run: cargo zigbuild --release --manifest-path tools/Cargo.toml -p attend-chat --target ${{ matrix.target }}
+
+      - name: Package binary
+        run: |
+          mkdir -p dist
+          cp tools/target/${{ matrix.target }}/release/attend-chat dist/attend-chat-${{ matrix.platform }}
+
+      - name: Smoke test
+        if: "!(matrix.target == 'aarch64-unknown-linux-gnu' && runner.os == 'Linux') && !(matrix.target == 'x86_64-apple-darwin' && runner.arch == 'ARM64')"
+        run: dist/attend-chat-${{ matrix.platform }} --version
+
+      - name: Verify binary (cross-compiled)
+        if: "(matrix.target == 'aarch64-unknown-linux-gnu' && runner.os == 'Linux') || (matrix.target == 'x86_64-apple-darwin' && runner.arch == 'ARM64')"
+        run: |
+          file dist/attend-chat-${{ matrix.platform }}
+          ls -lh dist/attend-chat-${{ matrix.platform }}
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: attend-chat-${{ matrix.platform }}
+          path: dist/attend-chat-${{ matrix.platform }}
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run tests
+        run: cargo test --manifest-path tools/Cargo.toml -p attend-chat
+
+  collect:
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          path: binaries
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: |
+          cd binaries
+          sha256sum attend-chat-* > checksums.txt
+          cat checksums.txt
+          ls -lh
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: attend-chat-all-platforms
+          path: binaries/
+
+  release:
+    needs: collect
+    if: startsWith(github.ref, 'refs/tags/attend-chat-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          name: attend-chat-all-platforms
+          path: binaries
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "attend-chat ${TAG#attend-chat-}" \
+            --notes "Pre-built attend-chat binaries for 4 platforms.
+
+          Build from source: \`make attend-chat\`" \
+            binaries/*

--- a/Makefile
+++ b/Makefile
@@ -231,17 +231,20 @@ ways-audit:
 
 # Build attend binary from workspace.
 attend:
-	@if [ -x $(ATTEND_BIN) ] && $(ATTEND_BIN) --help >/dev/null 2>&1; then \
+	@if [ -x $(ATTEND_BIN) ] && $(ATTEND_BIN) --version >/dev/null 2>&1; then \
 		echo "attend already built."; \
+	elif bash tools/attend/download-attend.sh 2>/dev/null; then \
+		echo "Pre-built attend binary installed."; \
+		$(MAKE) -s --no-print-directory _attend_state_hint; \
 	elif command -v cargo >/dev/null 2>&1; then \
-		echo "Building attend..."; \
+		echo "No pre-built binary, building attend from source..."; \
 		cargo build --release --manifest-path tools/Cargo.toml -p attend; \
 		mkdir -p bin; \
 		$(LINK) "$(CURDIR)/tools/target/release/attend$(EXE)" $(ATTEND_BIN); \
 		echo "Built: $(ATTEND_BIN) ($$(ls -lh $(ATTEND_BIN) | awk '{print $$5}'))"; \
 		$(MAKE) -s --no-print-directory _attend_state_hint; \
 	else \
-		echo "error: cargo not found. Install Rust: https://rustup.rs/"; \
+		echo "error: No pre-built binary and cargo not found. Install Rust: https://rustup.rs/"; \
 		exit 1; \
 	fi
 
@@ -268,17 +271,20 @@ attend-rebuild:
 
 # Build attend-chat binary from workspace.
 attend-chat:
-	@if [ -x $(ATTEND_CHAT_BIN) ] && $(ATTEND_CHAT_BIN) --help >/dev/null 2>&1; then \
+	@if [ -x $(ATTEND_CHAT_BIN) ] && $(ATTEND_CHAT_BIN) --version >/dev/null 2>&1; then \
 		echo "attend-chat already built."; \
+	elif bash tools/attend-chat/download-attend-chat.sh 2>/dev/null; then \
+		echo "Pre-built attend-chat binary installed."; \
+		$(MAKE) -s --no-print-directory _attend_state_hint; \
 	elif command -v cargo >/dev/null 2>&1; then \
-		echo "Building attend-chat..."; \
+		echo "No pre-built binary, building attend-chat from source..."; \
 		cargo build --release --manifest-path tools/Cargo.toml -p attend-chat; \
 		mkdir -p bin; \
 		$(LINK) "$(CURDIR)/tools/target/release/attend-chat$(EXE)" $(ATTEND_CHAT_BIN); \
 		echo "Built: $(ATTEND_CHAT_BIN) ($$(ls -lh $(ATTEND_CHAT_BIN) | awk '{print $$5}'))"; \
 		$(MAKE) -s --no-print-directory _attend_state_hint; \
 	else \
-		echo "error: cargo not found. Install Rust: https://rustup.rs/"; \
+		echo "error: No pre-built binary and cargo not found. Install Rust: https://rustup.rs/"; \
 		exit 1; \
 	fi
 

--- a/tools/attend-chat/download-attend-chat.sh
+++ b/tools/attend-chat/download-attend-chat.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Download the pre-built attend-chat binary for the current platform
+#
+# Detects OS/arch, downloads from GitHub Releases, verifies it runs.
+# Falls back to build-from-source instructions if no pre-built binary exists.
+#
+# Usage:
+#   download-ways.sh [--release TAG] [output-dir]
+#
+# The binary is placed at: bin/attend-chat (relative to repo root)
+
+set -euo pipefail
+
+# Platform detection
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m | sed 's/arm64/aarch64/')
+PLATFORM="${OS}-${ARCH}"
+
+GH_REPO="aaronsb/agent-ways"
+RELEASE_TAG="${ATTEND_CHAT_RELEASE:-latest}"
+BIN_NAME="attend-chat-${PLATFORM}"
+
+# Default output: repo bin/ directory
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+OUTPUT_DIR="${REPO_ROOT}/bin"
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release)
+      RELEASE_TAG="$2"
+      shift 2 ;;
+    --help|-h)
+      echo "Usage: $0 [--release TAG] [output-dir]"
+      echo ""
+      echo "  --release TAG  GitHub Release tag (default: latest attend-chat-* release)"
+      echo "  output-dir     Override output directory (default: bin/)"
+      echo ""
+      echo "Platform: ${PLATFORM}"
+      echo "Available: linux-x86_64, linux-aarch64, darwin-x86_64, darwin-arm64"
+      exit 0 ;;
+    *)
+      OUTPUT_DIR="$1"
+      shift ;;
+  esac
+done
+
+OUTPUT_FILE="${OUTPUT_DIR}/attend-chat"
+PLATFORM_FILE="${OUTPUT_DIR}/${BIN_NAME}"
+
+# Check if already present and working
+if [[ -x "$OUTPUT_FILE" ]] && "$OUTPUT_FILE" --version >/dev/null 2>&1; then
+  echo "attend-chat already installed and working: $OUTPUT_FILE" >&2
+  "$OUTPUT_FILE" --version >&2
+  echo "$OUTPUT_FILE"
+  exit 0
+fi
+
+# Need gh CLI
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI not found — build from source instead:" >&2
+  echo "  cd \"$REPO_ROOT\" && make attend-chat" >&2
+  exit 1
+fi
+
+# Create output directory
+mkdir -p "$OUTPUT_DIR"
+
+# Find the latest ways release
+if [[ "$RELEASE_TAG" == "latest" ]]; then
+  RELEASE_TAG=$(gh release list --repo "$GH_REPO" --limit 20 --json tagName --jq '.[].tagName' 2>/dev/null \
+    | grep '^attend-chat-v' | head -1)
+  if [[ -z "$RELEASE_TAG" ]]; then
+    echo "No attend-chat release found. Build from source:" >&2
+    echo "  cd \"$REPO_ROOT\" && make attend-chat" >&2
+    exit 1
+  fi
+fi
+
+echo "Platform: ${PLATFORM}" >&2
+echo "Release:  ${RELEASE_TAG}" >&2
+
+# Check if our platform binary exists in the release
+if ! gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep -q "^${BIN_NAME}$"; then
+  echo "No pre-built binary for ${PLATFORM} in release ${RELEASE_TAG}." >&2
+  echo "Available binaries:" >&2
+  gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep "attend-chat-" | sed 's/^/  /' >&2
+  echo "" >&2
+  echo "Build from source instead:" >&2
+  echo "  cd \"$REPO_ROOT\" && make attend-chat" >&2
+  exit 1
+fi
+
+# Download binary + checksums
+echo "Downloading ${BIN_NAME}..." >&2
+gh release download "$RELEASE_TAG" \
+  --repo "$GH_REPO" \
+  --pattern "$BIN_NAME" \
+  --dir "$OUTPUT_DIR" \
+  --clobber
+
+# Verify checksum
+CHECKSUMS_FILE="${OUTPUT_DIR}/checksums.txt"
+if gh release download "$RELEASE_TAG" \
+    --repo "$GH_REPO" \
+    --pattern "checksums.txt" \
+    --dir "$OUTPUT_DIR" \
+    --clobber 2>/dev/null; then
+  expected_hash=$(grep "${BIN_NAME}" "$CHECKSUMS_FILE" | awk '{print $1}')
+  if [[ -n "$expected_hash" ]]; then
+    actual_hash=$(sha256sum "$PLATFORM_FILE" 2>/dev/null | cut -d' ' -f1 \
+      || shasum -a 256 "$PLATFORM_FILE" 2>/dev/null | cut -d' ' -f1)
+    if [[ "$actual_hash" != "$expected_hash" ]]; then
+      echo "CHECKSUM MISMATCH for ${BIN_NAME}" >&2
+      echo "  Expected: ${expected_hash}" >&2
+      echo "  Got:      ${actual_hash}" >&2
+      rm -f "$PLATFORM_FILE" "$CHECKSUMS_FILE"
+      exit 1
+    fi
+    echo "Checksum verified: ${actual_hash:0:12}..." >&2
+  fi
+  rm -f "$CHECKSUMS_FILE"
+else
+  echo "WARNING: checksums.txt not found in release — skipping verification" >&2
+fi
+
+# Make executable and install
+chmod +x "$PLATFORM_FILE"
+cp "$PLATFORM_FILE" "$OUTPUT_FILE"
+chmod +x "$OUTPUT_FILE"
+
+# Verify it runs
+if "$OUTPUT_FILE" --version >/dev/null 2>&1; then
+  echo "Installed: $OUTPUT_FILE ($("$OUTPUT_FILE" --version))" >&2
+  ls -lh "$OUTPUT_FILE" >&2
+else
+  echo "WARNING: binary downloaded but won't execute on this platform" >&2
+  echo "Build from source instead:" >&2
+  echo "  cd \"$REPO_ROOT\" && make attend-chat" >&2
+  rm -f "$OUTPUT_FILE" "$PLATFORM_FILE"
+  exit 1
+fi
+
+# Output path for scripts to capture
+echo "$OUTPUT_FILE"

--- a/tools/attend-chat/download-attend-chat.sh
+++ b/tools/attend-chat/download-attend-chat.sh
@@ -5,7 +5,7 @@
 # Falls back to build-from-source instructions if no pre-built binary exists.
 #
 # Usage:
-#   download-ways.sh [--release TAG] [output-dir]
+#   download-attend-chat.sh [--release TAG] [output-dir]
 #
 # The binary is placed at: bin/attend-chat (relative to repo root)
 
@@ -67,7 +67,7 @@ fi
 # Create output directory
 mkdir -p "$OUTPUT_DIR"
 
-# Find the latest ways release
+# Find the latest attend-chat release
 if [[ "$RELEASE_TAG" == "latest" ]]; then
   RELEASE_TAG=$(gh release list --repo "$GH_REPO" --limit 20 --json tagName --jq '.[].tagName' 2>/dev/null \
     | grep '^attend-chat-v' | head -1)
@@ -85,7 +85,7 @@ echo "Release:  ${RELEASE_TAG}" >&2
 if ! gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep -q "^${BIN_NAME}$"; then
   echo "No pre-built binary for ${PLATFORM} in release ${RELEASE_TAG}." >&2
   echo "Available binaries:" >&2
-  gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep "attend-chat-" | sed 's/^/  /' >&2
+  gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null |  grep "^attend-chat-" | sed 's/^/  /' >&2
   echo "" >&2
   echo "Build from source instead:" >&2
   echo "  cd \"$REPO_ROOT\" && make attend-chat" >&2

--- a/tools/attend/download-attend.sh
+++ b/tools/attend/download-attend.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Download the pre-built attend binary for the current platform
+#
+# Detects OS/arch, downloads from GitHub Releases, verifies it runs.
+# Falls back to build-from-source instructions if no pre-built binary exists.
+#
+# Usage:
+#   download-ways.sh [--release TAG] [output-dir]
+#
+# The binary is placed at: bin/attend (relative to repo root)
+
+set -euo pipefail
+
+# Platform detection
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m | sed 's/arm64/aarch64/')
+PLATFORM="${OS}-${ARCH}"
+
+GH_REPO="aaronsb/agent-ways"
+RELEASE_TAG="${ATTEND_RELEASE:-latest}"
+BIN_NAME="attend-${PLATFORM}"
+
+# Default output: repo bin/ directory
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+OUTPUT_DIR="${REPO_ROOT}/bin"
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release)
+      RELEASE_TAG="$2"
+      shift 2 ;;
+    --help|-h)
+      echo "Usage: $0 [--release TAG] [output-dir]"
+      echo ""
+      echo "  --release TAG  GitHub Release tag (default: latest attend-* release)"
+      echo "  output-dir     Override output directory (default: bin/)"
+      echo ""
+      echo "Platform: ${PLATFORM}"
+      echo "Available: linux-x86_64, linux-aarch64, darwin-x86_64, darwin-arm64"
+      exit 0 ;;
+    *)
+      OUTPUT_DIR="$1"
+      shift ;;
+  esac
+done
+
+OUTPUT_FILE="${OUTPUT_DIR}/attend"
+PLATFORM_FILE="${OUTPUT_DIR}/${BIN_NAME}"
+
+# Check if already present and working
+if [[ -x "$OUTPUT_FILE" ]] && "$OUTPUT_FILE" --version >/dev/null 2>&1; then
+  echo "attend already installed and working: $OUTPUT_FILE" >&2
+  "$OUTPUT_FILE" --version >&2
+  echo "$OUTPUT_FILE"
+  exit 0
+fi
+
+# Need gh CLI
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI not found — build from source instead:" >&2
+  echo "  cd \"$REPO_ROOT\" && make attend" >&2
+  exit 1
+fi
+
+# Create output directory
+mkdir -p "$OUTPUT_DIR"
+
+# Find the latest ways release
+if [[ "$RELEASE_TAG" == "latest" ]]; then
+  RELEASE_TAG=$(gh release list --repo "$GH_REPO" --limit 20 --json tagName --jq '.[].tagName' 2>/dev/null \
+    | grep '^attend-v' | head -1)
+  if [[ -z "$RELEASE_TAG" ]]; then
+    echo "No attend release found. Build from source:" >&2
+    echo "  cd \"$REPO_ROOT\" && make attend" >&2
+    exit 1
+  fi
+fi
+
+echo "Platform: ${PLATFORM}" >&2
+echo "Release:  ${RELEASE_TAG}" >&2
+
+# Check if our platform binary exists in the release
+if ! gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep -q "^${BIN_NAME}$"; then
+  echo "No pre-built binary for ${PLATFORM} in release ${RELEASE_TAG}." >&2
+  echo "Available binaries:" >&2
+  gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep "attend-" | sed 's/^/  /' >&2
+  echo "" >&2
+  echo "Build from source instead:" >&2
+  echo "  cd \"$REPO_ROOT\" && make attend" >&2
+  exit 1
+fi
+
+# Download binary + checksums
+echo "Downloading ${BIN_NAME}..." >&2
+gh release download "$RELEASE_TAG" \
+  --repo "$GH_REPO" \
+  --pattern "$BIN_NAME" \
+  --dir "$OUTPUT_DIR" \
+  --clobber
+
+# Verify checksum
+CHECKSUMS_FILE="${OUTPUT_DIR}/checksums.txt"
+if gh release download "$RELEASE_TAG" \
+    --repo "$GH_REPO" \
+    --pattern "checksums.txt" \
+    --dir "$OUTPUT_DIR" \
+    --clobber 2>/dev/null; then
+  expected_hash=$(grep "${BIN_NAME}" "$CHECKSUMS_FILE" | awk '{print $1}')
+  if [[ -n "$expected_hash" ]]; then
+    actual_hash=$(sha256sum "$PLATFORM_FILE" 2>/dev/null | cut -d' ' -f1 \
+      || shasum -a 256 "$PLATFORM_FILE" 2>/dev/null | cut -d' ' -f1)
+    if [[ "$actual_hash" != "$expected_hash" ]]; then
+      echo "CHECKSUM MISMATCH for ${BIN_NAME}" >&2
+      echo "  Expected: ${expected_hash}" >&2
+      echo "  Got:      ${actual_hash}" >&2
+      rm -f "$PLATFORM_FILE" "$CHECKSUMS_FILE"
+      exit 1
+    fi
+    echo "Checksum verified: ${actual_hash:0:12}..." >&2
+  fi
+  rm -f "$CHECKSUMS_FILE"
+else
+  echo "WARNING: checksums.txt not found in release — skipping verification" >&2
+fi
+
+# Make executable and install
+chmod +x "$PLATFORM_FILE"
+cp "$PLATFORM_FILE" "$OUTPUT_FILE"
+chmod +x "$OUTPUT_FILE"
+
+# Verify it runs
+if "$OUTPUT_FILE" --version >/dev/null 2>&1; then
+  echo "Installed: $OUTPUT_FILE ($("$OUTPUT_FILE" --version))" >&2
+  ls -lh "$OUTPUT_FILE" >&2
+else
+  echo "WARNING: binary downloaded but won't execute on this platform" >&2
+  echo "Build from source instead:" >&2
+  echo "  cd \"$REPO_ROOT\" && make attend" >&2
+  rm -f "$OUTPUT_FILE" "$PLATFORM_FILE"
+  exit 1
+fi
+
+# Output path for scripts to capture
+echo "$OUTPUT_FILE"

--- a/tools/attend/download-attend.sh
+++ b/tools/attend/download-attend.sh
@@ -5,7 +5,7 @@
 # Falls back to build-from-source instructions if no pre-built binary exists.
 #
 # Usage:
-#   download-ways.sh [--release TAG] [output-dir]
+#   download-attend.sh [--release TAG] [output-dir]
 #
 # The binary is placed at: bin/attend (relative to repo root)
 
@@ -67,7 +67,7 @@ fi
 # Create output directory
 mkdir -p "$OUTPUT_DIR"
 
-# Find the latest ways release
+# Find the latest attend release
 if [[ "$RELEASE_TAG" == "latest" ]]; then
   RELEASE_TAG=$(gh release list --repo "$GH_REPO" --limit 20 --json tagName --jq '.[].tagName' 2>/dev/null \
     | grep '^attend-v' | head -1)
@@ -85,7 +85,7 @@ echo "Release:  ${RELEASE_TAG}" >&2
 if ! gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep -q "^${BIN_NAME}$"; then
   echo "No pre-built binary for ${PLATFORM} in release ${RELEASE_TAG}." >&2
   echo "Available binaries:" >&2
-  gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep "attend-" | sed 's/^/  /' >&2
+  gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null |  grep "^attend-" | sed 's/^/  /' >&2
   echo "" >&2
   echo "Build from source instead:" >&2
   echo "  cd \"$REPO_ROOT\" && make attend" >&2

--- a/tools/ways-cli/src/cmd/update.rs
+++ b/tools/ways-cli/src/cmd/update.rs
@@ -12,9 +12,10 @@
 //! - **Prefer pre-built binaries.** `make update` force-*builds* via cargo/cmake,
 //!   which fails for anyone without a toolchain. This mirrors the *install* flow
 //!   instead: download-first, build-fallback (the Makefile's `ways` / way-embed
-//!   `setup-binary` targets). `attend`/`attend-chat` have no pre-built binaries
-//!   yet, so they are refreshed **only if a toolchain is present**, else left
-//!   running their current version.
+//!   `setup-binary` targets). `attend`/`attend-chat` are download-first too now
+//!   (ADR-152 sibling work): their `make` targets fetch the pre-built binary
+//!   before building, so they refresh without a toolchain; only the build
+//!   fallback needs cargo.
 //! - **Rename-then-revert, never leave a broken install.** Each component's
 //!   binary is *renamed* aside (not removed) to defeat the "already installed"
 //!   early-return; if re-acquiring it fails, the old binary is moved back. A
@@ -60,11 +61,7 @@ pub fn run(dry_run: bool) -> Result<()> {
         println!("  1. scripts/update.sh          — git pull (autostash-safe)");
         println!("  2. refresh ways               — download pre-built (guarded: never older than source), else build");
         println!("  3. refresh way-embed          — download pre-built, else build (optional)");
-        if has_toolchain {
-            println!("  4. refresh attend/attend-chat — build (toolchain present)");
-        } else {
-            println!("  4. skip attend/attend-chat    — no pre-built + no toolchain; keep current version");
-        }
+        println!("  4. refresh attend/attend-chat — download pre-built, else build (optional)");
         println!("  5. {} corpus + reconcile      — regenerate corpus, reproject ~/.claude", ways_bin.display());
         println!("(dry-run — nothing executed)");
         return Ok(());
@@ -100,19 +97,15 @@ pub fn run(dry_run: bool) -> Result<()> {
         eprintln!("  ⚠ way-embed not refreshed ({e}); semantic matching degrades to regex until next update.");
     }
 
-    // 4. Awareness — attend/attend-chat. Build-only today, so gate on a toolchain.
-    if has_toolchain {
-        eprintln!("==> refresh attend/attend-chat (build)");
-        for comp in ["attend", "attend-chat"] {
-            if let Err(e) = refresh_component(&app, comp, &[comp], &app) {
-                eprintln!("  ⚠ {comp} not refreshed ({e}); it keeps its current version.");
-            }
+    // 4. Awareness — attend/attend-chat. Now download-first (their `make` targets
+    //    try the pre-built binary before building), so they refresh even without a
+    //    toolchain; the build fallback still needs cargo but the download path does
+    //    not. A failed refresh reverts and keeps the current version.
+    eprintln!("==> refresh attend/attend-chat (pre-built first)");
+    for comp in ["attend", "attend-chat"] {
+        if let Err(e) = refresh_component(&app, comp, &[comp], &app) {
+            eprintln!("  ⚠ {comp} not refreshed ({e}); it keeps its current version.");
         }
-    } else {
-        eprintln!(
-            "==> attend/attend-chat: skipped — no pre-built binary and no build toolchain. \
-             They keep running the current version; run `make deps` then `ways update` to refresh them."
-        );
     }
 
     // 5. Regenerate the corpus (best-effort — it self-heals on next session) and

--- a/tools/ways-cli/src/cmd/update.rs
+++ b/tools/ways-cli/src/cmd/update.rs
@@ -12,10 +12,11 @@
 //! - **Prefer pre-built binaries.** `make update` force-*builds* via cargo/cmake,
 //!   which fails for anyone without a toolchain. This mirrors the *install* flow
 //!   instead: download-first, build-fallback (the Makefile's `ways` / way-embed
-//!   `setup-binary` targets). `attend`/`attend-chat` are download-first too now
-//!   (ADR-152 sibling work): their `make` targets fetch the pre-built binary
-//!   before building, so they refresh without a toolchain; only the build
-//!   fallback needs cargo.
+//!   `setup-binary` targets). `attend`/`attend-chat` are download-first too now:
+//!   their `make` targets fetch the pre-built binary before building, so they
+//!   refresh without a toolchain — `attend` already publishes binaries, while
+//!   `attend-chat` falls back to a build until its first release is cut. Only the
+//!   build fallback needs cargo.
 //! - **Rename-then-revert, never leave a broken install.** Each component's
 //!   binary is *renamed* aside (not removed) to defeat the "already installed"
 //!   early-return; if re-acquiring it fails, the old binary is moved back. A


### PR DESCRIPTION
## Summary

`attend` already publishes per-platform binaries (`build-attend.yml`, `attend-v*` releases), but nothing fetched them — `ways update` built them (or skipped without a toolchain). `attend-chat` had no CI at all. This wires both to the same **download-first** path `ways` and way-embed use.

## Changes

- **`tools/attend/download-attend.sh`, `tools/attend-chat/download-attend-chat.sh`** — mirror `download-ways.sh`: platform detect → GitHub Release download → checksum verify → build-from-source fallback.
- **`.github/workflows/build-attend-chat.yml`** — mirrors `build-attend.yml` so `attend-chat-v*` tags publish 4-platform binaries + checksums + a Release (`attend-chat` is already a `release.sh` component).
- **Makefile** `attend`/`attend-chat` targets — download-first, then build-fallback (matching `ways`); liveness probe switched to `--version`.
- **`ways update`** — attend/attend-chat refresh is no longer toolchain-gated; their `make` targets download the pre-built binary, so `ways update` refreshes them **without cargo** (only the build fallback needs a toolchain).

## Test plan

- Both download scripts pass `bash -n`; key substitutions verified (`BIN_NAME`, tag-prefix grep, output paths).
- `build-attend-chat.yml` is valid YAML (`-p attend-chat`, `attend-chat-v*` tag gate, correct artifact names).
- `ways` builds clean.

## Follow-up (release)

`attend-chat`'s first release (`attend-chat-v*`) still needs cutting for its binaries to exist; until then its download path falls back to build. `attend` binaries already exist (`attend-v0.7.1`), so its download path works today.