### PR TITLE
chore: fix non-tui build + gitignore the regenerable ways scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ hooks/ways/.obsidian/
 /.claude/*
 !/.claude/ways/
 !/.claude/skills/
+# ...except the way-authoring scaffold `ways init` regenerates on demand — it's
+# generated (from TEMPLATE_CONTENT in cmd/init.rs), not a tracked source.
+/.claude/ways/_template.md
 
 # --- Secrets / local env ---
 # The conventional (track-by-default) posture has no implicit safety net, so guard

--- a/tools/ways-cli/src/cmd/compositor.rs
+++ b/tools/ways-cli/src/cmd/compositor.rs
@@ -17,6 +17,7 @@
 //! grain those callers already use; East-Asian double-width and combining marks are
 //! not accounted for (that would need a new dependency the lean binary declines).
 
+#[cfg(feature = "tui")]
 use std::fmt::Write;
 
 // ── ANSI-visible-width primitives ─────────────────────────────
@@ -43,6 +44,7 @@ pub fn visible_len(s: &str) -> usize {
 /// Truncate `s` to at most `max` **visible** chars, preserving ANSI escapes
 /// (escape bytes don't count toward the budget). If truncation cuts the string
 /// mid-style, a reset (`\x1b[0m`) is appended so styling can't bleed past the cut.
+#[cfg(feature = "tui")]
 pub fn truncate_visible(s: &str, max: usize) -> String {
     let mut result = String::new();
     let mut visible = 0;
@@ -88,6 +90,7 @@ pub fn pad_visible(s: &str, width: usize) -> String {
 }
 
 /// Fit `s` to exactly `width` visible chars: truncate if longer, pad if shorter.
+#[cfg(feature = "tui")]
 pub fn fit_visible(s: &str, width: usize) -> String {
     pad_visible(&truncate_visible(s, width), width)
 }
@@ -97,12 +100,14 @@ pub fn fit_visible(s: &str, width: usize) -> String {
 /// A rectangular block of ANSI-styled text: its `lines` and their common visible
 /// `width`. Construction records the width so downstream placement doesn't have to
 /// re-measure the whole block.
+#[cfg(feature = "tui")]
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Panel {
     pub lines: Vec<String>,
     pub width: usize,
 }
 
+#[cfg(feature = "tui")]
 impl Panel {
     /// A panel from raw lines; `width` is the widest line's visible length.
     pub fn from_lines(lines: Vec<String>) -> Self {
@@ -163,6 +168,7 @@ impl Panel {
 /// stay aligned; a panel shorter than the tallest contributes blank rows for its
 /// missing lines. Give panels equal height first (via [`Panel::viewport`]) when a
 /// stable frame is wanted.
+#[cfg(feature = "tui")]
 pub fn hjoin(panels: &[Panel], gap: usize) -> Vec<String> {
     let rows = panels.iter().map(Panel::height).max().unwrap_or(0);
     let spacer = " ".repeat(gap);
@@ -181,6 +187,7 @@ pub fn hjoin(panels: &[Panel], gap: usize) -> Vec<String> {
 }
 
 /// Two-panel convenience over [`hjoin`].
+#[cfg(feature = "tui")]
 pub fn hjoin2(left: &Panel, right: &Panel, gap: usize) -> Vec<String> {
     hjoin(&[left.clone(), right.clone()], gap)
 }
@@ -190,6 +197,7 @@ pub fn hjoin2(left: &Panel, right: &Panel, gap: usize) -> Vec<String> {
 /// A one-line tab bar: each label padded with a space on each side, the `active`
 /// index shown in reverse video (`\x1b[7m`), the rest dim (`\x1b[2m`). Out-of-range
 /// `active` simply highlights nothing.
+#[cfg(feature = "tui")]
 pub fn tab_bar(tabs: &[&str], active: usize) -> String {
     let mut out = String::new();
     for (i, label) in tabs.iter().enumerate() {
@@ -204,7 +212,7 @@ pub fn tab_bar(tabs: &[&str], active: usize) -> String {
 
 // ── Tests ─────────────────────────────────────────────────────
 
-#[cfg(test)]
+#[cfg(all(test, feature = "tui"))]
 mod tests {
     use super::*;
 

--- a/tools/ways-cli/src/cmd/rethink/layout.rs
+++ b/tools/ways-cli/src/cmd/rethink/layout.rs
@@ -1,6 +1,7 @@
 //! Screen composition: the fixed-height frame layout, the shared header and status
 //! bar both views use, and terminal fitting.
 
+#[cfg(feature = "tui")]
 use std::fmt::Write;
 
 #[cfg(feature = "tui")]
@@ -8,6 +9,7 @@ use crate::cmd::compositor;
 #[cfg(feature = "tui")]
 use crate::cmd::render;
 
+#[cfg(feature = "tui")]
 use super::model::{Player, View, SPEEDS};
 
 // ── Frame renderer ────────────────────────────────────────────
@@ -165,6 +167,7 @@ pub(super) fn render_frame(player: &mut Player) -> String {
 /// tab-bar + view-appropriate key hints, distributed evenly across the terminal
 /// width (space-between). The `tab`/`esc`/position tail is identical across views so
 /// the legend never jumps when toggling.
+#[cfg(feature = "tui")]
 pub(super) fn render_status_bar(out: &mut String, player: &Player) {
     let width = (player.term_width as usize).max(1);
     let _ = writeln!(out, "\x1b[2m{}\x1b[0m", "─".repeat(width));
@@ -319,6 +322,7 @@ fn ago_label(secs: u64) -> String {
 
 /// Fit rendered output to terminal dimensions.
 /// Uses \r\n because raw mode requires explicit carriage return.
+#[cfg(feature = "tui")]
 pub(super) fn fit_to_terminal(output: &str, width: usize, height: usize) -> String {
     let mut result = String::new();
     let max_lines = height.saturating_sub(1);

--- a/tools/ways-cli/src/cmd/rethink/model.rs
+++ b/tools/ways-cli/src/cmd/rethink/model.rs
@@ -55,12 +55,16 @@ pub(crate) struct Frame {
     /// segmented at each `session_start` boundary; epoch/distance restart per window
     /// and the accumulated ways reset, so the latest window mirrors `ways list`. The
     /// boundary itself surfaces as a `⎯ compaction ⎯` entry in `new_events`.
+    /// Set unconditionally by frame reconstruction, but only *read* by the tui
+    /// header (`window W/M`), so it's dead in a non-tui build.
+    #[cfg_attr(not(feature = "tui"), allow(dead_code))]
     pub(crate) window: u64,
 }
 
 /// Which view the replay shows. `Timeline` is the cumulative frame table; `WhyFired`
 /// is the drill-down that joins the current frame's ways to the `SessionIntrospection`
 /// model by `way_id` (ADR-154 §1 boundary — no epoch alignment).
+#[cfg(feature = "tui")]
 #[derive(Clone, Copy, PartialEq)]
 pub(super) enum View {
     Timeline,
@@ -68,6 +72,7 @@ pub(super) enum View {
 }
 
 /// Playback state.
+#[cfg(feature = "tui")]
 pub(super) struct Player {
     pub(super) frames: Vec<Frame>,
     pub(super) current: usize,
@@ -102,6 +107,7 @@ pub(super) struct Player {
     pub(super) events_sig: (u64, u64),
 }
 
+#[cfg(feature = "tui")]
 pub(super) const SPEEDS: &[(u64, &str)] = &[
     (2000, "2.0s"),
     (1000, "1.0s"),

--- a/tools/ways-cli/src/cmd/rethink/sessions.rs
+++ b/tools/ways-cli/src/cmd/rethink/sessions.rs
@@ -256,12 +256,6 @@ pub(super) fn pick_session(content: &str, project_filter: Option<&str>) -> Optio
     }
 }
 
-#[cfg(not(feature = "tui"))]
-pub(super) fn pick_session(_content: &str, _project_filter: Option<&str>) -> Option<String> {
-    eprintln!("Interactive picker requires the 'tui' feature.");
-    None
-}
-
 fn format_duration(secs: u64) -> String {
     if secs < 60 {
         format!("{secs}s")


### PR DESCRIPTION
Two pre-existing housekeeping items surfaced during the markdown-rendering work.

## 1. `cargo build --no-default-features` was broken
`render_status_bar` (rethink/layout.rs) used tui-only `compositor::tab_bar`/`justify` but wasn't `#[cfg(feature = "tui")]` like every other fn in the module → `E0433`/`E0425`.

Fixed the break (the missing gate), then **finished the feature-gating the module never completed** so the non-tui build is also **warning-clean** (was 15 dead-code warnings). Gated the interactive viewer's definitions that only tui code uses:
- `model.rs`: `Player`, `View`, `SPEEDS`; `Frame.window` (set unconditionally, read only by the tui header) marked `#[cfg_attr(not(tui), allow(dead_code))]`.
- `layout.rs`: `fit_to_terminal` + the tui-only imports.
- `compositor.rs`: `Panel` (+impl), `hjoin`, `hjoin2`, `tab_bar`, `truncate_visible`, `fit_visible`, the `Write` import, and the test module (`cfg(all(test, tui))`). `visible_len`/`pad_visible` stay ungated (used by non-tui `render.rs`).
- `sessions.rs`: dropped the never-called non-tui `pick_session` stub.

**Verification (both configs):**
- `cargo build --no-default-features` → clean, **0 warnings**.
- `cargo test --no-default-features --no-run` → compiles clean.
- `cargo build` (tui) → green; `cargo test` → **240 pass**; clippy → only the unrelated pre-existing `compile.rs` lint.

## 2. Gitignore the regenerable ways scaffold
`.claude/ways/_template.md` is written by `ways init` from `TEMPLATE_CONTENT` (cmd/init.rs) only if missing — a generated scaffold, not a tracked source (the repo tracks real project ways but not this). Added `/.claude/ways/_template.md` to `.gitignore` so it stops showing as untracked noise and doesn't reappear after a future `ways init`.

https://claude.ai/code/session_013LujXMCgxspdXURWvTWSaz