### PR TITLE
feat(introspect): complete the surface (replay/list) + deprecate rethink + hoist parse_ts_secs

### DIFF
--- a/tools/ways-cli/src/cmd/introspect.rs
+++ b/tools/ways-cli/src/cmd/introspect.rs
@@ -1,12 +1,38 @@
 //! `ways introspect` — the user/agent-facing surface over the ways-core
-//! `SessionIntrospection` model (ADR-154 §1). This increment ships only the
-//! non-interactive `dump` mode (the agent-facing MVP); `replay`/`live` and the
-//! why-fired drill-down follow.
+//! `SessionIntrospection` model (ADR-154). Modes: `replay` (interactive),
+//! `list`, `dump` (agent-facing JSON). `live` and the why-fired drill-down
+//! follow in later increments.
+//!
+//! `replay`/`list` currently delegate to the proven `rethink` pipeline
+//! (`build_frames` → TUI); re-pointing them at the `SessionIntrospection` model
+//! is deferred until the drill-down needs it, since it requires reconciling that
+//! model's fire-centric clustering with `build_frames`' full-event-stream
+//! clustering (ADR-154 §1 — not a drop-in swap). `dump` already reads the model.
 
 use anyhow::Result;
 
 use crate::cmd::{rethink, rethink_dump};
 use crate::session;
+
+/// `ways introspect replay` — interactive replay of a session's way firings.
+pub fn replay(
+    session: Option<&str>,
+    project: Option<&str>,
+    all: bool,
+    speed: Option<u64>,
+) -> Result<()> {
+    rethink::run(session, project, speed, false, all)
+}
+
+/// `ways introspect list` — enumerate candidate sessions in scope, as a table or
+/// (`--json`) machine-listable data for an agent to pick from before dumping.
+pub fn list(project: Option<&str>, all: bool, json: bool) -> Result<()> {
+    if json {
+        rethink_dump::run_list_json(project, all)
+    } else {
+        rethink::run(None, project, None, true, all)
+    }
+}
 
 /// `ways introspect dump` — emit a session's reconstructed introspection (turns,
 /// fired ways, criteria, keyed transcript join, matched spans) as JSON, so an

--- a/tools/ways-cli/src/cmd/rethink.rs
+++ b/tools/ways-cli/src/cmd/rethink.rs
@@ -19,7 +19,7 @@ use std::io::Write;
 
 use crate::cmd::render::{self, WayRow};
 use crate::session;
-use crate::util::{detect_project_dir, home_dir};
+use crate::util::{detect_project_dir, home_dir, parse_ts_secs};
 
 // ── Data structures ───────────────────────────────────────────
 
@@ -927,20 +927,6 @@ fn format_duration(secs: u64) -> String {
     }
 }
 
