### PR TITLE
docs(adr): draft session-introspection design (ADR-153/154 + plan)

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -73,6 +73,8 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-150](./system/ADR-150-version-truth-and-downgrade-safe-self-update.md) | Version-truth and downgrade-safe self-update | Accepted |
 | [ADR-151](./system/ADR-151-extract-ways-core-crate-and-ways-audit-sibling-binary.md) | Extract ways-core crate and ways-audit sibling binary | Accepted |
 | [ADR-152](./system/ADR-152-framework-default-secret-path-deny-baseline.md) | Framework-default secret-path deny baseline | Accepted |
+| [ADR-153](./system/ADR-153-session-introspection-substrate-correlating-fired-ways-to-turns.md) | Session-introspection substrate — correlating fired ways to turns | Draft |
+| [ADR-154](./system/ADR-154-rethink-think-and-non-interactive-introspection-one-model-three-front-ends.md) | rethink, think, and non-interactive introspection — one model, three front-ends | Draft |
 
 ## Governance
 _Provenance, traceability, controls, compliance mapping_

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -73,8 +73,8 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-150](./system/ADR-150-version-truth-and-downgrade-safe-self-update.md) | Version-truth and downgrade-safe self-update | Accepted |
 | [ADR-151](./system/ADR-151-extract-ways-core-crate-and-ways-audit-sibling-binary.md) | Extract ways-core crate and ways-audit sibling binary | Accepted |
 | [ADR-152](./system/ADR-152-framework-default-secret-path-deny-baseline.md) | Framework-default secret-path deny baseline | Accepted |
-| [ADR-153](./system/ADR-153-session-introspection-substrate-correlating-fired-ways-to-turns.md) | Session-introspection substrate — correlating fired ways to turns | Draft |
-| [ADR-154](./system/ADR-154-rethink-think-and-non-interactive-introspection-one-model-three-front-ends.md) | rethink, think, and non-interactive introspection — one model, three front-ends | Draft |
+| [ADR-153](./system/ADR-153-session-introspection-substrate-correlating-fired-ways-to-turns.md) | Session-introspection substrate — correlating fired ways to turns | Accepted |
+| [ADR-154](./system/ADR-154-rethink-think-and-non-interactive-introspection-one-model-three-front-ends.md) | `ways introspect` — one model, three front-ends | Accepted |
 
 ## Governance
 _Provenance, traceability, controls, compliance mapping_

