### PR TITLE
feat(introspect): ways introspect dump — agent-facing MVP over the model

### DIFF
--- a/tools/ways-cli/src/cmd/introspect.rs
+++ b/tools/ways-cli/src/cmd/introspect.rs
@@ -1,0 +1,63 @@
+//! `ways introspect` — the user/agent-facing surface over the ways-core
+//! `SessionIntrospection` model (ADR-154 §1). This increment ships only the
+//! non-interactive `dump` mode (the agent-facing MVP); `replay`/`live` and the
+//! why-fired drill-down follow.
+
+use anyhow::Result;
+
+use crate::cmd::{rethink, rethink_dump};
+use crate::session;
+
+/// `ways introspect dump` — emit a session's reconstructed introspection (turns,
+/// fired ways, criteria, keyed transcript join, matched spans) as JSON, so an
+/// agent can investigate *which ways fired, on which turn, and why* without a TUI.
+///
+/// Scoping mirrors `rethink`: default the current project, `--project` for a
+/// specific one, `--all` across every project (which only affects session
+/// picking). With no `--session`, the most recent session in scope is dumped.
+pub fn dump(session: Option<&str>, project: Option<&str>, all: bool) -> Result<()> {
+    let content = ways_core::firing::load_events_text();
+    if content.trim().is_empty() {
+        println!("{{\"error\":\"no events recorded yet\"}}");
+        return Ok(());
+    }
+
+    // Fail-loud scope resolution, as JSON (agent-facing).
+    let scope = match rethink::resolve_project_scope(project, all) {
+        Ok(s) => s,
+        Err(e) => {
+            println!("{{\"error\":{}}}", serde_json::to_string(&e.to_string())?);
+            return Ok(());
+        }
+    };
+
+    let session_id = match session {
+        Some(s) => s.to_string(),
+        None => match rethink_dump::most_recent_session(&content, scope.as_deref()) {
+            Some(s) => s,
+            None => {
+                println!("{{\"error\":\"no sessions found in scope\"}}");
+                return Ok(());
+            }
+        }
+    };
+
+    // Project path drives the criteria corpus and the transcript slug. Prefer the
+    // caller's scope (explicit `--project` or the detected current project) — it's
+    // authoritative — over the session's first recorded `session_start` project,
+    // which can be a stray subagent/hook cwd. The transcript reader scans by
+    // session id if the slug misses, so a wrong path here still resolves the join.
+    let project_path = scope
+        .clone()
+        .or_else(|| rethink::find_session_project(&content, &session_id))
+        .unwrap_or_default();
+    let window_k = session::detect_context_window_for(&project_path, &session_id) / 1000;
+
+    let model = ways_core::introspection::SessionIntrospection::from_session(
+        &session_id,
+        &project_path,
+        window_k,
+    );
+    println!("{}", serde_json::to_string_pretty(&model)?);
+    Ok(())
+}

--- a/tools/ways-cli/src/cmd/mod.rs
+++ b/tools/ways-cli/src/cmd/mod.rs
@@ -5,6 +5,7 @@ pub mod disable;
 pub mod embed;
 pub mod graph;
 pub mod init;
+pub mod introspect;
 pub mod language;
 pub mod lint;
 pub mod list;

--- a/tools/ways-cli/src/cmd/rethink_dump.rs
+++ b/tools/ways-cli/src/cmd/rethink_dump.rs
@@ -278,7 +278,7 @@ fn session_events<'a>(
 }
 
 /// Latest session (by session_start timestamp) within an optional project scope.
