### PR TITLE
fix(introspect): increment 1 — rethink correctness (events-log, scoping, --list --json)

### DIFF
--- a/hooks/ways/clear-markers.sh
+++ b/hooks/ways/clear-markers.sh
@@ -6,6 +6,7 @@
 # Clears this session's state directory only — other sessions stay intact
 
 source "$(dirname "$0")/sessions-root.sh"
+source "$(dirname "$0")/events-log.sh"
 
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
@@ -18,11 +19,11 @@ else
   rm -rf "${SESSIONS_ROOT}" 2>/dev/null
 fi
 
-# Log session event
-mkdir -p "${HOME}/.claude/stats" 2>/dev/null
+# Log session event (canonical events-log path resolved via events-log.sh)
+mkdir -p "$(dirname "$EVENTS_LOG")" 2>/dev/null
 jq -nc --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   --arg event "session_start" \
   --arg project "${CLAUDE_PROJECT_DIR:-$PWD}" \
   --arg session "${SESSION_ID:-unknown}" \
   '{ts:$ts,event:$event,project:$project,session:$session}' \
-  >> "${HOME}/.claude/stats/events.jsonl" 2>/dev/null
+  >> "$EVENTS_LOG" 2>/dev/null

--- a/hooks/ways/events-log.sh
+++ b/hooks/ways/events-log.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Canonical telemetry events-log path — shared by every hook that appends events.
+#
+# MUST resolve to the same file as ways-core `paths::events_log()`, which the
+# Rust writer (`session::log_event`) and every reader (`firing::load_events`)
+# use. That path has XDG-vs-legacy fallback logic (ADR-142/ADR-153) that is
+# awkward to reproduce faithfully in bash, so instead we ask the binary via
+# `ways events-log-path` — the same delegation pattern as `ways
+# response-topics-path`. Hardcoding `~/.claude/stats/events.jsonl` here is what
+# orphaned post-migration `session_start` lines from `rethink` (ADR-153 §1).
+#
+# If the binary is unavailable we fall back to the legacy path so telemetry still
+# lands somewhere; the reader's union recovers it later.
+#
+# Usage: source this file, then use $EVENTS_LOG
+#   source "$(dirname "$0")/events-log.sh"
+
+_ways_bin="${HOME}/.claude/bin/ways"
+EVENTS_LOG=""
+if [[ -x "$_ways_bin" ]]; then
+  EVENTS_LOG=$("$_ways_bin" events-log-path 2>/dev/null)
+fi
+EVENTS_LOG="${EVENTS_LOG:-${HOME}/.claude/stats/events.jsonl}"
+unset _ways_bin

--- a/hooks/ways/inject-subagent.sh
+++ b/hooks/ways/inject-subagent.sh
@@ -15,6 +15,7 @@
 # context regardless of what the parent already triggered.
 
 source "$(dirname "$0")/sessions-root.sh"
+source "$(dirname "$0")/events-log.sh"
 
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
@@ -144,11 +145,11 @@ while IFS= read -r waypath; do
     log_args=(event=way_fired way="$waypath" domain="$DOMAIN"
       trigger="${MATCH_CH}" scope="$scope" project="$PROJECT_DIR" session="$SESSION_ID")
     [[ -n "$TEAM_NAME" ]] && log_args+=(team="$TEAM_NAME")
-    # Inline event logging
-    mkdir -p "${HOME}/.claude/stats" 2>/dev/null
+    # Inline event logging (canonical events-log path resolved via events-log.sh)
+    mkdir -p "$(dirname "$EVENTS_LOG")" 2>/dev/null
     _args=(--arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)") _obj="ts:\$ts"
     for _kv in "${log_args[@]}"; do _args+=(--arg "${_kv%%=*}" "${_kv#*=}"); _obj+=",${_kv%%=*}:\$${_kv%%=*}"; done
