### PR TITLE
feat(dist): make ways-audit a first-class suite member in install + update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # Update:        make update
 
 .DEFAULT_GOAL := help
-.PHONY: setup install uninstall update update-binaries sync-to-home sync-to-home-link sync-to-home-test clean help deps ways ways-rebuild ways-audit attend attend-rebuild attend-chat attend-chat-rebuild hooks-install way-embed-rebuild lint test test-unit test-sim test-lang test-locales test-multilingual release purge-attend-state
+.PHONY: setup install uninstall update update-binaries sync-to-home sync-to-home-link sync-to-home-test clean help deps ways ways-rebuild ways-audit ways-audit-rebuild attend attend-rebuild attend-chat attend-chat-rebuild hooks-install way-embed-rebuild lint test test-unit test-sim test-lang test-locales test-multilingual release purge-attend-state
 
 ifeq ($(OS),Windows_NT)
     SHELL := C:/Program Files/Git/usr/bin/bash.exe
@@ -45,7 +45,7 @@ help:
 	@echo "  make sync-to-home-link  [legacy] symlink variant of sync-to-home"
 	@echo "  make ways         Get ways binary (download or build from source)"
 	@echo "  make ways-rebuild Force rebuild ways from source"
-	@echo "  make ways-audit   Build + link the optional compliance binary (ADR-151)"
+	@echo "  make ways-audit   Get ways-audit compliance binary (download or build)"
 	@echo "  make attend       Build attend binary"
 	@echo "  make attend-rebuild Force rebuild attend from source"
 	@echo "  make lint         Run clippy on Rust workspace (warnings = errors)"
@@ -95,7 +95,7 @@ deps:
 	@echo "Toolchain ready. Now run: make setup"
 
 # Build ways CLI + set up embedding engine + generate initial corpus.
-setup: ways attend attend-chat
+setup: ways ways-audit attend attend-chat
 	@echo "Setting up embedding engine..."
 	@# Optional accelerator — if its build deps are missing, warn and continue so
 	@# the rest of install (incl. the PATH symlinks) still completes. Without it,
@@ -117,6 +117,7 @@ setup: ways attend attend-chat
 install: hooks-executable setup hooks-install
 	@mkdir -p "$(XDG_BIN)"
 	@$(LINK) "$(CURDIR)/$(WAYS_BIN)" "$(XDG_BIN)/ways"
+	@$(LINK) "$(CURDIR)/$(WAYS_AUDIT_BIN)" "$(XDG_BIN)/ways-audit"
 	@$(LINK) "$(CURDIR)/$(ATTEND_BIN)" "$(XDG_BIN)/attend"
 	@$(LINK) "$(CURDIR)/$(ATTEND_CHAT_BIN)" "$(XDG_BIN)/attend-chat"
 	@mkdir -p "$(CLAUDE_BIN)"
@@ -131,6 +132,7 @@ install: hooks-executable setup hooks-install
 	@echo ""
 	@echo "Install complete."
 	@echo "  ways binary:        $(XDG_BIN)/ways → $(CURDIR)/$(WAYS_BIN)"
+	@echo "  ways-audit binary:  $(XDG_BIN)/ways-audit → $(CURDIR)/$(WAYS_AUDIT_BIN)"
 	@echo "  attend binary:      $(XDG_BIN)/attend → $(CURDIR)/$(ATTEND_BIN)"
 	@echo "  attend-chat binary: $(XDG_BIN)/attend-chat → $(CURDIR)/$(ATTEND_CHAT_BIN)"
 	@echo "  way-embed binary:   $(CLAUDE_BIN)/way-embed → $(CURDIR)/$(WAY_EMBED_BIN)"
@@ -179,7 +181,7 @@ sync-to-home-test:
 # on the same `make update` run that pulls the change — sub-makes
 # re-read the Makefile, but the in-memory `update:` recipe is fixed at
 # make-process startup.
-update-binaries: ways-rebuild attend-rebuild attend-chat-rebuild way-embed-rebuild
+update-binaries: ways-rebuild ways-audit-rebuild attend-rebuild attend-chat-rebuild way-embed-rebuild
 
 # --- Build ---
 
@@ -214,20 +216,39 @@ ways-rebuild:
 	@$(LINK) "$(CURDIR)/tools/target/release/ways$(EXE)" $(WAYS_BIN)
 	@echo "Built: $(WAYS_BIN) ($$(ls -lh $(WAYS_BIN) | awk '{print $$5}'))"
 
