### PR TITLE
feat(introspection): 3a — post-hoc transcript_uuid keyed joins + ADR-153 §3 correction

### DIFF
--- a/docs/architecture/system/ADR-153-session-introspection-substrate-correlating-fired-ways-to-turns.md
+++ b/docs/architecture/system/ADR-153-session-introspection-substrate-correlating-fired-ways-to-turns.md
@@ -93,21 +93,43 @@ grain: keyed where a key exists, heuristic (time/token bucket) where it does not
 and every heuristic edge is labelled as such in the model so a consumer never
 mistakes a proximity guess for a foreign key.
 
-### 3. Enrich `way_fired` at fire time to make "why" precise
+### 3. Make "why" precise — `transcript_uuid` post-hoc, `matched_span` at fire time
 
-The precise "what caused this hook to fire" is unanswerable from today's log. Add,
-at the fire sites (`cmd/show/mod.rs`, `cmd/scan/mod.rs`):
+> **Correction (implementation finding, 2026-07-03).** The original §3 assumed the
+> fire path could record a `transcript_uuid` "because the hook receives the message
+> id on stdin." It does not: the real `UserPromptSubmit` hook payload carries only
+> `prompt`, `session_id`, `cwd`, `agent_id` — no message uuid (the prompt's uuid is
+> assigned by Claude Code, after the hook). Investigation of a live transcript found
+> a *better* source, so the two halves are sourced differently.
 
-- **`transcript_uuid`** — the triggering message id (the hook receives it on
-  stdin). Converts the heuristic time-join into a foreign key.
-- **`matched_span`** — for keyword/command/file channels, the regex/glob match
-  text. The only way to show the exact clip without transcript replay.
+- **`transcript_uuid` — resolved *post-hoc* from the transcript, not at fire
+  time.** Every `UserPromptSubmit` hook injection is recorded in the session
+  transcript as an `attachment` (its `.attachment.content` holds the injected way
+  bodies), and its `parentUuid` chain walks back to the triggering `user` message
+  (verified empirically). The introspection model reads the transcript, matches each
+  turn — its fire-timestamp cluster — to the corresponding `UserPromptSubmit`
+  attachment, and follows `parentUuid` to the user-message uuid: a genuine foreign
+  key. This is strictly better than fire-time capture — no hot-path change, and it
+  works for historical sessions whose transcript survives. Only the turn→attachment
+  step is heuristic (session + sub-second timestamp — the fire happens *inside* the
+  hook); the attachment→message link is keyed. A turn whose transcript is
+  absent/unmatched stays `Heuristic`.
+
+- **`matched_span` — recorded at fire time** (`cmd/show/*`, `cmd/scan/*`). The
+  transcript's injected content is way-*anonymous* (concatenated bodies for the
+  whole prompt), so *what text matched an individual way* cannot be recovered
+  post-hoc. For the keyword/command/file channels the fire path captures the
+  regex/glob match text — additive, forward-only (old records lack it), kept cheap
+  and line-atomic on the hot path.
+
 - Semantic stays **way-level**: `fire_score` ≥ `embed_threshold` is the honest
   grain; per-vocabulary-term attribution is impossible (one embedding per way) and
   must not be faked.
 
-Enrichment is **additive and forward-only** — old records lack the fields, the
-model marks their join heuristic, and no backfill is claimed.
+Both enrichments are **additive**: the model uses each field when present and falls
+back to the heuristic time/token-bucket grain when absent. The post-hoc transcript
+join degrades to `Heuristic` when the transcript is unavailable; `matched_span`
+claims no backfill.
 
 ### 4. Share the substrate with the compliance finding pipeline (ADR-201)
 
@@ -146,11 +168,15 @@ correlation rather than two drifting re-derivations.
   durable fix: it papers over the split-brain and re-breaks the next time a path
   moves. A single resolved writer path is the real correction (a bridging union
   read on top is fine as a transition).