-    jq -nc "${_args[@]}" "{${_obj}}" >> "${HOME}/.claude/stats/events.jsonl" 2>/dev/null
+    jq -nc "${_args[@]}" "{${_obj}}" >> "$EVENTS_LOG" 2>/dev/null
   fi
 done <<< "$WAYS"
 

--- a/tools/ways-cli/src/cmd/rethink.rs
+++ b/tools/ways-cli/src/cmd/rethink.rs
@@ -13,7 +13,7 @@ use crossterm::{
 };
 
 use anyhow::{bail, Result};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Write as FmtWrite;
 use std::io::Write;
 
@@ -137,6 +137,13 @@ pub(crate) fn resolve_project_scope(project: Option<&str>, all: bool) -> Result<
 /// Whether an event's stored `project` path belongs to `scope`, compared as
 /// normalized absolute paths — replacing the old loose `contains` substring test
 /// that let unrelated projects (`/a/foo` vs `/a/foo-bar`) bleed together.
+///
+/// The comparison is exact (modulo trailing slash). On the primary path this is
+/// right: `CLAUDE_PROJECT_DIR` is the scope at both write and read time, so the
+/// strings match. On a *manual* run where scope falls back to `detect_project_dir`
+/// (a symlink-resolved cwd), a session whose stored `project` was a logical or
+/// symlinked path — or a subdirectory `$PWD` — won't match and is simply absent
+/// from the list (not an error). Pass `--all` or an explicit `--project` to see it.
 pub(crate) fn project_matches(stored: &str, scope: &str) -> bool {
     normalize_project_path(stored) == normalize_project_path(scope)
 }
@@ -683,6 +690,11 @@ pub(crate) fn gather_sessions(content: &str, project_filter: Option<&str>) -> Ve
     let mut sessions: Vec<SessionInfo> = Vec::new();
     let mut event_counts: HashMap<String, (u32, u32)> = HashMap::new();
     let mut last_ts: HashMap<String, String> = HashMap::new();
+    // One entry per session id. `clear-markers.sh` writes `session_start` on both
+    // SessionStart and post-compaction, so a compacted session has several such
+    // lines; keep the first (its origin) and let the post-loop pass fill the
+    // aggregated counts, so the list (and the `--list --json` `count`) don't dupe.
+    let mut seen: HashSet<String> = HashSet::new();
 
     for line in content.lines() {
         if line.is_empty() {
@@ -707,14 +719,16 @@ pub(crate) fn gather_sessions(content: &str, project_filter: Option<&str>) -> Ve
                     continue;
                 }
             }
-            sessions.push(SessionInfo {
-                id: sid.clone(),
-                ts: ts.clone(),
-                project,
-                event_count: 0,
-                way_fires: 0,
-                duration_secs: 0,
-            });
+            if seen.insert(sid.clone()) {
+                sessions.push(SessionInfo {
+                    id: sid.clone(),
+                    ts: ts.clone(),
+                    project,
+                    event_count: 0,
+                    way_fires: 0,
+                    duration_secs: 0,
+                });
+            }
         }
 
         let counts = event_counts.entry(sid.clone()).or_insert((0, 0));
@@ -990,6 +1004,23 @@ mod tests {
         assert!(!project_matches("/home/a/proj-2", "/home/a/proj"));
         assert!(!project_matches("/home/a/proj", "proj"));
         assert!(!project_matches("/home/a/other", "/home/a/proj"));
+    }
+
+    #[test]
+    fn gather_sessions_dedups_compaction_restarts() {
+        // Same session id with two `session_start` lines (initial + post-compaction).
+        let content = concat!(
+            r#"{"event":"session_start","session":"s1","ts":"2026-01-01T00:00:00Z","project":"/p"}"#, "\n",
+            r#"{"event":"way_fired","session":"s1","ts":"2026-01-01T00:01:00Z","way":"a/b"}"#, "\n",
+            r#"{"event":"session_start","session":"s1","ts":"2026-01-02T00:00:00Z","project":"/p"}"#, "\n",
+            r#"{"event":"way_fired","session":"s1","ts":"2026-01-02T00:01:00Z","way":"a/c"}"#, "\n",
+        );
+        let sessions = gather_sessions(content, Some("/p"));
+        assert_eq!(sessions.len(), 1, "one entry per session id, not per session_start");
+        assert_eq!(sessions[0].id, "s1");
+        assert_eq!(sessions[0].ts, "2026-01-01T00:00:00Z", "keeps the origin start");
+        assert_eq!(sessions[0].event_count, 4, "counts aggregate across the whole session");
+        assert_eq!(sessions[0].way_fires, 2);
     }
 
     #[test]

