### PR TITLE
test(settings): valid file:// URL for schema refresh on Windows (Layer 3)

### DIFF
--- a/tools/ways-cli/tests/settings_lint.rs
+++ b/tools/ways-cli/tests/settings_lint.rs
@@ -45,6 +45,21 @@ fn ways() -> Command {
     c
 }
 
+/// Build a `file://` URL from a local path that curl accepts on every OS. On
+/// Windows `canonicalize()` yields a `\\?\D:\..` verbatim path with backslashes,
+/// which is not a valid URL (curl can't fetch `file://\\?\D:\...`); normalize to
+/// forward slashes, drop the `\\?\` verbatim prefix, and use the
+/// `file:///<drive>/...` form. On Unix an absolute `/path` yields `file:///path`.
+fn file_url(path: &std::path::Path) -> String {
+    let s = path.to_string_lossy().replace('\\', "/");
+    let s = s.strip_prefix("//?/").unwrap_or(&s);
+    if s.starts_with('/') {
+        format!("file://{s}") // Unix: /home/x -> file:///home/x
+    } else {
+        format!("file:///{s}") // Windows: D:/a/x -> file:///D:/a/x
+    }
+}
+
 fn store(name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/settings-store")
@@ -186,7 +201,7 @@ fn schema_refresh_writes_the_user_copy() {
     let src = repo_schema().canonicalize().unwrap();
     let out = Command::new(ways_bin())
         .env("XDG_CONFIG_HOME", &cfg)
-        .env("WAYS_SETTINGS_SCHEMA_URL", format!("file://{}", src.display()))
+        .env("WAYS_SETTINGS_SCHEMA_URL", file_url(&src))
         .args(["settings", "schema", "--refresh"])
         .output()
         .unwrap();


### PR DESCRIPTION
## Windows Layer 3 (after #287 test portability, #288 stack overflow)
With the stack overflow fixed (#288), the `windows-latest` matrix surfaced its next hidden failure: `schema_refresh_writes_the_user_copy` failed with
```
Error: curl failed to fetch file://\\?\D:\a\agent-ways\agent-ways\share\claude-code-settings.schema.json
```
The test set `WAYS_SETTINGS_SCHEMA_URL` to `file://{canonicalize(path)}`. On Windows `canonicalize()` returns a `\\?\D:\..` **verbatim** path with backslashes, so the URL was malformed and curl couldn't fetch it. On Unix the path is already URL-shaped, so it worked and masked the bug.

## Fix (test-only)
Add `file_url()`: normalize to forward slashes, drop the `\\?\` verbatim prefix, use the `file:///<drive>/...` form.
- Unix: `/path` → `file:///path` (unchanged).
- Windows: `\\?\D:\a\…` → `file:///D:/a/…`.

The product's `schema_refresh` shells out to curl for its real `https://` SchemaStore source — `file://` is only this test's hermetic source, so no product change is warranted.

## Verification
- Linux: all 15 `settings_lint` tests pass (incl. `schema_refresh`); clippy clean.
- Windows: this PR's `windows-latest` leg is the validator. If it reveals that the runner's curl lacks `file://` support (rather than the URL being malformed), I'll pivot the approach — but a valid `file:///D:/...` URL is the expected fix.

This was the 3rd of ≥3 independent deterministic bugs behind the long-standing "flaky Windows matrix" reputation.

https://claude.ai/code/session_013LujXMCgxspdXURWvTWSaz