-- **Reconstruct "why" purely by transcript replay, persist nothing new.** Works
-  for keyword/command (re-run the regex on the stored prompt) but fails when the
-  transcript is absent/truncated and gives no foreign key; semantic stays
-  way-level regardless. Enrichment is the only path to a precise, transcript-
-  independent "why."
+- **Reconstruct "why" purely by transcript replay, persist nothing new.** Split
+  outcome after §3's correction: transcript replay *is* the right source for the
+  **foreign key** (`transcript_uuid` via the `parentUuid` chain — a real message id
+  no fire-time capture can supply), but it *cannot* recover `matched_span` — the
+  injected content is way-anonymous, so which text matched an individual way is
+  lost. Hence the hybrid: post-hoc transcript for the key, fire-time enrichment for
+  the span. Pure replay alone also gives no "why" when the transcript is
+  absent/truncated (the join degrades to `Heuristic`), and semantic stays way-level
+  regardless.
 - **Fake semantic term-level attribution** (highlight the "matching" vocabulary
   word). Rejected: the corpus stores one vector per way; there is no matched term
   to recover. Presenting one would be a confabulated explanation — the exact

--- a/docs/design-notes/session-introspection-implementation-plan.md
+++ b/docs/design-notes/session-introspection-implementation-plan.md
@@ -57,14 +57,27 @@ The bugs that make `rethink` wrong today. Land first; delivers value alone.
   `cmd/scan/candidates.rs`'s raw extraction).
 - No UI yet — model + unit tests over sample events + a fixture transcript.
 
-### 3 — Fire-time enrichment — ADR-153 §3 (forward-only)
+### 3 — Precise "why" — ADR-153 §3 (revised: split by source)
 
-- Add `transcript_uuid` (message id from hook stdin) + `matched_span` (regex/glob
-  match for keyword/command/file) at the fire sites: `cmd/show/mod.rs:152-186`,
-  `cmd/scan/mod.rs:108`, `cmd/scan/state.rs`.
-- Keep the fire path cheap and line-atomic. Semantic stays `fire_score` only.
-- Model (increment 2) reads the new fields when present, falls back to heuristic
-  when absent.
+Investigation (2026-07-03) corrected §3: no message uuid is available at fire time
+(`UserPromptSubmit` carries none), but the transcript records each hook injection
+with a `parentUuid` chain back to its user message. So the two halves are sourced
+differently and land as two independently-shippable sub-increments:
+
+- **3a — `transcript_uuid`, post-hoc in the ways-core model (no hot path).** Read
+  the transcript, index `UserPromptSubmit` `attachment`s (their `parentUuid` walks
+  to the triggering `user` message), match each turn to its attachment by
+  session + fire-timestamp, follow to the user-message uuid, and flip that turn's
+  join `Heuristic`→`Keyed`. Absent/unmatched transcript → stays `Heuristic`. Reuse
+  the transcript-reading pattern from `context.rs`/`rethink::build_token_timeline`.
+- **3b — `matched_span`, fire-time enrichment (hot path).** The injected content is
+  way-anonymous, so *what text matched a way* must be captured when it fires. Add
+  `matched_span` for the keyword/command/file channels at the fire sites
+  (`cmd/show/mod.rs` `way_scored` log block ~155-186, via `scan/scoring.rs:179`;
+  `cmd/scan/state.rs`). Plumb the regex/glob match through `PromptMatch::Fired` →
+  `scoring.rs` → `way_scored`. Cheap, line-atomic. Semantic stays `fire_score` only.
+- Model reads each field when present, falls back to the heuristic grain when
+  absent.
 
 ### 4 — `ways introspect` surface + non-interactive dump — ADR-154 §1, §4 (agent-facing MVP)
 

--- a/tools/ways-core/src/introspection.rs
+++ b/tools/ways-core/src/introspection.rs
@@ -131,6 +131,9 @@ pub struct IntrospectionSummary {
     pub turns: usize,
     pub distinct_ways: usize,
     pub total_fires: u64,
+    /// Turns whose join was upgraded to `Keyed` by a transcript foreign key
+    /// (ADR-153 §3). `0` until [`SessionIntrospection::join_transcript`] runs.
+    pub keyed_turns: usize,
 }
 
 /// A session's introspection: its turns and the ways each fired.
