### PR TITLE
fix(cli): run on a big-stack thread so Windows doesn't stack-overflow (+ corpus test diagnostics)

### DIFF
--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -697,9 +697,15 @@ fn main() -> Result<()> {
     // crashing the spawned release binary immediately with STATUS_STACK_OVERFLOW
     // (0xC00000FD) and no output — while in-process unit tests, which run on the
     // test harness's larger-stack threads, pass. Run the real work on a thread
-    // with an explicit, generous stack so behavior matches across platforms (the
-    // same shape rustc uses for its own main thread). The Err/panic outcome is
-    // propagated unchanged so exit codes and error messages are preserved.
+    // with an explicit, generous stack (the same shape rustc uses for its own
+    // main thread).
+    //
+    // Outcome is preserved on both panic profiles: a returned `Err` flows straight
+    // out of `main` (Termination prints `Error: …`, exit 1). A panic under release
+    // `panic = "abort"` (tools/Cargo.toml) aborts at the site — thread-agnostic, so
+    // the same single message + abort exit as before; the `resume_unwind` arm is
+    // only live under unwind (dev/test), where it re-propagates the panic out of
+    // `main` without re-invoking the hook (no double "panicked at" line).
     let worker = std::thread::Builder::new()
         .name("ways-main".into())
         .stack_size(16 * 1024 * 1024)

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -692,6 +692,26 @@ fn parse_settings_scope(scope: Option<String>) -> Result<Option<cmd::settings::f
 }
 
 fn main() -> Result<()> {
+    // Windows' default main-thread stack is 1 MB; Linux's is 8 MB. Some commands
+    // (e.g. `corpus`, `scan`) use a large-enough startup frame to overflow 1 MB,
+    // crashing the spawned release binary immediately with STATUS_STACK_OVERFLOW
+    // (0xC00000FD) and no output — while in-process unit tests, which run on the
+    // test harness's larger-stack threads, pass. Run the real work on a thread
+    // with an explicit, generous stack so behavior matches across platforms (the
+    // same shape rustc uses for its own main thread). The Err/panic outcome is
+    // propagated unchanged so exit codes and error messages are preserved.
+    let worker = std::thread::Builder::new()
+        .name("ways-main".into())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(run)
+        .expect("spawn ways-main worker thread");
+    match worker.join() {
+        Ok(result) => result,
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
+}
+
+fn run() -> Result<()> {
     // Show banner + help when invoked with no args or "help"
     let args: Vec<String> = std::env::args().collect();
     let bare = args.len() == 1;

--- a/tools/ways-cli/tests/project_ways.rs
+++ b/tools/ways-cli/tests/project_ways.rs
@@ -109,6 +109,24 @@ impl Drop for Env {
     }
 }
 
+/// Run a configured `ways corpus` invocation, asserting it exits 0 and — on
+/// failure — surfacing the exit code plus the child's stdout/stderr. On the
+/// windows-latest CI leg these tests fail with `success() == false` while
+/// `.status()` (inherited) left the streams empty, hiding the cause. Capturing
+/// the exit *code* is the tell (e.g. 0xC0000005 access violation / a large
+/// unsigned code vs 101 for a Rust panic), and callers run corpus WITHOUT
+/// `--quiet` so its own progress log shows how far it got before dying.
+fn assert_corpus_ok(cmd: &mut Command, ctx: &str) {
+    let out = cmd.output().expect("spawn ways corpus");
+    assert!(
+        out.status.success(),
+        "ways corpus failed [{ctx}]: exit={:?}\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
 fn corpus_ids(jsonl: &Path) -> Vec<String> {
     let content = std::fs::read_to_string(jsonl).unwrap_or_default();
     content
@@ -126,12 +144,10 @@ fn project_way_embeds_with_namespaced_id() {
 
     let mut cmd = Command::new(ways_bin());
     env.apply(&mut cmd);
-    let status = cmd
-        .args(["corpus", "--quiet"])
-        .env("CLAUDE_PROJECT_DIR", &project)
-        .status()
-        .expect("run ways corpus");
-    assert!(status.success(), "ways corpus failed");
+    assert_corpus_ok(
+        cmd.args(["corpus"]).env("CLAUDE_PROJECT_DIR", &project),
+        "embed",
+    );
 
     let ids = corpus_ids(&env.corpus_jsonl());
     let expected = format!("{}/projdomain/projway", encode_project_key(&project));
@@ -153,12 +169,10 @@ fn project_way_fires_via_keyword() {
     // the end-to-end path the reporter exercised).
     let mut gen = Command::new(ways_bin());
     env.apply(&mut gen);
-    assert!(gen
-        .args(["corpus", "--quiet"])
-        .env("CLAUDE_PROJECT_DIR", &project)
-        .status()
-        .expect("run ways corpus")
-        .success());
+    assert_corpus_ok(
+        gen.args(["corpus"]).env("CLAUDE_PROJECT_DIR", &project),
+        "keyword",
+    );
 
     let mut scan = Command::new(ways_bin());
     env.apply(&mut scan);
@@ -205,12 +219,10 @@ fn project_way_fires_via_semantic_when_model_present() {
 
     let mut gen = Command::new(ways_bin());
     env.apply(&mut gen);
-    assert!(gen
-        .args(["corpus", "--quiet"])
-        .env("CLAUDE_PROJECT_DIR", &project)
-        .status()
-        .expect("run ways corpus")
-        .success());
+    assert_corpus_ok(
+        gen.args(["corpus"]).env("CLAUDE_PROJECT_DIR", &project),
+        "semantic",
+    );
 
     // A semantic-only query: shares vocabulary with the way but does NOT match
     // its `(?i)zqxplugintest` keyword pattern, so a hit proves the embedding
@@ -268,7 +280,8 @@ fn crlf_authored_project_way_still_fires() {
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
         stdout.contains("CRLF Way"),
-        "CRLF-authored way was skipped by the collector.\nstdout: {stdout}\nstderr: {}",
+        "CRLF-authored way was skipped by the collector (scan exit={:?}).\nstdout: {stdout}\nstderr: {}",
+        out.status.code(),
         String::from_utf8_lossy(&out.stderr)
     );
 }
@@ -290,14 +303,13 @@ fn ways_dir_with_output_does_not_clobber_canonical() {
 
     let mut cmd = Command::new(ways_bin());
     env.apply(&mut cmd);
-    let status = cmd
-        .args(["corpus", "--quiet", "--ways-dir"])
-        .arg(&empty_ways)
-        .arg("--output")
-        .arg(&out_dir)
-        .status()
-        .expect("run ways corpus --output");
-    assert!(status.success());
+    assert_corpus_ok(
+        cmd.args(["corpus", "--ways-dir"])
+            .arg(&empty_ways)
+            .arg("--output")
+            .arg(&out_dir),
+        "clobber/--output",
+    );
 
     // Canonical corpus must be untouched; the isolated output must be written.
     assert_eq!(
@@ -328,7 +340,9 @@ fn ways_dir_without_output_warns_about_canonical() {
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
         stderr.contains("WARNING") && stderr.contains("--output"),
-        "Bug C: expected a footgun warning steering to --output.\nstderr: {stderr}"
+        "Bug C: expected a footgun warning steering to --output (corpus exit={:?}).\nstdout: {}\nstderr: {stderr}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout)
     );
 }
 
@@ -348,7 +362,7 @@ fn user_way_shadows_core_way() {
 
     let mut cmd = Command::new(ways_bin());
     env.apply(&mut cmd);
-    assert!(cmd.args(["corpus", "--quiet"]).status().expect("run ways corpus").success());
+    assert_corpus_ok(cmd.args(["corpus"]), "shadow");
 
     let ids = corpus_ids(&env.corpus_jsonl());
     assert_eq!(


### PR DESCRIPTION
## Root cause (Windows Layer 2, after #287)
Six `project_ways` tests failed on `windows-latest` because spawned `ways corpus`/`ways scan` crashed **immediately** with **`STATUS_STACK_OVERFLOW`** (`0xC00000FD`, exit `-1073741571`) and **zero output**. Windows' default main-thread stack is **1 MB** vs Linux's **8 MB**; some commands use a large-enough startup frame to overflow the smaller one. In-process unit tests pass because they run on the cargo test harness's larger-stack threads — only the *spawned release binary* hits it.

## Fix
Move `main`'s dispatch onto an explicit **16 MB-stack worker thread** (the same shape rustc uses for its own main thread), propagating the `Err`/panic outcome unchanged so exit codes and error messages are preserved. Platform-agnostic — no per-target build config.

## Diagnostics (kept)
The change that *revealed* the cause is worth keeping: `project_ways` now runs corpus via `.output()` through an `assert_corpus_ok` helper that, on failure, reports the **exit code** + captured stdout/stderr (and drops `--quiet` so corpus's progress log shows how far it got). The two tests that already captured output now report the exit code too. A test asserting a subprocess succeeded should say why it didn't.

## Verification
- Local (Linux): `ways --version`, `ways corpus`, and all 7 `project_ways` + 6 `update` tests pass; the thread wrapper is transparent.
- Windows: this PR's `windows-latest` leg is the proof — expected green for the first time.

Fixes the Windows cross-platform corpus/scan failures. Corrects the standing "windows matrix is flaky" assumption — it was two real, deterministic bugs (#287 test portability, then this stack overflow).

https://claude.ai/code/session_013LujXMCgxspdXURWvTWSaz