-# Build the ways-audit compliance binary from source and link it onto PATH.
-# Deliberately NOT part of `make setup`/`install` — it is optional, operator-
-# invoked tooling (ADR-151), so the default install stays lean. Run on demand.
+# Get the ways-audit compliance binary: try existing → download → build. A
+# first-class member of the suite (installed and updated like the others); it is
+# *deliberately-invoked* in the sense that you run `ways-audit` when you want it,
+# not that it's optional to install.
 ways-audit:
+	@if [ -x $(WAYS_AUDIT_BIN) ] && $(WAYS_AUDIT_BIN) --version >/dev/null 2>&1; then \
+		echo "ways-audit already installed: $$($(WAYS_AUDIT_BIN) --version)"; \
+	elif bash tools/ways-audit/download-ways-audit.sh 2>/dev/null; then \
+		echo "Pre-built ways-audit binary installed."; \
+	elif command -v cargo >/dev/null 2>&1; then \
+		echo "No pre-built binary, building ways-audit from source..."; \
+		bash scripts/check-rust.sh || exit 1; \
+		cargo build --release --manifest-path tools/Cargo.toml -p ways-audit; \
+		mkdir -p bin; \
+		$(LINK) "$(CURDIR)/tools/target/release/ways-audit$(EXE)" $(WAYS_AUDIT_BIN); \
+		echo "Built: $(WAYS_AUDIT_BIN) ($$(ls -lh $(WAYS_AUDIT_BIN) | awk '{print $$5}'))"; \
+	else \
+		echo "error: No pre-built binary and cargo not found."; \
+		echo "Install Rust: https://rustup.rs/"; \
+		exit 1; \
+	fi
+
+# Force rebuild ways-audit from source (ignores existing binary and download).
+ways-audit-rebuild:
 	@if ! command -v cargo >/dev/null 2>&1; then \
 		echo "error: cargo not found. Install Rust: https://rustup.rs/"; \
 		exit 1; \
 	fi
 	@bash scripts/check-rust.sh
 	cargo build --release --manifest-path tools/Cargo.toml -p ways-audit
-	@mkdir -p bin "$(XDG_BIN)"
+	@mkdir -p bin
 	@$(LINK) "$(CURDIR)/tools/target/release/ways-audit$(EXE)" $(WAYS_AUDIT_BIN)
-	@$(LINK) "$(CURDIR)/$(WAYS_AUDIT_BIN)" "$(XDG_BIN)/ways-audit"
-	@echo "Built + linked: $(XDG_BIN)/ways-audit → $(CURDIR)/$(WAYS_AUDIT_BIN)"
+	@echo "Built: $(WAYS_AUDIT_BIN) ($$(ls -lh $(WAYS_AUDIT_BIN) | awk '{print $$5}'))"
 
 # Build attend binary from workspace.
 attend:

--- a/docs/architecture/system/ADR-151-extract-ways-core-crate-and-ways-audit-sibling-binary.md
+++ b/docs/architecture/system/ADR-151-extract-ways-core-crate-and-ways-audit-sibling-binary.md
@@ -95,6 +95,17 @@ corpus at scale (ADR-200 §7).
 `ways` has. The marginal cost is one CI job and one download path — the same
 prebuilt-binary machinery already planned for the other app binaries (ADR-142/ADR-146).
 
+**`ways-audit` is a first-class member of the suite, not an opt-in add-on.**
+`ways update` manages the *entire* agent-ways collection; we do not ship partial
+tool collections, and no binary has a separate lifecycle. So `make install` /
+`make setup` build and link `ways-audit` alongside `ways`/`attend`, and
+`ways update` refreshes it through the same download-first `refresh_component`
+path as the rest. "Deliberately-invoked" (§2) describes how the tool is *used* —
+you run `ways-audit assemble` when you want it, the way you run `/ship` — not
+whether it is *installed*: it is always present, like `ways` itself. (An earlier
+implementation kept it out of the default install "to stay lean"; that produced a
+published-but-unfetchable binary and is corrected here.)
+
 ## Relationship to ADR-111
 
 ADR-111 folded shell-script sprawl into one binary because the *abstraction layer* — one