-fn most_recent_session(content: &str, scope: Option<&str>) -> Option<String> {
+pub(crate) fn most_recent_session(content: &str, scope: Option<&str>) -> Option<String> {
     let mut best: Option<(String, String)> = None; // (ts, session)
     for line in content.lines() {
         if !line.contains("session_start") {

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -271,6 +271,12 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Introspect a session over the SessionIntrospection model: which ways
+    /// fired, on which turn, and why (ADR-153/154). Currently: the `dump` mode.
+    Introspect {
+        #[command(subcommand)]
+        mode: IntrospectCommand,
+    },
     /// Engine health dashboard — binary, model, corpus, project status
     Status {
         /// Machine-readable JSON output
@@ -413,6 +419,24 @@ enum Commands {
     Settings {
         #[command(subcommand)]
         command: SettingsCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum IntrospectCommand {
+    /// Dump a session's reconstructed introspection as JSON (agent-facing MVP):
+    /// turns, fired ways, their criteria, keyed transcript join, and matched
+    /// spans. Defaults to the most recent session in the current project.
+    Dump {
+        /// Session ID to dump (default: most recent in scope)
+        #[arg(long)]
+        session: Option<String>,
+        /// Scope to this project path (default: current project)
+        #[arg(long)]
+        project: Option<String>,
+        /// Pick the session across every project, not just the current one
+        #[arg(long)]
+        all: bool,
     },
 }
 
@@ -685,6 +709,11 @@ fn main() -> Result<()> {
             (false, true) => cmd::rethink_dump::run_json(session.as_deref(), project.as_deref(), all),
             // interactive replay, or `--list` text.
             _ => cmd::rethink::run(session.as_deref(), project.as_deref(), speed, list, all),
+        },
+        Commands::Introspect { mode } => match mode {
+            IntrospectCommand::Dump { session, project, all } => {
+                cmd::introspect::dump(session.as_deref(), project.as_deref(), all)
+            }
         },
         Commands::Status { json } => cmd::status::run(json),
         Commands::Scan { mode } => match mode {

--- a/tools/ways-core/src/introspection.rs
+++ b/tools/ways-core/src/introspection.rs
@@ -499,7 +499,13 @@ pub fn default_criteria_map() -> CriteriaMap {
 
 /// The full ADR-143 corpus for a given project: project ways shadow user, user
 /// shadows core — so a fired way resolves to the criteria that actually fired.
+/// An empty `project` (unknown project) resolves user+core only — never a
+/// *relative* `.claude/ways` that would fold in whatever repo the CWD happens to
+/// be inside.
 pub fn project_criteria_map(project: &str) -> CriteriaMap {
+    if project.is_empty() {
+        return default_criteria_map();
+    }
     build_criteria_map(&[
         PathBuf::from(project).join(".claude").join("ways"),
         crate::paths::user_ways_root(),

--- a/tools/ways-core/src/transcript.rs
+++ b/tools/ways-core/src/transcript.rs
@@ -24,23 +24,36 @@ pub struct PromptTurn {
     pub user_uuid: String,
 }
 
-/// The transcript path for a session. Uses the lossy `/`,`.`→`-` slug Claude Code
-/// names project dirs with (matching `rethink::build_token_timeline` and
-/// `session.rs`). Session ids are globally unique, so a slug miss could also be
-/// recovered by scanning every `projects/*` dir — deferred until it's needed.
-fn transcript_path(project: &str, session_id: &str) -> PathBuf {
+/// Locate a session's transcript. First tries the lossy `/`,`.`→`-` slug Claude
+/// Code names project dirs with (matching `rethink::build_token_timeline` and
+/// `session.rs`); on a miss — the recorded project can differ from the dir the
+/// transcript actually lives in (subagent cwd, a `session_start` logged elsewhere)
+/// — falls back to scanning every `projects/*` dir, since session ids are globally
+/// unique. `None` if no matching transcript exists.
+fn transcript_path(project: &str, session_id: &str) -> Option<PathBuf> {
+    let root = crate::paths::transcripts_root();
+    let file = format!("{session_id}.jsonl");
+
     let slug = project.replace(['/', '.'], "-");
-    crate::paths::transcripts_root()
-        .join(slug)
-        .join(format!("{session_id}.jsonl"))
+    let direct = root.join(&slug).join(&file);
+    if direct.is_file() {
+        return Some(direct);
+    }
+
+    // Slug miss → the id is unique, so find it wherever it lives.
+    std::fs::read_dir(&root)
+        .ok()?
+        .flatten()
+        .map(|e| e.path().join(&file))
+        .find(|p| p.is_file())
 }
 
 /// Resolve every `UserPromptSubmit` injection in a session's transcript to its
 /// triggering user message. Empty when the transcript is absent/unreadable.
 pub fn prompt_turns(project: &str, session_id: &str) -> Vec<PromptTurn> {
-    match std::fs::read_to_string(transcript_path(project, session_id)) {
-        Ok(content) => prompt_turns_from_str(&content),
-        Err(_) => Vec::new(),
+    match transcript_path(project, session_id).and_then(|p| std::fs::read_to_string(p).ok()) {
+        Some(content) => prompt_turns_from_str(&content),
+        None => Vec::new(),
     }
 }
 


### PR DESCRIPTION
The first slice of increment 4 (ADR-154 §1): a user/agent-facing surface over the ways-core `SessionIntrospection` model, so everything built in increments 1–3 is usable today.

## What this adds

`ways introspect dump [--session <id>] [--project <path>] [--all]` — emits a session's reconstructed introspection as JSON: turns, fired ways, their criteria, the keyed transcript join (`transcript_uuid` + `keyed_turns`), and matched spans. Scoping mirrors `rethink` (default current project, `--project`, `--all`); no `--session` dumps the most recent in scope; fail-loud as a JSON error.

New `cmd/introspect` module + CLI wiring. The heavy lifting is all in the already-merged ways-core model — this is thin glue.

## Two fixes surfaced by end-to-end testing

- **Transcript resolution by session-id scan.** The recorded `session_start` project can be a stray subagent/hook cwd that differs from the dir the transcript actually lives in, so the lossy project-slug path missed → `keyed_turns: 0`. `transcript.rs` now falls back to scanning `projects/*` for `<session>.jsonl` (session ids are globally unique → exact). This is the "deferred until needed" fallback ADR-153 §3 anticipated.
- **Project-path precedence.** `introspect::dump` prefers the caller's scope (explicit `--project` / detected current) over `find_session_project`, fixing a misleading `project` field and a wrong criteria root.

## Verification

Dump of a real 270-turn session → **131 keyed turns** with real user-message uuids, correct `project`, matched spans where recorded (older fires predate 3b → `None`, honestly forward-only).

## Test plan

- `cargo test -p ways -p ways-core`: 201 + 7 pass; ways-core passes. `cargo clippy -p ways -p ways-core`: clean. The 9 `session_sim` failures are pre-existing on main.
- The dump command is thin IO glue; its components (model, transcript, criteria) are unit-tested. Manually verified end-to-end.

Scope: `replay`/`live` modes, the `rethink` deprecated-alias, and the `build_frames` clustering reconciliation remain for the rest of increment 4.

https://claude.ai/code/session_01TFyiQNDZ8RTMHX4Tnmp1wY