### PR TITLE
feat(introspection): 3b — matched_span fire-time enrichment (ADR-153 §3)

### DIFF
--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -105,8 +105,8 @@ pub fn prompt(query: &str, session_id: &str, project: Option<&str>) -> Result<()
             &embed_matches,
             near_miss_margin,
         ) {
-            PromptMatch::Fired { channel, score } => {
-                let out = capture_show_way(&way.id, session_id, &channel, score);
+            PromptMatch::Fired { channel, score, matched_span } => {
+                let out = capture_show_way(&way.id, session_id, &channel, score, matched_span.as_deref());
                 if !out.is_empty() {
                     context.push_str(&out);
                     context.push_str("\n\n");
@@ -244,26 +244,19 @@ pub fn command(
             continue;
         }
 
-        let mut matched = false;
+        // Commands regex first, then the description pattern — capture the span
+        // of whichever matched (ADR-153 §3).
+        let matched_span = way
+            .commands
+            .as_deref()
+            .and_then(|p| regex_span(p, cmd))
+            .or_else(|| match (description, way.pattern.as_deref()) {
+                (Some(desc), Some(pat)) => regex_span(pat, &desc.to_lowercase()),
+                _ => None,
+            });
 
-        if let Some(ref cmds_pattern) = way.commands {
-            if regex_matches(cmds_pattern, cmd) {
-                matched = true;
-            }
-        }
-
-        if !matched {
-            if let Some(desc) = description {
-                if let Some(ref pat) = way.pattern {
-                    if regex_matches(pat, &desc.to_lowercase()) {
-                        matched = true;
-                    }
-                }
-            }
-        }
-
-        if matched {
-            let out = capture_show_way(&way.id, session_id, "bash", None);
+        if let Some(span) = matched_span {
+            let out = capture_show_way(&way.id, session_id, "bash", None, Some(span.as_str()));
             if !out.is_empty() {
                 context.push_str(&out);
             }
@@ -348,8 +341,8 @@ pub fn file(filepath: &str, session_id: &str, project: Option<&str>) -> Result<(
         }
 
         if let Some(ref files_pattern) = way.files {
-            if regex_matches(files_pattern, filepath) {
-                let out = capture_show_way(&way.id, session_id, "file", None);
+            if let Some(span) = regex_span(files_pattern, filepath) {
+                let out = capture_show_way(&way.id, session_id, "file", None, Some(span.as_str()));
                 if !out.is_empty() {
                     context.push_str(&out);
                 }
@@ -411,7 +404,9 @@ enum PromptMatch {
     /// The way fired. `channel` is the trigger channel; `score` is the
     /// embedding score that cleared threshold (`None` for deterministic keyword
     /// fires) — logged onto `way_fired` for embed_threshold tuning (ADR-134 D).
-    Fired { channel: String, score: Option<f64> },
+    /// `matched_span` is the regex match text for the keyword channel (ADR-153 §3);
+    /// `None` for semantic — one embedding per way, so there is no term to recover.
+    Fired { channel: String, score: Option<f64>, matched_span: Option<String> },
     /// The way did NOT fire, but at least one model scored within
     /// `near_miss_margin` below its effective threshold (ADR-134). Carries the
     /// already-computed scores for telemetry — no new embedding is done.
@@ -442,8 +437,12 @@ fn match_prompt(
     // Channel 1: Regex pattern — deterministic, scoreless. A pattern miss is
     // never a near-miss (there is no margin to be near).
     if let Some(ref pat) = pattern {
-        if regex_matches(pat, query) {
-            return PromptMatch::Fired { channel: "keyword".to_string(), score: None };
+        if let Some(span) = regex_span(pat, query) {
+            return PromptMatch::Fired {
+                channel: "keyword".to_string(),
+                score: None,
+                matched_span: Some(span),
+            };
         }
     }
 
@@ -457,10 +456,18 @@ fn match_prompt(
     let score_multi = scores.best_multi(corpus_id);
 
     if score_en.is_some_and(|s| s >= thresholds.en) {
-        return PromptMatch::Fired { channel: "semantic:embedding:en".to_string(), score: score_en };
+        return PromptMatch::Fired {
+            channel: "semantic:embedding:en".to_string(),
+            score: score_en,
+            matched_span: None,
+        };
     }
     if score_multi.is_some_and(|s| s >= thresholds.multi) {
-        return PromptMatch::Fired { channel: "semantic:embedding:multi".to_string(), score: score_multi };
+        return PromptMatch::Fired {
+            channel: "semantic:embedding:multi".to_string(),
+            score: score_multi,
+            matched_span: None,
+        };
     }
 
     // No fire. Record a near-miss when a model landed in the band just below
@@ -600,6 +607,21 @@ fn regex_matches(pattern: &str, text: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// The first regex match in `text`, length-capped for the event log (ADR-153 §3
+/// `matched_span`). `None` if the pattern is invalid or doesn't match — mirroring
+/// [`regex_matches`]' error tolerance. The cap bounds how much of the matched
+/// input (a prompt/command/path fragment) lands in local telemetry; the pattern
+/// itself is author-controlled, so a match is normally a bounded keyword.
+fn regex_span(pattern: &str, text: &str) -> Option<String> {
+    const MAX_SPAN: usize = 120;
+    let m = Regex::new(pattern).ok()?.find(text)?;
+    let s = m.as_str();
+    Some(match s.char_indices().nth(MAX_SPAN) {
+        Some((byte, _)) => format!("{}…", &s[..byte]),
+        None => s.to_string(),
+    })
+}
+
 /// Emit accumulated context using the envelope shape required by the
 /// invoking hook event. The Claude Code hook contract treats
 /// `hookSpecificOutput` as canonical for all events; the simpler top-level
@@ -666,16 +688,18 @@ mod near_miss_tests {
         }
         // multi fire (EN below) carries the multi score, not EN's.
         match run(Some(0.20), Some(0.56), None) {
-            PromptMatch::Fired { channel, score } => {
+            PromptMatch::Fired { channel, score, matched_span } => {
                 assert_eq!(channel, "semantic:embedding:multi");
                 assert_eq!(score, Some(0.56));
+                assert_eq!(matched_span, None, "semantic carries no matched term");
             }
             _ => panic!("expected multi Fired"),
         }
         match run(Some(0.41), None, Some("query")) {
-            PromptMatch::Fired { channel, score } => {
+            PromptMatch::Fired { channel, score, matched_span } => {
                 assert_eq!(channel, "keyword");
                 assert_eq!(score, None);
+                assert_eq!(matched_span.as_deref(), Some("query"), "keyword records the regex match");
             }
             _ => panic!("expected keyword Fired"),
         }

--- a/tools/ways-cli/src/cmd/scan/scoring.rs
+++ b/tools/ways-cli/src/cmd/scan/scoring.rs
@@ -175,8 +175,10 @@ pub(crate) fn capture_show_way(
     session_id: &str,
     trigger: &str,
     fire_score: Option<f64>,
+    matched_span: Option<&str>,
 ) -> String {
-    crate::cmd::show::way_scored(id, session_id, trigger, fire_score).unwrap_or_default()
+    crate::cmd::show::way_scored(id, session_id, trigger, fire_score, matched_span)
+        .unwrap_or_default()
 }
 
 pub(crate) fn capture_show_check(id: &str, session_id: &str, trigger: &str, score: f64) -> String {

--- a/tools/ways-cli/src/cmd/scan/state.rs
+++ b/tools/ways-cli/src/cmd/scan/state.rs
@@ -109,7 +109,7 @@ pub fn state(
             }
         } else {
             // Standard one-shot: marker-gated via show
-            let out = capture_show_way(&way.id, session_id, "state", None);
+            let out = capture_show_way(&way.id, session_id, "state", None, None);
             if !out.is_empty() {
                 context.push_str(&out);
                 context.push_str("\n\n");

--- a/tools/ways-cli/src/cmd/show/mod.rs
+++ b/tools/ways-cli/src/cmd/show/mod.rs
@@ -16,7 +16,7 @@ use metrics::{compute_tree_metrics, count_siblings, git_version, dirty_status_te
 // ── ways show way ───────────────────────────────────────────────
 
 pub fn way(id: &str, session_id: &str, trigger: &str) -> Result<String> {
-    way_scored(id, session_id, trigger, None)
+    way_scored(id, session_id, trigger, None, None)
 }
 
 /// Like [`way`], but records the embedding score that caused a semantic fire
@@ -29,6 +29,7 @@ pub fn way_scored(
     session_id: &str,
     trigger: &str,
     fire_score: Option<f64>,
+    matched_span: Option<&str>,
 ) -> Result<String> {
     let project_dir = std::env::var("CLAUDE_PROJECT_DIR")
         .unwrap_or_else(|_| std::env::var("PWD").unwrap_or_else(|_| ".".to_string()));
@@ -170,6 +171,12 @@ pub fn way_scored(
     // and makes the field self-documenting: its presence marks a placement event.
     if let (false, Some(score)) = (is_redisclosure, fire_score) {
         log_fields.push(("fire_score", format!("{score:.4}")));
+    }
+    // ADR-153 §3: the deterministic-channel match text, so introspection can show
+    // *what* fired the way without transcript replay. First-fire only (a
+    // redisclosure's re-trigger is a different match); semantic never carries one.
+    if let (false, Some(span)) = (is_redisclosure, matched_span) {
+        log_fields.push(("matched_span", span.to_string()));
     }
     if let Some(ref p) = parent_id {
         log_fields.push(("parent", p.clone()));

--- a/tools/ways-cli/src/cmd/show/mod.rs
+++ b/tools/ways-cli/src/cmd/show/mod.rs
@@ -176,7 +176,12 @@ pub fn way_scored(
     // *what* fired the way without transcript replay. First-fire only (a
     // redisclosure's re-trigger is a different match); semantic never carries one.
     if let (false, Some(span)) = (is_redisclosure, matched_span) {
-        log_fields.push(("matched_span", span.to_string()));
+        // A zero-width author pattern (e.g. `^`) fires but matches an empty string;
+        // recording an empty span is pure telemetry noise, so skip it (the fire
+        // decision was already made upstream — this only gates what's logged).
+        if !span.is_empty() {
+            log_fields.push(("matched_span", span.to_string()));
+        }
     }
     if let Some(ref p) = parent_id {
         log_fields.push(("parent", p.clone()));

--- a/tools/ways-core/src/introspection.rs
+++ b/tools/ways-core/src/introspection.rs
@@ -307,7 +307,13 @@ fn build_turn(cluster: &[&FireRow], epoch: u64, criteria: &CriteriaMap) -> Turn 
                 fire_score: f.fire_score,
                 way_path: meta.path,
                 criteria: meta.criteria,
-                match_detail: None, // enrichment: increment 3
+                // The matched span is a fire-time record of exactly what hit, so
+                // it is itself Keyed when present (ADR-153 §3). Absent for semantic
+                // (no term) and for pre-enrichment records.
+                match_detail: f.matched_span.clone().map(|span| MatchDetail {
+                    matched_span: Some(span),
+                    confidence: JoinConfidence::Keyed,
+                }),
             }
         })
         .collect();
@@ -330,6 +336,7 @@ struct FireRow {
     trigger: String,
     fire_score: Option<f64>,
     token_position: u64,
+    matched_span: Option<String>,
 }
 
 impl FireRow {
@@ -341,6 +348,7 @@ impl FireRow {
             trigger: v["trigger"].as_str().unwrap_or("").to_string(),
             fire_score: str_or_num_f64(&v["fire_score"]),
             token_position: str_or_num_u64(&v["token_position"]).unwrap_or(0),
+            matched_span: v["matched_span"].as_str().map(|s| s.to_string()),
         })
     }
 }
@@ -556,7 +564,7 @@ scope: subagent
         // Two fires 1s apart (one turn), then a third 10s later (a second turn).
         // A fire from another session and a non-fire event must be excluded.
         let events = vec![
-            json!({"event":"way_fired","session":"s1","ts":"2026-01-01T00:00:00Z","way":"d/a","trigger":"keyword","token_position":"100"}),
+            json!({"event":"way_fired","session":"s1","ts":"2026-01-01T00:00:00Z","way":"d/a","trigger":"keyword","token_position":"100","matched_span":"commit"}),
             json!({"event":"way_fired","session":"s1","ts":"2026-01-01T00:00:01Z","way":"d/b","trigger":"semantic:embedding:en","fire_score":"0.73","token_position":"120"}),
             json!({"event":"way_fired","session":"s1","ts":"2026-01-01T00:00:11Z","way":"d/a","trigger":"keyword","token_position":"400"}),
             json!({"event":"way_fired","session":"other","ts":"2026-01-01T00:00:01Z","way":"d/z","trigger":"keyword"}),
@@ -588,12 +596,16 @@ scope: subagent
         assert_eq!(a.fire_score, None);
         assert_eq!(a.way_path.as_deref(), Some("/w/a.md"));
         assert_eq!(a.criteria.pattern.as_deref(), Some("aaa"));
-        assert!(a.match_detail.is_none());
+        // The recorded matched_span becomes a Keyed MatchDetail.
+        let md = a.match_detail.as_ref().expect("matched_span → match_detail");
+        assert_eq!(md.matched_span.as_deref(), Some("commit"));
+        assert_eq!(md.confidence, JoinConfidence::Keyed);
 
         let b = &t0.fired_ways[1];
         assert_eq!(b.way_id, "d/b");
         assert_eq!(b.fire_score, Some(0.73)); // parsed from string
         assert_eq!(b.criteria, MatchCriteria::default()); // unresolved → empty
+        assert!(b.match_detail.is_none(), "semantic fire has no matched span");
 
         assert_eq!(s.turns[1].epoch, 2);
         assert_eq!(s.turns[1].token_position, 400);


### PR DESCRIPTION
Increment 3b — the fire-time half of ADR-153 §3, and the last piece of increment 3. Records **what text hit** a way, for the deterministic channels, so introspection can show *why* a way fired without transcript replay.

## Changes (hot path)

- New `regex_span(pattern, text)` — the first regex match, length-capped at 120 chars. `matched_span` is threaded through `PromptMatch::Fired` → `capture_show_way` → `way_scored` → the `way_fired` log block (first-fire only, mirroring `fire_score`).
- Channels: **keyword** → the regex match against the prompt; **bash** → the matched command (else the description-pattern match); **file** → the matched filepath; **semantic** → `None` (one embedding per way — no term to recover, never faked); **state / `ways show`** → `None`.
- Model: `FireRow` parses `matched_span`; a present span becomes a **Keyed** `MatchDetail` on the `FiredWay` (a fire-time record of exactly what hit). Forward-only — old records stay match-less.

## Privacy

`matched_span` is a fragment of the prompt/command/path. It stays in the **local** events log (never transmitted), is **capped** at 120 chars, and the matching pattern is **author-controlled** (a way's `pattern`), so a match is normally a bounded keyword. The cap guards against a greedy pattern dumping prompt text.

## Verification

Smoke on a real scan (`please write an adr and commit … to git`): keyword fires recorded `' adr '` and `'commit'`; all 7 semantic fires correctly `None`. So the "why" is precise for deterministic channels and honestly empty for semantic.

## Test plan

- `cargo test -p ways -p ways-core`: ways 201 unit + 7 integration pass; ways-core passes. New: keyword-records-span + semantic-records-none (`scan/mod.rs`), event `matched_span` → Keyed `MatchDetail` + semantic none (`introspection`). The 9 `session_sim` failures are pre-existing on main (environment-dependent), unchanged.
- `cargo clippy -p ways -p ways-core`: clean. `cargo build --workspace`: clean.

Completes increment 3. Next: increment 4 (`ways introspect <replay|live|dump>` surface).

https://claude.ai/code/session_01TFyiQNDZ8RTMHX4Tnmp1wY