### PR TITLE
feat(introspect): why-fired drill-down + micro-compositor (increment 5)

### DIFF
--- a/docs/architecture/system/ADR-154-rethink-think-and-non-interactive-introspection-one-model-three-front-ends.md
+++ b/docs/architecture/system/ADR-154-rethink-think-and-non-interactive-introspection-one-model-three-front-ends.md
@@ -61,6 +61,24 @@ Generalize the proven triplet into a module (mirroring the `cmd/scan`,
   - **drill-down** — a selection/tab loop compositing model panels, shared by
     `replay` and `live`.
 
+**Model ↔ replay-timeline boundary (resolved 2026-07-03).** The
+`SessionIntrospection` model and `rethink::build_frames` are **two distinct
+views, not one clustering** — and are deliberately kept that way rather than
+unified. `build_frames` is the *animation* projection: it folds the full event
+stream (`way_fired` + `check_fired` + `way_redisclosed`) into cumulative
+"what's active at epoch N" frames, and drives `replay`'s timeline. The model is
+the *analytical* substrate: per-turn fired-way deltas joined to `MatchCriteria`,
+`matched_span`, and the transcript key, and it drives `dump` and the drill-down's
+"why" panel. The drill-down bridges them **by `way_id`** — focus a way in a
+`build_frames` frame, and its detail is looked up in the model by id — so their
+divergent epoch numbering never has to be reconciled. This preserves the proven
+replay timeline untouched, keeps the model scoped to the fire stream (ADR-153),
+and confines the JSON-vs-TUI drift the model guards against to the two surfaces
+that actually share it (`dump` and the drill-down), both of which read the model.
+Converging `build_frames` onto the model was rejected: it would load the
+fire-stream substrate with cumulative-state, redisclosure, refire-threshold, and
+token-timeline concerns that belong to the animation view alone.
+
 ### 2. Keep crossterm; grow a small micro-compositor — do not adopt ratatui
 
 Build a ~200–400-line internal compositor over the existing ANSI-`String` panels:

--- a/tools/ways-cli/src/cmd/compositor.rs
+++ b/tools/ways-cli/src/cmd/compositor.rs
@@ -1,0 +1,328 @@
+//! Micro-compositor for terminal panels (ADR-154 §2).
+//!
+//! A tiny layout layer over the ANSI-`String` panels that `cmd/render` already
+//! produces. A [`Panel`] is a list of ANSI-styled lines plus its visible width;
+//! the helpers place panels side by side ([`hjoin`]), scroll a panel to a
+//! fixed-height viewport ([`Panel::viewport`]), and render a [`tab_bar`]. This is
+//! the deliberate zero-dependency alternative to ratatui (ADR-154 §2), right-sized
+//! for "list-left / detail-right with independent scroll" and "table + status bar"
+//! — the shapes the introspect drill-down needs. If the inspector ever grows to
+//! need text selection or resizable/mouse panes, the ADR's escape hatch to ratatui
+//! applies; short of that, this stays.
+//!
+//! It owns the canonical ANSI-visible-width primitives ([`visible_len`],
+//! [`truncate_visible`], [`pad_visible`]) that `render.rs` (`ansi_pad`/
+//! `ansi_visible_len`) and `rethink.rs` (`truncate_visible`) each grew their own
+//! copies of. Width is measured in `char`s, ignoring SGR escapes — the same grain
+//! those callers already use; East-Asian double-width and combining marks are not
+//! accounted for (that would need a new dependency the lean binary declines).
+
+use std::fmt::Write;
+
+// ── ANSI-visible-width primitives ─────────────────────────────
+
+/// Visible length of `s` in `char`s, ignoring ANSI escape sequences (`\x1b[…X`,
+/// terminated by an ASCII letter — covers the SGR color codes our panels use).
+pub fn visible_len(s: &str) -> usize {
+    let mut len = 0;
+    let mut in_escape = false;
+    for c in s.chars() {
+        if in_escape {
+            if c.is_ascii_alphabetic() {
+                in_escape = false;
+            }
+        } else if c == '\x1b' {
+            in_escape = true;
+        } else {
+            len += 1;
+        }
+    }
+    len
+}
+
+/// Truncate `s` to at most `max` **visible** chars, preserving ANSI escapes
+/// (escape bytes don't count toward the budget). If truncation cuts the string
+/// mid-style, a reset (`\x1b[0m`) is appended so styling can't bleed past the cut.
+pub fn truncate_visible(s: &str, max: usize) -> String {
+    let mut result = String::new();
+    let mut visible = 0;
+    let mut in_escape = false;
+    let mut truncated = false;
+
+    for c in s.chars() {
+        if in_escape {
+            result.push(c);
+            if c.is_ascii_alphabetic() {
+                in_escape = false;
+            }
+            continue;
+        }
+        if c == '\x1b' {
+            in_escape = true;
+            result.push(c);
+            continue;
+        }
+        if visible >= max {
+            truncated = true;
+            break;
+        }
+        result.push(c);
+        visible += 1;
+    }
+    if truncated && result.contains('\x1b') {
+        result.push_str("\x1b[0m");
+    }
+    result
+}
+
+/// Right-pad `s` with spaces to a fixed visible `width`. Never truncates — a line
+/// already wider than `width` is returned unchanged (use [`truncate_visible`]
+/// first if a hard cap is needed).
+pub fn pad_visible(s: &str, width: usize) -> String {
+    let vis = visible_len(s);
+    if vis >= width {
+        s.to_string()
+    } else {
+        format!("{s}{}", " ".repeat(width - vis))
+    }
+}
+
+/// Fit `s` to exactly `width` visible chars: truncate if longer, pad if shorter.
+pub fn fit_visible(s: &str, width: usize) -> String {
+    pad_visible(&truncate_visible(s, width), width)
+}
+
+// ── Panel ─────────────────────────────────────────────────────
+
+/// A rectangular block of ANSI-styled text: its `lines` and their common visible
+/// `width`. Construction records the width so downstream placement doesn't have to
+/// re-measure the whole block.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Panel {
+    pub lines: Vec<String>,
+    pub width: usize,
+}
+
+impl Panel {
+    /// A panel from raw lines; `width` is the widest line's visible length.
+    pub fn from_lines(lines: Vec<String>) -> Self {
+        let width = lines.iter().map(|l| visible_len(l)).max().unwrap_or(0);
+        Panel { lines, width }
+    }
+
+    /// A panel from a `\n`-separated block (e.g. a `render.rs` buffer). A trailing
+    /// newline does not add a blank final line.
+    pub fn from_text(text: &str) -> Self {
+        Self::from_lines(text.lines().map(str::to_string).collect())
+    }
+
+    /// Override the panel's declared `width` — the column width [`hjoin`] pads and
+    /// truncates each line to. Use when a column must hold a fixed width regardless
+    /// of content, so a side-by-side divider stays put across frames and long lines
+    /// are clipped to the column instead of overflowing it.
+    pub fn fixed_width(mut self, width: usize) -> Self {
+        self.width = width;
+        self
+    }
+
+    pub fn height(&self) -> usize {
+        self.lines.len()
+    }
+
+    /// A fixed-height viewport onto this panel: exactly `height` lines starting
+    /// `offset` lines down, blank-padded if the content is shorter or the offset
+    /// runs past the end. Width is preserved, so viewports of unequal-length panels
+    /// still align when placed side by side. `offset` is clamped to a valid start.
+    pub fn viewport(&self, offset: usize, height: usize) -> Panel {
+        let offset = offset.min(self.max_scroll(height));
+        let mut lines: Vec<String> = self
+            .lines
+            .iter()
+            .skip(offset)
+            .take(height)
+            .cloned()
+            .collect();
+        while lines.len() < height {
+            lines.push(String::new());
+        }
+        Panel { lines, width: self.width }
+    }
+
+    /// The largest scroll offset that still shows content in a `view_h`-tall
+    /// viewport (`0` when the panel fits). Callers clamp their own scroll state to
+    /// this so paging can't strand the viewport past the end.
+    pub fn max_scroll(&self, view_h: usize) -> usize {
+        self.height().saturating_sub(view_h)
+    }
+}
+
+// ── Placement ─────────────────────────────────────────────────
+
+/// Place `panels` side by side with `gap` spaces between columns, returning the
+/// composited lines. Each panel's lines are padded to its own `width` so columns
+/// stay aligned; a panel shorter than the tallest contributes blank rows for its
+/// missing lines. Give panels equal height first (via [`Panel::viewport`]) when a
+/// stable frame is wanted.
+pub fn hjoin(panels: &[Panel], gap: usize) -> Vec<String> {
+    let rows = panels.iter().map(Panel::height).max().unwrap_or(0);
+    let spacer = " ".repeat(gap);
+    (0..rows)
+        .map(|r| {
+            panels
+                .iter()
+                .map(|p| {
+                    let line = p.lines.get(r).map(String::as_str).unwrap_or("");
+                    fit_visible(line, p.width)
+                })
+                .collect::<Vec<_>>()
+                .join(&spacer)
+        })
+        .collect()
+}
+
+/// Two-panel convenience over [`hjoin`].
+pub fn hjoin2(left: &Panel, right: &Panel, gap: usize) -> Vec<String> {
+    hjoin(&[left.clone(), right.clone()], gap)
+}
+
+// ── Tab bar ───────────────────────────────────────────────────
+
+/// A one-line tab bar: each label padded with a space on each side, the `active`
+/// index shown in reverse video (`\x1b[7m`), the rest dim (`\x1b[2m`). Out-of-range
+/// `active` simply highlights nothing.
+pub fn tab_bar(tabs: &[&str], active: usize) -> String {
+    let mut out = String::new();
+    for (i, label) in tabs.iter().enumerate() {
+        if i == active {
+            let _ = write!(out, "\x1b[7m {label} \x1b[0m");
+        } else {
+            let _ = write!(out, "\x1b[2m {label} \x1b[0m");
+        }
+    }
+    out
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RED: &str = "\x1b[0;31m";
+    const RST: &str = "\x1b[0m";
+
+    #[test]
+    fn visible_len_ignores_ansi() {
+        assert_eq!(visible_len("abc"), 3);
+        assert_eq!(visible_len(&format!("{RED}abc{RST}")), 3);
+        assert_eq!(visible_len(""), 0);
+        // Truecolor SGR (ends in 'm') is fully skipped.
+        assert_eq!(visible_len("\x1b[38;2;99;179;237m●\x1b[0m"), 1);
+    }
+
+    #[test]
+    fn truncate_visible_counts_only_visible_and_seals_style() {
+        assert_eq!(truncate_visible("abcdef", 3), "abc");
+        assert_eq!(truncate_visible("abc", 10), "abc"); // shorter → unchanged
+        // Styled content truncated mid-style gets a reset appended.
+        let t = truncate_visible(&format!("{RED}abcdef{RST}"), 3);
+        assert_eq!(visible_len(&t), 3);
+        assert!(t.ends_with(RST), "truncation must seal the style: {t:?}");
+        // Not truncated → no extra reset beyond the original.
+        let whole = truncate_visible(&format!("{RED}ab{RST}"), 5);
+        assert_eq!(whole, format!("{RED}ab{RST}"));
+    }
+
+    #[test]
+    fn pad_and_fit_reach_exact_visible_width() {
+        assert_eq!(pad_visible("ab", 5), "ab   ");
+        assert_eq!(visible_len(&pad_visible(&format!("{RED}ab{RST}"), 5)), 5);
+        assert_eq!(pad_visible("abcde", 3), "abcde"); // wider → unchanged
+        // fit both truncates and pads to land exactly on width.
+        assert_eq!(visible_len(&fit_visible("abcdef", 4)), 4);
+        assert_eq!(visible_len(&fit_visible("ab", 4)), 4);
+    }
+
+    #[test]
+    fn panel_from_lines_measures_widest() {
+        let p = Panel::from_lines(vec!["a".into(), "abcd".into(), "ab".into()]);
+        assert_eq!(p.width, 4);
+        assert_eq!(p.height(), 3);
+        // ANSI doesn't inflate the measured width.
+        let styled = Panel::from_lines(vec![format!("{RED}abc{RST}")]);
+        assert_eq!(styled.width, 3);
+    }
+
+    #[test]
+    fn from_text_no_trailing_blank() {
+        let p = Panel::from_text("one\ntwo\n");
+        assert_eq!(p.lines, vec!["one", "two"]);
+    }
+
+    #[test]
+    fn fixed_width_overrides_measured_and_hjoin_clips_to_it() {
+        // A content-measured width of 4, forced down to 2.
+        let p = Panel::from_lines(vec!["abcd".into()]).fixed_width(2);
+        assert_eq!(p.width, 2);
+        // hjoin then truncates the over-long line to the forced column width.
+        let rows = hjoin(&[p], 0);
+        assert_eq!(rows[0], "ab");
+        // Forced wider than content pads out to the column.
+        let wide = Panel::from_lines(vec!["x".into()]).fixed_width(4);
+        assert_eq!(hjoin(&[wide], 0)[0], "x   ");
+    }
+
+    #[test]
+    fn viewport_is_fixed_height_and_clamps_offset() {
+        let p = Panel::from_lines((0..5).map(|i| i.to_string()).collect());
+        // Window in the middle.
+        let v = p.viewport(1, 3);
+        assert_eq!(v.lines, vec!["1", "2", "3"]);
+        assert_eq!(v.width, 1);
+        // Shorter content → blank-padded to the requested height.
+        let short = Panel::from_lines(vec!["x".into()]);
+        let vs = short.viewport(0, 3);
+        assert_eq!(vs.lines, vec!["x", "", ""]);
+        // Offset past the end is clamped so content still shows.
+        let clamped = p.viewport(99, 2);
+        assert_eq!(clamped.lines, vec!["3", "4"]);
+    }
+
+    #[test]
+    fn max_scroll_bounds_paging() {
+        let p = Panel::from_lines((0..5).map(|i| i.to_string()).collect());
+        assert_eq!(p.max_scroll(3), 2); // 5 lines, 3-tall view → last start is 2
+        assert_eq!(p.max_scroll(5), 0); // exactly fits
+        assert_eq!(p.max_scroll(10), 0); // taller than content
+    }
+
+    #[test]
+    fn hjoin_aligns_columns_and_pads_short_panel() {
+        let left = Panel::from_lines(vec!["aa".into(), "b".into()]);
+        let right = Panel::from_lines(vec!["1".into(), "22".into(), "3".into()]);
+        let rows = hjoin(&[left, right], 1);
+        assert_eq!(rows.len(), 3, "tallest panel sets the row count");
+        // Left padded to width 2, one space gap, right padded to width 2.
+        assert_eq!(rows[0], "aa 1 ");
+        assert_eq!(rows[1], "b  22");
+        assert_eq!(rows[2], "   3 "); // left ran out → blank of its width
+    }
+
+    #[test]
+    fn hjoin_keeps_alignment_under_ansi() {
+        let left = Panel::from_lines(vec![format!("{RED}aa{RST}")]);
+        let right = Panel::from_lines(vec!["z".into()]);
+        let rows = hjoin(&[left, right], 2);
+        // Visible width: 2 (left) + 2 (gap) + 1 (right) = 5.
+        assert_eq!(visible_len(&rows[0]), 5);
+    }
+
+    #[test]
+    fn tab_bar_highlights_active_only() {
+        let bar = tab_bar(&["Replay", "Why"], 1);
+        assert!(bar.contains("\x1b[7m Why \x1b[0m"), "active is reversed");
+        assert!(bar.contains("\x1b[2m Replay \x1b[0m"), "inactive is dim");
+        // Out-of-range active highlights nothing (no reverse-video sequence).
+        assert!(!tab_bar(&["a", "b"], 9).contains("\x1b[7m"));
+    }
+}