@@ -209,6 +212,7 @@ impl SessionIntrospection {
             turns: turns.len(),
             distinct_ways: distinct.len(),
             total_fires,
+            keyed_turns: 0, // set by join_transcript once a transcript is joined
         };
 
         SessionIntrospection {
@@ -222,12 +226,57 @@ impl SessionIntrospection {
 
     /// Convenience: build for a session from the live event log (the increment-1
     /// union reader) and the project-aware way corpus (so a fired way resolves to
-    /// the criteria that actually fired, honoring ADR-143 override precedence).
+    /// the criteria that actually fired, honoring ADR-143 override precedence),
+    /// then upgrade the join with the session transcript when it's present.
     pub fn from_session(session_id: &str, project: &str, window_k: u64) -> Self {
         let events = crate::firing::load_events();
         let criteria = project_criteria_map(project);
-        Self::build(&events, session_id, project, window_k, &criteria)
+        let mut s = Self::build(&events, session_id, project, window_k, &criteria);
+        s.join_transcript(&crate::transcript::prompt_turns(project, session_id));
+        s
     }
+
+    /// Attach `transcript_uuid` to each turn by matching its fire timestamp to the
+    /// nearest `UserPromptSubmit` injection, flipping matched turns
+    /// `Heuristic`→`Keyed` (ADR-153 §3). The turn→injection match is the one
+    /// heuristic step (session + sub-second timestamp — the fire happens *inside*
+    /// the hook); the injection→message link the [`crate::transcript`] reader
+    /// already followed is keyed. Turns with no injection within tolerance keep
+    /// their `Heuristic` label. Passing an empty slice (absent transcript) is a
+    /// no-op — the model stays honestly heuristic.
+    pub fn join_transcript(&mut self, prompt_turns: &[crate::transcript::PromptTurn]) {
+        for turn in &mut self.turns {
+            if let Some(pt) = nearest_prompt_turn(&turn.ts, prompt_turns) {
+                turn.transcript_uuid = Some(pt.user_uuid.clone());
+                turn.join_confidence = JoinConfidence::Keyed;
+            }
+        }
+        self.summary.keyed_turns = self
+            .turns
+            .iter()
+            .filter(|t| t.join_confidence == JoinConfidence::Keyed)
+            .count();
+    }
+}
+
+/// The tolerance for matching a turn's fire timestamp to a prompt injection. The
+/// injection is recorded when the hook returns — at/just after the fires it
+/// carries — so a few seconds covers hook runtime and clock skew without reaching
+/// an adjacent prompt.
+const JOIN_TOLERANCE_SECS: u64 = 8;
+
+/// The prompt injection whose timestamp is closest to `turn_ts`, within tolerance.
+fn nearest_prompt_turn<'a>(
+    turn_ts: &str,
+    prompt_turns: &'a [crate::transcript::PromptTurn],
+) -> Option<&'a crate::transcript::PromptTurn> {
+    let turn_secs = parse_ts_secs(turn_ts);
+    prompt_turns
+        .iter()
+        .map(|pt| (pt, parse_ts_secs(&pt.ts).abs_diff(turn_secs)))
+        .filter(|(_, diff)| *diff <= JOIN_TOLERANCE_SECS)
+        .min_by_key(|(_, diff)| *diff)
+        .map(|(pt, _)| pt)
 }
 
 fn build_turn(cluster: &[&FireRow], epoch: u64, criteria: &CriteriaMap) -> Turn {
@@ -568,6 +617,38 @@ scope: subagent
         assert_eq!(todos.criteria.trigger.as_deref(), Some("context-threshold"));
 
         let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn join_transcript_keys_matching_turns_only() {
+        use crate::transcript::PromptTurn;
+        // Two turns, 5 min apart (distinct epochs).
+        let events = vec![
+            json!({"event":"way_fired","session":"s1","ts":"2026-01-01T00:00:00Z","way":"d/a","trigger":"keyword"}),
+            json!({"event":"way_fired","session":"s1","ts":"2026-01-01T00:05:00Z","way":"d/b","trigger":"keyword"}),
+        ];
+        let mut s = SessionIntrospection::build(&events, "s1", "/p", 200, &CriteriaMap::new());
+        assert_eq!(s.turns.len(), 2);
+        assert!(s.turns.iter().all(|t| t.join_confidence == JoinConfidence::Heuristic));
+
+        // One injection ~1s after the first turn; nothing near the second.
+        let pts = vec![PromptTurn {
+            ts: "2026-01-01T00:00:01Z".into(),
+            user_uuid: "user-1".into(),
+        }];
+        s.join_transcript(&pts);
+
+        assert_eq!(s.turns[0].join_confidence, JoinConfidence::Keyed);
+        assert_eq!(s.turns[0].transcript_uuid.as_deref(), Some("user-1"));
+        assert_eq!(s.turns[1].join_confidence, JoinConfidence::Heuristic, "no injection within tolerance");
+        assert_eq!(s.turns[1].transcript_uuid, None);
+        assert_eq!(s.summary.keyed_turns, 1);
+
+        // Absent transcript (empty slice) is a no-op — stays as-is.
+        let mut s2 = SessionIntrospection::build(&events, "s1", "/p", 200, &CriteriaMap::new());
+        s2.join_transcript(&[]);
+        assert_eq!(s2.summary.keyed_turns, 0);
+        assert!(s2.turns.iter().all(|t| t.join_confidence == JoinConfidence::Heuristic));
     }
 
     #[test]

--- a/tools/ways-core/src/introspection.rs
+++ b/tools/ways-core/src/introspection.rs
@@ -265,16 +265,31 @@ impl SessionIntrospection {
 /// an adjacent prompt.
 const JOIN_TOLERANCE_SECS: u64 = 8;
 
-/// The prompt injection whose timestamp is closest to `turn_ts`, within tolerance.
+/// The prompt injection whose timestamp is closest to `turn_ts`, within tolerance
+/// — but only when the match is **unambiguous**. If two prompts submitted within
+/// tolerance of each other collapse into one turn (fires ≤3s apart cluster, and a
+/// rapid re-submit can land inside that window), their injections resolve to
+/// *different* user messages; there is then no single correct key for the turn, so
+/// this returns `None` and the turn stays `Heuristic`. `Keyed` thus always means an
+/// unambiguous foreign key — never a coin-flip between two candidate messages.
 fn nearest_prompt_turn<'a>(
     turn_ts: &str,
     prompt_turns: &'a [crate::transcript::PromptTurn],
 ) -> Option<&'a crate::transcript::PromptTurn> {
     let turn_secs = parse_ts_secs(turn_ts);
-    prompt_turns
+    let in_tolerance: Vec<(&crate::transcript::PromptTurn, u64)> = prompt_turns
         .iter()
         .map(|pt| (pt, parse_ts_secs(&pt.ts).abs_diff(turn_secs)))
         .filter(|(_, diff)| *diff <= JOIN_TOLERANCE_SECS)
+        .collect();
+
+    // Ambiguity guard: ≥2 candidates pointing at different messages → don't key.
+    let distinct: HashSet<&str> = in_tolerance.iter().map(|(pt, _)| pt.user_uuid.as_str()).collect();
+    if distinct.len() > 1 {
+        return None;
+    }
+    in_tolerance
+        .into_iter()
         .min_by_key(|(_, diff)| *diff)
         .map(|(pt, _)| pt)
 }
