### PR TITLE
fix(threat-modeling): ground 2 satisfied_when criteria in a real defect

### DIFF
--- a/hooks/ways/softwaredev/architecture/threat-modeling/provenance.yaml
+++ b/hooks/ways/softwaredev/architecture/threat-modeling/provenance.yaml
@@ -4,21 +4,26 @@ policy:
 controls:
   - id: OWASP Threat Modeling Cheat Sheet
     justifications:
-      - STRIDE framework applied at design phase before code review
+      - STRIDE framework applied across the design's trust boundaries
       - Trust boundaries identified between components and external systems
     satisfied_when: >
-      Before implementation, the session performed a STRIDE pass over the design
-      and enumerated the trust boundaries where data crosses trust levels — the
-      threat analysis preceded writing the code rather than following it.
+      The trust boundaries in the design where data crosses trust levels are
+      enumerated, and each is examined against the STRIDE categories for
+      applicable threats. A trust boundary that carries untrusted input across a
+      trust level with no threat identified against it — an attack surface
+      introduced without analysis — is the failure case.
   - id: NIST SP 800-30 (Risk Assessment)
     justifications:
-      - Risk register documents accepted risks with expiration dates
+      - Accepted risks documented with a recorded acceptance rationale
       - Likelihood and impact assessed for each identified threat
     satisfied_when: >
-      Identified threats were recorded in a risk register with likelihood and
-      impact assessed for each, and any risk marked accepted carries an expiration
-      date rather than being accepted indefinitely.
-verified: 2026-02-17
+      Each identified threat is recorded with its likelihood and impact assessed,
+      so its risk level is ranked rather than unknown, and any risk that is
+      accepted rather than mitigated carries a documented rationale for the
+      acceptance. A threat recorded without the likelihood-and-impact scoring
+      needed to rank and triage it, or a risk accepted with no recorded rationale
+      — silent acceptance — is the failure case.
+verified: 2026-07-03
 rationale: >
   Security Way covers code-level detection (SQL injection, XSS, secrets).
   Threat modeling operates at design altitude — understanding adversaries,


### PR DESCRIPTION
## What
Tightens the two `satisfied_when` criteria in `hooks/ways/softwaredev/architecture/threat-modeling/provenance.yaml` so each tracks a genuinely-missing threat-provenance defect rather than an internally-consistent-but-vacuous condition. Grounded against the `code/quality` principle — *a check earns its place only if its violation is a real defect someone would hit* — and styled to match the sibling `security/provenance.yaml`, where every criterion ends by naming its failure case.

## Why the old criteria were vacuous
- **OWASP STRIDE** — the crux was temporal ordering (*"threat analysis preceded writing the code rather than following it"*). That's weakly assessable and isn't the defect threat modeling guards; you can produce valid threat provenance concurrently with code. Re-grounded on the real defect: **a trust boundary carrying untrusted input across a trust level with no threat identified against it** — attack surface introduced without analysis.
- **NIST SP 800-30** — *"any risk marked accepted carries an expiration date"* is **vacuously true whenever nothing is accepted** and prescribes a mechanism (a date) rather than an outcome. Re-grounded on the real defect: **a threat recorded without the likelihood-and-impact scoring needed to rank and triage it**; accepted risks now require a documented rationale (the real defect being silent acceptance, not a missing expiry). The drifting justification line was realigned to match.

## Notes
- `verified` bumped to 2026-07-03 (re-examined against NIST SP 800-30 / OWASP STRIDE).
- Structural provenance lint unchanged — `ways lint --check` reports 0 errors, 0 warnings.
- Data-only change; no test snapshots the prior wording.

Closes #282

https://claude.ai/code/session_013LujXMCgxspdXURWvTWSaz