--- a/tools/ways-cli/src/cmd/compositor.rs
+++ b/tools/ways-cli/src/cmd/compositor.rs
@@ -10,12 +10,13 @@
 //! need text selection or resizable/mouse panes, the ADR's escape hatch to ratatui
 //! applies; short of that, this stays.
 //!
-//! It owns the canonical ANSI-visible-width primitives ([`visible_len`],
-//! [`truncate_visible`], [`pad_visible`]) that `render.rs` (`ansi_pad`/
-//! `ansi_visible_len`) and `rethink.rs` (`truncate_visible`) each grew their own
-//! copies of. Width is measured in `char`s, ignoring SGR escapes — the same grain
-//! those callers already use; East-Asian double-width and combining marks are not
-//! accounted for (that would need a new dependency the lean binary declines).
+//! It provides ANSI-visible-width primitives ([`visible_len`], [`truncate_visible`],
+//! [`pad_visible`]) meant as the canonical home for that logic — `render.rs`
+//! (`ansi_pad`/`ansi_visible_len`) and `rethink.rs` (`truncate_visible`) still carry
+//! their own older copies, which can migrate here in a follow-up. Width is measured
+//! in `char`s, ignoring SGR escapes — the same grain those callers already use;
+//! East-Asian double-width and combining marks are not accounted for (that would
+//! need a new dependency the lean binary declines).
 
 use std::fmt::Write;
 