--- a/docs/architecture/system/ADR-153-session-introspection-substrate-correlating-fired-ways-to-turns.md
+++ b/docs/architecture/system/ADR-153-session-introspection-substrate-correlating-fired-ways-to-turns.md
@@ -1,0 +1,162 @@
+---
+status: Draft
+date: 2026-07-02
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-142
+  - ADR-134
+  - ADR-201
+---
+
+# ADR-153: Session-introspection substrate — correlating fired ways to turns
+
+## Context
+
+We want to answer, for any past or live session: **which ways were injected into
+context, on which turn, and *why* — what caused the hook to fire.** Three
+front-ends want this (post-hoc `rethink`, live `think`, a non-interactive dump
+for autonomous agents — ADR-154), so the correlation belongs in one shared
+substrate below them, not re-derived per front-end.
+
+A research pass (2026-07-02) mapped exactly what data exists. The findings define
+what the substrate can join today and what it cannot:
+
+**The firing-event log** (`$XDG_STATE/agent-ways/events.jsonl`, append-only JSONL;
+written by `session::log_event`, read by `firing::load_events`). A `way_fired`
+record carries `way`, `domain`, `trigger`, `scope`, `project`, `session`,
+`token_position`, and — for semantic fires only — `fire_score`. Sibling event
+types: `way_nearmiss` (with `score_en/multi`, `thr_en/multi`, `margin`,
+`query_tokens` *count*), `session_start` (`{ts, project, session}` only),
+`check_fired`, `way_redisclosed`.
+
+**The `trigger` field records the match *channel*, not the matched term** —
+`keyword` / `semantic:embedding:en|multi` / `bash` / `file` / `state`. It tells
+you the mechanism, never which vocabulary word or regex substring hit.
+
+**Session transcripts** live at `~/.claude/projects/<slug>/<session>.jsonl`
+(Claude-Code-owned, read-only; ms-precision timestamps, `uuid`/`parentUuid`
+threading). Injected way guidance appears as an `attachment` line
+(`hook_additional_context`) whose `content` is the **concatenated way bodies for
+one prompt** — way-*anonymous*, one blob per prompt, and sometimes truncated to a
+spilled `tool-results/…-additionalContext.txt` file.
+
+**Two correctness problems block the substrate before it starts:**
+
+1. **The events log is split-brained.** `session_start` — the only event that
+   defines a session for `rethink` — is written by shell hooks
+   (`clear-markers.sh`, `inject-subagent.sh`) that **hardcode the legacy
+   `~/.claude/stats/events.jsonl`**, while every reader resolves through
+   `paths::events_log()`, which *prefers* the migrated `$XDG_STATE` file
+   post-ADR-142. New sessions' `session_start` lines land in the orphaned file and
+   are invisible. Any introspection over an incomplete log is wrong.
+
+2. **The join to a specific turn is heuristic, not keyed.** `way_fired` carries no
+   transcript message `uuid` and no turn index; the finest available link is
+   `(session, token_position, ts≈)` → a prompt bucket → the one attachment → its
+   `user` turn via `parentUuid`. And "what text matched" is persisted for
+   *nothing* — keyword matches are re-runnable against the prompt (if the
+   transcript is present), semantic matches are only a way-level cosine.
+
+## Decision
+
+### 1. Single-writer the events log (correctness prerequisite)
+
+Add a `ways events-log-path` subcommand (precedent: `ways response-topics-path`,
+which shell hooks already consult instead of hardcoding). Rewire
+`clear-markers.sh` and `inject-subagent.sh` to resolve the path from the binary,
+so every `session_start` / `way_fired` writer and every reader agree on one file.
+A migration-time union read can bridge existing orphaned logs, but the durable fix
+is one writer path.
+
+### 2. A typed introspection model in `ways-core`
+
+Factor a `SessionIntrospection` model that joins the three sources into pure,
+serde-serializable data — no ANSI, no terminal. It generalizes the already-proven
+`reconstruct_frames` → `render`/`serialize` triplet (ADR-154). Shape:
+
+```
+Session { id, project, window_k, summary }
+  └─ Turn { epoch, token_position, ts, transcript_uuid? }
+       └─ FiredWay { way_id, trigger_channel, fire_score?, way_path,
+                     criteria: MatchCriteria,        // from frontmatter
+                     match: MatchDetail? }           // what hit (see §3)
+```
+
+`MatchCriteria` surfaces the fire-bearing frontmatter (`pattern`, `vocabulary`,
+`commands`, `files`, `trigger`, `embed_threshold`). The join is honest about its
+grain: keyed where a key exists, heuristic (time/token bucket) where it does not,
+and every heuristic edge is labelled as such in the model so a consumer never
+mistakes a proximity guess for a foreign key.
+
+### 3. Enrich `way_fired` at fire time to make "why" precise
+
+The precise "what caused this hook to fire" is unanswerable from today's log. Add,
+at the fire sites (`cmd/show/mod.rs`, `cmd/scan/mod.rs`):
+
+- **`transcript_uuid`** — the triggering message id (the hook receives it on
+  stdin). Converts the heuristic time-join into a foreign key.
+- **`matched_span`** — for keyword/command/file channels, the regex/glob match
+  text. The only way to show the exact clip without transcript replay.
+- Semantic stays **way-level**: `fire_score` ≥ `embed_threshold` is the honest
+  grain; per-vocabulary-term attribution is impossible (one embedding per way) and
+  must not be faked.
+
+Enrichment is **additive and forward-only** — old records lack the fields, the
+model marks their join heuristic, and no backfill is claimed.
+
+### 4. Share the substrate with the compliance finding pipeline (ADR-201)
+
+ADR-201's finding assembler needs exactly this: a way's firing evidence tied to
+transcript pointers. The `SessionIntrospection` join *is* that evidence substrate.
+Building it once, in `ways-core`, means findings and introspection read the same
+correlation rather than two drifting re-derivations.
+
+## Consequences
+
+### Positive
+
+- One honest correlation, shared by three front-ends and the finding pipeline.
+- The split-brain fix repairs `rethink` (and any events-log reader) for
+  post-migration installs — a real bug, not just a feature enabler.
+- "Why fired" becomes precise for keyword/command/file once enrichment lands, and
+  honestly way-level for semantic — no fabricated term-level attribution.
+
+### Negative
+
+- Fire-time enrichment touches the hot fire path; the added fields must be cheap
+  and must never break the log's append-only, line-atomic contract.
+- The model must encode *degrees* of join confidence (keyed vs. heuristic), which
+  is more complex than pretending every link is exact — but the honesty is the
+  point.
+
+### Neutral
+
+- Enrichment is forward-only; historical sessions keep the coarse heuristic join.
+- Transcripts remain Claude-Code-owned and read-only; the substrate depends on
+  their availability and tolerates truncation-to-spill-file.
+
+## Alternatives Considered
+
+- **Union-read both event-log paths, leave the hooks hardcoded.** Rejected as the
+  durable fix: it papers over the split-brain and re-breaks the next time a path
+  moves. A single resolved writer path is the real correction (a bridging union
+  read on top is fine as a transition).
+- **Reconstruct "why" purely by transcript replay, persist nothing new.** Works
+  for keyword/command (re-run the regex on the stored prompt) but fails when the
+  transcript is absent/truncated and gives no foreign key; semantic stays
+  way-level regardless. Enrichment is the only path to a precise, transcript-
+  independent "why."
+- **Fake semantic term-level attribution** (highlight the "matching" vocabulary
+  word). Rejected: the corpus stores one vector per way; there is no matched term
+  to recover. Presenting one would be a confabulated explanation — the exact
+  epistemic error the compliance work (ADR-200) exists to avoid.
+
+## References
+
+- **ADR-142** — the XDG projection whose migration created the events-log split.
+- **ADR-134** — the near-miss telemetry stream this model also surfaces.
+- **ADR-201** — the finding pipeline that shares this transcript-evidence substrate.
+- Research pass 2026-07-02 (events-log schema, transcript shape, frontmatter match
+  fields, join feasibility) — the ground truth this ADR is built on.

