### PR TITLE
fix(dist): ways update links newly-added suite binaries onto PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # Update:        make update
 
 .DEFAULT_GOAL := help
-.PHONY: setup install uninstall update update-binaries sync-to-home sync-to-home-link sync-to-home-test clean help deps ways ways-rebuild ways-audit ways-audit-rebuild attend attend-rebuild attend-chat attend-chat-rebuild hooks-install way-embed-rebuild lint test test-unit test-sim test-lang test-locales test-multilingual release purge-attend-state
+.PHONY: setup install relink uninstall update update-binaries sync-to-home sync-to-home-link sync-to-home-test clean help deps ways ways-rebuild ways-audit ways-audit-rebuild attend attend-rebuild attend-chat attend-chat-rebuild hooks-install way-embed-rebuild lint test test-unit test-sim test-lang test-locales test-multilingual release purge-attend-state
 
 ifeq ($(OS),Windows_NT)
     SHELL := C:/Program Files/Git/usr/bin/bash.exe
@@ -113,22 +113,28 @@ setup: ways ways-audit attend attend-chat
 	@echo "Generating corpus..."
 	@$(WAYS_BIN) corpus --quiet
 
+# Idempotent (re)linking of the suite binaries onto PATH. Only links what exists
+# in bin/, so it is safe to run before every binary is built and safe to re-run.
+# Both `install` and `ways update` call this — that is what lets a binary NEWLY
+# ADDED to the suite get its PATH symlink without a fresh `make install`. The
+# suite binaries (ways, ways-audit, attend, attend-chat) link into $(XDG_BIN);
+# way-embed lives in $(CLAUDE_BIN).
+relink:
+	@mkdir -p "$(XDG_BIN)"
+	@for b in ways ways-audit attend attend-chat; do \
+		if [ -e "$(CURDIR)/bin/$$b" ]; then \
+			$(LINK) "$(CURDIR)/bin/$$b" "$(XDG_BIN)/$$b"; \
+		fi; \
+	done
+	@if [ -e "$(CURDIR)/$(WAY_EMBED_BIN)" ]; then \
+		mkdir -p "$(CLAUDE_BIN)"; \
+		if [ "$(CURDIR)/$(WAY_EMBED_BIN)" -ef "$(CLAUDE_BIN)/way-embed" ]; then :; \
+		else $(LINK) "$(CURDIR)/$(WAY_EMBED_BIN)" "$(CLAUDE_BIN)/way-embed"; fi; \
+	fi
+
 # Full install: build, setup, symlink to PATH.
 install: hooks-executable setup hooks-install
-	@mkdir -p "$(XDG_BIN)"
-	@$(LINK) "$(CURDIR)/$(WAYS_BIN)" "$(XDG_BIN)/ways"
-	@$(LINK) "$(CURDIR)/$(WAYS_AUDIT_BIN)" "$(XDG_BIN)/ways-audit"
-	@$(LINK) "$(CURDIR)/$(ATTEND_BIN)" "$(XDG_BIN)/attend"
-	@$(LINK) "$(CURDIR)/$(ATTEND_CHAT_BIN)" "$(XDG_BIN)/attend-chat"
-	@mkdir -p "$(CLAUDE_BIN)"
-	@# When the repo IS ~/.claude, $(CURDIR)/bin/way-embed already equals
-	@# $(CLAUDE_BIN)/way-embed — linking a file to itself errors ("same file").
-	@# Skip the link in that case; the binary is already where tools look for it.
-	@if [ "$(CURDIR)/$(WAY_EMBED_BIN)" -ef "$(CLAUDE_BIN)/way-embed" ]; then \
-		echo "  way-embed: already in place ($(CLAUDE_BIN)/way-embed) — no link needed"; \
-	else \
-		$(LINK) "$(CURDIR)/$(WAY_EMBED_BIN)" "$(CLAUDE_BIN)/way-embed"; \
-	fi
+	@$(MAKE) -s --no-print-directory relink
 	@echo ""
 	@echo "Install complete."
 	@echo "  ways binary:        $(XDG_BIN)/ways → $(CURDIR)/$(WAYS_BIN)"