--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -60,9 +60,9 @@ git remote add upstream https://github.com/aaronsb/agent-ways
 ./scripts/install.sh
 ```
 
-Running the installer from inside the app dir is what links the `ways`/`attend`
-binaries onto your `PATH`; `make setup` alone builds them but does not. Pull
-upstream improvements later:
+Running the installer from inside the app dir is what links the suite binaries
+(`ways`, `ways-audit`, `attend`, `attend-chat`) onto your `PATH`; `make setup`
+alone builds them but does not. Pull upstream improvements later:
 
 ```bash
 cd "$XDG_DATA_HOME/agent-ways"
@@ -90,6 +90,8 @@ Pre-1.0, the way to keep an existing `~/.claude` untouched was the **subdirector
 | Artifact | Size | Location | Source | Verification |
 |----------|------|----------|--------|--------------|
 | `ways` binary | ~3.6MB | `$XDG_DATA_HOME/agent-ways/bin/` (symlinked onto `PATH`) | GitHub Releases (or built from source) | SHA-256 checksum |
+| `ways-audit` binary | ~2.6MB | `$XDG_DATA_HOME/agent-ways/bin/` (symlinked onto `PATH`) | GitHub Releases (or built from source) | SHA-256 checksum |
+| `attend` / `attend-chat` binaries | ~2–3MB each | `$XDG_DATA_HOME/agent-ways/bin/` (symlinked onto `PATH`) | GitHub Releases (or built from source) | SHA-256 checksum |
 | `way-embed` binary | ~3MB | XDG cache (`…/user/`) | GitHub Releases | SHA-256 checksum |
 | `minilm-l6-v2.gguf` model | ~21MB | XDG cache (`…/user/`) | GitHub Releases (or HuggingFace) | SHA-256 checksum |
 