--- a/docs/architecture/system/ADR-153-session-introspection-substrate-correlating-fired-ways-to-turns.md
+++ b/docs/architecture/system/ADR-153-session-introspection-substrate-correlating-fired-ways-to-turns.md
@@ -16,9 +16,10 @@ related:
 
 We want to answer, for any past or live session: **which ways were injected into
 context, on which turn, and *why* — what caused the hook to fire.** Three
-front-ends want this (post-hoc `rethink`, live `think`, a non-interactive dump
-for autonomous agents — ADR-154), so the correlation belongs in one shared
-substrate below them, not re-derived per front-end.
+front-ends want this (the `ways introspect <replay|live|dump>` surface of
+ADR-154 — post-hoc replay, live monitor, and a non-interactive dump for
+autonomous agents), so the correlation belongs in one shared substrate below
+them, not re-derived per front-end.
 
 A research pass (2026-07-02) mapped exactly what data exists. The findings define
 what the substrate can join today and what it cannot:
@@ -26,7 +27,9 @@ what the substrate can join today and what it cannot:
 **The firing-event log** (`$XDG_STATE/agent-ways/events.jsonl`, append-only JSONL;
 written by `session::log_event`, read by `firing::load_events`). A `way_fired`
 record carries `way`, `domain`, `trigger`, `scope`, `project`, `session`,
-`token_position`, and — for semantic fires only — `fire_score`. Sibling event
+`token_position`, and — for semantic fires only — `fire_score` (plus
+conditionally-emitted subagent/relationship fields `parent`, `tree_depth`,
+`epoch_distance`, `team`). Sibling event
 types: `way_nearmiss` (with `score_en/multi`, `thr_en/multi`, `margin`,
 `query_tokens` *count*), `session_start` (`{ts, project, session}` only),
 `check_fired`, `way_redisclosed`.

--- a/docs/architecture/system/ADR-153-session-introspection-substrate-correlating-fired-ways-to-turns.md
+++ b/docs/architecture/system/ADR-153-session-introspection-substrate-correlating-fired-ways-to-turns.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-07-02
 deciders:
   - aaronsb

--- a/docs/architecture/system/ADR-154-rethink-think-and-non-interactive-introspection-one-model-three-front-ends.md
+++ b/docs/architecture/system/ADR-154-rethink-think-and-non-interactive-introspection-one-model-three-front-ends.md
@@ -9,19 +9,19 @@ related:
   - ADR-111
 ---
 
-# ADR-154: rethink, think, and non-interactive introspection — one model, three front-ends
+# ADR-154: `ways introspect` — one model, three front-ends
 
 ## Context
 
 ADR-153 defines a shared `SessionIntrospection` model. This ADR decides the
-surfaces over it. There are three, plus a drill-down, and the user wants them to
-feel like one tool a user can move between:
+surfaces over it. There are three, plus a drill-down, and they should feel like
+one tool a user can move between — which §4 realizes as one `ways introspect
+<mode>` command:
 
-- **`rethink`** — post-hoc replay of a finished session (exists today).
-- **`think`** — a *live* monitor of the current session, same UI, refreshing as
-  new ways fire.
-- **non-interactive dump** — structured output an autonomous agent reads to
-  investigate a session (a JSON dump exists today via `rethink --json`).
+- **post-hoc replay** of a finished session (exists today as `ways rethink`).
+- a **live** monitor of the current session, same UI, refreshing as new ways fire.
+- a **non-interactive dump** — structured output an autonomous agent reads to
+  investigate a session (exists today via `rethink --json`).
 - **the why-fired drill-down** — from a list of fired ways, enter one and read the
   way, its trigger criteria, and the clip of session that matched.
 