--- a/tools/ways-cli/src/cmd/update.rs
+++ b/tools/ways-cli/src/cmd/update.rs
@@ -64,7 +64,8 @@ pub fn run(dry_run: bool) -> Result<()> {
         println!("  2. refresh ways               — download pre-built (guarded: never older than source), else build");
         println!("  3. refresh way-embed          — download pre-built, else build (optional)");
         println!("  4. refresh ways-audit/attend/attend-chat — download pre-built, else build");
-        println!("  5. {} corpus + reconcile      — regenerate corpus, reproject ~/.claude", ways_bin.display());
+        println!("  5. make relink                — ensure every suite binary is symlinked onto PATH");
+        println!("  6. {} corpus + reconcile      — regenerate corpus, reproject ~/.claude", ways_bin.display());
         println!("(dry-run — nothing executed)");
         return Ok(());
     }
@@ -113,6 +114,19 @@ pub fn run(dry_run: bool) -> Result<()> {
         if let Err(e) = refresh_component(&app, comp, &[comp], &app) {
             eprintln!("  ⚠ {comp} not refreshed ({e}); it keeps its current version.");
         }
+    }
+
+    // Ensure every suite binary is linked onto PATH. Refreshing only updates
+    // `bin/`; a binary NEWLY ADDED to the suite (e.g. ways-audit for an install
+    // that predates it) has no `$XDG_BIN` symlink from the original `make install`,
+    // so without this it would sit in `bin/` unreachable. `make relink` is
+    // idempotent and only links what exists.
+    eprintln!("==> relink suite binaries onto PATH");
+    if let Err(e) = run_step(Command::new("make").arg("relink").current_dir(&app), "relink") {
+        eprintln!(
+            "  ⚠ could not relink binaries ({e}); run `make install` in {} to fix PATH links.",
+            app.display()
+        );
     }
 
     // 5. Regenerate the corpus (best-effort — it self-heals on next session) and


### PR DESCRIPTION
## The bug

After `ways update`, `ways-audit` was **not on PATH**. Root cause: `$XDG_BIN/<bin>` PATH symlinks were created **only by `make install`**. `ways update` refreshes `bin/` but relied on those symlinks pre-existing — true for `ways`/`attend` (linked at the original install), but **not** for a binary *added to the suite later*. So `ways-audit` (once a 1.0.4 update builds it) lands in `bin/` with no PATH link; `reconcile` only handles the `~/.claude` projection, not `$XDG_BIN`. My #267 removal of the `make ways-audit` self-link sealed the gap.

## The fix

A single idempotent **`make relink`** target that symlinks every *present* suite binary onto PATH:
- `ways`, `ways-audit`, `attend`, `attend-chat` → `$XDG_BIN`
- `way-embed` → `$CLAUDE_BIN`

Existence-guarded (safe before all binaries are built) and idempotent (`ln -sf`). **`install`** now uses it (DRY), and **`ways update`** runs it after the refresh loop — so a binary *newly added to the suite* self-heals its PATH link on the next update, no fresh `make install` needed.

This is the **general** fix, not a ways-audit-specific patch: the next binary added to the suite is handled the same way, through the one mechanism.

## Test plan

- `make relink` against a scratch `$XDG_BIN`: links only existing binaries (`ways`/`ways-audit` present → linked; `attend*` absent → skipped), idempotent on re-run, does not touch the real `~/.local/bin`.
- `ways` builds; `install`/`relink` targets parse.
- Confirmed the live repro on a real install and manually unstuck it (built + linked `ways-audit`; `ways-audit 1.0.0` now resolves on PATH).

## One-release lag

The fix lives in the `ways` binary (`update.rs`), so it's live from the next release; an older install self-heals once updated to it. `make install` is the manual recovery meanwhile.