--- a/tools/ways-audit/download-ways-audit.sh
+++ b/tools/ways-audit/download-ways-audit.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Download the pre-built ways-audit binary for the current platform
+#
+# Detects OS/arch, downloads from GitHub Releases, verifies it runs.
+# Falls back to build-from-source instructions if no pre-built binary exists.
+#
+# Usage:
+#   download-ways-audit.sh [--release TAG] [output-dir]
+#
+# The binary is placed at: bin/ways-audit (relative to repo root)
+
+set -euo pipefail
+
+# Platform detection
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m | sed 's/arm64/aarch64/')
+PLATFORM="${OS}-${ARCH}"
+
+GH_REPO="aaronsb/agent-ways"
+RELEASE_TAG="${WAYS_AUDIT_RELEASE:-latest}"
+BIN_NAME="ways-audit-${PLATFORM}"
+
+# Default output: repo bin/ directory
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+OUTPUT_DIR="${REPO_ROOT}/bin"
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release)
+      RELEASE_TAG="$2"
+      shift 2 ;;
+    --help|-h)
+      echo "Usage: $0 [--release TAG] [output-dir]"
+      echo ""
+      echo "  --release TAG  GitHub Release tag (default: latest ways-audit-* release)"
+      echo "  output-dir     Override output directory (default: bin/)"
+      echo ""
+      echo "Platform: ${PLATFORM}"
+      echo "Available: linux-x86_64, linux-aarch64, darwin-x86_64, darwin-arm64"
+      exit 0 ;;
+    *)
+      OUTPUT_DIR="$1"
+      shift ;;
+  esac
+done
+
+OUTPUT_FILE="${OUTPUT_DIR}/ways-audit"
+PLATFORM_FILE="${OUTPUT_DIR}/${BIN_NAME}"
+
+# Check if already present and working
+if [[ -x "$OUTPUT_FILE" ]] && "$OUTPUT_FILE" --version >/dev/null 2>&1; then
+  echo "ways-audit already installed and working: $OUTPUT_FILE" >&2
+  "$OUTPUT_FILE" --version >&2
+  echo "$OUTPUT_FILE"
+  exit 0
+fi
+
+# Need gh CLI
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI not found — build from source instead:" >&2
+  echo "  cd \"$REPO_ROOT\" && make ways-audit" >&2
+  exit 1
+fi
+
+# Create output directory
+mkdir -p "$OUTPUT_DIR"
+
+# Find the latest ways-audit release
+if [[ "$RELEASE_TAG" == "latest" ]]; then
+  RELEASE_TAG=$(gh release list --repo "$GH_REPO" --limit 20 --json tagName --jq '.[].tagName' 2>/dev/null \
+    | grep '^ways-audit-v' | head -1)
+  if [[ -z "$RELEASE_TAG" ]]; then
+    echo "No ways-audit release found. Build from source:" >&2
+    echo "  cd \"$REPO_ROOT\" && make ways-audit" >&2
+    exit 1
+  fi
+fi
+
+echo "Platform: ${PLATFORM}" >&2
+echo "Release:  ${RELEASE_TAG}" >&2
+
+# Check if our platform binary exists in the release
+if ! gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep -q "^${BIN_NAME}$"; then
+  echo "No pre-built binary for ${PLATFORM} in release ${RELEASE_TAG}." >&2
+  echo "Available binaries:" >&2
+  gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep "^ways-audit-" | sed 's/^/  /' >&2
+  echo "" >&2
+  echo "Build from source instead:" >&2
+  echo "  cd \"$REPO_ROOT\" && make ways-audit" >&2
+  exit 1
+fi
+
+# Download binary + checksums
+echo "Downloading ${BIN_NAME}..." >&2
+gh release download "$RELEASE_TAG" \
+  --repo "$GH_REPO" \
+  --pattern "$BIN_NAME" \
+  --dir "$OUTPUT_DIR" \
+  --clobber
+
+# Verify checksum
+CHECKSUMS_FILE="${OUTPUT_DIR}/checksums.txt"
+if gh release download "$RELEASE_TAG" \
+    --repo "$GH_REPO" \
+    --pattern "checksums.txt" \
+    --dir "$OUTPUT_DIR" \
+    --clobber 2>/dev/null; then
+  expected_hash=$(grep "${BIN_NAME}" "$CHECKSUMS_FILE" | awk '{print $1}')
+  if [[ -n "$expected_hash" ]]; then
+    actual_hash=$(sha256sum "$PLATFORM_FILE" 2>/dev/null | cut -d' ' -f1 \
+      || shasum -a 256 "$PLATFORM_FILE" 2>/dev/null | cut -d' ' -f1)
+    if [[ "$actual_hash" != "$expected_hash" ]]; then
+      echo "CHECKSUM MISMATCH for ${BIN_NAME}" >&2
+      echo "  Expected: ${expected_hash}" >&2
+      echo "  Got:      ${actual_hash}" >&2
+      rm -f "$PLATFORM_FILE" "$CHECKSUMS_FILE"
+      exit 1
+    fi
+    echo "Checksum verified: ${actual_hash:0:12}..." >&2
+  fi
+  rm -f "$CHECKSUMS_FILE"
+else
+  echo "WARNING: checksums.txt not found in release — skipping verification" >&2
+fi
+
+# Make executable and install
+chmod +x "$PLATFORM_FILE"
+cp "$PLATFORM_FILE" "$OUTPUT_FILE"
+chmod +x "$OUTPUT_FILE"
+
+# Verify it runs
+if "$OUTPUT_FILE" --version >/dev/null 2>&1; then
+  echo "Installed: $OUTPUT_FILE ($("$OUTPUT_FILE" --version))" >&2
+  ls -lh "$OUTPUT_FILE" >&2
+else
+  echo "WARNING: binary downloaded but won't execute on this platform" >&2
+  echo "Build from source instead:" >&2
+  echo "  cd \"$REPO_ROOT\" && make ways-audit" >&2
+  rm -f "$OUTPUT_FILE" "$PLATFORM_FILE"
+  exit 1
+fi
+
+# Output path for scripts to capture
+echo "$OUTPUT_FILE"

--- a/tools/ways-cli/src/cmd/update.rs
+++ b/tools/ways-cli/src/cmd/update.rs
@@ -11,12 +11,13 @@
 //!
 //! - **Prefer pre-built binaries.** `make update` force-*builds* via cargo/cmake,
 //!   which fails for anyone without a toolchain. This mirrors the *install* flow
-//!   instead: download-first, build-fallback (the Makefile's `ways` / way-embed
-//!   `setup-binary` targets). `attend`/`attend-chat` are download-first too now:
-//!   their `make` targets fetch the pre-built binary before building, so they
-//!   refresh without a toolchain — `attend` already publishes binaries, while
-//!   `attend-chat` falls back to a build until its first release is cut. Only the
-//!   build fallback needs cargo.
+//!   instead: download-first, build-fallback. Update manages the **whole suite**
+//!   uniformly — `ways` (downgrade-guarded), way-embed (its own cache path), and
+//!   the rest (`ways-audit`, `attend`, `attend-chat`) through one
+//!   `refresh_component` path via their download-first `make` targets. No tool has
+//!   a separate lifecycle, and none is optional to keep current; only the build
+//!   fallback needs cargo (`attend-chat` falls back to a build until its first
+//!   release is cut).
 //! - **Rename-then-revert, never leave a broken install.** Each component's
 //!   binary is *renamed* aside (not removed) to defeat the "already installed"
 //!   early-return; if re-acquiring it fails, the old binary is moved back. A