--- a/tools/ways-cli/src/cmd/rethink.rs
+++ b/tools/ways-cli/src/cmd/rethink.rs
@@ -12,7 +12,7 @@ use crossterm::{
     terminal::{self, ClearType},
 };
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use std::collections::HashMap;
 use std::fmt::Write as FmtWrite;
 use std::io::Write;
@@ -108,27 +108,60 @@ impl Drop for TermGuard {
     }
 }
 
+// ── Project scoping ───────────────────────────────────────────
+
+/// Resolve which project(s) to replay. `Ok(None)` means *every* project
+/// (`--all`); `Ok(Some(path))` scopes to one. Defaults to the current project
+/// and — the correctness fix (ADR-154 §4) — **fails loud** instead of silently
+/// globalizing when the current project can't be detected.
+pub(crate) fn resolve_project_scope(project: Option<&str>, all: bool) -> Result<Option<String>> {
+    if all {
+        return Ok(None);
+    }
+    if let Some(p) = project {
+        return Ok(Some(p.to_string()));
+    }
+    match std::env::var("CLAUDE_PROJECT_DIR")
+        .ok()
+        .or_else(detect_project_dir)
+    {
+        Some(p) => Ok(Some(p)),
+        None => bail!(
+            "couldn't detect the current project: CLAUDE_PROJECT_DIR is unset and no \
+             .claude/settings.json or CLAUDE.md was found above the working directory. \
+             Pass --project <path> to scope to a project, or --all to replay across every project."
+        ),
+    }
+}
+
+/// Whether an event's stored `project` path belongs to `scope`, compared as
+/// normalized absolute paths — replacing the old loose `contains` substring test
+/// that let unrelated projects (`/a/foo` vs `/a/foo-bar`) bleed together.
+pub(crate) fn project_matches(stored: &str, scope: &str) -> bool {
+    normalize_project_path(stored) == normalize_project_path(scope)
+}
+
+fn normalize_project_path(p: &str) -> String {
+    p.trim_end_matches('/').to_string()
+}
+
 // ── Entry point ───────────────────────────────────────────────
 
 #[cfg(feature = "tui")]
