### PR TITLE
feat(introspect): live monitor + compaction windows + interactive UX (increment 6)

### DIFF
--- a/tools/ways-cli/src/cmd/compositor.rs
+++ b/tools/ways-cli/src/cmd/compositor.rs
@@ -10,13 +10,12 @@
 //! need text selection or resizable/mouse panes, the ADR's escape hatch to ratatui
 //! applies; short of that, this stays.
 //!
-//! It provides ANSI-visible-width primitives ([`visible_len`], [`truncate_visible`],
-//! [`pad_visible`]) meant as the canonical home for that logic — `render.rs`
-//! (`ansi_pad`/`ansi_visible_len`) and `rethink.rs` (`truncate_visible`) still carry
-//! their own older copies, which can migrate here in a follow-up. Width is measured
-//! in `char`s, ignoring SGR escapes — the same grain those callers already use;
-//! East-Asian double-width and combining marks are not accounted for (that would
-//! need a new dependency the lean binary declines).
+//! It owns the canonical ANSI-visible-width primitives ([`visible_len`],
+//! [`truncate_visible`], [`pad_visible`]): `render.rs`'s row padding and
+//! `rethink.rs`'s `fit_to_terminal` both call these instead of the local copies
+//! they used to keep. Width is measured in `char`s, ignoring SGR escapes — the same
+//! grain those callers already use; East-Asian double-width and combining marks are
+//! not accounted for (that would need a new dependency the lean binary declines).
 
 use std::fmt::Write;
 

--- a/tools/ways-cli/src/cmd/introspect.rs
+++ b/tools/ways-cli/src/cmd/introspect.rs
@@ -24,6 +24,35 @@ pub fn replay(
     rethink::run(session, project, speed, false, all)
 }
 