@@ -649,6 +664,34 @@ scope: subagent
         s2.join_transcript(&[]);
         assert_eq!(s2.summary.keyed_turns, 0);
         assert!(s2.turns.iter().all(|t| t.join_confidence == JoinConfidence::Heuristic));
+    }
+
+    #[test]
+    fn join_leaves_ambiguous_turns_heuristic() {
+        use crate::transcript::PromptTurn;
+        let events = vec![
+            json!({"event":"way_fired","session":"s1","ts":"2026-01-01T00:00:00Z","way":"d/a","trigger":"keyword"}),
+        ];
+        // Two DIFFERENT prompts within tolerance of the one turn → can't attribute.
+        let ambiguous = vec![
+            PromptTurn { ts: "2026-01-01T00:00:01Z".into(), user_uuid: "user-A".into() },
+            PromptTurn { ts: "2026-01-01T00:00:02Z".into(), user_uuid: "user-B".into() },
+        ];
+        let mut s = SessionIntrospection::build(&events, "s1", "/p", 200, &CriteriaMap::new());
+        s.join_transcript(&ambiguous);
+        assert_eq!(s.turns[0].join_confidence, JoinConfidence::Heuristic, "ambiguous → not keyed");
+        assert_eq!(s.turns[0].transcript_uuid, None);
+        assert_eq!(s.summary.keyed_turns, 0);
+
+        // Two injections resolving to the SAME message are not ambiguous — key it.
+        let same = vec![
+            PromptTurn { ts: "2026-01-01T00:00:01Z".into(), user_uuid: "user-A".into() },
+            PromptTurn { ts: "2026-01-01T00:00:02Z".into(), user_uuid: "user-A".into() },
+        ];
+        let mut s2 = SessionIntrospection::build(&events, "s1", "/p", 200, &CriteriaMap::new());
+        s2.join_transcript(&same);
+        assert_eq!(s2.turns[0].join_confidence, JoinConfidence::Keyed);
+        assert_eq!(s2.turns[0].transcript_uuid.as_deref(), Some("user-A"));
     }
 
     #[test]