--- a/tools/ways-cli/src/cmd/mod.rs
+++ b/tools/ways-cli/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub mod banner;
+pub mod compositor;
 pub mod context;
 pub mod corpus;
 pub mod disable;

--- a/tools/ways-cli/src/cmd/rethink.rs
+++ b/tools/ways-cli/src/cmd/rethink.rs
@@ -431,10 +431,8 @@ fn handle_why_key(player: &mut Player, key: KeyEvent) {
 
 // ── Why-fired drill-down (ADR-154 §1, §2) ─────────────────────
 
-/// Per-way "why it fired", aggregated from the `SessionIntrospection` model across
-/// all of the way's fires in the session. Keyed by `way_id` — the join the
-/// drill-down uses, per the ADR-154 §1 boundary (no epoch alignment). Criteria are
-/// way-level (identical across a way's fires); matched spans are collected distinctly.
+/// One channel's "why it fired" for a way, aggregated from the model across the
+/// way's fires *on that channel*. Matched spans are collected distinctly.
 #[cfg(feature = "tui")]
 struct WhyEntry {
     way_path: Option<String>,
@@ -444,16 +442,29 @@ struct WhyEntry {
     matched_spans: Vec<String>,
 }
 
+/// Index key: `(way_id, trigger_channel)`. A single way commonly fires on several
+/// channels in one session (verified against the event log: e.g. `documentation`
+/// fires bash + file + keyword + semantic). Each channel is its own coherent facet —
+/// its own score and matched spans. Folding them into one `way_id` entry would let a
+/// keyword span be shown under a semantic trigger, fabricating a semantic matched
+/// term (the forbidden case, ADR-153). Keying by channel keeps each facet honest;
+/// the drill-down looks up the channel the focused frame shows for that way. Still a
+/// way_id-based join (no epoch alignment) per the ADR-154 §1 boundary — just at
+/// channel granularity.
 #[cfg(feature = "tui")]
-type WhyIndex = HashMap<String, WhyEntry>;
+type WhyKey = (String, String);
 
-/// Fold the model's per-turn fired-ways into a `way_id → WhyEntry` index.
+#[cfg(feature = "tui")]
+type WhyIndex = HashMap<WhyKey, WhyEntry>;
+
+/// Fold the model's per-turn fired-ways into a `(way_id, channel) → WhyEntry` index.
 #[cfg(feature = "tui")]
 fn build_why_index(model: &SessionIntrospection) -> WhyIndex {
     let mut idx: WhyIndex = HashMap::new();
     for turn in &model.turns {
         for fw in &turn.fired_ways {
-            let e = idx.entry(fw.way_id.clone()).or_insert_with(|| WhyEntry {
+            let key = (fw.way_id.clone(), fw.trigger_channel.clone());
+            let e = idx.entry(key).or_insert_with(|| WhyEntry {
                 way_path: fw.way_path.clone(),
                 trigger_channel: fw.trigger_channel.clone(),
                 fire_score: fw.fire_score,
@@ -470,17 +481,33 @@ fn build_why_index(model: &SessionIntrospection) -> WhyIndex {
     idx
 }
 
-/// Read a way file's body (everything after a leading frontmatter fence).
+/// Read a way file's body: everything after a leading `---`/`---` frontmatter
+/// block. Line-based so a body that legitimately opens with a markdown list (`- …`)
+/// or a `---` rule is preserved. A file with no opening fence, or an unterminated
+/// fence, is returned whole (nothing is silently dropped).
 #[cfg(feature = "tui")]
 fn read_way_body(path: &str) -> Option<String> {
     let content = std::fs::read_to_string(path).ok()?;
-    let body = match content.strip_prefix("---\n") {
-        Some(rest) => match rest.find("\n---") {
-            Some(end) => rest[end + 4..].trim_start_matches(['\n', '-']).to_string(),
-            None => content,
-        },
-        None => content,
-    };
+    let mut lines = content.lines();
+    if lines.next() != Some("---") {
+        return Some(content); // no opening fence — treat all as body
+    }
+    let mut in_frontmatter = true;
+    let mut body = String::new();
+    for line in lines {
+        if in_frontmatter {
+            if line == "---" {
+                in_frontmatter = false; // consume the closing fence line
+            }
+            continue;
+        }
+        body.push_str(line);
+        body.push('\n');
+    }
+    // Unterminated frontmatter (no closing fence) → don't drop the whole file.
+    if in_frontmatter {
+        return Some(content);
+    }
     Some(body)
 }
 
@@ -590,10 +617,15 @@ fn render_why(player: &mut Player) -> String {
         let frame = &player.frames[player.current];
         epoch = frame.epoch;
 
+        // Look up the model facet for the channel this frame shows the way on, so a
+        // multi-channel way's detail is coherent (a keyword span never surfaces under
+        // a semantic trigger).
+        let facet = |w: &ActiveWay| idx.get(&(w.id.clone(), w.trigger.clone()));
+
         let mut left_lines: Vec<String> = Vec::with_capacity(frame.ways.len());
         for (i, w) in frame.ways.iter().enumerate() {
-            // A filled bullet marks a way the model has a fire record for.
-            let bullet = if idx.contains_key(&w.id) { "•" } else { "·" };
+            // A filled bullet marks a way the model has a fire record for on this channel.
+            let bullet = if facet(w).is_some() { "•" } else { "·" };
             let line = format!("{bullet} {}", w.id);
             if i == sel {
                 left_lines.push(format!("\x1b[7m{}\x1b[0m", compositor::fit_visible(&line, left_w)));
@@ -608,7 +640,7 @@ fn render_why(player: &mut Player) -> String {
         let detail = frame
             .ways
             .get(sel)
-            .map(|w| render_why_detail(&w.id, idx.get(&w.id)))
+            .map(|w| render_why_detail(&w.id, facet(w)))
             .unwrap_or_else(|| "\x1b[2mno ways fired in this frame\x1b[0m".to_string());
 
         (
@@ -1374,18 +1406,41 @@ mod why_tests {
         }
     }
 
+    fn key(way: &str, channel: &str) -> WhyKey {
+        (way.to_string(), channel.to_string())
+    }
+
     #[test]
-    fn why_index_folds_fires_and_dedups_spans() {
+    fn why_index_keys_by_channel_and_dedups_spans() {
         let m = model(vec![
             vec![fired("d/a", "keyword", Some("commit"), None)],
             vec![
-                fired("d/a", "keyword", Some("commit"), None), // dup span across turns
+                fired("d/a", "keyword", Some("commit"), None), // dup span, same channel
                 fired("d/a", "keyword", Some("stage"), None),  // new span
             ],
         ]);
         let idx = build_why_index(&m);
-        let e = idx.get("d/a").expect("way indexed");
-        assert_eq!(e.matched_spans, vec!["commit", "stage"], "deduped, in first-seen order");
+        let e = idx.get(&key("d/a", "keyword")).expect("keyed by (way, channel)");
+        assert_eq!(e.matched_spans, vec!["commit", "stage"], "deduped, first-seen order");
+    }
+
+    #[test]
+    fn multichannel_way_keeps_each_facet_honest() {
+        // The real hole (verified common in the event log): a way fires BOTH
+        // semantically and by keyword in one session. The semantic facet must never
+        // borrow the keyword fire's span (that would fabricate a semantic term).
+        let idx = build_why_index(&model(vec![
+            vec![fired("d/doc", "semantic:embedding:en", None, Some(0.71))], // semantic first
+            vec![fired("d/doc", "keyword", Some("diataxis"), None)],         // keyword later
+        ]));
+
+        let sem = render_why_detail("d/doc", idx.get(&key("d/doc", "semantic:embedding:en")));
+        assert!(sem.contains("no recoverable term"), "semantic facet stays term-free: {sem}");
+        assert!(!sem.contains("diataxis"), "keyword span must NOT appear under semantic");
+        assert!(sem.contains("score 0.71"));
+
+        let kw = render_why_detail("d/doc", idx.get(&key("d/doc", "keyword")));
+        assert!(kw.contains("diataxis"), "keyword facet shows its own real span");
     }
 
     #[test]
@@ -1394,7 +1449,7 @@ mod why_tests {
         let sem = build_why_index(&model(vec![vec![fired(
             "d/s", "semantic:embedding:en", None, Some(0.73),
         )]]));
-        let out = render_why_detail("d/s", sem.get("d/s"));
+        let out = render_why_detail("d/s", sem.get(&key("d/s", "semantic:embedding:en")));
         assert!(out.contains("no recoverable term"), "semantic honesty: {out}");
         assert!(out.contains("score 0.73"));
 
@@ -1402,15 +1457,36 @@ mod why_tests {
         let kw = build_why_index(&model(vec![vec![fired(
             "d/k", "keyword", Some("threat model"), None,
         )]]));
-        assert!(render_why_detail("d/k", kw.get("d/k")).contains("threat model"));
+        assert!(render_why_detail("d/k", kw.get(&key("d/k", "keyword"))).contains("threat model"));
 
         // Keyword fire, no span (pre-enrichment) → says so, invents nothing.
         let none = build_why_index(&model(vec![vec![fired("d/n", "keyword", None, None)]]));
-        assert!(render_why_detail("d/n", none.get("d/n")).contains("no span recorded"));
+        assert!(render_why_detail("d/n", none.get(&key("d/n", "keyword"))).contains("no span recorded"));
     }
 
     #[test]
     fn detail_handles_way_with_no_model_record() {
         assert!(render_why_detail("d/x", None).contains("no fire record"));
+    }
+
+    #[test]
+    fn read_way_body_preserves_leading_dashes_and_handles_edges() {
+        let base = std::env::temp_dir().join(format!("ways-body-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&base);
+        let write_read = |name: &str, content: &str| {
+            let p = base.join(name);
+            std::fs::write(&p, content).unwrap();
+            read_way_body(p.to_str().unwrap()).unwrap()
+        };
+        // A body opening with a markdown list keeps its leading dashes.
+        assert_eq!(
+            write_read("list.md", "---\ndescription: d\n---\n- one\n- two\n"),
+            "- one\n- two\n"
+        );
+        // Empty frontmatter → body is everything after the closing fence.
+        assert_eq!(write_read("empty.md", "---\n---\nbody line\n"), "body line\n");
+        // No opening fence → the whole file is the body.
+        assert_eq!(write_read("nofm.md", "just text\nmore\n"), "just text\nmore\n");
+        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/tools/ways-cli/src/cmd/rethink.rs
+++ b/tools/ways-cli/src/cmd/rethink.rs
@@ -21,6 +21,11 @@ use crate::cmd::render::{self, WayRow};
 use crate::session;
 use crate::util::{detect_project_dir, home_dir, parse_ts_secs};
 
+#[cfg(feature = "tui")]
+use crate::cmd::compositor::{self, Panel};
+#[cfg(feature = "tui")]
+use ways_core::introspection::{MatchCriteria, SessionIntrospection};
+
 // ── Data structures ───────────────────────────────────────────
 
 /// A way event from events.jsonl.
@@ -64,6 +69,15 @@ pub(crate) struct Frame {
     pub(crate) new_events: Vec<String>,
 }
 
+/// Which view the replay shows. `Timeline` is the cumulative frame table; `WhyFired`
+/// is the drill-down that joins the current frame's ways to the `SessionIntrospection`
+/// model by `way_id` (ADR-154 §1 boundary — no epoch alignment).
+#[derive(Clone, Copy, PartialEq)]
+enum View {
+    Timeline,
+    WhyFired,
+}
+
 /// Playback state.
 struct Player {
     frames: Vec<Frame>,
@@ -71,9 +85,20 @@ struct Player {
     playing: bool,
     speed_idx: usize,
     session_id: String,
+    project_name: String,
     context_window_k: u64,
     term_width: u16,
     term_height: u16,
+    /// Current view; the drill-down state below is only meaningful in `WhyFired`.
+    view: View,
+    /// The per-way "why" index, built lazily on first entry to the drill-down so a
+    /// plain replay never pays for the model + transcript read.
+    #[cfg(feature = "tui")]
+    why_index: Option<WhyIndex>,
+    /// Which fired way of the current frame is focused in the drill-down.
+    why_selected: usize,
+    /// Scroll offset into the focused way's detail panel.
+    why_detail_scroll: usize,
 }
 
 const SPEEDS: &[(u64, &str)] = &[
@@ -217,9 +242,14 @@ pub fn run(
         playing: false,
         speed_idx,
         session_id,
+        project_name,
         context_window_k,
         term_width,
         term_height,
+        view: View::Timeline,
+        why_index: None,
+        why_selected: 0,
+        why_detail_scroll: 0,
     };
 
     run_tui(&mut player)
@@ -264,7 +294,10 @@ fn tui_loop(player: &mut Player) -> Result<()> {
             player.term_height = h;
         }
 
-        let raw_output = render_frame(player);
+        let raw_output = match player.view {
+            View::Timeline => render_frame(player),
+            View::WhyFired => render_why(player),
+        };
         let output = fit_to_terminal(&raw_output, player.term_width as usize, player.term_height as usize);
         execute!(stdout, cursor::MoveTo(0, 0), terminal::Clear(ClearType::All))?;
         write!(stdout, "{output}")?;
@@ -278,59 +311,29 @@ fn tui_loop(player: &mut Player) -> Result<()> {
 
         if event::poll(timeout)? {
             if let Event::Key(key) = event::read()? {
+                // Global keys, then per-view dispatch.
                 match key {
                     KeyEvent { code: KeyCode::Esc, .. }
                     | KeyEvent { code: KeyCode::Char('q'), .. } => break,
 
                     KeyEvent { code: KeyCode::Char('c'), modifiers: KeyModifiers::CONTROL, .. } => break,
 
-                    KeyEvent { code: KeyCode::Right, .. }
-                    | KeyEvent { code: KeyCode::Char('l'), .. } => {
+                    // Tab toggles the why-fired drill-down. Entering it pauses
+                    // playback and starts the focus at the top of the frame's ways.
+                    KeyEvent { code: KeyCode::Tab, .. } => {
+                        player.view = match player.view {
+                            View::Timeline => View::WhyFired,
+                            View::WhyFired => View::Timeline,
+                        };
                         player.playing = false;
-                        if player.current < player.frames.len() - 1 {
-                            player.current += 1;
-                        }
+                        player.why_selected = 0;
+                        player.why_detail_scroll = 0;
                     }
 
-                    KeyEvent { code: KeyCode::Left, .. }
-                    | KeyEvent { code: KeyCode::Char('h'), .. } => {
-                        player.playing = false;
-                        if player.current > 0 {
-                            player.current -= 1;
-                        }
-                    }
-
-                    KeyEvent { code: KeyCode::Char(' '), .. } => {
-                        player.playing = !player.playing;
-                    }
-
-                    KeyEvent { code: KeyCode::Up, .. }
-                    | KeyEvent { code: KeyCode::Char('k'), .. } => {
-                        if player.speed_idx < SPEEDS.len() - 1 {
-                            player.speed_idx += 1;
-                        }
-                    }
-
-                    KeyEvent { code: KeyCode::Down, .. }
-                    | KeyEvent { code: KeyCode::Char('j'), .. } => {
-                        if player.speed_idx > 0 {
-                            player.speed_idx -= 1;
-                        }
-                    }
-
-                    KeyEvent { code: KeyCode::Home, .. }
-                    | KeyEvent { code: KeyCode::Char('g'), .. } => {
-                        player.current = 0;
-                        player.playing = false;
-                    }
-
-                    KeyEvent { code: KeyCode::End, .. }
-                    | KeyEvent { code: KeyCode::Char('G'), .. } => {
-                        player.current = player.frames.len() - 1;
-                        player.playing = false;
-                    }
-
-                    _ => {}
+                    _ => match player.view {
+                        View::Timeline => handle_timeline_key(player, key),
+                        View::WhyFired => handle_why_key(player, key),
+                    },
                 }
             }
         } else if player.playing {
@@ -342,6 +345,311 @@ fn tui_loop(player: &mut Player) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Timeline-view keys: frame navigation, play/pause, and speed.
+#[cfg(feature = "tui")]
+fn handle_timeline_key(player: &mut Player, key: KeyEvent) {
+    match key {
+        KeyEvent { code: KeyCode::Right, .. } | KeyEvent { code: KeyCode::Char('l'), .. } => {
+            player.playing = false;
+            if player.current < player.frames.len() - 1 {
+                player.current += 1;
+            }
+        }
+        KeyEvent { code: KeyCode::Left, .. } | KeyEvent { code: KeyCode::Char('h'), .. } => {
+            player.playing = false;
+            if player.current > 0 {
+                player.current -= 1;
+            }
+        }
+        KeyEvent { code: KeyCode::Char(' '), .. } => player.playing = !player.playing,
+        KeyEvent { code: KeyCode::Up, .. } | KeyEvent { code: KeyCode::Char('k'), .. } => {
+            if player.speed_idx < SPEEDS.len() - 1 {
+                player.speed_idx += 1;
+            }
+        }
+        KeyEvent { code: KeyCode::Down, .. } | KeyEvent { code: KeyCode::Char('j'), .. } => {
+            if player.speed_idx > 0 {
+                player.speed_idx -= 1;
+            }
+        }
+        KeyEvent { code: KeyCode::Home, .. } | KeyEvent { code: KeyCode::Char('g'), .. } => {
+            player.current = 0;
+            player.playing = false;
+        }
+        KeyEvent { code: KeyCode::End, .. } | KeyEvent { code: KeyCode::Char('G'), .. } => {
+            player.current = player.frames.len() - 1;
+            player.playing = false;
+        }
+        _ => {}
+    }
+}
+
+/// Drill-down keys: ▲▼ select a fired way, ◀▶ move between frames without leaving
+/// the drill-down, PgUp/PgDn (or `[`/`]`) scroll the detail panel.
+#[cfg(feature = "tui")]
+fn handle_why_key(player: &mut Player, key: KeyEvent) {
+    let ways_len = player.frames[player.current].ways.len();
+    match key {
+        KeyEvent { code: KeyCode::Up, .. } | KeyEvent { code: KeyCode::Char('k'), .. } => {
+            player.why_selected = player.why_selected.saturating_sub(1);
+            player.why_detail_scroll = 0;
+        }
+        KeyEvent { code: KeyCode::Down, .. } | KeyEvent { code: KeyCode::Char('j'), .. } => {
+            if player.why_selected + 1 < ways_len {
+                player.why_selected += 1;
+            }
+            player.why_detail_scroll = 0;
+        }
+        KeyEvent { code: KeyCode::Right, .. } | KeyEvent { code: KeyCode::Char('l'), .. } => {
+            if player.current < player.frames.len() - 1 {
+                player.current += 1;
+            }
+            player.why_selected = 0;
+            player.why_detail_scroll = 0;
+        }
+        KeyEvent { code: KeyCode::Left, .. } | KeyEvent { code: KeyCode::Char('h'), .. } => {
+            if player.current > 0 {
+                player.current -= 1;
+            }
+            player.why_selected = 0;
+            player.why_detail_scroll = 0;
+        }
+        KeyEvent { code: KeyCode::PageDown, .. } | KeyEvent { code: KeyCode::Char(']'), .. } => {
+            player.why_detail_scroll = player.why_detail_scroll.saturating_add(5);
+        }
+        KeyEvent { code: KeyCode::PageUp, .. } | KeyEvent { code: KeyCode::Char('['), .. } => {
+            player.why_detail_scroll = player.why_detail_scroll.saturating_sub(5);
+        }
+        KeyEvent { code: KeyCode::Home, .. } | KeyEvent { code: KeyCode::Char('g'), .. } => {
+            player.why_detail_scroll = 0;
+        }
+        _ => {}
+    }
+}
+
+// ── Why-fired drill-down (ADR-154 §1, §2) ─────────────────────
+
+/// Per-way "why it fired", aggregated from the `SessionIntrospection` model across
+/// all of the way's fires in the session. Keyed by `way_id` — the join the
+/// drill-down uses, per the ADR-154 §1 boundary (no epoch alignment). Criteria are
+/// way-level (identical across a way's fires); matched spans are collected distinctly.
+#[cfg(feature = "tui")]
+struct WhyEntry {
+    way_path: Option<String>,
+    trigger_channel: String,
+    fire_score: Option<f64>,
+    criteria: MatchCriteria,
+    matched_spans: Vec<String>,
+}
+
+#[cfg(feature = "tui")]
+type WhyIndex = HashMap<String, WhyEntry>;
+
+/// Fold the model's per-turn fired-ways into a `way_id → WhyEntry` index.
+#[cfg(feature = "tui")]
+fn build_why_index(model: &SessionIntrospection) -> WhyIndex {
+    let mut idx: WhyIndex = HashMap::new();
+    for turn in &model.turns {
+        for fw in &turn.fired_ways {
+            let e = idx.entry(fw.way_id.clone()).or_insert_with(|| WhyEntry {
+                way_path: fw.way_path.clone(),
+                trigger_channel: fw.trigger_channel.clone(),
+                fire_score: fw.fire_score,
+                criteria: fw.criteria.clone(),
+                matched_spans: Vec::new(),
+            });
+            if let Some(span) = fw.match_detail.as_ref().and_then(|m| m.matched_span.clone()) {
+                if !e.matched_spans.contains(&span) {
+                    e.matched_spans.push(span);
+                }
+            }
+        }
+    }
+    idx
+}
+
+/// Read a way file's body (everything after a leading frontmatter fence).
+#[cfg(feature = "tui")]
+fn read_way_body(path: &str) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let body = match content.strip_prefix("---\n") {
+        Some(rest) => match rest.find("\n---") {
+            Some(end) => rest[end + 4..].trim_start_matches(['\n', '-']).to_string(),
+            None => content,
+        },
+        None => content,
+    };
+    Some(body)
+}
+
+/// Render the detail panel for one way: its trigger, resolved `MatchCriteria`, the
+/// matched spans (or an honest note when there's no recoverable term), and the way
+/// body a human would read. `None` entry means the frame's way has no model record.
+#[cfg(feature = "tui")]
+fn render_why_detail(way_id: &str, entry: Option<&WhyEntry>) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "\x1b[1m{way_id}\x1b[0m");
+    let Some(e) = entry else {
+        let _ = writeln!(out, "\x1b[2mno fire record in the model for this way\x1b[0m");
+        return out;
+    };
+    if let Some(p) = &e.way_path {
+        let _ = writeln!(out, "\x1b[2m{p}\x1b[0m");
+    }
+    let _ = writeln!(out);
+
+    let channel = render::format_trigger(&e.trigger_channel);
+    match e.fire_score {
+        Some(s) => {
+            let _ = writeln!(out, "\x1b[1mTrigger\x1b[0m  {channel}  \x1b[2m(score {s:.2})\x1b[0m");
+        }
+        None => {
+            let _ = writeln!(out, "\x1b[1mTrigger\x1b[0m  {channel}");
+        }
+    }
+
+    let _ = writeln!(out, "\x1b[1mCriteria\x1b[0m");
+    let c = &e.criteria;
+    let mut wrote = false;
+    for (label, val) in [
+        ("pattern", &c.pattern),
+        ("commands", &c.commands),
+        ("files", &c.files),
+        ("trigger", &c.trigger),
+        ("vocabulary", &c.vocabulary),
+        ("scope", &c.scope),
+    ] {
+        if let Some(v) = val {
+            let _ = writeln!(out, "  \x1b[2m{label}:\x1b[0m {v}");
+            wrote = true;
+        }
+    }
+    if let Some(t) = c.embed_threshold {
+        let _ = writeln!(out, "  \x1b[2membed_threshold:\x1b[0m {t}");
+        wrote = true;
+    }
+    if !wrote {
+        let _ = writeln!(out, "  \x1b[2m(none recorded)\x1b[0m");
+    }
+
+    let _ = writeln!(out);
+    let _ = writeln!(out, "\x1b[1mMatched\x1b[0m");
+    if e.matched_spans.is_empty() {
+        if e.trigger_channel.starts_with("semantic") {
+            let _ = writeln!(out, "  \x1b[2msemantic fire — matched by embedding; no recoverable term\x1b[0m");
+        } else {
+            let _ = writeln!(out, "  \x1b[2mno span recorded (fired before matched-span enrichment)\x1b[0m");
+        }
+    } else {
+        for span in &e.matched_spans {
+            let _ = writeln!(out, "  \x1b[0;36m“{span}”\x1b[0m");
+        }
+    }
+
+    if let Some(body) = e.way_path.as_deref().and_then(read_way_body) {
+        let _ = writeln!(out);
+        let _ = writeln!(out, "\x1b[2m── way ─────────────\x1b[0m");
+        for line in body.lines() {
+            let _ = writeln!(out, "{line}");
+        }
+    }
+    out
+}
+
+/// Render the why-fired drill-down: the current frame's fired ways on the left,
+/// the selected way's model-derived detail on the right, composed with the
+/// micro-compositor (ADR-154 §2). The model index is built lazily on first entry.
+#[cfg(feature = "tui")]
+fn render_why(player: &mut Player) -> String {
+    if player.why_index.is_none() {
+        let model = SessionIntrospection::from_session(
+            &player.session_id,
+            &player.project_name,
+            player.context_window_k,
+        );
+        player.why_index = Some(build_why_index(&model));
+    }
+
+    let ways_len = player.frames[player.current].ways.len();
+    let sel = player.why_selected.min(ways_len.saturating_sub(1));
+    player.why_selected = sel;
+
+    let total_w = player.term_width as usize;
+    let body_h = (player.term_height as usize).saturating_sub(6).max(3);
+    let gap = 2;
+    let left_w = (total_w / 3).clamp(16, 40).min(total_w.saturating_sub(gap + 12).max(16));
+    let right_w = total_w.saturating_sub(left_w + gap).max(12);
+
+    // Build both panels while borrowing the index + frame, then drop those borrows
+    // before the scroll write-backs below.
+    let epoch;
+    let (left, right) = {
+        let idx = player.why_index.as_ref().unwrap();
+        let frame = &player.frames[player.current];
+        epoch = frame.epoch;
+
+        let mut left_lines: Vec<String> = Vec::with_capacity(frame.ways.len());
+        for (i, w) in frame.ways.iter().enumerate() {
+            // A filled bullet marks a way the model has a fire record for.
+            let bullet = if idx.contains_key(&w.id) { "•" } else { "·" };
+            let line = format!("{bullet} {}", w.id);
+            if i == sel {
+                left_lines.push(format!("\x1b[7m{}\x1b[0m", compositor::fit_visible(&line, left_w)));
+            } else {
+                left_lines.push(line);
+            }
+        }
+        if left_lines.is_empty() {
+            left_lines.push("\x1b[2m(no ways in this frame)\x1b[0m".to_string());
+        }
+
+        let detail = frame
+            .ways
+            .get(sel)
+            .map(|w| render_why_detail(&w.id, idx.get(&w.id)))
+            .unwrap_or_else(|| "\x1b[2mno ways fired in this frame\x1b[0m".to_string());
+
+        (
+            Panel::from_lines(left_lines).fixed_width(left_w),
+            Panel::from_text(&detail).fixed_width(right_w),
+        )
+    };
+
+    let detail_scroll = player.why_detail_scroll.min(right.max_scroll(body_h));
+    player.why_detail_scroll = detail_scroll;
+    let left_scroll = sel
+        .saturating_sub(body_h.saturating_sub(1))
+        .min(left.max_scroll(body_h));
+
+    let composited = compositor::hjoin2(
+        &left.viewport(left_scroll, body_h),
+        &right.viewport(detail_scroll, body_h),
+        gap,
+    );
+
+    let mut out = String::new();
+    let short_id = &player.session_id[..player.session_id.len().min(12)];
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "{}  \x1b[2mSession {short_id}… · epoch {epoch} · frame {}/{}\x1b[0m",
+        compositor::tab_bar(&["Timeline", "Why fired"], 1),
+        player.current + 1,
+        player.frames.len(),
+    );
+    let _ = writeln!(out);
+    for line in composited {
+        let _ = writeln!(out, "{line}");
+    }
+    let _ = writeln!(out);
+    let _ = writeln!(out, "\x1b[2m{}\x1b[0m", "─".repeat(total_w.min(85)));
+    let _ = write!(
+        out,
+        " \x1b[7m ▲▼ \x1b[0m way  \x1b[7m ◀ ▶ \x1b[0m frame  \x1b[7m PgUp/Dn \x1b[0m scroll  \x1b[7m tab \x1b[0m timeline  \x1b[7m esc \x1b[0m quit"
+    );
+    out
 }
 
 // ── Frame renderer ────────────────────────────────────────────
@@ -1019,5 +1327,90 @@ mod tests {
             resolve_project_scope(Some("/home/a/proj"), false).unwrap(),
             Some("/home/a/proj".to_string())
         );
+    }
+}
+
+// Drill-down "why" folding + rendering (the join-honesty-critical part).
+#[cfg(all(test, feature = "tui"))]
+mod why_tests {
+    use super::*;
+    use ways_core::introspection::{
+        FiredWay, IntrospectionSummary, JoinConfidence, MatchCriteria, MatchDetail,
+        SessionIntrospection, Turn,
+    };
+
+    fn fired(way: &str, channel: &str, span: Option<&str>, score: Option<f64>) -> FiredWay {
+        FiredWay {
+            way_id: way.into(),
+            trigger_channel: channel.into(),
+            fire_score: score,
+            way_path: None,
+            criteria: MatchCriteria { pattern: Some("p".into()), ..Default::default() },
+            match_detail: span.map(|s| MatchDetail {
+                matched_span: Some(s.into()),
+                confidence: JoinConfidence::Keyed,
+            }),
+        }
+    }
+
+    fn model(turns_ways: Vec<Vec<FiredWay>>) -> SessionIntrospection {
+        let turns = turns_ways
+            .into_iter()
+            .map(|fired_ways| Turn {
+                epoch: 1,
+                token_position: 0,
+                ts: "2026-01-01T00:00:00Z".into(),
+                transcript_uuid: None,
+                join_confidence: JoinConfidence::Heuristic,
+                fired_ways,
+            })
+            .collect();
+        SessionIntrospection {
+            id: "s".into(),
+            project: "/p".into(),
+            window_k: 200,
+            summary: IntrospectionSummary::default(),
+            turns,
+        }
+    }
+
+    #[test]
+    fn why_index_folds_fires_and_dedups_spans() {
+        let m = model(vec![
+            vec![fired("d/a", "keyword", Some("commit"), None)],
+            vec![
+                fired("d/a", "keyword", Some("commit"), None), // dup span across turns
+                fired("d/a", "keyword", Some("stage"), None),  // new span
+            ],
+        ]);
+        let idx = build_why_index(&m);
+        let e = idx.get("d/a").expect("way indexed");
+        assert_eq!(e.matched_spans, vec!["commit", "stage"], "deduped, in first-seen order");
+    }
+
+    #[test]
+    fn detail_labels_semantic_and_missing_spans_honestly() {
+        // Semantic fire → names the embedding + score, never a fabricated term.
+        let sem = build_why_index(&model(vec![vec![fired(
+            "d/s", "semantic:embedding:en", None, Some(0.73),
+        )]]));
+        let out = render_why_detail("d/s", sem.get("d/s"));
+        assert!(out.contains("no recoverable term"), "semantic honesty: {out}");
+        assert!(out.contains("score 0.73"));
+
+        // Keyword fire with a span → shows the quoted span.
+        let kw = build_why_index(&model(vec![vec![fired(
+            "d/k", "keyword", Some("threat model"), None,
+        )]]));
+        assert!(render_why_detail("d/k", kw.get("d/k")).contains("threat model"));
+
+        // Keyword fire, no span (pre-enrichment) → says so, invents nothing.
+        let none = build_why_index(&model(vec![vec![fired("d/n", "keyword", None, None)]]));
+        assert!(render_why_detail("d/n", none.get("d/n")).contains("no span recorded"));
+    }
+
+    #[test]
+    fn detail_handles_way_with_no_model_record() {
+        assert!(render_why_detail("d/x", None).contains("no fire record"));
     }
 }

--- a/tools/ways-core/src/introspection.rs
+++ b/tools/ways-core/src/introspection.rs
@@ -18,19 +18,24 @@
 //! [`FiredWay::fire_score`]. `match_detail` will carry a span only for the
 //! keyword/command/file channels, and only once enrichment records it.
 //!
-//! This increment builds the model + the join from the event log; it does not yet
-//! rewire the `rethink` replay pipeline (still in `ways-cli`) to consume it — that
-//! convergence is increment 4.
+//! This model is the *analytical* substrate (why a way fired: criteria, matched
+//! span, transcript key). The `rethink` **replay** pipeline (still in `ways-cli`)
+//! stays a distinct *animation* projection — `build_frames` folds the full event
+//! stream into cumulative "what's active at epoch N" frames. The two are **not**
+//! unified into one clustering (decided 2026-07-03, ADR-153 module note / ADR-154
+//! §1): they are different views serving different jobs, joined only where they
+//! meet — the why-fired drill-down looks up a frame's focused way in this model
+//! **by `way_id`**, which needs no epoch alignment.
 //!
 //! **The clustering shares the `≤3s` gap *rule* with `rethink::build_frames`, but
-//! is not identical to it** — the two are reconciled at increment 4, not assumed
-//! equivalent now. Deliberate differences: this model clusters the *fire* stream
-//! only (a [`Turn`] is defined by the ways that fired, not by `session_start` /
+//! is deliberately not identical to it** — and, per the boundary above, is not
+//! meant to be. Deliberate differences: this model clusters the *fire* stream only
+//! (a [`Turn`] is defined by the ways that fired, not by the `session_start` /
 //! `way_redisclosed` events the replay also folds in), sorts by timestamp, numbers
 //! epochs over fire-bearing clusters only, and takes each turn's token position
 //! from the event's own recorded value rather than a transcript-timeline lookup.
-//! Increment 4 must reconcile these where the surfaces need to agree — it cannot
-//! assume a drop-in swap.
+//! A consumer that needs the cumulative timeline reads `build_frames`; one that
+//! needs the per-turn "why" reads this model; the drill-down bridges them by id.
 
 use crate::util::parse_ts_secs;
 use serde::Serialize;


### PR DESCRIPTION
## Summary

Increment 5 of the session-introspection arc (ADR-153/154): the **why-fired drill-down** over the `SessionIntrospection` model, plus the **micro-compositor** it's built on. Tab into `ways introspect replay` (or the `rethink` alias), focus a fired way, and read *why* it fired — its trigger, resolved `MatchCriteria`, the matched span, and the way body.

## What's here

- **The model↔replay-timeline boundary, recorded** (ADR-154 §1 + the `introspection.rs` module note that promised "reconciled at increment 4"). Resolution: `build_frames` (cumulative animation) and the model (per-turn analytical substrate) are **two distinct views, joined at the drill-down by `way_id`** — *not* one clustering unified. No epoch alignment; the proven replay timeline is untouched. Converging them was considered and rejected (it would load the fire-stream substrate with animation concerns).
- **`cmd/compositor.rs`** — the ADR-154 §2 micro-compositor: a `Panel` (`Vec<String>` + visible width) with a fixed-height viewport, an `hjoin` side-by-side placer, a `tab_bar`, and the canonical ANSI-visible-width primitives (`visible_len`/`truncate_visible`/`pad_visible`/`fit_visible`) that `render.rs` and `rethink.rs` each grew local copies of. **Zero new deps** — the deliberate alternative to ratatui.
- **The drill-down in `rethink.rs`** — a `View` enum + drill-down state on `Player`; Tab toggles Timeline↔Why; the `way_id → criteria/spans/path` index is built **lazily** on first entry so a plain replay never pays for it. ▲▼ select a way, ◀▶ move frames without leaving the view, PgUp/Dn scroll the detail.

## Join honesty (load-bearing)

- Semantic fires show `fire_score` + "no recoverable term" — **never a fabricated matched term** (one embedding per way).
- A keyword/file fire with no recorded span says so, rather than inventing one.

Covered by `why_tests` (semantic vs keyword-with-span vs no-span, span dedup) and the compositor unit tests.

## Test plan

- `cargo test -p ways -p ways-core` — 215 unit + 11 compositor + 3 drill-down + 7 ways-core, all green.
- `cargo clippy -p ways --all-targets -D warnings` — clean on every touched file. (The one remaining error, `settings/compile.rs:334`, is a pre-existing newer-clippy lint in untouched test code, deferred to its own CI-health PR.)
- `session_sim` failures are pre-existing on clean `main` (verified via stash) — a local `/run/user` environment issue, not a regression.

Increment 6 (`ways introspect live`) is the remaining piece of task #20.

https://claude.ai/code/session_01TFyiQNDZ8RTMHX4Tnmp1wY