@@ -51,12 +51,15 @@ Generalize the proven triplet into a module (mirroring the `cmd/scan`,
 - **model** — build `SessionIntrospection` (ADR-153).
 - **render** — extend `cmd/render`'s ANSI-`String` contract with
   `render_way_detail` / `render_clip`; no new rendering paradigm.
-- **front-ends**, each a thin loop over the same model:
-  - one-shot render → print (like `list`);
-  - **`think`** — the existing `rethink::tui_loop` poll skeleton, re-reading on a
+- **front-ends** (the `ways introspect <mode>` modes of §4), each a thin loop over
+  the same model:
+  - **`replay`** — one-shot render → print, then the frame-player loop (today's
+    `rethink`);
+  - **`live`** — the existing `rethink::tui_loop` poll skeleton, re-reading on a
     tick (see §3);
-  - **JSON** — serde-serialize (extend `rethink_dump`);
-  - **drill-down** — a selection/tab loop compositing model panels.
+  - **`dump`** — serde-serialize (extend `rethink_dump`);
+  - **drill-down** — a selection/tab loop compositing model panels, shared by
+    `replay` and `live`.
 
 ### 2. Keep crossterm; grow a small micro-compositor — do not adopt ratatui
 
@@ -78,7 +81,7 @@ with independent scroll"; ratatui is right for a true windowed inspector.
 
 ### 3. Live refresh: poll-with-timeout + mtime/size stat gate — not `notify`
 
-`think` reuses crossterm `poll(Duration)`: the timeout is the refresh interval
+`introspect live` reuses crossterm `poll(Duration)`: the timeout is the refresh interval
 (~100–250 ms, imperceptible), on timeout re-read the *tail* of the (append-only)
 events log + transcript and re-render, on key event handle input. Skip the
 re-parse when the files' mtime/length are unchanged. This stays synchronous, adds
@@ -89,23 +92,31 @@ large-tree advantage does not apply to two append-only files.
 
 ### 4. Command surface and scoping semantics
 
-- **`ways rethink`** — post-hoc. Default to the **current Claude Code project**;
+The surfaces unify under a single **`ways introspect <mode>`** command (ADR-111
+single-surface spirit) rather than sibling top-level verbs. Modes:
+
+- **`ways introspect replay`** — post-hoc replay of a finished session (the
+  behaviour `rethink` has today). Default to the **current Claude Code project**;
   add `--all` for every project and keep `--project <path>` for a specific one.
   When current-project detection returns `None`, **fail loud** (name the missing
   marker) or fall back to cwd — never silently globalize. Compare on the encoded
   project slug / normalized path, not a loose substring.
-- **`ways rethink --list --json`** — enumerate candidate sessions as structured
+- **`ways introspect list --json`** — enumerate candidate sessions as structured
   data so an agent can pick one before dumping it (closes the non-interactive
   enumeration gap).
-- **`ways think`** — live monitor of the current session; same scoping default.
-- **the drill-down** — a tab in `rethink`/`think`: a fired-ways list; entering a
+- **`ways introspect dump`** — the non-interactive JSON dump of a session (the
+  behaviour `rethink --json` has today).
+- **`ways introspect live`** — live monitor of the current session; same scoping
+  default.
+- **the drill-down** — a tab in `replay`/`live`: a fired-ways list; entering a
   way opens a read-as-a-human panel with the way body, its trigger criteria
   (ADR-153 `MatchCriteria`), and the matched session clip (precise once ADR-153 §3
   enrichment lands; heuristic-labelled before).
 
-Consolidation (ADR-111 single-surface spirit): whether these live under `ways
-rethink`/`ways think` or a unified `ways introspect <mode>` is an open naming
-question for the implementation — the *model* is shared regardless.
+**Migration:** `ways rethink` becomes a thin **deprecated alias** for `ways
+introspect replay` (and `rethink --json` → `introspect dump`), printing a
+one-line deprecation notice to stderr while continuing to work. Muscle memory
+keeps working; the canonical surface is the consolidated one.
 
 ## Consequences
 
@@ -127,9 +138,12 @@ question for the implementation — the *model* is shared regardless.
 ### Neutral
 
 - If the inspector's ambitions grow, the escape hatch to ratatui is deliberate and
-  documented — this decision is reversible, not a dead end.
-- Final command naming (`rethink`/`think` vs. `introspect`) is left to
-  implementation.
+  documented — this decision is reversible, not a dead end. The concrete trigger
+  that would flip it: the drill-down needing **text selection or resizable /
+  mouse-driven panes**; short of that, the micro-compositor stays.
+- Command naming is **decided**: one `ways introspect <replay|live|dump>` surface,
+  with `ways rethink` kept as a deprecated alias. The `think`/`rethink` verb pair
+  was rejected as too cute — the modes are plain and descriptive instead.
 
 ## Alternatives Considered
 
@@ -148,7 +162,7 @@ question for the implementation — the *model* is shared regardless.
 ## References
 
 - **ADR-153** — the `SessionIntrospection` substrate these front-ends render.
-- **ADR-111** — the single-tool-surface consolidation spirit informing the command
-  naming question.
+- **ADR-111** — the single-tool-surface consolidation spirit this ADR follows in
+  choosing one `ways introspect <mode>` command over sibling verbs.
 - Research pass 2026-07-02 (TUI stack, crossterm-vs-ratatui trade study, refresh
   mechanism, shared-model factoring) — the ground truth this ADR is built on.

--- a/docs/architecture/system/ADR-154-rethink-think-and-non-interactive-introspection-one-model-three-front-ends.md
+++ b/docs/architecture/system/ADR-154-rethink-think-and-non-interactive-introspection-one-model-three-front-ends.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-07-02
 deciders:
   - aaronsb
@@ -132,8 +132,8 @@ keeps working; the canonical surface is the consolidated one.
 
 - The micro-compositor is hand-built layout code (panes, scroll, tabs) — bounded
   (~200–400 lines) but genuinely new, and less capable than ratatui's widgets.
-- A live `think` loop re-reading files is more moving parts than a one-shot dump;
-  the stat-gate must be correct to avoid needless re-parse flicker.
+- A live `introspect live` loop re-reading files is more moving parts than a
+  one-shot dump; the stat-gate must be correct to avoid needless re-parse flicker.
 
 ### Neutral
 

--- a/docs/architecture/system/ADR-154-rethink-think-and-non-interactive-introspection-one-model-three-front-ends.md
+++ b/docs/architecture/system/ADR-154-rethink-think-and-non-interactive-introspection-one-model-three-front-ends.md
@@ -1,0 +1,154 @@
+---
+status: Draft
+date: 2026-07-02
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-153
+  - ADR-111
+---
+
+# ADR-154: rethink, think, and non-interactive introspection — one model, three front-ends
+
+## Context
+
+ADR-153 defines a shared `SessionIntrospection` model. This ADR decides the
+surfaces over it. There are three, plus a drill-down, and the user wants them to
+feel like one tool a user can move between:
+
+- **`rethink`** — post-hoc replay of a finished session (exists today).
+- **`think`** — a *live* monitor of the current session, same UI, refreshing as
+  new ways fire.
+- **non-interactive dump** — structured output an autonomous agent reads to
+  investigate a session (a JSON dump exists today via `rethink --json`).
+- **the why-fired drill-down** — from a list of fired ways, enter one and read the
+  way, its trigger criteria, and the clip of session that matched.
+
+The research pass established the current surface and its gaps:
+
+- `rethink` is raw **crossterm + hand-rolled ANSI strings** (not ratatui), two
+  sequential blocking loops (session picker → frame player), sharing the
+  `cmd/render` table writer with `ways list`. Single-panel, full-clear-redraw.
+- The **model→(render | serialize) split already half-exists**: `reconstruct_frames`
+  (pure data) feeds both the TUI and `rethink_dump`'s JSON — the exact factoring
+  the three front-ends want.
+- Two bugs (owned here as command semantics): `rethink` **silently globalizes**
+  when current-project detection returns `None` (run manually, `CLAUDE_PROJECT_DIR`
+  is unset), and there is **no `--list --json`** for an agent to enumerate sessions
+  before dumping one. (The events-log discovery bug is fixed in ADR-153.)
+- `attend-chat` uses **iocraft** (a declarative TUI) with an async runtime for its
+  rich interface — the maintainer's rich-TUI precedent, but it drags `smol`/
+  `async-channel` that `ways-cli` (fully synchronous) deliberately lacks.
+
+## Decision
+
+### 1. One `cmd/introspect/` module; front-ends differ only in their loop
+
+Generalize the proven triplet into a module (mirroring the `cmd/scan`,
+`cmd/settings`, `cmd/lint` subdir convention):
+
+- **model** — build `SessionIntrospection` (ADR-153).
+- **render** — extend `cmd/render`'s ANSI-`String` contract with
+  `render_way_detail` / `render_clip`; no new rendering paradigm.
+- **front-ends**, each a thin loop over the same model:
+  - one-shot render → print (like `list`);
+  - **`think`** — the existing `rethink::tui_loop` poll skeleton, re-reading on a
+    tick (see §3);
+  - **JSON** — serde-serialize (extend `rethink_dump`);
+  - **drill-down** — a selection/tab loop compositing model panels.
+
+### 2. Keep crossterm; grow a small micro-compositor — do not adopt ratatui
+
+Build a ~200–400-line internal compositor over the existing ANSI-`String` panels:
+`panel = Vec<String> + width`, a side-by-side placer, a scroll-window helper, a
+tab-bar helper. This preserves the lean `opt-level=z` binary (~3.3 MB), adds **zero
+dependencies**, and reuses `render.rs`'s output verbatim as the "matched clip"
+content.
+
+Rejected for now: **ratatui** — ~+300–600 KB and 15–30 crates against a size-tuned
+binary, a real compile hit under `lto`/`codegen-units=1`, and — decisively — its
+immediate-mode `Line`/`Span` model breaks the ANSI-`String` contract that
+`cmd/render` shares with `ways list`, forcing a rewrite of both. **Escape hatch,
+stated up front:** if the drill-down is meant to become a genuine multi-pane,
+mouse-driven, resizable, text-selectable inspector, adopt ratatui *at that point*
+rather than grow a poor reimplementation and migrate later. The micro-compositor
+is right for "live table + status bar" and "list-left / read-only-detail-right
+with independent scroll"; ratatui is right for a true windowed inspector.
+
+### 3. Live refresh: poll-with-timeout + mtime/size stat gate — not `notify`
+
+`think` reuses crossterm `poll(Duration)`: the timeout is the refresh interval
+(~100–250 ms, imperceptible), on timeout re-read the *tail* of the (append-only)
+events log + transcript and re-render, on key event handle input. Skip the
+re-parse when the files' mtime/length are unchanged. This stays synchronous, adds
+zero dependencies, and matches the project's existing poll style. Rejected:
+`notify` (event-driven) — it forces a background thread + channel + a blocking
+select that `attend-chat` solved only by bringing in an async runtime; its
+large-tree advantage does not apply to two append-only files.
+
+### 4. Command surface and scoping semantics
+
+- **`ways rethink`** — post-hoc. Default to the **current Claude Code project**;
+  add `--all` for every project and keep `--project <path>` for a specific one.
+  When current-project detection returns `None`, **fail loud** (name the missing
+  marker) or fall back to cwd — never silently globalize. Compare on the encoded
+  project slug / normalized path, not a loose substring.
+- **`ways rethink --list --json`** — enumerate candidate sessions as structured
+  data so an agent can pick one before dumping it (closes the non-interactive
+  enumeration gap).
+- **`ways think`** — live monitor of the current session; same scoping default.
+- **the drill-down** — a tab in `rethink`/`think`: a fired-ways list; entering a
+  way opens a read-as-a-human panel with the way body, its trigger criteria
+  (ADR-153 `MatchCriteria`), and the matched session clip (precise once ADR-153 §3
+  enrichment lands; heuristic-labelled before).
+
+Consolidation (ADR-111 single-surface spirit): whether these live under `ways
+rethink`/`ways think` or a unified `ways introspect <mode>` is an open naming
+question for the implementation — the *model* is shared regardless.
+
+## Consequences
+
+### Positive
+
+- Three surfaces + a drill-down from one model — no drift between what an agent
+  reads as JSON and what a human sees in the TUI.
+- Zero new dependencies; the lean binary and the shared `render.rs` contract both
+  survive.
+- `rethink` stops silently globalizing and gains machine-listable sessions.
+
+### Negative
+
+- The micro-compositor is hand-built layout code (panes, scroll, tabs) — bounded
+  (~200–400 lines) but genuinely new, and less capable than ratatui's widgets.
+- A live `think` loop re-reading files is more moving parts than a one-shot dump;
+  the stat-gate must be correct to avoid needless re-parse flicker.
+
+### Neutral
+
+- If the inspector's ambitions grow, the escape hatch to ratatui is deliberate and
+  documented — this decision is reversible, not a dead end.
+- Final command naming (`rethink`/`think` vs. `introspect`) is left to
+  implementation.
+
+## Alternatives Considered
+
+- **Adopt ratatui now** for real layout/widget primitives. Rejected for the
+  current scope on binary-size, compile-cost, and the `render.rs`-rewrite grounds
+  above — with the explicit escape hatch if scope grows.
+- **Reuse `attend-chat`'s iocraft + async stack.** Rejected: it would drag an
+  async runtime into a deliberately synchronous CLI — a larger intrusion than
+  ratatui for less fit.
+- **`notify` filesystem watcher for `think`.** Rejected: event-driven latency is
+  not needed for two append-only files, and it forces the async architecture
+  ways-cli avoids; poll + stat-gate is the lean match.
+- **Keep three independent implementations** (rethink as-is, a separate think, a
+  separate dumper). Rejected: guarantees drift; the whole point is one model.
+
+## References
+
+- **ADR-153** — the `SessionIntrospection` substrate these front-ends render.
+- **ADR-111** — the single-tool-surface consolidation spirit informing the command
+  naming question.
+- Research pass 2026-07-02 (TUI stack, crossterm-vs-ratatui trade study, refresh
+  mechanism, shared-model factoring) — the ground truth this ADR is built on.

--- a/docs/design-notes/session-introspection-implementation-plan.md
+++ b/docs/design-notes/session-introspection-implementation-plan.md
@@ -3,7 +3,7 @@
 > **Type:** Design note (not an ADR)
 > **Status:** Working draft — sequencing for ADR-153 + ADR-154, deferred implementation
 > **Cites:** ADR-153 (introspection substrate), ADR-154 (three front-ends), ADR-201 (shared finding evidence), ADR-134 (near-miss telemetry)
-> **Motivates:** `ways rethink` fixes, `ways think`, non-interactive introspection, the why-fired drill-down
+> **Motivates:** the `ways introspect <replay|live|dump>` surface (`ways rethink` fixes + a live monitor + non-interactive dump) and the why-fired drill-down
 
 ## What this note is
 

--- a/docs/design-notes/session-introspection-implementation-plan.md
+++ b/docs/design-notes/session-introspection-implementation-plan.md
@@ -1,0 +1,95 @@
+## Session Introspection — Implementation Plan
+
+> **Type:** Design note (not an ADR)
+> **Status:** Working draft — sequencing for ADR-153 + ADR-154, deferred implementation
+> **Cites:** ADR-153 (introspection substrate), ADR-154 (three front-ends), ADR-201 (shared finding evidence), ADR-134 (near-miss telemetry)
+> **Motivates:** `ways rethink` fixes, `ways think`, non-interactive introspection, the why-fired drill-down
+
+## What this note is
+
+The two ADRs decide *what* and *why*; this note sequences the *how* into
+independently-shippable increments, so the work can land incrementally without a
+big-bang PR. Grounded in the 2026-07-02 research pass (three probes: rethink
+internals, correlation data model, TUI trade study).
+
+## Guardrails (carry into every increment)
+
+- **Join honesty (ADR-153).** The fired-way ↔ turn link is *keyed* only after
+  enrichment (increment 3); before that it is a `(session, token_position, ts≈)`
+  heuristic bucket. The model must *label* each edge's confidence; never render a
+  proximity guess as a foreign key.
+- **No fabricated semantic "why."** One embedding per way — there is no matched
+  vocabulary term to recover. Present semantic fires as way-level cosine
+  (`fire_score` ≥ `embed_threshold`), never a highlighted term.
+- **Lean binary.** Zero new deps is the target (crossterm + micro-compositor, poll
+  + stat-gate). Adopting ratatui is the documented escape hatch *only* if the
+  inspector grows into a true multi-pane/mouse/resizable tool — decide before, not
+  during.
+- **Transcripts are read-only** (Claude-Code-owned) and may be truncated to a
+  spilled `tool-results/…-additionalContext.txt`; tolerate absence and truncation.
+
+## Increments
+
+### 1 — Correctness fixes (fast, independently shippable) — ADR-153 §1, ADR-154 §4
+
+The bugs that make `rethink` wrong today. Land first; delivers value alone.
+
+- **Events-log single-writer.** Add `ways events-log-path`; rewire
+  `hooks/.../clear-markers.sh` and `inject-subagent.sh` to resolve it from the
+  binary (precedent: `ways response-topics-path`). Optional transitional union-read
+  in `resolve_events`. *This is the fix for "rethink doesn't see post-1.0.0
+  sessions."*
+- **Project scoping.** `rethink`/`rethink_dump`: default to current project,
+  add `--all`, fail-loud (or cwd-fallback) when detection is `None`, compare on
+  slug/normalized path not substring. Insertion points: `rethink.rs:123-134` +
+  `665-668`; `rethink_dump.rs:94-102` + `277-281`.
+- **`ways rethink --list --json`** — machine-listable session enumeration.
+- Key files: `session.rs` (log_event / new path cmd), the two shell hooks,
+  `cmd/rethink.rs`, `cmd/rethink_dump.rs`, `ways-core/src/paths.rs`.
+
+### 2 — The `SessionIntrospection` model — ADR-153 §2
+
+- New `ways-core` module (or `cmd/introspect/model.rs`): pure serde structs
+  `Session → Turn → FiredWay{criteria, match?}` with confidence-labelled joins.
+- Generalize `rethink::reconstruct_frames` into it (keep the existing frame data;
+  add `MatchCriteria` from frontmatter fire-bearing fields, read via
+  `cmd/scan/candidates.rs`'s raw extraction).
+- No UI yet — model + unit tests over sample events + a fixture transcript.
+
+### 3 — Fire-time enrichment — ADR-153 §3 (forward-only)
+
+- Add `transcript_uuid` (message id from hook stdin) + `matched_span` (regex/glob
+  match for keyword/command/file) at the fire sites: `cmd/show/mod.rs:152-186`,
+  `cmd/scan/mod.rs:108`, `cmd/scan/state.rs`.
+- Keep the fire path cheap and line-atomic. Semantic stays `fire_score` only.
+- Model (increment 2) reads the new fields when present, falls back to heuristic
+  when absent.
+
+### 4 — Non-interactive dump over the model — ADR-154 §1 (agent-facing MVP)
+
+- Re-point `rethink_dump` (or a unified `ways introspect --json`) at the increment-2
+  model. This is the autonomous-investigation surface — ship it before the TUIs.
+
+### 5 — Micro-compositor + why-fired drill-down — ADR-154 §2
+
+- ~200–400-line compositor over `render.rs`'s ANSI-`String` panels: panel
+  (`Vec<String>`+width), side-by-side placer, scroll-window, tab-bar.
+- Drill-down tab in `rethink`: fired-ways list → enter → way body + `MatchCriteria`
+  + matched clip (precise post-enrichment, heuristic-labelled before).
+
+### 6 — `ways think` live monitor — ADR-154 §3
+
+- New command; reuse `rethink::tui_loop`'s `poll(Duration)` skeleton with the
+  refresh interval as timeout; re-read tail of events-log + transcript on tick;
+  mtime/size stat-gate to skip unchanged re-parse. Same compositor + model.
+
+## Open questions for the next session
+
+- **Command naming:** `ways rethink`/`ways think` vs. a unified `ways introspect
+  <replay|live|dump>` (ADR-111 single-surface spirit). Decide before increment 4.
+- **Shared substrate with ADR-201:** confirm the `SessionIntrospection` model is
+  the finding pipeline's evidence source, so they don't diverge. Likely means the
+  model lives in `ways-core`, not `ways-cli`.
+- **ratatui escape-hatch trigger:** name the concrete feature (text selection?
+  resizable panes? mouse?) that would flip the decision, so it's a criterion, not a
+  vibe.

--- a/docs/design-notes/session-introspection-implementation-plan.md
+++ b/docs/design-notes/session-introspection-implementation-plan.md
@@ -43,7 +43,8 @@ The bugs that make `rethink` wrong today. Land first; delivers value alone.
   add `--all`, fail-loud (or cwd-fallback) when detection is `None`, compare on
   slug/normalized path not substring. Insertion points: `rethink.rs:123-134` +
   `665-668`; `rethink_dump.rs:94-102` + `277-281`.
-- **`ways rethink --list --json`** — machine-listable session enumeration.
+- **`ways rethink --list --json`** — machine-listable session enumeration. (Becomes
+  `ways introspect list --json` at increment 4; the alias preserves this form.)
 - Key files: `session.rs` (log_event / new path cmd), the two shell hooks,
   `cmd/rethink.rs`, `cmd/rethink_dump.rs`, `ways-core/src/paths.rs`.
 
@@ -65,10 +66,12 @@ The bugs that make `rethink` wrong today. Land first; delivers value alone.
 - Model (increment 2) reads the new fields when present, falls back to heuristic
   when absent.
 
-### 4 — Non-interactive dump over the model — ADR-154 §1 (agent-facing MVP)
+### 4 — `ways introspect` surface + non-interactive dump — ADR-154 §1, §4 (agent-facing MVP)
 
-- Re-point `rethink_dump` (or a unified `ways introspect --json`) at the increment-2
-  model. This is the autonomous-investigation surface — ship it before the TUIs.
+- Introduce the `ways introspect <replay|live|dump|list>` command; wire `ways
+  rethink` as a deprecated alias → `introspect replay` (stderr notice, still works).
+- Re-point `rethink_dump` at the increment-2 model as `ways introspect dump`. This
+  is the autonomous-investigation surface — ship it before the TUIs.
 
 ### 5 — Micro-compositor + why-fired drill-down — ADR-154 §2
 
@@ -77,19 +80,25 @@ The bugs that make `rethink` wrong today. Land first; delivers value alone.
 - Drill-down tab in `rethink`: fired-ways list → enter → way body + `MatchCriteria`
   + matched clip (precise post-enrichment, heuristic-labelled before).
 
-### 6 — `ways think` live monitor — ADR-154 §3
+### 6 — `ways introspect live` monitor — ADR-154 §3
 
-- New command; reuse `rethink::tui_loop`'s `poll(Duration)` skeleton with the
+- New mode; reuse `rethink::tui_loop`'s `poll(Duration)` skeleton with the
   refresh interval as timeout; re-read tail of events-log + transcript on tick;
   mtime/size stat-gate to skip unchanged re-parse. Same compositor + model.
 
-## Open questions for the next session
+## Resolved decisions (settled 2026-07-02)
 
-- **Command naming:** `ways rethink`/`ways think` vs. a unified `ways introspect
-  <replay|live|dump>` (ADR-111 single-surface spirit). Decide before increment 4.
-- **Shared substrate with ADR-201:** confirm the `SessionIntrospection` model is
-  the finding pipeline's evidence source, so they don't diverge. Likely means the
-  model lives in `ways-core`, not `ways-cli`.
-- **ratatui escape-hatch trigger:** name the concrete feature (text selection?
-  resizable panes? mouse?) that would flip the decision, so it's a criterion, not a
-  vibe.
+- **Command naming — DECIDED:** one unified `ways introspect <replay|live|dump>`
+  surface (ADR-111 single-surface spirit), *not* the `ways rethink`/`ways think`
+  verb pair (rejected as too cute). `ways rethink` is kept as a **deprecated alias**
+  → `introspect replay` (and `rethink --json` → `introspect dump`) so existing
+  muscle memory keeps working. The `introspect` CLI surface + alias is a thin step
+  introduced at **increment 4** (the first new command); increments 1–3 fix and
+  factor the *underlying* code that `introspect replay` will call.
+- **Shared substrate with ADR-201 — DECIDED:** the `SessionIntrospection` model
+  lives in **`ways-core`** (not `ways-cli`) and is the finding pipeline's evidence
+  source, so introspection and findings read one correlation, not two drifting
+  re-derivations.
+- **ratatui escape-hatch trigger — DECIDED:** the concrete criterion is the
+  drill-down needing **text selection or resizable / mouse-driven panes**. Short of
+  that, the micro-compositor stays. It's a criterion now, not a vibe.


### PR DESCRIPTION
## Summary

**Design drafts — not for immediate merge.** Research-grounded ADRs + implementation plan for the session-introspection tooling (rethink fixes, `ways think` live monitor, non-interactive dump, why-fired drill-down). Status **Draft**; to review/refine next session before implementation.

- **ADR-153 (Draft)** — the introspection *substrate*: one typed model joining events log + transcripts + frontmatter. Captures the correctness prerequisite (the events-log split-brain that causes "rethink misses post-1.0.0 sessions") and the **honest join grain** (fired-way↔criteria solid; fired-way↔turn heuristic until fire-time enrichment; semantic stays way-level cosine, never a fabricated term). Shares the transcript-evidence substrate with ADR-201 findings.
- **ADR-154 (Draft)** — three front-ends over one model: keep crossterm + a ~300-line micro-compositor (not ratatui — with a documented escape hatch), poll+stat-gate refresh (not notify), project-scoping fix + `--list --json`.
- **Design note** — 6 independently-shippable increments (correctness fixes first), guardrails, open questions.

## Provenance

Grounded in a 3-probe research pass (rethink internals, correlation data model, TUI trade study) with `file:line` citations throughout. `adr lint` / `doc lint` clean.

## Next

Review the drafts → settle the open questions (command naming, ways-core placement, the ratatui escape-hatch criterion) → implement increment 1 (the rethink correctness fixes, independently shippable).