--- a/tools/ways-core/src/lib.rs
+++ b/tools/ways-core/src/lib.rs
@@ -21,4 +21,5 @@ pub mod introspection;
 pub mod paths;
 pub mod provenance;
 pub mod scanner;
+pub mod transcript;
 pub mod util;

--- a/tools/ways-core/src/transcript.rs
+++ b/tools/ways-core/src/transcript.rs
@@ -1,0 +1,133 @@
+//! Read-only reader for Claude-Code session transcripts (ADR-153 §3).
+//!
+//! Transcripts live at `~/.claude/projects/<slug>/<session>.jsonl`
+//! (Claude-Code-owned; agent-ways is a read-only consumer). We use them for one
+//! thing: recovering the **foreign key** the firing-event log lacks. Every
+//! `UserPromptSubmit` hook injection is recorded as an `attachment` line whose
+//! `parentUuid` chain walks back to the `user` message it augmented — so the
+//! message a set of ways was injected into is recoverable post-hoc, without any
+//! fire-time capture and even for historical sessions.
+//!
+//! This is deliberately *not* a general transcript parser: it extracts only
+//! `(timestamp, user-message uuid)` per prompt injection. Absence and truncation
+//! are normal (return empty), never an error.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// One `UserPromptSubmit` injection resolved to the user message it augmented:
+/// the injection's timestamp (for matching to a turn's fires) and the keyed
+/// user-message uuid.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PromptTurn {
+    pub ts: String,
+    pub user_uuid: String,
+}
+
+/// The transcript path for a session. Uses the lossy `/`,`.`→`-` slug Claude Code
+/// names project dirs with (matching `rethink::build_token_timeline` and
+/// `session.rs`). Session ids are globally unique, so a slug miss could also be
+/// recovered by scanning every `projects/*` dir — deferred until it's needed.
+fn transcript_path(project: &str, session_id: &str) -> PathBuf {
+    let slug = project.replace(['/', '.'], "-");
+    crate::paths::transcripts_root()
+        .join(slug)
+        .join(format!("{session_id}.jsonl"))
+}
+
+/// Resolve every `UserPromptSubmit` injection in a session's transcript to its
+/// triggering user message. Empty when the transcript is absent/unreadable.
+pub fn prompt_turns(project: &str, session_id: &str) -> Vec<PromptTurn> {
+    match std::fs::read_to_string(transcript_path(project, session_id)) {
+        Ok(content) => prompt_turns_from_str(&content),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Pure core: parse a transcript's JSONL text into resolved prompt turns.
+/// Factored out so the `parentUuid`-walk is testable against a fixture string.
+pub fn prompt_turns_from_str(content: &str) -> Vec<PromptTurn> {
+    // uuid -> (parentUuid, type). Only the fields the walk needs are retained, so
+    // even a large transcript stays light.
+    let mut parent_of: HashMap<String, (Option<String>, String)> = HashMap::new();
+    // (ts, own uuid) for each UserPromptSubmit attachment, in file order.
+    let mut injections: Vec<(String, String)> = Vec::new();
+
+    for line in content.lines() {
+        let v: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let Some(uuid) = v["uuid"].as_str() else {
+            continue;
+        };
+        let ty = v["type"].as_str().unwrap_or("").to_string();
+        let parent = v["parentUuid"].as_str().map(|s| s.to_string());
+        if ty == "attachment" && v["attachment"]["hookEvent"].as_str() == Some("UserPromptSubmit")
+        {
+            let ts = v["timestamp"].as_str().unwrap_or("").to_string();
+            injections.push((ts, uuid.to_string()));
+        }
+        parent_of.insert(uuid.to_string(), (parent, ty));
+    }
+
+    injections
+        .into_iter()
+        .filter_map(|(ts, uuid)| {
+            walk_to_user(&uuid, &parent_of).map(|user_uuid| PromptTurn { ts, user_uuid })
+        })
+        .collect()
+}
+
+/// Follow `parentUuid` from `start` back to the first `type == "user"` entry.
+/// Bounded so a malformed/cyclic chain can't loop forever.
+fn walk_to_user(start: &str, parent_of: &HashMap<String, (Option<String>, String)>) -> Option<String> {
+    let mut cur = start.to_string();
+    for _ in 0..64 {
+        let (parent, _) = parent_of.get(&cur)?;
+        let parent = parent.as_ref()?;
+        let (_, ty) = parent_of.get(parent)?;
+        if ty == "user" {
+            return Some(parent.clone());
+        }
+        cur = parent.clone();
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_ups_injection_to_its_user_message() {
+        // user message → an intervening attachment → the UserPromptSubmit
+        // injection. The parentUuid chain must walk from the injection back to
+        // the user message, skipping the intervening attachment.
+        let jsonl = [
+            r#"{"uuid":"u1","parentUuid":"a0","type":"user","timestamp":"2026-01-01T00:00:00.000Z"}"#,
+            r#"{"uuid":"mid","parentUuid":"u1","type":"attachment","timestamp":"2026-01-01T00:00:01.000Z"}"#,
+            r#"{"uuid":"ups","parentUuid":"mid","type":"attachment","timestamp":"2026-01-01T00:00:01.200Z","attachment":{"hookEvent":"UserPromptSubmit","content":"[ways]"}}"#,
+            r#"{"uuid":"asst","parentUuid":"ups","type":"assistant","timestamp":"2026-01-01T00:00:02.000Z"}"#,
+        ]
+        .join("\n");
+
+        let turns = prompt_turns_from_str(&jsonl);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].user_uuid, "u1");
+        assert_eq!(turns[0].ts, "2026-01-01T00:00:01.200Z");
+    }
+
+    #[test]
+    fn ignores_non_ups_and_unresolvable() {
+        let jsonl = [
+            // A PreToolUse hook attachment — not a prompt injection.
+            r#"{"uuid":"x","parentUuid":"u1","type":"attachment","attachment":{"hookEvent":"PreToolUse"}}"#,
+            // A UPS injection whose chain never reaches a user message.
+            r#"{"uuid":"orphan","parentUuid":"missing","type":"attachment","timestamp":"t","attachment":{"hookEvent":"UserPromptSubmit"}}"#,
+            r#"garbage-not-json"#,
+        ]
+        .join("\n");
+        assert!(prompt_turns_from_str(&jsonl).is_empty());
+    }
+}


### PR DESCRIPTION
Increment 3a of session-introspection. Investigation (see the ADR-153 §3 amendment in this PR) found the original §3 premise wrong — the `UserPromptSubmit` hook exposes no message uuid — but a **better** source: the transcript records each hook injection with a `parentUuid` chain back to its user message. So `transcript_uuid` is resolved **post-hoc from the transcript**, not at fire time.

## What this delivers

- **`ways-core::transcript`** — a read-only transcript reader that finds every `UserPromptSubmit` injection and walks its `parentUuid` chain back to the triggering `user` message (bounded against cycles). Returns `(timestamp, user-message uuid)` per prompt; absence/truncation → empty (never an error).
- **`SessionIntrospection::join_transcript`** — matches each turn to the nearest injection by session + fire timestamp (the one heuristic step: the fire happens *inside* the hook, sub-second) and flips matched turns `Heuristic`→`Keyed` with the real user-message uuid. Unmatched turns keep `Heuristic`. `from_session` wires it; summary gains `keyed_turns`.
- **ADR-153 §3 corrected** to record the post-hoc approach (+ the Alternatives entry and the implementation plan).

## Why post-hoc beats fire-time

No hot-path change, and it works for **historical sessions** whose transcript survives. The attachment→message link is a genuine keyed foreign key; only turn→injection matching is heuristic (and reliable — fires and their injection share a hook execution).

## Honesty

`Keyed` only when a real user-message uuid is found; everything else stays `Heuristic`. Semantic fires still carry only `fire_score`. Smoke on a real 269-turn session: **132 keyed (49%)** with real uuids — the other 51% are bash/file/state-triggered fires with no `UserPromptSubmit` injection to key against, correctly left heuristic rather than force-keyed.

## Test plan

- `cargo test -p ways-core`: 95 pass. New: `parentUuid`-walk (incl. non-UPS attachments + unresolvable chains + garbage lines), turn↔injection matching (keyed / out-of-tolerance / empty-transcript no-op).
- `cargo clippy -p ways-core`: clean. `cargo build --workspace`: clean.

Next: 3b (matched_span, fire-time enrichment) as a separate PR.

https://claude.ai/code/session_01TFyiQNDZ8RTMHX4Tnmp1wY