@@ -62,7 +63,7 @@ pub fn run(dry_run: bool) -> Result<()> {
         println!("  1. scripts/update.sh          — git pull (autostash-safe)");
         println!("  2. refresh ways               — download pre-built (guarded: never older than source), else build");
         println!("  3. refresh way-embed          — download pre-built, else build (optional)");
-        println!("  4. refresh attend/attend-chat — download pre-built, else build (optional)");
+        println!("  4. refresh ways-audit/attend/attend-chat — download pre-built, else build");
         println!("  5. {} corpus + reconcile      — regenerate corpus, reproject ~/.claude", ways_bin.display());
         println!("(dry-run — nothing executed)");
         return Ok(());
@@ -102,8 +103,13 @@ pub fn run(dry_run: bool) -> Result<()> {
     //    try the pre-built binary before building), so they refresh even without a
     //    toolchain; the build fallback still needs cargo but the download path does
     //    not. A failed refresh reverts and keeps the current version.
-    eprintln!("==> refresh attend/attend-chat (pre-built first)");
-    for comp in ["attend", "attend-chat"] {
+    // These are the rest of the suite — ways-audit (compliance) and the attend
+    // awareness pair. `ways` (step 2, downgrade-guarded) and way-embed (step 3,
+    // its own cache path) are refreshed above; everything else flows through the
+    // same `refresh_component` path so the whole collection updates uniformly —
+    // no separate lifecycle for any one tool.
+    eprintln!("==> refresh ways-audit/attend/attend-chat (pre-built first)");
+    for comp in ["ways-audit", "attend", "attend-chat"] {
         if let Err(e) = refresh_component(&app, comp, &[comp], &app) {
             eprintln!("  ⚠ {comp} not refreshed ({e}); it keeps its current version.");
         }


### PR DESCRIPTION
## Summary

Closes the gap the release exposed: `ways-audit`'s **publish** side shipped (CI + `ways-audit-v1.0.0` is live), but nothing **fetched** it — `make ways-audit` was build-only, `install`/`setup` skipped it, and `ways update` never refreshed it. A published-but-unfetchable binary, and any opted-in copy would silently go stale.

Per the principle: **`ways update` manages the entire agent-ways collection — no partial tool collections, no per-tool lifecycle.** So `ways-audit` joins the suite through the **same machinery** as `ways`/`attend`, not a bespoke path.

## Changes

- **`tools/ways-audit/download-ways-audit.sh`** — mirrors `download-ways.sh`. **Verified end-to-end against the live `ways-audit-v1.0.0` release**: platform-detects, downloads, checksum-verifies (`a8140c69…`), runs (`ways-audit 1.0.0`).
- **Makefile** — `make ways-audit` is now download-first → build-fallback (matching `ways`; produces `bin/`, `install` links it); new `ways-audit-rebuild`; **`setup` builds it, `install` links it, `update-binaries` rebuilds it** (uninstall already removed it).
- **`ways update`** — `ways-audit` refreshes through the **existing** `refresh_component` loop (`[ways-audit, attend, attend-chat]`) via its download-first `make` target. No new lifecycle manager, no toolchain gate.
- **ADR-151 §4** — records the principle: `ways-audit` is a first-class suite member, not an opt-in add-on; "deliberately-invoked" (§2) is about *usage* (you run it when you want it, like `/ship`), not *installation*. Corrects PR-B's lean-install call that stranded the binary.
- **install-guide** — suite binary list + the "what gets downloaded" table reconciled (it was stale for `attend` too, from #265).

## Design note

This is deliberately **not** a separate suite lifecycle manager — every binary flows through the one existing update path (`refresh_component` → its download-first `make` target). Adding `ways-audit` is one more entry in the same list, in the same places `attend` already appears.

## Test plan

- Download script: fetches + checksum-verifies + runs the real `ways-audit-v1.0.0` binary.
- `ways` builds; `make -n ways-audit` parses; `setup` depends on `ways-audit`.
- `adr lint` / `doc lint` 0/0.