-pub fn run(session: Option<&str>, project: Option<&str>, speed: Option<u64>, list: bool) -> Result<()> {
-    let events_file = crate::paths::events_log();
-    if !events_file.is_file() {
+pub fn run(
+    session: Option<&str>,
+    project: Option<&str>,
+    speed: Option<u64>,
+    list: bool,
+    all: bool,
+) -> Result<()> {
+    let content = ways_core::firing::load_events_text();
+    if content.trim().is_empty() {
         println!("No events recorded yet.");
         return Ok(());
     }
 
-    let content = std::fs::read_to_string(&events_file)?;
-
-    // Auto-detect project scope if not explicitly provided
-    let detected_project = if project.is_none() {
-        std::env::var("CLAUDE_PROJECT_DIR")
-            .ok()
-            .or_else(detect_project_dir)
-    } else {
-        None
-    };
-    let project_scope = project.map(|s| s.to_string()).or(detected_project);
+    let project_scope = resolve_project_scope(project, all)?;
 
     if list {
         return list_sessions(&content, project_scope.as_deref());
@@ -186,15 +219,21 @@ pub fn run(session: Option<&str>, project: Option<&str>, speed: Option<u64>, lis
 }
 
 #[cfg(not(feature = "tui"))]
-pub fn run(_session: Option<&str>, _project: Option<&str>, _speed: Option<u64>, list: bool) -> Result<()> {
+pub fn run(
+    _session: Option<&str>,
+    project: Option<&str>,
+    _speed: Option<u64>,
+    list: bool,
+    all: bool,
+) -> Result<()> {
     if list {
-        let events_file = crate::paths::events_log();
-        if !events_file.is_file() {
+        let content = ways_core::firing::load_events_text();
+        if content.trim().is_empty() {
             println!("No events recorded yet.");
             return Ok(());
         }
-        let content = std::fs::read_to_string(&events_file)?;
-        return list_sessions(&content, None);
+        let scope = resolve_project_scope(project, all)?;
+        return list_sessions(&content, scope.as_deref());
     }
     println!("Rethink requires the 'tui' feature. Build with: cargo build --features tui");
     Ok(())
@@ -630,16 +669,17 @@ pub(crate) fn find_session_project(content: &str, session_id: &str) -> Option<St
 
 // ── Session listing and picker ────────────────────────────────
 
-struct SessionInfo {
-    id: String,
-    ts: String,
-    project: String,
-    event_count: u32,
-    way_fires: u32,
-    duration_secs: u64,
+#[derive(serde::Serialize)]
+pub(crate) struct SessionInfo {
+    pub(crate) id: String,
+    pub(crate) ts: String,
+    pub(crate) project: String,
+    pub(crate) event_count: u32,
+    pub(crate) way_fires: u32,
+    pub(crate) duration_secs: u64,
 }
 
-fn gather_sessions(content: &str, project_filter: Option<&str>) -> Vec<SessionInfo> {
+pub(crate) fn gather_sessions(content: &str, project_filter: Option<&str>) -> Vec<SessionInfo> {
     let mut sessions: Vec<SessionInfo> = Vec::new();
     let mut event_counts: HashMap<String, (u32, u32)> = HashMap::new();
     let mut last_ts: HashMap<String, String> = HashMap::new();
@@ -663,7 +703,7 @@ fn gather_sessions(content: &str, project_filter: Option<&str>) -> Vec<SessionIn
         if event == "session_start" {
             let project = v["project"].as_str().unwrap_or("").to_string();
             if let Some(pf) = project_filter {
-                if !project.contains(pf) {
+                if !project_matches(&project, pf) {
                     continue;
                 }
             }
@@ -933,4 +973,34 @@ fn truncate_visible(s: &str, max_visible: usize) -> String {
         result.push_str("\x1b[0m");
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_matches_is_exact_not_substring() {
+        // Exact path (and trailing-slash normalization) matches.
+        assert!(project_matches("/home/a/proj", "/home/a/proj"));
+        assert!(project_matches("/home/a/proj/", "/home/a/proj"));
+        assert!(project_matches("/home/a/proj", "/home/a/proj/"));
+        // The bug the fix closes: sibling / prefixed projects must NOT match,
+        // which the old `contains` substring test wrongly conflated.
+        assert!(!project_matches("/home/a/proj-2", "/home/a/proj"));
+        assert!(!project_matches("/home/a/proj", "proj"));
+        assert!(!project_matches("/home/a/other", "/home/a/proj"));
+    }
+
+    #[test]
+    fn scope_all_is_none_and_explicit_wins() {
+        // `--all` → every project, regardless of env.
+        assert_eq!(resolve_project_scope(None, true).unwrap(), None);
+        assert_eq!(resolve_project_scope(Some("/x"), true).unwrap(), None);
+        // Explicit `--project` is honored without touching detection.
+        assert_eq!(
+            resolve_project_scope(Some("/home/a/proj"), false).unwrap(),
+            Some("/home/a/proj".to_string())
+        );
+    }
 }

--- a/tools/ways-cli/src/cmd/rethink_dump.rs
+++ b/tools/ways-cli/src/cmd/rethink_dump.rs
@@ -12,7 +12,6 @@ use std::collections::BTreeMap;
 
 use super::rethink;
 use crate::session;
-use crate::util::detect_project_dir;
 
 // ── Output shape ──────────────────────────────────────────────
 
@@ -83,23 +82,22 @@ struct NearMiss {
 
 /// Emit a session's reconstructed timeline as a single pretty-printed JSON
 /// document. With no `session`, dumps the most recent session in scope.
-pub fn run_json(session: Option<&str>, project: Option<&str>) -> Result<()> {
-    let events_file = crate::paths::events_log();
-    if !events_file.is_file() {
+pub fn run_json(session: Option<&str>, project: Option<&str>, all: bool) -> Result<()> {
+    let content = ways_core::firing::load_events_text();
+    if content.trim().is_empty() {
         println!("{{\"error\":\"no events recorded yet\"}}");
         return Ok(());
     }
-    let content = std::fs::read_to_string(&events_file)?;
 
-    // Auto-detect project scope when not given, mirroring `rethink::run`.
-    let detected = if project.is_none() {
-        std::env::var("CLAUDE_PROJECT_DIR")
-            .ok()
-            .or_else(detect_project_dir)
-    } else {
-        None
+    // Scope to the current project by default; emit a JSON error (not a bail) so
+    // agent consumers get structured output even on the fail-loud path.
+    let scope = match rethink::resolve_project_scope(project, all) {
+        Ok(s) => s,
+        Err(e) => {
+            println!("{{\"error\":{}}}", serde_json::to_string(&e.to_string())?);
+            return Ok(());
+        }
     };
-    let scope = project.map(|s| s.to_string()).or(detected);
 
     let session_id = match session {
         Some(s) => s.to_string(),
@@ -116,6 +114,29 @@ pub fn run_json(session: Option<&str>, project: Option<&str>) -> Result<()> {
         Some(dump) => println!("{}", serde_json::to_string_pretty(&dump)?),
         None => println!("{{\"error\":\"no events for session\",\"session\":\"{session_id}\"}}"),
     }
+    Ok(())
+}
+
+/// `ways rethink --list --json`: enumerate candidate sessions in scope as
+/// structured data, so an agent can pick one before dumping it (ADR-154 §4).
+/// Newest first. `scope` is null when `--all` was passed.
+pub fn run_list_json(project: Option<&str>, all: bool) -> Result<()> {
+    let content = ways_core::firing::load_events_text();
+    let scope = match rethink::resolve_project_scope(project, all) {
+        Ok(s) => s,
+        Err(e) => {
+            println!("{{\"error\":{}}}", serde_json::to_string(&e.to_string())?);
+            return Ok(());
+        }
+    };
+    let mut sessions = rethink::gather_sessions(&content, scope.as_deref());
+    sessions.sort_by(|a, b| b.ts.cmp(&a.ts)); // newest first
+    let out = serde_json::json!({
+        "scope": scope,
+        "count": sessions.len(),
+        "sessions": sessions,
+    });
+    println!("{}", serde_json::to_string_pretty(&out)?);
     Ok(())
 }
 
@@ -275,7 +296,7 @@ fn most_recent_session(content: &str, scope: Option<&str>) -> Option<String> {
             _ => continue,
         };
         if let Some(sc) = scope {
-            if !v["project"].as_str().unwrap_or("").contains(sc) {
+            if !rethink::project_matches(v["project"].as_str().unwrap_or(""), sc) {
                 continue;
             }
         }

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -255,6 +255,11 @@ enum Commands {
         /// Filter to sessions from this project path
         #[arg(long)]
         project: Option<String>,
+        /// Replay across every project, not just the current one (default is the
+        /// current project; detection failure is an error, never a silent
+        /// globalize)
+        #[arg(long)]
+        all: bool,
         /// Initial frame speed in milliseconds (default: 1000)
         #[arg(long)]
         speed: Option<u64>,
@@ -673,13 +678,14 @@ fn main() -> Result<()> {
         Commands::Reconcile { source, dest, mode, dry_run, quiet } => {
             cmd::reconcile::run(source, dest, mode, dry_run, quiet, false)
         }
-        Commands::Rethink { session, project, speed, list, json } => {
-            if json {
-                cmd::rethink_dump::run_json(session.as_deref(), project.as_deref())
-            } else {
-                cmd::rethink::run(session.as_deref(), project.as_deref(), speed, list)
-            }
-        }
+        Commands::Rethink { session, project, all, speed, list, json } => match (list, json) {
+            // `--list --json`: machine-listable session enumeration (ADR-154 §4).
+            (true, true) => cmd::rethink_dump::run_list_json(project.as_deref(), all),
+            // `--json`: dump one session's reconstructed timeline.
+            (false, true) => cmd::rethink_dump::run_json(session.as_deref(), project.as_deref(), all),
+            // interactive replay, or `--list` text.
+            _ => cmd::rethink::run(session.as_deref(), project.as_deref(), speed, list, all),
+        },
         Commands::Status { json } => cmd::status::run(json),
         Commands::Scan { mode } => match mode {
             ScanCommand::Prompt { query, session, project } => {

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -305,6 +305,13 @@ enum Commands {
     /// CI) verify they resolve the same path as the binary on every platform —
     /// the contract documented in `hooks/ways/sessions-root.sh`.
     SessionsRoot,
+    /// Print the canonical events-log path. The single source of truth for every
+    /// telemetry writer — the Rust `session::log_event` and the shell hooks
+    /// (`clear-markers.sh`, `inject-subagent.sh` via `events-log.sh`) — and every
+    /// reader (`firing::load_events`). Resolving through the binary keeps the
+    /// hooks from hardcoding a path that drifts from `paths::events_log()` after
+    /// the ADR-142 XDG migration (ADR-153 §1).
+    EventsLogPath,
     /// Manage configuration (init/show/path)
     Config {
         #[command(subcommand)]
@@ -765,6 +772,10 @@ fn main() -> Result<()> {
         }
         Commands::SessionsRoot => {
             println!("{}", session::sessions_root());
+            Ok(())
+        }
+        Commands::EventsLogPath => {
+            println!("{}", paths::events_log().display());
             Ok(())
         }
         Commands::ResponseTopicsPath { session } => {

--- a/tools/ways-core/src/firing.rs
+++ b/tools/ways-core/src/firing.rs
@@ -8,19 +8,24 @@
 use serde_json::Value;
 use std::collections::HashMap;
 
-/// Load all firing events from the events log, one JSON object per line.
+/// Load all firing events, one JSON object per line, unioned across every
+/// existing events-log file (ADR-153 §1).
 ///
-/// A missing or unreadable log is not an error — it yields an empty vector
-/// (a fresh install simply has no firing history yet).
+/// A missing or unreadable log is not an error — it contributes nothing (a fresh
+/// install simply has no firing history yet). The union recovers `session_start`
+/// lines that older shell hooks orphaned in the legacy `~/.claude/stats` file
+/// after the XDG migration; see [`crate::paths::events_log_sources`] for why the
+/// files never overlap.
 pub fn load_events() -> Vec<Value> {
-    let path = crate::paths::events_log();
-    let content = match std::fs::read_to_string(&path) {
-        Ok(c) => c,
-        Err(_) => return Vec::new(),
-    };
-    content
-        .lines()
-        .filter_map(|line| serde_json::from_str(line).ok())
+    crate::paths::events_log_sources()
+        .iter()
+        .filter_map(|path| std::fs::read_to_string(path).ok())
+        .flat_map(|content| {
+            content
+                .lines()
+                .filter_map(|line| serde_json::from_str(line).ok())
+                .collect::<Vec<Value>>()
+        })
         .collect()
 }
 

--- a/tools/ways-core/src/firing.rs
+++ b/tools/ways-core/src/firing.rs
@@ -29,6 +29,21 @@ pub fn load_events() -> Vec<Value> {
         .collect()
 }
 
+/// Concatenated raw text of every existing events-log file (ADR-153 §1 union).
+///
+/// The line-oriented timeline reconstruction in `ways rethink` works over raw
+/// JSONL lines rather than parsed values, so it needs the text, not
+/// [`load_events`]'s `Vec<Value>`. Same union guarantee: recovers `session_start`
+/// lines orphaned in the legacy log. Files are joined with a newline; the empty
+/// line any trailing newline produces is inert to line parsers.
+pub fn load_events_text() -> String {
+    crate::paths::events_log_sources()
+        .iter()
+        .filter_map(|path| std::fs::read_to_string(path).ok())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Count `way_fired` events per way ID across the given events.
 pub fn count_fires(events: &[Value]) -> HashMap<String, u64> {
     let mut counts: HashMap<String, u64> = HashMap::new();

--- a/tools/ways-core/src/paths.rs
+++ b/tools/ways-core/src/paths.rs
@@ -243,6 +243,34 @@ fn resolve_events(state: &Path, projection: &Path) -> PathBuf {
     preferred
 }
 
+/// Every existing event-log file a reader should union, newest-canonical first
+/// (ADR-153 §1, transitional). [`events_log`] resolves the single *write* target;
+/// this resolves the set to *read*. On a migrated install where the shell hooks
+/// were still hardcoding the legacy `~/.claude/stats/events.jsonl` (pre-fix),
+/// their `session_start` lines were orphaned in the legacy file while the Rust
+/// writer moved to `$XDG_STATE`. Reading both recovers those orphaned sessions
+/// without a backfill. The migrator *moves* `stats/` (never copies), so the two
+/// files never overlap and the union is a plain concatenation — no dedup needed.
+pub fn events_log_sources() -> Vec<PathBuf> {
+    resolve_event_sources(&state_root(), &projection_root())
+}
+
+/// Pure resolution for [`events_log_sources`], factored out for testing without
+/// touching `$XDG_STATE`/`$HOME`. Returns only files that exist, preferred
+/// (`$XDG_STATE`) before legacy, and never lists the same path twice.
+fn resolve_event_sources(state: &Path, projection: &Path) -> Vec<PathBuf> {
+    let preferred = state.join("events.jsonl");
+    let legacy = projection.join("stats").join("events.jsonl");
+    let mut out = Vec::new();
+    if preferred.exists() {
+        out.push(preferred.clone());
+    }
+    if legacy.exists() && legacy != preferred {
+        out.push(legacy);
+    }
+    out
+}
+
 // --- cache ($XDG_CACHE) ---
 
 /// The embedding-engine working dir (model, corpus, manifest):
@@ -321,6 +349,35 @@ mod tests {
         // State events present → state wins (post-migration).
         std::fs::write(state.join("events.jsonl"), "{}\n").unwrap();
         assert!(resolve_events(&state, &projection).starts_with(&state));
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn event_sources_unions_state_and_orphaned_legacy() {
+        let base = std::env::temp_dir().join(format!("ways-evsrc-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let state = base.join("state");
+        let projection = base.join(".claude");
+        std::fs::create_dir_all(&state).unwrap();
+        std::fs::create_dir_all(projection.join("stats")).unwrap();
+
+        // Neither exists → empty (a reader over this is simply empty history).
+        assert!(resolve_event_sources(&state, &projection).is_empty());
+
+        // Only legacy → just legacy (un-migrated install).
+        std::fs::write(projection.join("stats/events.jsonl"), "{}\n").unwrap();
+        let only_legacy = resolve_event_sources(&state, &projection);
+        assert_eq!(only_legacy.len(), 1);
+        assert!(only_legacy[0].starts_with(&projection));
+
+        // Both present → union, preferred (state) first, legacy second. This is
+        // the post-migration orphaned-session_start case the union recovers.
+        std::fs::write(state.join("events.jsonl"), "{}\n").unwrap();
+        let both = resolve_event_sources(&state, &projection);
+        assert_eq!(both.len(), 2);
+        assert!(both[0].starts_with(&state));
+        assert!(both[1].starts_with(&projection));
 
         let _ = std::fs::remove_dir_all(&base);
     }


### PR DESCRIPTION
Increment 1 of the session-introspection work (ADR-153/154, PR #271). These are the correctness fixes that make `ways rethink` right today — independently shippable, no dependency on the later introspection increments.

## What was broken

1. **`rethink` missed post-1.0.0 sessions.** The shell hooks (`clear-markers.sh`, `inject-subagent.sh`) hardcoded the legacy `~/.claude/stats/events.jsonl` while the Rust writer and all readers resolve `paths::events_log()`, which prefers `$XDG_STATE` post-ADR-142. On migrated installs every `session_start` the hooks wrote was orphaned in the legacy file — invisible to rethink.
2. **`rethink` silently globalized.** When current-project detection returned `None` (manual run, no `CLAUDE_PROJECT_DIR`), it replayed across *all* projects instead of failing. It also filtered with a loose `project.contains(scope)` substring, so sibling paths (`/a/proj` vs `/a/proj-2`) bled together.
3. **No machine-listable session enumeration.** `--json` ignored `--list` and dumped a session; an agent had no way to enumerate sessions before picking one.

## Fixes

- **Single-writer events log + transitional union-read** (ADR-153 §1). New `ways events-log-path` subcommand (mirrors `sessions-root`) is the one canonical path every writer resolves; new `hooks/ways/events-log.sh` helper resolves it via the binary (pattern of `response-topics-path`) with a legacy fallback, and both hooks write `$EVENTS_LOG`. `paths::events_log_sources()` + `firing::load_events_text()`/`load_events()` union the `$XDG_STATE` and legacy logs so already-orphaned sessions surface without a backfill. The migrator *moves* `stats/` (never copies), so the files never overlap — no dedup needed.
- **Project scoping** (ADR-154 §4). Default current project; add `--all`; **fail loud** (naming the missing marker + remedies) instead of globalizing; compare normalized absolute paths for equality, not substring. Shared `resolve_project_scope` + `project_matches`.
- **`ways rethink --list --json`** enumerates in-scope sessions (newest first; `scope` + `count`) as structured data.

## Deployment / manifest

`events-log.sh` is git-tracked, so it ships via the existing `hooks/ways` tree symlink on `ways update` (no `settings.json` registration — it's a sourced helper like `sessions-root.sh`). The `events-log-path` subcommand is compiled into the binary that `ways update` refreshes; during any window where pulled hooks meet an old binary, the helper falls back to the legacy path (no breakage — verified against the currently-installed v1.0.5).

## Test plan

- New unit tests: `resolve_event_sources` union resolution; `project_matches` exact-not-substring; scope resolution (`--all`→all, explicit wins).
- `cargo test -p ways -p ways-core`: 198 + 7 pass; the 9 `session_sim` failures are pre-existing on `main` (environment-dependent), unchanged by this PR.
- `cargo clippy -p ways -p ways-core`: clean under `-D warnings`.
- Manually verified all four surfaces: scoped `--list --json` (now shows the live post-1.0.0 session), `--all` (1322 across projects), and both fail-loud paths (text + JSON error).

https://claude.ai/code/session_01TFyiQNDZ8RTMHX4Tnmp1wY