-fn parse_ts_secs(ts: &str) -> u64 {
-    if ts.len() < 19 {
-        return 0;
-    }
-    let year: u64 = ts[0..4].parse().unwrap_or(0);
-    let month: u64 = ts[5..7].parse().unwrap_or(0);
-    let day: u64 = ts[8..10].parse().unwrap_or(0);
-    let hour: u64 = ts[11..13].parse().unwrap_or(0);
-    let min: u64 = ts[14..16].parse().unwrap_or(0);
-    let sec: u64 = ts[17..19].parse().unwrap_or(0);
-
-    let days = year * 365 + year / 4 + month * 30 + day;
-    days * 86400 + hour * 3600 + min * 60 + sec
-}
 
 /// Fit rendered output to terminal dimensions.
 /// Uses \r\n because raw mode requires explicit carriage return.

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -424,7 +424,34 @@ enum Commands {
 
 #[derive(Subcommand)]
 enum IntrospectCommand {
-    /// Dump a session's reconstructed introspection as JSON (agent-facing MVP):
+    /// Interactively replay a session's way firings (the animated TUI).
+    Replay {
+        /// Session ID to replay directly (default: pick interactively)
+        #[arg(long)]
+        session: Option<String>,
+        /// Scope to this project path (default: current project)
+        #[arg(long)]
+        project: Option<String>,
+        /// Consider sessions from every project, not just the current one
+        #[arg(long)]
+        all: bool,
+        /// Initial frame speed in milliseconds (default: 1000)
+        #[arg(long)]
+        speed: Option<u64>,
+    },
+    /// List candidate sessions in scope (table, or `--json` for an agent).
+    List {
+        /// Scope to this project path (default: current project)
+        #[arg(long)]
+        project: Option<String>,
+        /// List sessions from every project, not just the current one
+        #[arg(long)]
+        all: bool,
+        /// Machine-readable JSON output
+        #[arg(long)]
+        json: bool,
+    },
+    /// Dump a session's reconstructed introspection as JSON (agent-facing):
     /// turns, fired ways, their criteria, keyed transcript join, and matched
     /// spans. Defaults to the most recent session in the current project.
     Dump {
@@ -702,15 +729,27 @@ fn main() -> Result<()> {
         Commands::Reconcile { source, dest, mode, dry_run, quiet } => {
             cmd::reconcile::run(source, dest, mode, dry_run, quiet, false)
         }
-        Commands::Rethink { session, project, all, speed, list, json } => match (list, json) {
-            // `--list --json`: machine-listable session enumeration (ADR-154 §4).
-            (true, true) => cmd::rethink_dump::run_list_json(project.as_deref(), all),
-            // `--json`: dump one session's reconstructed timeline.
-            (false, true) => cmd::rethink_dump::run_json(session.as_deref(), project.as_deref(), all),
-            // interactive replay, or `--list` text.
-            _ => cmd::rethink::run(session.as_deref(), project.as_deref(), speed, list, all),
-        },
+        Commands::Rethink { session, project, all, speed, list, json } => {
+            eprintln!(
+                "note: `ways rethink` is deprecated — use `ways introspect replay` \
+                 (or `introspect list` / `introspect dump`). It still works for now."
+            );
+            match (list, json) {
+                // `--list --json`: machine-listable session enumeration (ADR-154 §4).
+                (true, true) => cmd::rethink_dump::run_list_json(project.as_deref(), all),
+                // `--json`: dump one session's reconstructed timeline.
+                (false, true) => cmd::rethink_dump::run_json(session.as_deref(), project.as_deref(), all),
+                // interactive replay, or `--list` text.
+                _ => cmd::rethink::run(session.as_deref(), project.as_deref(), speed, list, all),
+            }
+        }
         Commands::Introspect { mode } => match mode {
+            IntrospectCommand::Replay { session, project, all, speed } => {
+                cmd::introspect::replay(session.as_deref(), project.as_deref(), all, speed)
+            }
+            IntrospectCommand::List { project, all, json } => {
+                cmd::introspect::list(project.as_deref(), all, json)
+            }
             IntrospectCommand::Dump { session, project, all } => {
                 cmd::introspect::dump(session.as_deref(), project.as_deref(), all)
             }

--- a/tools/ways-core/src/introspection.rs
+++ b/tools/ways-core/src/introspection.rs
@@ -32,6 +32,7 @@
 //! Increment 4 must reconcile these where the surfaces need to agree — it cannot
 //! assume a drop-in swap.
 
+use crate::util::parse_ts_secs;
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
@@ -359,23 +360,6 @@ fn str_or_num_f64(v: &Value) -> Option<f64> {
 
 fn str_or_num_u64(v: &Value) -> Option<u64> {
     v.as_str().and_then(|s| s.parse().ok()).or_else(|| v.as_u64())
-}
-
-/// Timestamp → seconds, for gap clustering. Mirrors `rethink::parse_ts_secs`:
-/// an approximate monotonic-enough encoding (dep-free; not calendar-exact), which
-/// is all the `≤3s` gap test needs. Increment 4 can hoist a single copy.
-fn parse_ts_secs(ts: &str) -> u64 {
-    if ts.len() < 19 {
-        return 0;
-    }
-    let year: u64 = ts[0..4].parse().unwrap_or(0);
-    let month: u64 = ts[5..7].parse().unwrap_or(0);
-    let day: u64 = ts[8..10].parse().unwrap_or(0);
-    let hour: u64 = ts[11..13].parse().unwrap_or(0);
-    let min: u64 = ts[14..16].parse().unwrap_or(0);
-    let sec: u64 = ts[17..19].parse().unwrap_or(0);
-    let days = year * 365 + year / 4 + month * 30 + day;
-    days * 86400 + hour * 3600 + min * 60 + sec
 }
 
 // ── Criteria parsing ──────────────────────────────────────────

--- a/tools/ways-core/src/util.rs
+++ b/tools/ways-core/src/util.rs
@@ -44,6 +44,32 @@ pub fn path_to_id(rel: &Path) -> String {
         .join("/")
 }
 
+/// Parse an ISO-8601 timestamp (`YYYY-MM-DDThh:mm:ss…`) to approximate epoch
+/// seconds — enough for gap and nearest-neighbour comparisons within a session
+/// (the introspection turn clustering and the transcript join). Calendar-correct
+/// on month/year boundaries (cumulative month days + leap years), so adjacent days
+/// never collide the way a naive `month*30` does. The absolute base is arbitrary;
+/// only differences are meaningful, and both sides route through here.
+pub fn parse_ts_secs(ts: &str) -> u64 {
+    if ts.len() < 19 {
+        return 0;
+    }
+    let field = |a: usize, b: usize| ts.get(a..b).and_then(|s| s.parse::<u64>().ok()).unwrap_or(0);
+    let (year, month, day) = (field(0, 4), field(5, 7), field(8, 10));
+    let (hour, min, sec) = (field(11, 13), field(14, 16), field(17, 19));
+
+    // Days before the 1st of each month in a non-leap year.
+    const CUM: [u64; 12] = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+    let m = (month.clamp(1, 12) - 1) as usize;
+    let leap_days = |y: u64| y / 4 - y / 100 + y / 400; // leap days in years [1, y]
+    let is_leap = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+    let mut days = year * 365 + leap_days(year.saturating_sub(1)) + CUM[m] + day;
+    if m >= 2 && is_leap {
+        days += 1; // this year's Feb-29 precedes March onward
+    }
+    days * 86_400 + hour * 3_600 + min * 60 + sec
+}
+
 /// Encode a real project path into the namespace key that prefixes
 /// project-local way IDs in the corpus.
 ///
@@ -215,6 +241,21 @@ pub fn days_to_ymd(days: u64) -> (u64, u64, u64) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_ts_secs_diffs_are_calendar_correct() {
+        let s = parse_ts_secs;
+        // Same second → equal; a 3s gap is exactly 3.
+        assert_eq!(s("2026-07-03T01:02:03Z"), s("2026-07-03T01:02:03.999Z"));
+        assert_eq!(s("2026-07-03T01:02:06Z") - s("2026-07-03T01:02:03Z"), 3);
+        // Adjacent days across a month boundary differ by exactly one day — the
+        // month*30 bug reported Jan31≡Feb01 (diff 0) here.
+        assert_eq!(s("2026-02-01T00:00:00Z") - s("2026-01-31T00:00:00Z"), 86_400);
+        // Leap year: Feb has 29 days, so Mar 1 is one day after Feb 29 (2024).
+        assert_eq!(s("2024-03-01T00:00:00Z") - s("2024-02-29T00:00:00Z"), 86_400);
+        // Too-short input degrades to 0, not a panic.
+        assert_eq!(s("2026-07"), 0);
+    }
 
     #[test]
     fn days_to_ymd_known_dates() {


### PR DESCRIPTION
Rounds out increment 4's non-interactive surface (ADR-154 §4). Builds on the merged dump MVP.

## Changes

- **`ways introspect <replay|list|dump>`** — `replay` (interactive TUI) and `list` (table or `--json`) join the shipped `dump`. `replay`/`list` delegate to the proven `rethink` pipeline for now; re-pointing them at the `SessionIntrospection` model is deferred until the drill-down needs it (it requires reconciling the model's fire-centric clustering with `build_frames`' full-event-stream clustering — ADR-154 flagged this as not-a-drop-in-swap). `dump` reads the model.
- **`ways rethink` deprecated** — now prints a stderr notice pointing at `introspect replay`; still fully works.
- **`parse_ts_secs` hoisted** to one ways-core `util` copy, made **calendar-correct** (cumulative month days + leap years). Removes the duplicate in `rethink.rs` + `introspection.rs` and fixes the month-boundary `abs_diff` collision noted in the 3a review (`Jan31 ≡ Feb01`). Within-second diffs — all the clustering and the transcript join actually use — are unchanged.

## Test plan

- `cargo test -p ways -p ways-core`: ways 201 + 7, ways-core 97 (new `parse_ts_secs_diffs_are_calendar_correct`). `cargo clippy -p ways -p ways-core`: clean.
- Smoke: `introspect list --json` returns the scoped session; `rethink` emits the deprecation notice on stderr and still runs.
- The 9 `session_sim` failures are pre-existing on main (environment-dependent).

Remaining for increment 4/5: re-point `replay` at the model (with the clustering reconciliation), the why-fired drill-down TUI, and `introspect live`.

https://claude.ai/code/session_01TFyiQNDZ8RTMHX4Tnmp1wY