+/// `ways introspect live` — monitor the current session's way firings, following
+/// the newest frame as ways fire. The "current" session is the most recent one in
+/// scope (the one actively writing events); `--session` overrides it. Scoping
+/// mirrors `replay`: defaults to the current project, `--project` for a specific
+/// one, and fails loud rather than silently globalizing when detection fails.
+pub fn live(session: Option<&str>, project: Option<&str>) -> Result<()> {
+    let content = ways_core::firing::load_events_text();
+    if content.trim().is_empty() {
+        println!("No events recorded yet.");
+        return Ok(());
+    }
+
+    // Live is inherently single-project (the session you're in), so no `--all`.
+    let scope = rethink::resolve_project_scope(project, false)?;
+
+    let session_id = match session {
+        Some(s) => s.to_string(),
+        None => match rethink_dump::most_recent_session(&content, scope.as_deref()) {
+            Some(s) => s,
+            None => {
+                println!("No sessions found in scope to monitor.");
+                return Ok(());
+            }
+        }
+    };
+
+    rethink::run_live(&session_id, scope.as_deref(), None)
+}
+
 /// `ways introspect list` — enumerate candidate sessions in scope, as a table or
 /// (`--json`) machine-listable data for an agent to pick from before dumping.
 pub fn list(project: Option<&str>, all: bool, json: bool) -> Result<()> {

--- a/tools/ways-cli/src/cmd/introspect.rs
+++ b/tools/ways-cli/src/cmd/introspect.rs
@@ -36,21 +36,33 @@ pub fn live(session: Option<&str>, project: Option<&str>) -> Result<()> {
         return Ok(());
     }
 
-    // Live is inherently single-project (the session you're in), so no `--all`.
-    let scope = rethink::resolve_project_scope(project, false)?;
-
-    let session_id = match session {
-        Some(s) => s.to_string(),
-        None => match rethink_dump::most_recent_session(&content, scope.as_deref()) {
+    // Resolve which session to monitor:
+    // - explicit `--session` wins;
+    // - `--project` scopes to the latest session recorded under that project;
+    // - otherwise the *most recently active* session anywhere — the one still
+    //   appending events. We deliberately don't scope the default to a detected
+    //   project: a long-running session's recorded project can be stale/wrong (the
+    //   boundary hook logs `CLAUDE_PROJECT_DIR:-$PWD`), and "live" means "what's
+    //   happening now," which is an activity signal, not a project one.
+    let session_id = match (session, project) {
+        (Some(s), _) => s.to_string(),
+        (None, Some(p)) => match rethink_dump::most_recent_session(&content, Some(p)) {
             Some(s) => s,
             None => {
-                println!("No sessions found in scope to monitor.");
+                println!("No sessions found for project {p}.");
                 return Ok(());
             }
-        }
+        },
+        (None, None) => match rethink_dump::most_recent_active_session(&content) {
+            Some(s) => s,
+            None => {
+                println!("No sessions found to monitor.");
+                return Ok(());
+            }
+        },
     };
 
-    rethink::run_live(&session_id, scope.as_deref(), None)
+    rethink::run_live(&session_id, project, None)
 }
 
 /// `ways introspect list` — enumerate candidate sessions in scope, as a table or

--- a/tools/ways-cli/src/cmd/render.rs
+++ b/tools/ways-cli/src/cmd/render.rs
@@ -197,7 +197,7 @@ pub fn write_way_row_with<W: WayRow>(
     };
 
     // Pad re-disclosure to fixed visible width (ANSI-aware)
-    let next_padded = ansi_pad(&next, 13);
+    let next_padded = crate::cmd::compositor::pad_visible(&next, 13);
 
     let _ = writeln!(
         out,
@@ -510,28 +510,5 @@ pub fn truncate(s: &str, max: usize) -> String {
     }
 }
 
-/// Pad a string containing ANSI codes to a fixed visible width.
-fn ansi_pad(s: &str, width: usize) -> String {
-    let visible = ansi_visible_len(s);
-    if visible >= width {
-        s.to_string()
-    } else {
-        format!("{s}{}", " ".repeat(width - visible))
-    }
-}
-
-/// Measure visible length of a string, ignoring ANSI escape sequences.
-fn ansi_visible_len(s: &str) -> usize {
-    let mut len = 0;
-    let mut in_escape = false;
-    for c in s.chars() {
-        if in_escape {
-            if c == 'm' { in_escape = false; }
-        } else if c == '\x1b' {
-            in_escape = true;
-        } else {
-            len += 1;
-        }
-    }
-    len
-}
+// ANSI-visible-width helpers (`pad_visible`/`visible_len`) live in `cmd::compositor`
+// — the canonical home — so `render`, `rethink`, and the compositor share one copy.

--- a/tools/ways-cli/src/cmd/rethink.rs
+++ b/tools/ways-cli/src/cmd/rethink.rs
@@ -67,6 +67,11 @@ pub(crate) struct Frame {
     pub(crate) token_position_k: u64,
     pub(crate) ways: Vec<ActiveWay>,
     pub(crate) new_events: Vec<String>,
+    /// Which compaction window (1-based) this frame belongs to. A long session is
+    /// segmented at each `session_start` boundary; epoch/distance restart per window
+    /// and the accumulated ways reset, so the latest window mirrors `ways list`. The
+    /// boundary itself surfaces as a `⎯ compaction ⎯` entry in `new_events`.
+    pub(crate) window: u64,
 }
 
 /// Which view the replay shows. `Timeline` is the cumulative frame table; `WhyFired`
@@ -87,6 +92,8 @@ struct Player {
     session_id: String,
     project_name: String,
     context_window_k: u64,
+    /// Total compaction windows across the frames (for the `window W/M` header).
+    windows: u64,
     term_width: u16,
     term_height: u16,
     /// Current view; the drill-down state below is only meaningful in `WhyFired`.
@@ -238,6 +245,7 @@ pub fn run(
         println!("No frames to replay.");
         return Ok(());
     }
+    let windows = frames.iter().map(|f| f.window).max().unwrap_or(1);
 
     let speed_idx = match speed {
         Some(ms) => SPEEDS.iter().position(|(s, _)| *s <= ms).unwrap_or(1),
@@ -254,6 +262,7 @@ pub fn run(
         session_id,
         project_name,
         context_window_k,
+        windows,
         term_width,
         term_height,
         view: View::Timeline,
@@ -314,6 +323,7 @@ pub fn run_live(session_id: &str, project: Option<&str>, speed: Option<u64>) -> 
         println!("No frames to monitor yet.");
         return Ok(());
     }
+    let windows = frames.iter().map(|f| f.window).max().unwrap_or(1);
 
     let speed_idx = match speed {
         Some(ms) => SPEEDS.iter().position(|(s, _)| *s <= ms).unwrap_or(1),
@@ -330,6 +340,7 @@ pub fn run_live(session_id: &str, project: Option<&str>, speed: Option<u64>) -> 
         session_id: session_id.to_string(),
         project_name,
         context_window_k,
+        windows,
         term_width,
         term_height,
         view: View::Timeline,
@@ -394,6 +405,7 @@ fn refresh_live(player: &mut Player) {
 
     let was_last = player.current + 1 >= player.frames.len();
     player.frames = frames;
+    player.windows = player.frames.iter().map(|f| f.window).max().unwrap_or(1);
     let last = player.frames.len() - 1;
     // Follow the newest frame unless the user has scrolled back to inspect history.
     player.current = if player.following || was_last {
@@ -1138,12 +1150,12 @@ fn header_lines(player: &Player, col_header: Vec<String>) -> Vec<String> {
             player.project_name
         ),
         format!(
-            "  \x1b[2mepoch {} · {}K ctx · {} ways fired · frame {}/{}\x1b[0m{live}",
+            "  \x1b[2mepoch {} · {}K ctx · {} ways · window {}/{}\x1b[0m{live}",
             frame.epoch,
             player.context_window_k,
             frame.ways.len(),
-            player.current + 1,
-            player.frames.len(),
+            frame.window,
+            player.windows,
         ),
     ];
     h.extend(col_header);
@@ -1194,6 +1206,7 @@ fn build_frames(
     let mut active_ways: HashMap<String, ActiveWay> = HashMap::new();
     let mut check_fires: HashMap<String, u64> = HashMap::new();
     let mut epoch: u64 = 0;
+    let mut window: u64 = 1;
 
     let start_ts = events.first().map(|e| &e.ts).cloned().unwrap_or_default();
     let start_secs = parse_ts_secs(&start_ts);
@@ -1216,6 +1229,19 @@ fn build_frames(
     }
 
     for cluster in &clusters {
+        // A `session_start` after the session's origin is a compaction boundary: the
+        // real markers were cleared there, so reset the accumulated window state and
+        // restart epoch numbering. The latest window then reflects only what fired
+        // since the last compaction — the same grain `ways list` shows.
+        let boundary = !frames.is_empty()
+            && cluster.iter().any(|ev| ev.event == "session_start");
+        if boundary {
+            active_ways.clear();
+            check_fires.clear();
+            window += 1;
+            epoch = 0;
+        }
+
         epoch += 1;
         let cluster_ts = cluster[0].ts.clone();
         let cluster_secs = parse_ts_secs(&cluster_ts);
@@ -1224,6 +1250,9 @@ fn build_frames(
         let token_k = find_token_position(token_timeline, &cluster_ts);
 
         let mut new_events: Vec<String> = Vec::new();
+        if boundary {
+            new_events.push(format!("⎯ compaction · window {window} ⎯"));
+        }
 
         // Mark all existing ways as not-new
         for w in active_ways.values_mut() {
@@ -1290,6 +1319,7 @@ fn build_frames(
             token_position_k: token_k,
             ways,
             new_events,
+            window,
         });
     }
 
@@ -1832,7 +1862,46 @@ mod why_tests {
             token_position_k: 0,
             ways,
             new_events: vec![],
+            window: 1,
         }
+    }
+
+    #[test]
+    fn build_frames_segments_at_compaction_boundaries() {
+        let ev = |ts: &str, event: &str, way: &str| WayEvent {
+            ts: ts.into(),
+            event: event.into(),
+            way: way.into(),
+            trigger: "keyword".into(),
+            check: String::new(),
+        };
+        // Window 1: origin session_start + two fires. A second session_start
+        // (a compaction) opens window 2, which starts fresh with one fire.
+        let events = vec![
+            ev("2026-01-01T00:00:00Z", "session_start", ""),
+            ev("2026-01-01T00:00:01Z", "way_fired", "d/a"),
+            ev("2026-01-01T00:01:00Z", "way_fired", "d/b"),
+            ev("2026-01-01T02:00:00Z", "session_start", ""),
+            ev("2026-01-01T02:00:01Z", "way_fired", "d/c"),
+        ];
+        let frames = build_frames(&events, &[], &HashMap::new(), 50);
+
+        // The latest window reset the accumulated ways and restarted epoch numbering.
+        let last = frames.last().unwrap();
+        assert_eq!(last.window, 2);
+        let ids: Vec<&str> = last.ways.iter().map(|w| w.id.as_str()).collect();
+        assert_eq!(ids, vec!["d/c"], "window 2 shows only its own fires (reset)");
+        assert!(last.epoch <= 2, "epoch restarted per window, not continued from w1");
+
+        // Window 1 still accumulated both of its ways.
+        let w1 = frames.iter().find(|f| f.window == 1 && f.ways.len() == 2).unwrap();
+        assert!(w1.ways.iter().any(|w| w.id == "d/a"));
+        assert!(w1.ways.iter().any(|w| w.id == "d/b"));
+
+        // The boundary frame carries a compaction marker.
+        assert!(frames
+            .iter()
+            .any(|f| f.new_events.iter().any(|e| e.contains("compaction"))));
     }
 
     #[test]

--- a/tools/ways-cli/src/cmd/rethink.rs
+++ b/tools/ways-cli/src/cmd/rethink.rs
@@ -95,10 +95,20 @@ struct Player {
     /// plain replay never pays for the model + transcript read.
     #[cfg(feature = "tui")]
     why_index: Option<WhyIndex>,
-    /// Which fired way of the current frame is focused in the drill-down.
+    /// The selected way of the current frame — highlighted in the Timeline table
+    /// (↑/↓ move it, Enter opens its why-fired detail) and focused in the drill-down.
+    /// Shared so Enter/Tab carry the selection between the two views.
     why_selected: usize,
     /// Scroll offset into the focused way's detail panel.
     why_detail_scroll: usize,
+    /// `live` mode re-reads the event log on a tick and follows the newest frame
+    /// (ADR-154 §3). `following` is on until the user scrolls back to inspect an
+    /// earlier frame; End/`G` resumes it. `events_sig` is the stat-gate: skip the
+    /// re-parse while the event sources' combined (length, mtime) is unchanged.
+    live: bool,
+    following: bool,
+    #[cfg(feature = "tui")]
+    events_sig: (u64, u64),
 }
 
 const SPEEDS: &[(u64, &str)] = &[
@@ -248,8 +258,10 @@ pub fn run(
         term_height,
         view: View::Timeline,
         why_index: None,
-        why_selected: 0,
-        why_detail_scroll: 0,
+        why_selected: 0,        why_detail_scroll: 0,
+        live: false,
+        following: false,
+        events_sig: (0, 0),
     };
 
     run_tui(&mut player)
@@ -274,6 +286,122 @@ pub fn run(
     }
     println!("Rethink requires the 'tui' feature. Build with: cargo build --features tui");
     Ok(())
+}
+
+// ── Live monitor (ADR-154 §3) ─────────────────────────────────
+
+/// `ways introspect live` — monitor `session_id` as new ways fire, following the
+/// newest frame. Reuses the replay TUI; the loop re-reads the event log on a tick,
+/// gated by a stat check (§3). `project` is the resolved scope (the session's own
+/// recorded project takes precedence when present).
+#[cfg(feature = "tui")]
+pub fn run_live(session_id: &str, project: Option<&str>, speed: Option<u64>) -> Result<()> {
+    let content = ways_core::firing::load_events_text();
+    let project_name = find_session_project(&content, session_id)
+        .or_else(|| project.map(str::to_string))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let events = load_session_events(&content, session_id);
+    if events.is_empty() {
+        println!("No events for the current session yet.");
+        return Ok(());
+    }
+
+    let context_window = session::detect_context_window_for(&project_name, session_id);
+    let context_window_k = context_window / 1000;
+    let frames = reconstruct_frames(&events, &project_name, session_id, context_window);
+    if frames.is_empty() {
+        println!("No frames to monitor yet.");
+        return Ok(());
+    }
+
+    let speed_idx = match speed {
+        Some(ms) => SPEEDS.iter().position(|(s, _)| *s <= ms).unwrap_or(1),
+        None => 1,
+    };
+    let (term_width, term_height) = terminal::size().unwrap_or((120, 40));
+
+    let last = frames.len() - 1;
+    let mut player = Player {
+        frames,
+        current: last, // start pinned to the newest frame
+        playing: false,
+        speed_idx,
+        session_id: session_id.to_string(),
+        project_name,
+        context_window_k,
+        term_width,
+        term_height,
+        view: View::Timeline,
+        why_index: None,
+        why_selected: 0,        why_detail_scroll: 0,
+        live: true,
+        following: true,
+        events_sig: events_signature(),
+    };
+    run_tui(&mut player)
+}
+
+#[cfg(not(feature = "tui"))]
+pub fn run_live(_session_id: &str, _project: Option<&str>, _speed: Option<u64>) -> Result<()> {
+    println!("Live monitor requires the 'tui' feature. Build with: cargo build --features tui");
+    Ok(())
+}
+
+/// The stat-gate signature over the event sources: combined byte length and the
+/// newest mtime (seconds). A change in either means new events to re-read; equality
+/// means the append-only log is untouched, so the live loop skips the re-parse.
+#[cfg(feature = "tui")]
+fn events_signature() -> (u64, u64) {
+    let mut total_len = 0u64;
+    let mut max_mtime = 0u64;
+    for p in ways_core::paths::events_log_sources() {
+        if let Ok(meta) = std::fs::metadata(&p) {
+            total_len = total_len.saturating_add(meta.len());
+            if let Ok(secs) = meta
+                .modified()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).map_err(std::io::Error::other))
+            {
+                max_mtime = max_mtime.max(secs.as_secs());
+            }
+        }
+    }
+    (total_len, max_mtime)
+}
+
+/// Re-read the live session's events if the stat-gate shows a change, rebuild
+/// frames, and (when following) pin to the newest frame. Invalidates the drill-down
+/// index so its "why" panels rebuild against the fresh frames. A no-op while the log
+/// is unchanged, so idle ticks are cheap.
+#[cfg(feature = "tui")]
+fn refresh_live(player: &mut Player) {
+    let sig = events_signature();
+    if sig == player.events_sig {
+        return;
+    }
+    player.events_sig = sig;
+
+    let content = ways_core::firing::load_events_text();
+    let events = load_session_events(&content, &player.session_id);
+    if events.is_empty() {
+        return;
+    }
+    let context_window = player.context_window_k * 1000;
+    let frames = reconstruct_frames(&events, &player.project_name, &player.session_id, context_window);
+    if frames.is_empty() {
+        return;
+    }
+
+    let was_last = player.current + 1 >= player.frames.len();
+    player.frames = frames;
+    let last = player.frames.len() - 1;
+    // Follow the newest frame unless the user has scrolled back to inspect history.
+    player.current = if player.following || was_last {
+        last
+    } else {
+        player.current.min(last)
+    };
+    player.why_index = None; // fresh frames → rebuild the drill-down index lazily
 }
 
 // ── TUI loop ──────────────────────────────────────────────────
@@ -303,7 +431,9 @@ fn tui_loop(player: &mut Player) -> Result<()> {
         write!(stdout, "{output}")?;
         stdout.flush()?;
 
-        let timeout = if player.playing {
+        let timeout = if player.live {
+            std::time::Duration::from_millis(LIVE_REFRESH_MS)
+        } else if player.playing {
             std::time::Duration::from_millis(SPEEDS[player.speed_idx].0)
         } else {
             std::time::Duration::from_secs(60)
@@ -318,15 +448,14 @@ fn tui_loop(player: &mut Player) -> Result<()> {
 
                     KeyEvent { code: KeyCode::Char('c'), modifiers: KeyModifiers::CONTROL, .. } => break,
 
-                    // Tab toggles the why-fired drill-down. Entering it pauses
-                    // playback and starts the focus at the top of the frame's ways.
+                    // Tab toggles the why-fired drill-down, carrying the current
+                    // selection with it (like Enter). Entering it pauses playback.
                     KeyEvent { code: KeyCode::Tab, .. } => {
                         player.view = match player.view {
                             View::Timeline => View::WhyFired,
                             View::WhyFired => View::Timeline,
                         };
                         player.playing = false;
-                        player.why_selected = 0;
                         player.why_detail_scroll = 0;
                     }
 
@@ -336,51 +465,145 @@ fn tui_loop(player: &mut Player) -> Result<()> {
                     },
                 }
             }
-        } else if player.playing {
+        } else if player.playing && !player.live {
             if player.current < player.frames.len() - 1 {
                 player.current += 1;
             } else {
                 player.playing = false;
             }
         }
+
+        // Live mode re-reads the (append-only) event log each tick; the stat-gate
+        // in refresh_live makes an unchanged log a cheap no-op.
+        if player.live {
+            refresh_live(player);
+        }
     }
     Ok(())
 }
 
-/// Timeline-view keys: frame navigation, play/pause, and speed.
+/// The live-monitor refresh interval — the `poll` timeout in live mode (ADR-154 §3
+/// suggests ~100–250 ms; imperceptible, and the stat-gate keeps idle ticks cheap).
+#[cfg(feature = "tui")]
+const LIVE_REFRESH_MS: u64 = 250;
+
+/// The currently selected way's `(id, epoch_fired)` — the anchor carried across a
+/// frame change so the cursor stays on the same way instead of jumping to row 0.
+#[cfg(feature = "tui")]
+fn current_selected_way(player: &Player) -> Option<(String, u64)> {
+    let frame = player.frames.get(player.current)?;
+    if frame.ways.is_empty() {
+        return None;
+    }
+    let idx = player.why_selected.min(frame.ways.len() - 1);
+    frame.ways.get(idx).map(|w| (w.id.clone(), w.epoch_fired))
+}
+
+/// The row in `frame` that best preserves an anchor across a frame change: the same
+/// way if it's still active, else the nearest still-active way with `epoch_fired ≤`
+/// the anchor's (frame.ways is epoch-ascending, so that's the last such row), else
+/// the first row. Moving forward the anchor way is always present (frames are
+/// cumulative); moving backward it can vanish, and we snap to the nearest lesser epoch.
+#[cfg(feature = "tui")]
+fn reselect_by_anchor(frame: &Frame, anchor_id: &str, anchor_epoch: u64) -> usize {
+    if let Some(i) = frame.ways.iter().position(|w| w.id == anchor_id) {
+        return i;
+    }
+    frame
+        .ways
+        .iter()
+        .rposition(|w| w.epoch_fired <= anchor_epoch)
+        .unwrap_or(0)
+}
+
+/// Move to frame `target` (clamped), preserving the selected way via its anchor.
+/// Shared by the Timeline table and the drill-down so both keep the cursor put.
+#[cfg(feature = "tui")]
+fn jump_frame(player: &mut Player, target: usize) {
+    let anchor = current_selected_way(player);
+    let last = player.frames.len().saturating_sub(1);
+    player.current = target.min(last);
+    player.why_selected = match anchor {
+        Some((id, ep)) => reselect_by_anchor(&player.frames[player.current], &id, ep),
+        None => 0,
+    };
+}
+
+/// Timeline-view keys. ▲▼ select a way in the current frame (the viewport follows);
+/// Enter opens its why-fired detail. ◀▶/Home/End move along the time axis, keeping
+/// the cursor on the same way (nearest lesser epoch when it's rewound out of view).
+/// `+`/`-` set playback speed (the arrows now select, not speed). In live mode,
+/// manual navigation drops out of follow-the-newest; Space toggles following, and
+/// End/`G` resumes it.
 #[cfg(feature = "tui")]
 fn handle_timeline_key(player: &mut Player, key: KeyEvent) {
+    let ways_len = player.frames[player.current].ways.len();
     match key {
+        // Row selection within the current frame.
+        KeyEvent { code: KeyCode::Up, .. } | KeyEvent { code: KeyCode::Char('k'), .. } => {
+            player.why_selected = player.why_selected.saturating_sub(1);
+        }
+        KeyEvent { code: KeyCode::Down, .. } | KeyEvent { code: KeyCode::Char('j'), .. } => {
+            if player.why_selected + 1 < ways_len {
+                player.why_selected += 1;
+            }
+        }
+        KeyEvent { code: KeyCode::PageUp, .. } => {
+            player.why_selected = player.why_selected.saturating_sub(10);
+        }
+        KeyEvent { code: KeyCode::PageDown, .. } => {
+            player.why_selected = (player.why_selected + 10).min(ways_len.saturating_sub(1));
+        }
+        // Enter drills into the selected way's why-fired detail.
+        KeyEvent { code: KeyCode::Enter, .. } => {
+            if ways_len > 0 {
+                player.view = View::WhyFired;
+                player.playing = false;
+                player.why_detail_scroll = 0;
+            }
+        }
+        // Frame navigation (time axis); keeps the cursor on the same way.
         KeyEvent { code: KeyCode::Right, .. } | KeyEvent { code: KeyCode::Char('l'), .. } => {
             player.playing = false;
-            if player.current < player.frames.len() - 1 {
-                player.current += 1;
-            }
+            player.following = false;
+            jump_frame(player, player.current + 1);
         }
         KeyEvent { code: KeyCode::Left, .. } | KeyEvent { code: KeyCode::Char('h'), .. } => {
             player.playing = false;
-            if player.current > 0 {
-                player.current -= 1;
+            player.following = false;
+            jump_frame(player, player.current.saturating_sub(1));
+        }
+        KeyEvent { code: KeyCode::Home, .. } | KeyEvent { code: KeyCode::Char('g'), .. } => {
+            player.playing = false;
+            player.following = false;
+            jump_frame(player, 0);
+        }
+        KeyEvent { code: KeyCode::End, .. } | KeyEvent { code: KeyCode::Char('G'), .. } => {
+            player.playing = false;
+            player.following = player.live; // resume following the live tail
+            jump_frame(player, usize::MAX);
+        }
+        KeyEvent { code: KeyCode::Char(' '), .. } => {
+            // Live: pause/resume following. Replay: play/pause the animation.
+            if player.live {
+                player.following = !player.following;
+                if player.following {
+                    jump_frame(player, usize::MAX); // to newest, keeping the selected way
+                }
+            } else {
+                player.playing = !player.playing;
             }
         }
-        KeyEvent { code: KeyCode::Char(' '), .. } => player.playing = !player.playing,
-        KeyEvent { code: KeyCode::Up, .. } | KeyEvent { code: KeyCode::Char('k'), .. } => {
+        // Playback speed (moved off the arrows, which now select rows).
+        KeyEvent { code: KeyCode::Char('+'), .. } | KeyEvent { code: KeyCode::Char('='), .. } => {
             if player.speed_idx < SPEEDS.len() - 1 {
                 player.speed_idx += 1;
             }
         }
-        KeyEvent { code: KeyCode::Down, .. } | KeyEvent { code: KeyCode::Char('j'), .. } => {
+        KeyEvent { code: KeyCode::Char('-'), .. } | KeyEvent { code: KeyCode::Char('_'), .. } => {
             if player.speed_idx > 0 {
                 player.speed_idx -= 1;
             }
-        }
-        KeyEvent { code: KeyCode::Home, .. } | KeyEvent { code: KeyCode::Char('g'), .. } => {
-            player.current = 0;
-            player.playing = false;
-        }
-        KeyEvent { code: KeyCode::End, .. } | KeyEvent { code: KeyCode::Char('G'), .. } => {
-            player.current = player.frames.len() - 1;
-            player.playing = false;
         }
         _ => {}
     }
@@ -403,17 +626,13 @@ fn handle_why_key(player: &mut Player, key: KeyEvent) {
             player.why_detail_scroll = 0;
         }
         KeyEvent { code: KeyCode::Right, .. } | KeyEvent { code: KeyCode::Char('l'), .. } => {
-            if player.current < player.frames.len() - 1 {
-                player.current += 1;
-            }
-            player.why_selected = 0;
+            player.following = false;
+            jump_frame(player, player.current + 1);
             player.why_detail_scroll = 0;
         }
         KeyEvent { code: KeyCode::Left, .. } | KeyEvent { code: KeyCode::Char('h'), .. } => {
-            if player.current > 0 {
-                player.current -= 1;
-            }
-            player.why_selected = 0;
+            player.following = false;
+            jump_frame(player, player.current.saturating_sub(1));
             player.why_detail_scroll = 0;
         }
         KeyEvent { code: KeyCode::PageDown, .. } | KeyEvent { code: KeyCode::Char(']'), .. } => {
@@ -604,37 +823,63 @@ fn render_why(player: &mut Player) -> String {
     player.why_selected = sel;
 
     let total_w = player.term_width as usize;
-    let body_h = (player.term_height as usize).saturating_sub(6).max(3);
+    // Shared chrome is header (4) + footer (2) = 6 rows; the body fills the rest of
+    // the drawable height (`term_height − 1`, since fit_to_terminal drops the last
+    // cell to avoid a scroll), so 4 + body_h + 2 == term_height − 1.
+    let body_h = (player.term_height as usize).saturating_sub(7).max(3);
     let gap = 2;
     let left_w = (total_w / 3).clamp(16, 40).min(total_w.saturating_sub(gap + 12).max(16));
     let right_w = total_w.saturating_sub(left_w + gap).max(12);
 
     // Build both panels while borrowing the index + frame, then drop those borrows
     // before the scroll write-backs below.
-    let epoch;
     let (left, right) = {
         let idx = player.why_index.as_ref().unwrap();
         let frame = &player.frames[player.current];
-        epoch = frame.epoch;
 
         // Look up the model facet for the channel this frame shows the way on, so a
         // multi-channel way's detail is coherent (a keyword span never surfaces under
         // a semantic trigger).
         let facet = |w: &ActiveWay| idx.get(&(w.id.clone(), w.trigger.clone()));
 
+        // Prefix each row with the epoch the way fired in, so a row cross-references
+        // straight back to the Timeline's Epoch column. Right-align to the widest
+        // epoch in the frame so the way ids stay aligned.
+        let epoch_w = frame
+            .ways
+            .iter()
+            .map(|w| w.epoch_fired)
+            .max()
+            .unwrap_or(0)
+            .to_string()
+            .len();
+
+        // A 2-space left margin aligns this list with the Timeline's Way column (and
+        // `ways list`), so the lists don't shift horizontally when toggling views.
         let mut left_lines: Vec<String> = Vec::with_capacity(frame.ways.len());
         for (i, w) in frame.ways.iter().enumerate() {
             // A filled bullet marks a way the model has a fire record for on this channel.
             let bullet = if facet(w).is_some() { "•" } else { "·" };
-            let line = format!("{bullet} {}", w.id);
             if i == sel {
-                left_lines.push(format!("\x1b[7m{}\x1b[0m", compositor::fit_visible(&line, left_w)));
+                // Margin stays plain; only the content is reversed (as write_way_row does),
+                // so the highlight bar starts at the Way column, not in the margin.
+                let raw = format!("{bullet} e{:>ew$} {}", w.epoch_fired, w.id, ew = epoch_w);
+                left_lines.push(format!(
+                    "  \x1b[7m{}\x1b[0m",
+                    compositor::fit_visible(&raw, left_w.saturating_sub(2))
+                ));
             } else {
-                left_lines.push(line);
+                // Dim the epoch tag so the way id stays prominent.
+                left_lines.push(format!(
+                    "  {bullet} \x1b[2me{:>ew$}\x1b[0m {}",
+                    w.epoch_fired,
+                    w.id,
+                    ew = epoch_w
+                ));
             }
         }
         if left_lines.is_empty() {
-            left_lines.push("\x1b[2m(no ways in this frame)\x1b[0m".to_string());
+            left_lines.push("  \x1b[2m(no ways in this frame)\x1b[0m".to_string());
         }
 
         let detail = frame
@@ -661,120 +906,248 @@ fn render_why(player: &mut Player) -> String {
         gap,
     );
 
-    let mut out = String::new();
-    let short_id = &player.session_id[..player.session_id.len().min(12)];
-    let _ = writeln!(out);
-    let _ = writeln!(
-        out,
-        "{}  \x1b[2mSession {short_id}… · epoch {epoch} · frame {}/{}\x1b[0m",
-        compositor::tab_bar(&["Timeline", "Why fired"], 1),
-        player.current + 1,
-        player.frames.len(),
+    // Shared footer (same 2 rows as the Timeline).
+    let mut nav_buf = String::new();
+    render_status_bar(&mut nav_buf, player);
+    let nav: Vec<String> = nav_buf.lines().map(str::to_string).collect();
+
+    // Shared header, with the drill-down's own column labels + rule so the two
+    // panels are named the way the Timeline's columns are.
+    let labels = format!(
+        "\x1b[1m{}\x1b[0m{}\x1b[1mWhy it fired\x1b[0m",
+        compositor::pad_visible("  Way · epoch", left_w),
+        " ".repeat(gap),
     );
-    let _ = writeln!(out);
-    for line in composited {
-        let _ = writeln!(out, "{line}");
-    }
-    let _ = writeln!(out);
-    let _ = writeln!(out, "\x1b[2m{}\x1b[0m", "─".repeat(total_w.min(85)));
-    let _ = write!(
-        out,
-        " \x1b[7m ▲▼ \x1b[0m way  \x1b[7m ◀ ▶ \x1b[0m frame  \x1b[7m PgUp/Dn \x1b[0m scroll  \x1b[7m tab \x1b[0m timeline  \x1b[7m esc \x1b[0m quit"
+    let rule = format!(
+        "\x1b[2m{}\x1b[0m",
+        "─".repeat((left_w + gap + right_w).min(total_w))
     );
-    out
+    let header = header_lines(player, vec![labels, rule]);
+
+    // header (4) + body (body_h) + footer (2) = exactly the drawable height, so the
+    // chrome lines up row-for-row with the Timeline view when toggling.
+    let mut lines = header;
+    lines.extend(composited);
+    lines.extend(nav);
+    lines.join("\n")
 }
 
 // ── Frame renderer ────────────────────────────────────────────
 
-fn render_frame(player: &Player) -> String {
-    let frame = &player.frames[player.current];
-    let current_epoch = frame.epoch;
-    let context_window_k = player.context_window_k;
-    let current_tokens_k = frame.token_position_k;
+/// Assemble a **fixed-height** screen so the nav legend is always pinned to the
+/// bottom rows, whatever the content length or terminal size:
+///
+/// - `top` (header) is pinned at the top;
+/// - `rows` is the scrollable region, viewported to keep `sel_line` visible and
+///   blank-padded so it always fills its share of the height;
+/// - `extras` (e.g. the token timeline) are pinned just above the nav, but only
+///   when the terminal is tall enough to also show a few rows of the list;
+/// - `nav` is pinned as the final lines.
+///
+/// The result is exactly `drawable` lines — the height `fit_to_terminal` will keep
+/// (`term_height − 1`) — so nothing gets pushed off the bottom.
+#[cfg(feature = "tui")]
+fn compose_screen(
+    top: Vec<String>,
+    rows: Vec<String>,
+    sel_line: usize,
+    extras: Vec<String>,
+    nav: Vec<String>,
+    drawable: usize,
+) -> String {
+    let mut rows_area = drawable.saturating_sub(top.len() + nav.len()).max(1);
 
-    let mut out = String::new();
-
-    // Header
-    let short_id = &player.session_id[..player.session_id.len().min(12)];
-    let _ = writeln!(out);
-    let _ = writeln!(
-        out,
-        "\x1b[1mSession\x1b[0m {short_id}...  \x1b[2mepoch {current_epoch} · {context_window_k}K ctx · {} ways fired\x1b[0m",
-        frame.ways.len()
-    );
-    let _ = writeln!(
-        out,
-        "\x1b[2m  {} · +{}s elapsed\x1b[0m",
-        &frame.timestamp[..frame.timestamp.len().min(19)],
-        frame.elapsed_secs
-    );
-    let _ = writeln!(out);
-
-    if frame.ways.is_empty() {
-        let _ = writeln!(out, "  \x1b[2mNo ways triggered yet.\x1b[0m");
-        let _ = writeln!(out);
-        render_status_bar(&mut out, player);
-        return out;
+    // Show the extras only if they still leave a few rows of the list visible.
+    let show_extras = !extras.is_empty() && rows_area > extras.len() + 3;
+    if show_extras {
+        rows_area = rows_area.saturating_sub(extras.len());
     }
 
+    // Reserve one row of the list area for the scroll hint when the list overflows.
+    let overflow = rows.len() > rows_area;
+    let view_h = if overflow { rows_area.saturating_sub(1).max(1) } else { rows_area };
+    let scroll = if overflow {
+        let max_scroll = rows.len().saturating_sub(view_h);
+        // Bottom-anchor the selected line (same behaviour as the drill-down list).
+        sel_line.saturating_sub(view_h.saturating_sub(1)).min(max_scroll)
+    } else {
+        0
+    };
+
+    let mut lines: Vec<String> = Vec::with_capacity(drawable);
+    lines.extend(top);
+
+    let mut filled = 0;
+    for r in rows.iter().skip(scroll).take(view_h) {
+        lines.push(r.clone());
+        filled += 1;
+    }
+    if overflow {
+        let below = rows.len().saturating_sub(view_h + scroll);
+        lines.push(format!("  \x1b[2m⋮ {scroll} above · {below} below · ↑↓\x1b[0m"));
+        filled += 1;
+    }
+    // Pad the list area so the extras/nav stay anchored at the bottom.
+    while filled < rows_area {
+        lines.push(String::new());
+        filled += 1;
+    }
+
+    if show_extras {
+        lines.extend(extras);
+    }
+    lines.extend(nav);
+    lines.truncate(drawable); // safety net; the arithmetic already sums to `drawable`
+    lines.join("\n")
+}
+
+#[cfg(feature = "tui")]
+fn render_frame(player: &mut Player) -> String {
+    // Clamp the shared selection to this frame before borrowing it.
+    let ways_len = player.frames[player.current].ways.len();
+    let selected = player.why_selected.min(ways_len.saturating_sub(1));
+    player.why_selected = selected;
+
+    // `fit_to_terminal` keeps `term_height − 1` rows (it leaves the last cell empty
+    // to avoid a scroll), so that's the height we compose to.
+    let drawable = (player.term_height as usize).saturating_sub(1).max(6);
+    let context_window_k = player.context_window_k;
+
+    // Footer + header are the shared chrome (built before borrowing the frame).
+    let mut nav_buf = String::new();
+    render_status_bar(&mut nav_buf, player);
+    let nav: Vec<String> = nav_buf.lines().map(str::to_string).collect();
+
+    // The Timeline's column header is the shared ways-table header (labels + rule).
+    let mut th = String::new();
+    render::write_table_header(&mut th);
+    let top = header_lines(player, th.lines().map(str::to_string).collect());
+
+    let frame = &player.frames[player.current];
+    if frame.ways.is_empty() {
+        let rows = vec!["  \x1b[2mNo ways triggered yet.\x1b[0m".to_string()];
+        return compose_screen(top, rows, 0, Vec::new(), nav, drawable);
+    }
+
+    let current_epoch = frame.epoch;
+    let current_tokens_k = frame.token_position_k;
     let bar_positions = render::compute_bar_positions(&frame.ways, context_window_k);
     let unique_pos = render::unique_positions(&bar_positions);
 
-    render::write_table_header(&mut out);
-
+    // ── Scrollable, selectable rows ──
+    // One selectable unit per way; its rendered block (1 line, or 2 with a
+    // check-fires line) is tracked so the viewport can keep the selection visible.
+    let mut rows: Vec<String> = Vec::new();
+    let mut way_start_line: Vec<usize> = Vec::with_capacity(frame.ways.len());
     for (i, w) in frame.ways.iter().enumerate() {
-        let (prefix, suffix) = if w.is_new {
+        way_start_line.push(rows.len());
+        // The selection highlight takes visual precedence over new/redisclosed color.
+        let (prefix, suffix) = if i == selected {
+            ("\x1b[7m", "\x1b[0m")
+        } else if w.is_new {
             ("\x1b[1;32m", "\x1b[0m")
         } else if w.is_redisclosed {
             ("\x1b[1;36m", "\x1b[0m")
         } else {
             ("", "")
         };
-
+        let mut block = String::new();
         render::write_way_row(
-            &mut out, w, current_epoch, current_tokens_k,
+            &mut block, w, current_epoch, current_tokens_k,
             &bar_positions, &unique_pos, i, prefix, suffix,
         );
+        rows.extend(block.lines().map(str::to_string));
     }
+    let sel_line = way_start_line.get(selected).copied().unwrap_or(0);
 
+    // ── Extras pinned above the nav (token timeline + new events) ──
+    let mut extras: Vec<String> = Vec::new();
     if current_tokens_k > 0 {
-        let _ = writeln!(out);
+        let mut tl = String::new();
+        let _ = writeln!(tl);
         render::write_token_timeline(
-            &mut out, &frame.ways, &unique_pos,
+            &mut tl, &frame.ways, &unique_pos,
             current_tokens_k, context_window_k,
         );
+        extras.extend(tl.lines().map(str::to_string));
     }
-
-    let _ = writeln!(out);
-
-    // New events this frame
     if !frame.new_events.is_empty() {
-        let _ = writeln!(out, "  \x1b[1;32m+ {}\x1b[0m", frame.new_events.join(", "));
-        let _ = writeln!(out);
+        extras.push(String::new());
+        extras.push(format!("  \x1b[1;32m+ {}\x1b[0m", frame.new_events.join(", ")));
     }
 
-    render_status_bar(&mut out, player);
-    out
+    compose_screen(top, rows, sel_line, extras, nav, drawable)
 }
 
+/// The unified 2-row footer shared by both views: a rule, then the tab-bar (active
+/// view highlighted) + view-appropriate key hints. The `tab`/`esc`/frame-position
+/// tail is identical across views so the legend never jumps when toggling.
 fn render_status_bar(out: &mut String, player: &Player) {
-    let total = player.frames.len();
-    let current = player.current + 1;
-    let speed_label = SPEEDS[player.speed_idx].1;
-    let state = if player.playing { "▶ playing" } else { "⏸ paused" };
-
     let _ = writeln!(out, "\x1b[2m{}\x1b[0m", "─".repeat(85));
+
+    let active = if player.view == View::WhyFired { 1 } else { 0 };
+    let tabs = compositor::tab_bar(&["Timeline", "Why fired"], active);
+    let pos = format!("\x1b[1m{}/{}\x1b[0m", player.current + 1, player.frames.len());
+
+    let hints = match player.view {
+        View::Timeline => {
+            let mode = if player.live {
+                if player.following {
+                    "\x1b[7m space \x1b[0m follow  \x1b[1;32m● following\x1b[0m".to_string()
+                } else {
+                    "\x1b[7m space \x1b[0m follow  \x1b[1;33m● paused\x1b[0m".to_string()
+                }
+            } else {
+                format!(
+                    "\x1b[7m space \x1b[0m play  \x1b[7m +- \x1b[0m speed  \x1b[2m{}\x1b[0m",
+                    SPEEDS[player.speed_idx].1
+                )
+            };
+            format!("\x1b[7m ▲▼ \x1b[0m select  \x1b[7m ⏎ \x1b[0m why  \x1b[7m ◀▶ \x1b[0m frame  {mode}")
+        }
+        View::WhyFired => {
+            "\x1b[7m ▲▼ \x1b[0m way  \x1b[7m ◀▶ \x1b[0m frame  \x1b[7m PgUp/Dn \x1b[0m scroll".to_string()
+        }
+    };
+
     let _ = write!(
         out,
-        " \x1b[7m ◀ ▶ \x1b[0m frame  \
-         \x1b[7m ⏵ \x1b[0m play/pause  \
-         \x1b[7m ▲▼ \x1b[0m speed  \
-         \x1b[7m esc \x1b[0m quit  \
-         \x1b[2m│\x1b[0m  \
-         \x1b[1m{current}/{total}\x1b[0m  \
-         {speed_label}  \
-         {state}"
+        " {tabs}  {hints}  \x1b[7m tab \x1b[0m view  \x1b[7m esc \x1b[0m quit  \x1b[2m│\x1b[0m {pos}"
     );
+}
+
+/// The unified 4-row header both views share, so toggling never makes the header
+/// jump: `Session <id>  <path>`, a metrics line, then the view's own 2-row column
+/// header (labels + rule). `col_header` must be exactly 2 lines.
+#[cfg(feature = "tui")]
+fn header_lines(player: &Player, col_header: Vec<String>) -> Vec<String> {
+    let frame = &player.frames[player.current];
+    let short_id = &player.session_id[..player.session_id.len().min(12)];
+    let live = if player.live {
+        if player.following {
+            "  \x1b[1;32m● LIVE\x1b[0m"
+        } else {
+            "  \x1b[1;33m● LIVE paused\x1b[0m"
+        }
+    } else {
+        ""
+    };
+    let mut h = vec![
+        format!(
+            "\x1b[1mSession\x1b[0m {short_id}…  \x1b[2m{}\x1b[0m",
+            player.project_name
+        ),
+        format!(
+            "  \x1b[2mepoch {} · {}K ctx · {} ways fired · frame {}/{}\x1b[0m{live}",
+            frame.epoch,
+            player.context_window_k,
+            frame.ways.len(),
+            player.current + 1,
+            player.frames.len(),
+        ),
+    ];
+    h.extend(col_header);
+    h
 }
 
 // ── Frame construction ────────────────────────────────────────
@@ -1278,39 +1651,8 @@ fn fit_to_terminal(output: &str, width: usize, height: usize) -> String {
         if line_count >= max_lines {
             break;
         }
-        result.push_str(&truncate_visible(line, width));
+        result.push_str(&crate::cmd::compositor::truncate_visible(line, width));
         result.push_str("\r\n");
-    }
-    result
-}
-
-/// Truncate a string to `max_visible` visible characters, preserving ANSI escapes.
-fn truncate_visible(s: &str, max_visible: usize) -> String {
-    let mut result = String::new();
-    let mut visible = 0;
-    let mut in_escape = false;
-
-    for ch in s.chars() {
-        if in_escape {
-            result.push(ch);
-            if ch.is_ascii_alphabetic() {
-                in_escape = false;
-            }
-            continue;
-        }
-        if ch == '\x1b' {
-            in_escape = true;
-            result.push(ch);
-            continue;
-        }
-        if visible >= max_visible {
-            break;
-        }
-        result.push(ch);
-        visible += 1;
-    }
-    if result.contains('\x1b') {
-        result.push_str("\x1b[0m");
     }
     result
 }
@@ -1467,6 +1809,69 @@ mod why_tests {
     #[test]
     fn detail_handles_way_with_no_model_record() {
         assert!(render_why_detail("d/x", None).contains("no fire record"));
+    }
+
+    fn active(id: &str, epoch: u64) -> ActiveWay {
+        ActiveWay {
+            id: id.into(),
+            trigger: "keyword".into(),
+            epoch_fired: epoch,
+            token_pos: 0,
+            check_fires: 0,
+            is_new: false,
+            is_redisclosed: false,
+            refire_threshold_k: 0,
+        }
+    }
+
+    fn frame_of(ways: Vec<ActiveWay>) -> Frame {
+        Frame {
+            epoch: ways.iter().map(|w| w.epoch_fired).max().unwrap_or(0),
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            elapsed_secs: 0,
+            token_position_k: 0,
+            ways,
+            new_events: vec![],
+        }
+    }
+
+    #[test]
+    fn anchor_keeps_same_way_when_still_active() {
+        // Moving forward (or a frame where the way is still present) → exact id match.
+        let f = frame_of(vec![active("a", 1), active("b", 3), active("c", 5)]);
+        assert_eq!(reselect_by_anchor(&f, "b", 3), 1);
+    }
+
+    #[test]
+    fn compose_screen_is_fixed_height_with_nav_pinned() {
+        let top = vec!["h1".to_string(), "h2".to_string()];
+        let nav = vec!["sep".to_string(), "nav".to_string()];
+
+        // Long list, short screen → exactly `drawable` lines, nav on the last line.
+        let rows: Vec<String> = (0..50).map(|i| format!("row{i}")).collect();
+        let out = compose_screen(top.clone(), rows, 40, vec![], nav.clone(), 20);
+        let lines: Vec<&str> = out.split('\n').collect();
+        assert_eq!(lines.len(), 20, "composes to exactly the drawable height");
+        assert_eq!(lines[0], "h1", "header pinned at the top");
+        assert_eq!(lines[19], "nav", "nav pinned to the last line even when overflowing");
+
+        // Short list → the middle is blank-padded so the nav still sits at the bottom.
+        let out2 = compose_screen(top, vec!["only".to_string()], 0, vec![], nav, 20);
+        let l2: Vec<&str> = out2.split('\n').collect();
+        assert_eq!(l2.len(), 20);
+        assert_eq!(l2[2], "only");
+        assert_eq!(l2[19], "nav", "nav stays anchored to the bottom, not floating up");
+        assert_eq!(l2[10], "", "the list area is padded with blanks");
+    }
+
+    #[test]
+    fn anchor_snaps_to_nearest_lesser_epoch_when_rewound_out() {
+        // Rewound frame missing "c" (epoch 5): anchor c@5 → nearest present epoch ≤ 5
+        // is b@3 (row 1). Frames are epoch-ascending, so it's the last such row.
+        let f = frame_of(vec![active("a", 1), active("b", 3)]);
+        assert_eq!(reselect_by_anchor(&f, "c", 5), 1);
+        // Anchor epoch below everything present → first row.
+        assert_eq!(reselect_by_anchor(&f, "z", 0), 0);
     }
 
     #[test]

--- a/tools/ways-cli/src/cmd/rethink.rs
+++ b/tools/ways-cli/src/cmd/rethink.rs
@@ -1334,12 +1334,28 @@ fn build_frames(
                 "way_redisclosed" => {
                     if !ev.way.is_empty() {
                         new_events.push(format!("↻ {}", ev.way));
-                        active_ways.entry(ev.way.clone()).and_modify(|w| {
-                            w.epoch_fired = epoch;
-                            w.token_pos = token_k * 1000;
-                            w.is_redisclosed = true;
-                            w.is_new = false;
-                        });
+                        // A redisclosure means the way is active (re-injected). Update it
+                        // if present; otherwise ADD it — after a compaction-window reset a
+                        // still-active way first reappears via redisclosure, not a fresh
+                        // fire, and must repopulate the window or it looks empty.
+                        active_ways
+                            .entry(ev.way.clone())
+                            .and_modify(|w| {
+                                w.epoch_fired = epoch;
+                                w.token_pos = token_k * 1000;
+                                w.is_redisclosed = true;
+                                w.is_new = false;
+                            })
+                            .or_insert_with(|| ActiveWay {
+                                id: ev.way.clone(),
+                                trigger: ev.trigger.clone(),
+                                epoch_fired: epoch,
+                                token_pos: token_k * 1000,
+                                check_fires: check_fires.get(&ev.way).copied().unwrap_or(0),
+                                is_new: false,
+                                is_redisclosed: true,
+                                refire_threshold_k: refire_for(&ev.way),
+                            });
                     }
                 }
                 _ => {}
@@ -1939,6 +1955,33 @@ mod why_tests {
         assert!(frames
             .iter()
             .any(|f| f.new_events.iter().any(|e| e.contains("compaction"))));
+    }
+
+    #[test]
+    fn redisclosure_repopulates_a_reset_window() {
+        let ev = |ts: &str, event: &str, way: &str| WayEvent {
+            ts: ts.into(),
+            event: event.into(),
+            way: way.into(),
+            trigger: "keyword".into(),
+            check: String::new(),
+        };
+        // A way fires in window 1; after a compaction, it only *re-discloses* (no
+        // fresh fire) in window 2 — as a mature window mostly does. It must still show
+        // in window 2, or the current window looks empty (the regression this fixes).
+        let events = vec![
+            ev("2026-01-01T00:00:00Z", "session_start", ""),
+            ev("2026-01-01T00:00:01Z", "way_fired", "d/a"),
+            ev("2026-01-01T02:00:00Z", "session_start", ""),
+            ev("2026-01-01T02:00:01Z", "way_redisclosed", "d/a"),
+        ];
+        let frames = build_frames(&events, &[], &HashMap::new(), 50);
+        let last = frames.last().unwrap();
+        assert_eq!(last.window, 2);
+        assert!(
+            last.ways.iter().any(|w| w.id == "d/a"),
+            "a redisclosure must repopulate the reset window"
+        );
     }
 
     #[test]

--- a/tools/ways-cli/src/cmd/rethink.rs
+++ b/tools/ways-cli/src/cmd/rethink.rs
@@ -516,6 +516,11 @@ fn current_selected_way(player: &Player) -> Option<(String, u64)> {
 /// the anchor's (frame.ways is epoch-ascending, so that's the last such row), else
 /// the first row. Moving forward the anchor way is always present (frames are
 /// cumulative); moving backward it can vanish, and we snap to the nearest lesser epoch.
+///
+/// The epoch comparison is only meaningful *within* a window (epochs restart per
+/// compaction window). Across a window boundary the id-match usually resolves it, and
+/// the epoch fallback is just cursor placement — never correctness — so a cross-window
+/// mismatch at worst lands the cursor on a reasonable nearby row.
 #[cfg(feature = "tui")]
 fn reselect_by_anchor(frame: &Frame, anchor_id: &str, anchor_epoch: u64) -> usize {
     if let Some(i) = frame.ways.iter().position(|w| w.id == anchor_id) {

--- a/tools/ways-cli/src/cmd/rethink.rs
+++ b/tools/ways-cli/src/cmd/rethink.rs
@@ -1091,41 +1091,68 @@ fn render_frame(player: &mut Player) -> String {
     compose_screen(top, rows, sel_line, extras, nav, drawable)
 }
 
-/// The unified 2-row footer shared by both views: a rule, then the tab-bar (active
-/// view highlighted) + view-appropriate key hints. The `tab`/`esc`/frame-position
-/// tail is identical across views so the legend never jumps when toggling.
+/// The unified 2-row footer shared by both views: a full-width rule, then the
+/// tab-bar + view-appropriate key hints, distributed evenly across the terminal
+/// width (space-between). The `tab`/`esc`/position tail is identical across views so
+/// the legend never jumps when toggling.
 fn render_status_bar(out: &mut String, player: &Player) {
-    let _ = writeln!(out, "\x1b[2m{}\x1b[0m", "─".repeat(85));
+    let width = (player.term_width as usize).max(1);
+    let _ = writeln!(out, "\x1b[2m{}\x1b[0m", "─".repeat(width));
 
     let active = if player.view == View::WhyFired { 1 } else { 0 };
-    let tabs = compositor::tab_bar(&["Timeline", "Why fired"], active);
-    let pos = format!("\x1b[1m{}/{}\x1b[0m", player.current + 1, player.frames.len());
 
-    let hints = match player.view {
+    // Each element is one `[key] label` unit; `justify` spreads them across `width`.
+    let mut segs: Vec<String> = vec![compositor::tab_bar(&["Timeline", "Why fired"], active)];
+    match player.view {
         View::Timeline => {
-            let mode = if player.live {
-                if player.following {
-                    "\x1b[7m space \x1b[0m follow  \x1b[1;32m● following\x1b[0m".to_string()
+            segs.push("\x1b[7m ▲▼ \x1b[0m select".into());
+            segs.push("\x1b[7m ⏎ \x1b[0m why".into());
+            segs.push("\x1b[7m ◀▶ \x1b[0m frame".into());
+            if player.live {
+                segs.push(if player.following {
+                    "\x1b[7m space \x1b[0m \x1b[1;32m● following\x1b[0m".into()
                 } else {
-                    "\x1b[7m space \x1b[0m follow  \x1b[1;33m● paused\x1b[0m".to_string()
-                }
+                    "\x1b[7m space \x1b[0m \x1b[1;33m● paused\x1b[0m".into()
+                });
             } else {
-                format!(
-                    "\x1b[7m space \x1b[0m play  \x1b[7m +- \x1b[0m speed  \x1b[2m{}\x1b[0m",
-                    SPEEDS[player.speed_idx].1
-                )
-            };
-            format!("\x1b[7m ▲▼ \x1b[0m select  \x1b[7m ⏎ \x1b[0m why  \x1b[7m ◀▶ \x1b[0m frame  {mode}")
+                segs.push("\x1b[7m space \x1b[0m play".into());
+                segs.push(format!("\x1b[7m +- \x1b[0m \x1b[2m{}\x1b[0m", SPEEDS[player.speed_idx].1));
+            }
         }
         View::WhyFired => {
-            "\x1b[7m ▲▼ \x1b[0m way  \x1b[7m ◀▶ \x1b[0m frame  \x1b[7m PgUp/Dn \x1b[0m scroll".to_string()
+            segs.push("\x1b[7m ▲▼ \x1b[0m way".into());
+            segs.push("\x1b[7m ◀▶ \x1b[0m frame".into());
+            segs.push("\x1b[7m PgUp/Dn \x1b[0m scroll".into());
         }
-    };
+    }
+    segs.push("\x1b[7m tab \x1b[0m view".into());
+    segs.push("\x1b[7m esc \x1b[0m quit".into());
+    segs.push(format!("\x1b[1m{}/{}\x1b[0m", player.current + 1, player.frames.len()));
 
-    let _ = write!(
-        out,
-        " {tabs}  {hints}  \x1b[7m tab \x1b[0m view  \x1b[7m esc \x1b[0m quit  \x1b[2m│\x1b[0m {pos}"
-    );
+    out.push_str(&justify(&segs, width));
+}
+
+/// Lay `segments` out across `width` with even gaps between them (space-between):
+/// the first hugs the left edge, the last the right, the rest spread evenly. Falls
+/// back to a single-space join when the content is already wider than `width`.
+#[cfg(feature = "tui")]
+fn justify(segments: &[String], width: usize) -> String {
+    let content: usize = segments.iter().map(|s| compositor::visible_len(s)).sum();
+    let gaps = segments.len().saturating_sub(1);
+    if gaps == 0 || content + gaps >= width {
+        return segments.join(" ");
+    }
+    let total_space = width - content;
+    let base = total_space / gaps;
+    let extra = total_space % gaps;
+    let mut out = String::new();
+    for (i, seg) in segments.iter().enumerate() {
+        out.push_str(seg);
+        if i < gaps {
+            out.push_str(&" ".repeat(base + usize::from(i < extra)));
+        }
+    }
+    out
 }
 
 /// The unified 4-row header both views share, so toggling never makes the header
@@ -1134,7 +1161,6 @@ fn render_status_bar(out: &mut String, player: &Player) {
 #[cfg(feature = "tui")]
 fn header_lines(player: &Player, col_header: Vec<String>) -> Vec<String> {
     let frame = &player.frames[player.current];
-    let short_id = &player.session_id[..player.session_id.len().min(12)];
     let live = if player.live {
         if player.following {
             "  \x1b[1;32m● LIVE\x1b[0m"
@@ -1145,21 +1171,32 @@ fn header_lines(player: &Player, col_header: Vec<String>) -> Vec<String> {
         ""
     };
     let mut h = vec![
+        // Full session id (there's ample room), with the session's project path.
         format!(
-            "\x1b[1mSession\x1b[0m {short_id}…  \x1b[2m{}\x1b[0m",
-            player.project_name
+            "\x1b[1mSession\x1b[0m {}  \x1b[2m{}\x1b[0m",
+            player.session_id, player.project_name
         ),
+        // The current frame's wall-clock time anchors "when" you are as you scrub
+        // windows/frames — otherwise every window looks alike.
         format!(
-            "  \x1b[2mepoch {} · {}K ctx · {} ways · window {}/{}\x1b[0m{live}",
+            "  \x1b[2mepoch {} · {}K ctx · {} ways · window {}/{} · {}\x1b[0m{live}",
             frame.epoch,
             player.context_window_k,
             frame.ways.len(),
             frame.window,
             player.windows,
+            friendly_ts(&frame.timestamp),
         ),
     ];
     h.extend(col_header);
     h
+}
+
+/// `2026-07-03T16:52:00Z` → `2026-07-03 16:52` (minute precision, no `T`/`Z`).
+#[cfg(feature = "tui")]
+fn friendly_ts(ts: &str) -> String {
+    let spaced = ts.replace('T', " ");
+    spaced.get(..16).unwrap_or(&spaced).to_string()
 }
 
 // ── Frame construction ────────────────────────────────────────
@@ -1909,6 +1946,24 @@ mod why_tests {
         // Moving forward (or a frame where the way is still present) → exact id match.
         let f = frame_of(vec![active("a", 1), active("b", 3), active("c", 5)]);
         assert_eq!(reselect_by_anchor(&f, "b", 3), 1);
+    }
+
+    #[test]
+    fn justify_spreads_segments_to_full_width() {
+        let segs = vec!["a".to_string(), "bb".to_string(), "c".to_string()];
+        let line = justify(&segs, 20);
+        assert_eq!(compositor::visible_len(&line), 20, "fills the full width");
+        assert!(line.starts_with('a'), "first segment hugs the left");
+        assert!(line.ends_with('c'), "last segment hugs the right");
+        // Content wider than the width → single-space join, no panic.
+        let tight = justify(&segs, 3);
+        assert_eq!(tight, "a bb c");
+    }
+
+    #[test]
+    fn friendly_ts_trims_to_minute() {
+        assert_eq!(friendly_ts("2026-07-03T16:52:00Z"), "2026-07-03 16:52");
+        assert_eq!(friendly_ts("bogus"), "bogus"); // too short → returned as-is
     }
 
     #[test]

--- a/tools/ways-cli/src/cmd/rethink.rs
+++ b/tools/ways-cli/src/cmd/rethink.rs
@@ -1437,7 +1437,7 @@ fn find_token_position(timeline: &[(String, u64)], ts: &str) -> u64 {
 // ── Event loading ─────────────────────────────────────────────
 
 pub(crate) fn load_session_events(content: &str, session_id: &str) -> Vec<WayEvent> {
-    content
+    let mut events: Vec<WayEvent> = content
         .lines()
         .filter(|l| l.contains(session_id))
         .filter_map(|line| {
@@ -1453,7 +1453,14 @@ pub(crate) fn load_session_events(content: &str, session_id: &str) -> Vec<WayEve
                 check: v["check"].as_str().unwrap_or("").to_string(),
             })
         })
-        .collect()
+        .collect();
+    // The event log is a UNION of sources (state + legacy projection) concatenated
+    // without sorting, so a session's events can arrive out of order — which would
+    // scramble build_frames' ≤3s clustering and its compaction-window boundaries
+    // (the symptom: the "newest" frame stuck at an old legacy tail). Sort by
+    // timestamp so the stream is chronological. RFC-3339 UTC strings sort lexically.
+    events.sort_by(|a, b| a.ts.cmp(&b.ts));
+    events
 }
 
 pub(crate) fn find_session_project(content: &str, session_id: &str) -> Option<String> {
@@ -1917,6 +1924,22 @@ mod why_tests {
             new_events: vec![],
             window: 1,
         }
+    }
+
+    #[test]
+    fn load_session_events_sorts_by_timestamp() {
+        // The union of log sources can present a recent event before an older one;
+        // build_frames needs them chronological or its clustering/windows scramble.
+        let content = concat!(
+            r#"{"ts":"2026-01-02T00:00:00Z","event":"way_fired","session":"s","way":"d/late"}"#,
+            "\n",
+            r#"{"ts":"2026-01-01T00:00:00Z","event":"way_fired","session":"s","way":"d/early"}"#,
+            "\n",
+        );
+        let evs = load_session_events(content, "s");
+        assert_eq!(evs.len(), 2);
+        assert_eq!(evs[0].ts, "2026-01-01T00:00:00Z", "earliest first");
+        assert_eq!(evs[1].ts, "2026-01-02T00:00:00Z");
     }
 
     #[test]

--- a/tools/ways-cli/src/cmd/rethink.rs
+++ b/tools/ways-cli/src/cmd/rethink.rs
@@ -953,10 +953,16 @@ fn render_why(player: &mut Player) -> String {
     let header = header_lines(player, vec![labels, rule]);
 
     // header (4) + body (body_h) + footer (2) = exactly the drawable height, so the
-    // chrome lines up row-for-row with the Timeline view when toggling.
+    // chrome lines up row-for-row with the Timeline view when toggling. On a very
+    // short terminal (where body_h hits its floor) drop from the top so the footer
+    // stays visible, mirroring compose_screen.
+    let drawable = (player.term_height as usize).saturating_sub(1).max(4);
     let mut lines = header;
     lines.extend(composited);
     lines.extend(nav);
+    if lines.len() > drawable {
+        lines.drain(0..lines.len() - drawable);
+    }
     lines.join("\n")
 }
 
@@ -1025,7 +1031,11 @@ fn compose_screen(
         lines.extend(extras);
     }
     lines.extend(nav);
-    lines.truncate(drawable); // safety net; the arithmetic already sums to `drawable`
+    // On a very short terminal the pinned header + nav alone can exceed the height;
+    // drop from the TOP so the nav legend is never the thing that gets clipped.
+    if lines.len() > drawable {
+        lines.drain(0..lines.len() - drawable);
+    }
     lines.join("\n")
 }
 
@@ -2068,6 +2078,20 @@ mod why_tests {
         assert_eq!(l2[2], "only");
         assert_eq!(l2[19], "nav", "nav stays anchored to the bottom, not floating up");
         assert_eq!(l2[10], "", "the list area is padded with blanks");
+
+        // Tiny terminal where the pinned header+nav alone exceed the height: the nav
+        // must survive (the header is dropped instead of the footer).
+        let tiny = compose_screen(
+            vec!["h1".into(), "h2".into(), "h3".into()],
+            vec!["r".into()],
+            0,
+            vec![],
+            vec!["sep".into(), "nav".into()],
+            4,
+        );
+        let tl: Vec<&str> = tiny.split('\n').collect();
+        assert_eq!(tl.len(), 4, "never exceeds the drawable height");
+        assert_eq!(tl[3], "nav", "footer survives; the header is clipped instead");
     }
 
     #[test]

--- a/tools/ways-cli/src/cmd/rethink.rs
+++ b/tools/ways-cli/src/cmd/rethink.rs
@@ -621,22 +621,47 @@ fn handle_timeline_key(player: &mut Player, key: KeyEvent) {
     }
 }
 
-/// Drill-down keys: ▲▼ select a fired way, ◀▶ move between frames without leaving
-/// the drill-down, PgUp/PgDn (or `[`/`]`) scroll the detail panel.
+/// Drill-down keys. ▲▼ select a fired way (resets the reader to the top of its
+/// document); `j`/`k` scroll the selected way's document within the detail window
+/// (vim-style, the same pattern used to read subagent output); PgUp/PgDn page it,
+/// `g`/`G` jump to top/bottom; ◀▶ / `h` `l` move between frames.
 #[cfg(feature = "tui")]
 fn handle_why_key(player: &mut Player, key: KeyEvent) {
     let ways_len = player.frames[player.current].ways.len();
+    // A near-full page for PgUp/PgDn, sized to the detail window.
+    let page = (player.term_height as usize).saturating_sub(9).max(1);
     match key {
-        KeyEvent { code: KeyCode::Up, .. } | KeyEvent { code: KeyCode::Char('k'), .. } => {
+        // Select a way (arrows only, so j/k stay free for reading the document).
+        KeyEvent { code: KeyCode::Up, .. } => {
             player.why_selected = player.why_selected.saturating_sub(1);
             player.why_detail_scroll = 0;
         }
-        KeyEvent { code: KeyCode::Down, .. } | KeyEvent { code: KeyCode::Char('j'), .. } => {
+        KeyEvent { code: KeyCode::Down, .. } => {
             if player.why_selected + 1 < ways_len {
                 player.why_selected += 1;
             }
             player.why_detail_scroll = 0;
         }
+        // Scroll the way document (render_why clamps to its length).
+        KeyEvent { code: KeyCode::Char('j'), .. } => {
+            player.why_detail_scroll = player.why_detail_scroll.saturating_add(1);
+        }
+        KeyEvent { code: KeyCode::Char('k'), .. } => {
+            player.why_detail_scroll = player.why_detail_scroll.saturating_sub(1);
+        }
+        KeyEvent { code: KeyCode::PageDown, .. } => {
+            player.why_detail_scroll = player.why_detail_scroll.saturating_add(page);
+        }
+        KeyEvent { code: KeyCode::PageUp, .. } => {
+            player.why_detail_scroll = player.why_detail_scroll.saturating_sub(page);
+        }
+        KeyEvent { code: KeyCode::Char('g'), .. } | KeyEvent { code: KeyCode::Home, .. } => {
+            player.why_detail_scroll = 0;
+        }
+        KeyEvent { code: KeyCode::Char('G'), .. } | KeyEvent { code: KeyCode::End, .. } => {
+            player.why_detail_scroll = usize::MAX; // render_why clamps to the bottom
+        }
+        // Frame navigation (time axis).
         KeyEvent { code: KeyCode::Right, .. } | KeyEvent { code: KeyCode::Char('l'), .. } => {
             player.following = false;
             jump_frame(player, player.current + 1);
@@ -645,15 +670,6 @@ fn handle_why_key(player: &mut Player, key: KeyEvent) {
         KeyEvent { code: KeyCode::Left, .. } | KeyEvent { code: KeyCode::Char('h'), .. } => {
             player.following = false;
             jump_frame(player, player.current.saturating_sub(1));
-            player.why_detail_scroll = 0;
-        }
-        KeyEvent { code: KeyCode::PageDown, .. } | KeyEvent { code: KeyCode::Char(']'), .. } => {
-            player.why_detail_scroll = player.why_detail_scroll.saturating_add(5);
-        }
-        KeyEvent { code: KeyCode::PageUp, .. } | KeyEvent { code: KeyCode::Char('['), .. } => {
-            player.why_detail_scroll = player.why_detail_scroll.saturating_sub(5);
-        }
-        KeyEvent { code: KeyCode::Home, .. } | KeyEvent { code: KeyCode::Char('g'), .. } => {
             player.why_detail_scroll = 0;
         }
         _ => {}
@@ -1121,8 +1137,8 @@ fn render_status_bar(out: &mut String, player: &Player) {
         }
         View::WhyFired => {
             segs.push("\x1b[7m ▲▼ \x1b[0m way".into());
+            segs.push("\x1b[7m j/k \x1b[0m read".into());
             segs.push("\x1b[7m ◀▶ \x1b[0m frame".into());
-            segs.push("\x1b[7m PgUp/Dn \x1b[0m scroll".into());
         }
     }
     segs.push("\x1b[7m tab \x1b[0m view".into());

--- a/tools/ways-cli/src/cmd/rethink_dump.rs
+++ b/tools/ways-cli/src/cmd/rethink_dump.rs
@@ -277,6 +277,31 @@ fn session_events<'a>(
         .filter(move |v| v["session"].as_str() == Some(session_id))
 }
 
+/// The session with the most recent event of *any* kind — "what's live right now".
+/// Unlike [`most_recent_session`], this keys off the latest activity, not the latest
+/// `session_start`, and ignores the recorded project: a long-running session's
+/// `session_start` is old, and its project may be mis-recorded (the boundary hook
+/// logs `CLAUDE_PROJECT_DIR:-$PWD`, which isn't always the real project). For a live
+/// monitor, the currently-active session is the one still appending events.
+pub(crate) fn most_recent_active_session(content: &str) -> Option<String> {
+    let mut best: Option<(String, String)> = None; // (ts, session)
+    for line in content.lines() {
+        let v: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let sid = match v["session"].as_str() {
+            Some(s) if !s.is_empty() => s,
+            _ => continue,
+        };
+        let ts = v["ts"].as_str().unwrap_or("");
+        if best.as_ref().map(|(b, _)| ts > b.as_str()).unwrap_or(true) {
+            best = Some((ts.to_string(), sid.to_string()));
+        }
+    }
+    best.map(|(_, s)| s)
+}
+
 /// Latest session (by session_start timestamp) within an optional project scope.
 pub(crate) fn most_recent_session(content: &str, scope: Option<&str>) -> Option<String> {
     let mut best: Option<(String, String)> = None; // (ts, session)

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -465,6 +465,17 @@ enum IntrospectCommand {
         #[arg(long)]
         all: bool,
     },
+    /// Live-monitor the current session's way firings, following the newest frame
+    /// as ways fire (the replay TUI, refreshing on a tick). Defaults to the most
+    /// recent session in the current project.
+    Live {
+        /// Session ID to monitor (default: most recent in the current project)
+        #[arg(long)]
+        session: Option<String>,
+        /// Scope to this project path (default: current project)
+        #[arg(long)]
+        project: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -752,6 +763,9 @@ fn main() -> Result<()> {
             }
             IntrospectCommand::Dump { session, project, all } => {
                 cmd::introspect::dump(session.as_deref(), project.as_deref(), all)
+            }
+            IntrospectCommand::Live { session, project } => {
+                cmd::introspect::live(session.as_deref(), project.as_deref())
             }
         },
         Commands::Status { json } => cmd::status::run(json),


### PR DESCRIPTION
## Summary

Increment 6 of the session-introspection arc (ADR-153/154): the **`ways introspect live`** monitor, plus the interactive/legibility refinements that came out of hands-on use. Built on the shared model + micro-compositor from PR #278.

## What's here (4 commits)

- **Live monitor** (`introspect live`) — poll + stat-gate over the current session, following the newest frame as ways fire (ADR-154 §3). Reuses the replay TUI; zero new deps.
- **Interactive Timeline** — ▲▼ move a highlighted selection (viewport follows), **Enter** opens that way's why-fired detail; frame nav preserves the selected way by `(id, epoch)` anchor (same way if present, nearest lesser epoch when rewound out). Speed moved to `+`/`-`.
- **Compaction windows** — a long session (kept across many compactions) no longer accumulates every way it ever fired into one 90-way wall. `build_frames` resets at each `session_start` boundary and restarts epoch/distance per window; the header shows `window W/M` and the latest window mirrors `ways list`.
- **Fixed-height layout** — the nav legend is pinned to the bottom and the list scrolls, at any terminal size (resizes reflow). Unified 4-row header + 2-row footer shared by both views, so the chrome doesn't jump when you Tab. Full session id, a window timestamp, and a full-width space-between-justified footer.
- **Dedup** — `render.rs` and `rethink.rs` now use `compositor`'s canonical ANSI-width primitives instead of their own copies (closes the PR #278 review note); one `header_lines`/`render_status_bar` shared by both views.

## Test plan

- `cargo test -p ways -p ways-core` — 223 unit tests green (incl. anchor navigation, compaction segmentation, fixed-height compose, justified footer, drill-down join honesty).
- `cargo clippy -p ways --all-targets -D warnings` — clean on all touched files (the one remaining, `settings/compile.rs:334`, is a pre-existing newer-clippy lint in untouched code).
- Exercised interactively against a live 11-window, 5-day session.

Note: `matched_span` in the drill-down stays blank on pre-enrichment fires (increment 3b isn't in the currently-deployed binary) — that lights up once this ships and a fresh session runs under it. This is the release that carries it.

https://claude.ai/code/session_01TFyiQNDZ8RTMHX4Tnmp1wY