### PR TITLE
fix(update): use exe() in refresh tests so they pass on Windows

### DIFF
--- a/tools/ways-cli/src/cmd/update.rs
+++ b/tools/ways-cli/src/cmd/update.rs
@@ -501,11 +501,14 @@ mod tests {
         // Prior run was killed after rename-aside: slot empty, good copy in backup.
         let app = tmp();
         std::fs::create_dir_all(app.join("bin")).unwrap();
-        std::fs::write(app.join("bin").join("ways.pre-update"), "GOOD").unwrap();
+        // Use the same OS-aware binary name the production code derives via `exe()`
+        // (`ways.exe` on Windows); hardcoding the Unix name here made the recovery
+        // branch look for a backup the test never created, failing Windows-only.
+        std::fs::write(app.join("bin").join(format!("{}.pre-update", exe("ways"))), "GOOD").unwrap();
         // Even though this refresh's make target fails, recovery restores the good
         // copy first, and the revert keeps it in place.
         let _ = refresh_component(&app, "ways", &["bogus-target"], &app);
-        let bin = app.join("bin").join("ways");
+        let bin = app.join("bin").join(exe("ways"));
         assert!(bin.exists(), "orphaned backup must be restored");
         assert_eq!(std::fs::read_to_string(&bin).unwrap(), "GOOD");
         let _ = std::fs::remove_dir_all(&app);
@@ -517,14 +520,16 @@ mod tests {
         // original binary in place, not stranded.
         let app = tmp();
         std::fs::create_dir_all(app.join("bin")).unwrap();
-        let bin = app.join("bin").join("ways");
+        // OS-aware name (see the sibling recovery test): keeps this test genuinely
+        // exercising the revert path on Windows rather than passing vacuously.
+        let bin = app.join("bin").join(exe("ways"));
         std::fs::write(&bin, "OLD-BINARY").unwrap();
         // No Makefile / bogus target -> make fails -> revert.
         let err = refresh_component(&app, "ways", &["definitely-not-a-real-target"], &app).unwrap_err();
         assert!(err.to_string().contains("reverted"), "got: {err}");
         assert!(bin.exists(), "original binary must be restored");
         assert_eq!(std::fs::read_to_string(&bin).unwrap(), "OLD-BINARY", "and be the same file");
-        assert!(!app.join("bin").join("ways.pre-update").exists(), "backup consumed by the revert");
+        assert!(!app.join("bin").join(format!("{}.pre-update", exe("ways"))).exists(), "backup consumed by the revert");
         let _ = std::fs::remove_dir_all(&app);
     }
 


### PR DESCRIPTION
## Root cause
The **Cross-platform CI** `windows-latest` leg was **not flaky** — it failed *deterministically* on `refresh_recovers_an_orphaned_backup_from_an_interrupted_run`. Every recent run showed the identical split: windows fails, ubuntu + macos pass, same test, same line.

The test hardcoded the Unix binary name (`bin/ways`, `bin/ways.pre-update`) while production `refresh_component` derives names via `exe()` — which appends `.exe` on Windows. On Windows the recovery branch (`if !bin.exists() && backup.exists()`) looked for `ways.exe.pre-update`, a backup the test never created, so recovery never fired and the assertion on `ways` failed. On Unix `exe("ways") == "ways"`, so the names coincide and the bug was masked.

## Fix
Route both refresh tests through `exe()` for setup and assertions (test-only; production code was already correct and OS-aware). This also makes `refresh_reverts_the_binary_when_the_build_fails` genuinely exercise the revert path on Windows instead of passing vacuously — its "file untouched" assertion was trivially true when the name mismatch meant the code never touched the file.

## Verification
- `cargo test -p ways update::tests` → 6 passed on Unix (behavior unchanged; `exe()` is identity on non-Windows).
- No new clippy warnings (the one remaining warning is the pre-existing `settings/compile.rs` lint, unrelated).
- Windows behavior verified by logic: `exe("ways")` → `ways.exe`, matching what `refresh_component` writes/reads.

Corrects the standing "windows matrix is flaky-red" assumption — it was a single real portability defect in test code.

https://claude.ai/code/session_013LujXMCgxspdXURWvTWSaz