### PR TITLE
fix(hooks): record the session's real project on session_start

### DIFF
--- a/hooks/ways/clear-markers.sh
+++ b/hooks/ways/clear-markers.sh
@@ -11,6 +11,12 @@ source "$(dirname "$0")/events-log.sh"
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
 
+# The session's project. Prefer CLAUDE_PROJECT_DIR (the project root); fall back to
+# the hook payload's .cwd (the session's working directory) — NOT $PWD, which for a
+# SessionStart hook is the hooks dir (~/.claude) and mis-attributes every session's
+# project. Matches the resolution the check-*.sh hooks already use.
+PROJECT="${CLAUDE_PROJECT_DIR:-$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)}"
+
 # Clear session state
 if [[ -n "$SESSION_ID" ]]; then
   rm -rf "${SESSIONS_ROOT}/${SESSION_ID}" 2>/dev/null
@@ -23,7 +29,7 @@ fi
 mkdir -p "$(dirname "$EVENTS_LOG")" 2>/dev/null
 jq -nc --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   --arg event "session_start" \
-  --arg project "${CLAUDE_PROJECT_DIR:-$PWD}" \
+  --arg project "${PROJECT:-unknown}" \
   --arg session "${SESSION_ID:-unknown}" \
   '{ts:$ts,event:$event,project:$project,session:$session}' \
   >> "$EVENTS_LOG" 2>/dev/null


### PR DESCRIPTION
## Summary
`clear-markers.sh` logged `session_start` with `project=${CLAUDE_PROJECT_DIR:-$PWD}`. `CLAUDE_PROJECT_DIR` isn't set for the SessionStart hook, so it fell back to `$PWD` — the hooks dir (`~/.claude`) — mislabeling **every** session's project. (`/home/aaron/.claude` was the most-recorded "project" at 228 sessions; real repos like `agent-ways` never appeared.)

This is the data-quality bug behind the `introspect live` project mislabel found while dogfooding increment 6.

## Fix
Fall back to the hook payload's `.cwd` (the session's working directory) instead of `$PWD`, matching the `${CLAUDE_PROJECT_DIR:-$(jq -r .cwd)}` resolution the 7 `check-*.sh` hooks already use. Historical events can't be rewritten; new sessions are attributed correctly.

## Test
Verified the resolution in isolation: `CLAUDE_PROJECT_DIR` unset → payload `.cwd`; set → prefers it; neither → `unknown`.

Closes #22 (task) — was the workaround reason for defaulting `introspect live` to most-recently-active session.

https://claude.ai/code/session_01TFyiQNDZ8RTMHX4Tnmp1wY