### PR TITLE
fix(update): retry pre-built downloads so a transient blip doesn't source-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,10 +195,10 @@ update-binaries: ways-rebuild ways-audit-rebuild attend-rebuild attend-chat-rebu
 ways:
 	@if [ -x $(WAYS_BIN) ] && $(WAYS_BIN) --version >/dev/null 2>&1; then \
 		echo "ways already installed: $$($(WAYS_BIN) --version)"; \
-	elif bash tools/ways-cli/download-ways.sh 2>/dev/null; then \
+	elif bash tools/ways-cli/download-ways.sh; then \
 		echo "Pre-built binary installed."; \
 	elif command -v cargo >/dev/null 2>&1; then \
-		echo "No pre-built binary, building from source..."; \
+		echo "Pre-built unavailable (see above) — building from source..."; \
 		bash scripts/check-rust.sh || exit 1; \
 		cargo build --release --manifest-path tools/Cargo.toml -p ways; \
 		mkdir -p bin; \
@@ -229,10 +229,10 @@ ways-rebuild:
 ways-audit:
 	@if [ -x $(WAYS_AUDIT_BIN) ] && $(WAYS_AUDIT_BIN) --version >/dev/null 2>&1; then \
 		echo "ways-audit already installed: $$($(WAYS_AUDIT_BIN) --version)"; \
-	elif bash tools/ways-audit/download-ways-audit.sh 2>/dev/null; then \
+	elif bash tools/ways-audit/download-ways-audit.sh; then \
 		echo "Pre-built ways-audit binary installed."; \
 	elif command -v cargo >/dev/null 2>&1; then \
-		echo "No pre-built binary, building ways-audit from source..."; \
+		echo "Pre-built unavailable (see above) — building ways-audit from source..."; \
 		bash scripts/check-rust.sh || exit 1; \
 		cargo build --release --manifest-path tools/Cargo.toml -p ways-audit; \
 		mkdir -p bin; \
@@ -260,11 +260,11 @@ ways-audit-rebuild:
 attend:
 	@if [ -x $(ATTEND_BIN) ] && $(ATTEND_BIN) --version >/dev/null 2>&1; then \
 		echo "attend already built."; \
-	elif bash tools/attend/download-attend.sh 2>/dev/null; then \
+	elif bash tools/attend/download-attend.sh; then \
 		echo "Pre-built attend binary installed."; \
 		$(MAKE) -s --no-print-directory _attend_state_hint; \
 	elif command -v cargo >/dev/null 2>&1; then \
-		echo "No pre-built binary, building attend from source..."; \
+		echo "Pre-built unavailable (see above) — building attend from source..."; \
 		cargo build --release --manifest-path tools/Cargo.toml -p attend; \
 		mkdir -p bin; \
 		$(LINK) "$(CURDIR)/tools/target/release/attend$(EXE)" $(ATTEND_BIN); \
@@ -300,11 +300,11 @@ attend-rebuild:
 attend-chat:
 	@if [ -x $(ATTEND_CHAT_BIN) ] && $(ATTEND_CHAT_BIN) --version >/dev/null 2>&1; then \
 		echo "attend-chat already built."; \
-	elif bash tools/attend-chat/download-attend-chat.sh 2>/dev/null; then \
+	elif bash tools/attend-chat/download-attend-chat.sh; then \
 		echo "Pre-built attend-chat binary installed."; \
 		$(MAKE) -s --no-print-directory _attend_state_hint; \
 	elif command -v cargo >/dev/null 2>&1; then \
-		echo "No pre-built binary, building attend-chat from source..."; \
+		echo "Pre-built unavailable (see above) — building attend-chat from source..."; \
 		cargo build --release --manifest-path tools/Cargo.toml -p attend-chat; \
 		mkdir -p bin; \
 		$(LINK) "$(CURDIR)/tools/target/release/attend-chat$(EXE)" $(ATTEND_CHAT_BIN); \

--- a/tools/attend-chat/download-attend-chat.sh
+++ b/tools/attend-chat/download-attend-chat.sh
@@ -80,7 +80,7 @@ if [[ "$RELEASE_TAG" == "latest" ]]; then
     echo "  Falling back to build-from-source: cd \"$REPO_ROOT\" && make attend-chat" >&2
     exit 1
   fi
-  RELEASE_TAG=$(echo "$release_tags" | grep '^attend-chat-v' | head -1)
+  RELEASE_TAG=$(echo "$release_tags" | grep '^attend-chat-v' | head -1 || true)
   if [[ -z "$RELEASE_TAG" ]]; then
     echo "No attend-chat release found. Build from source:" >&2
     echo "  cd \"$REPO_ROOT\" && make attend-chat" >&2
@@ -119,14 +119,23 @@ if ! retry gh release download "$RELEASE_TAG" \
   exit 1
 fi
 
-# Verify checksum
+# Verify checksum. Whether the release HAS a checksums.txt is known from the
+# assets list, so a download failure here is a transient blip (retry), not
+# "absent" — and if it's present but unfetchable we refuse to install unverified
+# rather than silently skipping the integrity check.
 CHECKSUMS_FILE="${OUTPUT_DIR}/checksums.txt"
-if gh release download "$RELEASE_TAG" \
-    --repo "$GH_REPO" \
-    --pattern "checksums.txt" \
-    --dir "$OUTPUT_DIR" \
-    --clobber 2>/dev/null; then
-  expected_hash=$(grep "${BIN_NAME}" "$CHECKSUMS_FILE" | awk '{print $1}')
+if echo "$release_assets" | grep -q '^checksums\.txt$'; then
+  if ! retry gh release download "$RELEASE_TAG" \
+      --repo "$GH_REPO" \
+      --pattern "checksums.txt" \
+      --dir "$OUTPUT_DIR" \
+      --clobber; then
+    echo "error: checksums.txt is in ${RELEASE_TAG} but its download failed after retries —" >&2
+    echo "  refusing to install ${BIN_NAME} unverified. Build from source: cd \"$REPO_ROOT\" && make attend-chat" >&2
+    rm -f "$PLATFORM_FILE"
+    exit 1
+  fi
+  expected_hash=$(grep "${BIN_NAME}" "$CHECKSUMS_FILE" | awk '{print $1}' || true)
   if [[ -n "$expected_hash" ]]; then
     actual_hash=$(sha256sum "$PLATFORM_FILE" 2>/dev/null | cut -d' ' -f1 \
       || shasum -a 256 "$PLATFORM_FILE" 2>/dev/null | cut -d' ' -f1)
@@ -141,7 +150,7 @@ if gh release download "$RELEASE_TAG" \
   fi
   rm -f "$CHECKSUMS_FILE"
 else
-  echo "WARNING: checksums.txt not found in release — skipping verification" >&2
+  echo "WARNING: no checksums.txt in ${RELEASE_TAG} — skipping verification" >&2
 fi
 
 # Make executable and install

--- a/tools/attend-chat/download-attend-chat.sh
+++ b/tools/attend-chat/download-attend-chat.sh
@@ -11,6 +11,10 @@
 
 set -euo pipefail
 
+# Shared retry/backoff helpers — a transient gh/API blip must not silently
+# degrade `ways update` to a from-source build.
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" && pwd)/prebuilt-lib.sh"
+
 # Platform detection
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | sed 's/arm64/aarch64/')
@@ -69,8 +73,14 @@ mkdir -p "$OUTPUT_DIR"
 
 # Find the latest attend-chat release
 if [[ "$RELEASE_TAG" == "latest" ]]; then
-  RELEASE_TAG=$(gh release list --repo "$GH_REPO" --limit 20 --json tagName --jq '.[].tagName' 2>/dev/null \
-    | grep '^attend-chat-v' | head -1)
+  # Retry transient API failures, then distinguish "couldn't reach the API"
+  # (retries exhausted → honest error) from "reached it, no matching release".
+  if ! release_tags=$(retry gh release list --repo "$GH_REPO" --limit 30 --json tagName --jq '.[].tagName'); then
+    echo "error: could not reach GitHub Releases after retries (network/gh/auth?)." >&2
+    echo "  Falling back to build-from-source: cd \"$REPO_ROOT\" && make attend-chat" >&2
+    exit 1
+  fi
+  RELEASE_TAG=$(echo "$release_tags" | grep '^attend-chat-v' | head -1)
   if [[ -z "$RELEASE_TAG" ]]; then
     echo "No attend-chat release found. Build from source:" >&2
     echo "  cd \"$REPO_ROOT\" && make attend-chat" >&2
@@ -82,10 +92,15 @@ echo "Platform: ${PLATFORM}" >&2
 echo "Release:  ${RELEASE_TAG}" >&2
 
 # Check if our platform binary exists in the release
-if ! gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep -q "^${BIN_NAME}$"; then
+if ! release_assets=$(retry gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name'); then
+  echo "error: could not read assets of ${RELEASE_TAG} after retries (network/gh/auth?)." >&2
+  echo "  Falling back to build-from-source: cd \"$REPO_ROOT\" && make attend-chat" >&2
+  exit 1
+fi
+if ! echo "$release_assets" | grep -q "^${BIN_NAME}$"; then
   echo "No pre-built binary for ${PLATFORM} in release ${RELEASE_TAG}." >&2
   echo "Available binaries:" >&2
-  gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null |  grep "^attend-chat-" | sed 's/^/  /' >&2
+  echo "$release_assets" | grep "^attend-chat-" | sed 's/^/  /' >&2
   echo "" >&2
   echo "Build from source instead:" >&2
   echo "  cd \"$REPO_ROOT\" && make attend-chat" >&2
@@ -94,11 +109,15 @@ fi
 
 # Download binary + checksums
 echo "Downloading ${BIN_NAME}..." >&2
-gh release download "$RELEASE_TAG" \
-  --repo "$GH_REPO" \
-  --pattern "$BIN_NAME" \
-  --dir "$OUTPUT_DIR" \
-  --clobber
+if ! retry gh release download "$RELEASE_TAG" \
+    --repo "$GH_REPO" \
+    --pattern "$BIN_NAME" \
+    --dir "$OUTPUT_DIR" \
+    --clobber; then
+  echo "error: download of ${BIN_NAME} failed after retries — building from source instead." >&2
+  echo "  cd \"$REPO_ROOT\" && make attend-chat" >&2
+  exit 1
+fi
 
 # Verify checksum
 CHECKSUMS_FILE="${OUTPUT_DIR}/checksums.txt"

--- a/tools/attend/download-attend.sh
+++ b/tools/attend/download-attend.sh
@@ -11,6 +11,10 @@
 
 set -euo pipefail
 
+# Shared retry/backoff helpers — a transient gh/API blip must not silently
+# degrade `ways update` to a from-source build.
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" && pwd)/prebuilt-lib.sh"
+
 # Platform detection
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | sed 's/arm64/aarch64/')
@@ -69,8 +73,14 @@ mkdir -p "$OUTPUT_DIR"
 
 # Find the latest attend release
 if [[ "$RELEASE_TAG" == "latest" ]]; then
-  RELEASE_TAG=$(gh release list --repo "$GH_REPO" --limit 20 --json tagName --jq '.[].tagName' 2>/dev/null \
-    | grep '^attend-v' | head -1)
+  # Retry transient API failures, then distinguish "couldn't reach the API"
+  # (retries exhausted → honest error) from "reached it, no matching release".
+  if ! release_tags=$(retry gh release list --repo "$GH_REPO" --limit 30 --json tagName --jq '.[].tagName'); then
+    echo "error: could not reach GitHub Releases after retries (network/gh/auth?)." >&2
+    echo "  Falling back to build-from-source: cd \"$REPO_ROOT\" && make attend" >&2
+    exit 1
+  fi
+  RELEASE_TAG=$(echo "$release_tags" | grep '^attend-v' | head -1)
   if [[ -z "$RELEASE_TAG" ]]; then
     echo "No attend release found. Build from source:" >&2
     echo "  cd \"$REPO_ROOT\" && make attend" >&2
@@ -82,10 +92,15 @@ echo "Platform: ${PLATFORM}" >&2
 echo "Release:  ${RELEASE_TAG}" >&2
 
 # Check if our platform binary exists in the release
-if ! gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep -q "^${BIN_NAME}$"; then
+if ! release_assets=$(retry gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name'); then
+  echo "error: could not read assets of ${RELEASE_TAG} after retries (network/gh/auth?)." >&2
+  echo "  Falling back to build-from-source: cd \"$REPO_ROOT\" && make attend" >&2
+  exit 1
+fi
+if ! echo "$release_assets" | grep -q "^${BIN_NAME}$"; then
   echo "No pre-built binary for ${PLATFORM} in release ${RELEASE_TAG}." >&2
   echo "Available binaries:" >&2
-  gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null |  grep "^attend-" | sed 's/^/  /' >&2
+  echo "$release_assets" | grep "^attend-" | sed 's/^/  /' >&2
   echo "" >&2
   echo "Build from source instead:" >&2
   echo "  cd \"$REPO_ROOT\" && make attend" >&2
@@ -94,11 +109,15 @@ fi
 
 # Download binary + checksums
 echo "Downloading ${BIN_NAME}..." >&2
-gh release download "$RELEASE_TAG" \
-  --repo "$GH_REPO" \
-  --pattern "$BIN_NAME" \
-  --dir "$OUTPUT_DIR" \
-  --clobber
+if ! retry gh release download "$RELEASE_TAG" \
+    --repo "$GH_REPO" \
+    --pattern "$BIN_NAME" \
+    --dir "$OUTPUT_DIR" \
+    --clobber; then
+  echo "error: download of ${BIN_NAME} failed after retries — building from source instead." >&2
+  echo "  cd \"$REPO_ROOT\" && make attend" >&2
+  exit 1
+fi
 
 # Verify checksum
 CHECKSUMS_FILE="${OUTPUT_DIR}/checksums.txt"

--- a/tools/attend/download-attend.sh
+++ b/tools/attend/download-attend.sh
@@ -80,7 +80,7 @@ if [[ "$RELEASE_TAG" == "latest" ]]; then
     echo "  Falling back to build-from-source: cd \"$REPO_ROOT\" && make attend" >&2
     exit 1
   fi
-  RELEASE_TAG=$(echo "$release_tags" | grep '^attend-v' | head -1)
+  RELEASE_TAG=$(echo "$release_tags" | grep '^attend-v' | head -1 || true)
   if [[ -z "$RELEASE_TAG" ]]; then
     echo "No attend release found. Build from source:" >&2
     echo "  cd \"$REPO_ROOT\" && make attend" >&2
@@ -119,14 +119,23 @@ if ! retry gh release download "$RELEASE_TAG" \
   exit 1
 fi
 
-# Verify checksum
+# Verify checksum. Whether the release HAS a checksums.txt is known from the
+# assets list, so a download failure here is a transient blip (retry), not
+# "absent" — and if it's present but unfetchable we refuse to install unverified
+# rather than silently skipping the integrity check.
 CHECKSUMS_FILE="${OUTPUT_DIR}/checksums.txt"
-if gh release download "$RELEASE_TAG" \
-    --repo "$GH_REPO" \
-    --pattern "checksums.txt" \
-    --dir "$OUTPUT_DIR" \
-    --clobber 2>/dev/null; then
-  expected_hash=$(grep "${BIN_NAME}" "$CHECKSUMS_FILE" | awk '{print $1}')
+if echo "$release_assets" | grep -q '^checksums\.txt$'; then
+  if ! retry gh release download "$RELEASE_TAG" \
+      --repo "$GH_REPO" \
+      --pattern "checksums.txt" \
+      --dir "$OUTPUT_DIR" \
+      --clobber; then
+    echo "error: checksums.txt is in ${RELEASE_TAG} but its download failed after retries —" >&2
+    echo "  refusing to install ${BIN_NAME} unverified. Build from source: cd \"$REPO_ROOT\" && make attend" >&2
+    rm -f "$PLATFORM_FILE"
+    exit 1
+  fi
+  expected_hash=$(grep "${BIN_NAME}" "$CHECKSUMS_FILE" | awk '{print $1}' || true)
   if [[ -n "$expected_hash" ]]; then
     actual_hash=$(sha256sum "$PLATFORM_FILE" 2>/dev/null | cut -d' ' -f1 \
       || shasum -a 256 "$PLATFORM_FILE" 2>/dev/null | cut -d' ' -f1)
@@ -141,7 +150,7 @@ if gh release download "$RELEASE_TAG" \
   fi
   rm -f "$CHECKSUMS_FILE"
 else
-  echo "WARNING: checksums.txt not found in release — skipping verification" >&2
+  echo "WARNING: no checksums.txt in ${RELEASE_TAG} — skipping verification" >&2
 fi
 
 # Make executable and install

--- a/tools/scripts/prebuilt-lib.sh
+++ b/tools/scripts/prebuilt-lib.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Shared helpers for the per-component pre-built download scripts
+# (download-attend.sh, download-attend-chat.sh, download-ways.sh,
+# download-ways-audit.sh). Sourced, not executed.
+#
+# Why this exists: a transient GitHub API / network blip on a `gh release`
+# call used to be swallowed (the call was `... 2>/dev/null`), so an empty
+# result read as "no release" and `ways update` silently degraded to a
+# from-source build. These helpers retry transient failures and — critically —
+# distinguish "the API call failed" from "the API succeeded but found nothing",
+# so a real blip is retried and, if it persists, reported honestly instead of
+# masquerading as a missing binary.
+
+# Run a command, retrying on failure with exponential backoff. Returns the
+# command's own exit status once it succeeds, or non-zero after the last try.
+# Progress notes go to stderr so callers can capture stdout cleanly.
+retry() {
+  local n=1 max="${RETRY_MAX:-3}" delay="${RETRY_DELAY:-2}"
+  while true; do
+    if "$@"; then
+      return 0
+    fi
+    if [[ "$n" -ge "$max" ]]; then
+      return 1
+    fi
+    echo "  (attempt ${n}/${max} failed; retrying in ${delay}s...)" >&2
+    sleep "$delay"
+    n=$((n + 1))
+    delay=$((delay * 2))
+  done
+}

--- a/tools/ways-audit/download-ways-audit.sh
+++ b/tools/ways-audit/download-ways-audit.sh
@@ -11,6 +11,10 @@
 
 set -euo pipefail
 
+# Shared retry/backoff helpers — a transient gh/API blip must not silently
+# degrade `ways update` to a from-source build.
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" && pwd)/prebuilt-lib.sh"
+
 # Platform detection
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | sed 's/arm64/aarch64/')
@@ -69,8 +73,14 @@ mkdir -p "$OUTPUT_DIR"
 
 # Find the latest ways-audit release
 if [[ "$RELEASE_TAG" == "latest" ]]; then
-  RELEASE_TAG=$(gh release list --repo "$GH_REPO" --limit 20 --json tagName --jq '.[].tagName' 2>/dev/null \
-    | grep '^ways-audit-v' | head -1)
+  # Retry transient API failures, then distinguish "couldn't reach the API"
+  # (retries exhausted → honest error) from "reached it, no matching release".
+  if ! release_tags=$(retry gh release list --repo "$GH_REPO" --limit 30 --json tagName --jq '.[].tagName'); then
+    echo "error: could not reach GitHub Releases after retries (network/gh/auth?)." >&2
+    echo "  Falling back to build-from-source: cd \"$REPO_ROOT\" && make ways-audit" >&2
+    exit 1
+  fi
+  RELEASE_TAG=$(echo "$release_tags" | grep '^ways-audit-v' | head -1)
   if [[ -z "$RELEASE_TAG" ]]; then
     echo "No ways-audit release found. Build from source:" >&2
     echo "  cd \"$REPO_ROOT\" && make ways-audit" >&2
@@ -82,10 +92,15 @@ echo "Platform: ${PLATFORM}" >&2
 echo "Release:  ${RELEASE_TAG}" >&2
 
 # Check if our platform binary exists in the release
-if ! gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep -q "^${BIN_NAME}$"; then
+if ! release_assets=$(retry gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name'); then
+  echo "error: could not read assets of ${RELEASE_TAG} after retries (network/gh/auth?)." >&2
+  echo "  Falling back to build-from-source: cd \"$REPO_ROOT\" && make ways-audit" >&2
+  exit 1
+fi
+if ! echo "$release_assets" | grep -q "^${BIN_NAME}$"; then
   echo "No pre-built binary for ${PLATFORM} in release ${RELEASE_TAG}." >&2
   echo "Available binaries:" >&2
-  gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep "^ways-audit-" | sed 's/^/  /' >&2
+  echo "$release_assets" | grep "^ways-audit-" | sed 's/^/  /' >&2
   echo "" >&2
   echo "Build from source instead:" >&2
   echo "  cd \"$REPO_ROOT\" && make ways-audit" >&2
@@ -94,11 +109,15 @@ fi
 
 # Download binary + checksums
 echo "Downloading ${BIN_NAME}..." >&2
-gh release download "$RELEASE_TAG" \
-  --repo "$GH_REPO" \
-  --pattern "$BIN_NAME" \
-  --dir "$OUTPUT_DIR" \
-  --clobber
+if ! retry gh release download "$RELEASE_TAG" \
+    --repo "$GH_REPO" \
+    --pattern "$BIN_NAME" \
+    --dir "$OUTPUT_DIR" \
+    --clobber; then
+  echo "error: download of ${BIN_NAME} failed after retries — building from source instead." >&2
+  echo "  cd \"$REPO_ROOT\" && make ways-audit" >&2
+  exit 1
+fi
 
 # Verify checksum
 CHECKSUMS_FILE="${OUTPUT_DIR}/checksums.txt"

--- a/tools/ways-audit/download-ways-audit.sh
+++ b/tools/ways-audit/download-ways-audit.sh
@@ -80,7 +80,7 @@ if [[ "$RELEASE_TAG" == "latest" ]]; then
     echo "  Falling back to build-from-source: cd \"$REPO_ROOT\" && make ways-audit" >&2
     exit 1
   fi
-  RELEASE_TAG=$(echo "$release_tags" | grep '^ways-audit-v' | head -1)
+  RELEASE_TAG=$(echo "$release_tags" | grep '^ways-audit-v' | head -1 || true)
   if [[ -z "$RELEASE_TAG" ]]; then
     echo "No ways-audit release found. Build from source:" >&2
     echo "  cd \"$REPO_ROOT\" && make ways-audit" >&2
@@ -119,14 +119,23 @@ if ! retry gh release download "$RELEASE_TAG" \
   exit 1
 fi
 
-# Verify checksum
+# Verify checksum. Whether the release HAS a checksums.txt is known from the
+# assets list, so a download failure here is a transient blip (retry), not
+# "absent" — and if it's present but unfetchable we refuse to install unverified
+# rather than silently skipping the integrity check.
 CHECKSUMS_FILE="${OUTPUT_DIR}/checksums.txt"
-if gh release download "$RELEASE_TAG" \
-    --repo "$GH_REPO" \
-    --pattern "checksums.txt" \
-    --dir "$OUTPUT_DIR" \
-    --clobber 2>/dev/null; then
-  expected_hash=$(grep "${BIN_NAME}" "$CHECKSUMS_FILE" | awk '{print $1}')
+if echo "$release_assets" | grep -q '^checksums\.txt$'; then
+  if ! retry gh release download "$RELEASE_TAG" \
+      --repo "$GH_REPO" \
+      --pattern "checksums.txt" \
+      --dir "$OUTPUT_DIR" \
+      --clobber; then
+    echo "error: checksums.txt is in ${RELEASE_TAG} but its download failed after retries —" >&2
+    echo "  refusing to install ${BIN_NAME} unverified. Build from source: cd \"$REPO_ROOT\" && make ways-audit" >&2
+    rm -f "$PLATFORM_FILE"
+    exit 1
+  fi
+  expected_hash=$(grep "${BIN_NAME}" "$CHECKSUMS_FILE" | awk '{print $1}' || true)
   if [[ -n "$expected_hash" ]]; then
     actual_hash=$(sha256sum "$PLATFORM_FILE" 2>/dev/null | cut -d' ' -f1 \
       || shasum -a 256 "$PLATFORM_FILE" 2>/dev/null | cut -d' ' -f1)
@@ -141,7 +150,7 @@ if gh release download "$RELEASE_TAG" \
   fi
   rm -f "$CHECKSUMS_FILE"
 else
-  echo "WARNING: checksums.txt not found in release — skipping verification" >&2
+  echo "WARNING: no checksums.txt in ${RELEASE_TAG} — skipping verification" >&2
 fi
 
 # Make executable and install

--- a/tools/ways-cli/download-ways.sh
+++ b/tools/ways-cli/download-ways.sh
@@ -11,6 +11,10 @@
 
 set -euo pipefail
 
+# Shared retry/backoff helpers — a transient gh/API blip must not silently
+# degrade `ways update` to a from-source build.
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" && pwd)/prebuilt-lib.sh"
+
 # Platform detection
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | sed 's/arm64/aarch64/')
@@ -69,8 +73,14 @@ mkdir -p "$OUTPUT_DIR"
 
 # Find the latest ways release
 if [[ "$RELEASE_TAG" == "latest" ]]; then
-  RELEASE_TAG=$(gh release list --repo "$GH_REPO" --limit 20 --json tagName --jq '.[].tagName' 2>/dev/null \
-    | grep '^ways-v' | head -1)
+  # Retry transient API failures, then distinguish "couldn't reach the API"
+  # (retries exhausted → honest error) from "reached it, no matching release".
+  if ! release_tags=$(retry gh release list --repo "$GH_REPO" --limit 30 --json tagName --jq '.[].tagName'); then
+    echo "error: could not reach GitHub Releases after retries (network/gh/auth?)." >&2
+    echo "  Falling back to build-from-source: cd \"$REPO_ROOT\" && make ways" >&2
+    exit 1
+  fi
+  RELEASE_TAG=$(echo "$release_tags" | grep '^ways-v' | head -1)
   if [[ -z "$RELEASE_TAG" ]]; then
     echo "No ways release found. Build from source:" >&2
     echo "  cd \"$REPO_ROOT\" && make ways" >&2
@@ -82,10 +92,15 @@ echo "Platform: ${PLATFORM}" >&2
 echo "Release:  ${RELEASE_TAG}" >&2
 
 # Check if our platform binary exists in the release
-if ! gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep -q "^${BIN_NAME}$"; then
+if ! release_assets=$(retry gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name'); then
+  echo "error: could not read assets of ${RELEASE_TAG} after retries (network/gh/auth?)." >&2
+  echo "  Falling back to build-from-source: cd \"$REPO_ROOT\" && make ways" >&2
+  exit 1
+fi
+if ! echo "$release_assets" | grep -q "^${BIN_NAME}$"; then
   echo "No pre-built binary for ${PLATFORM} in release ${RELEASE_TAG}." >&2
   echo "Available binaries:" >&2
-  gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep "ways-" | sed 's/^/  /' >&2
+  echo "$release_assets" | grep "ways-" | sed 's/^/  /' >&2
   echo "" >&2
   echo "Build from source instead:" >&2
   echo "  cd \"$REPO_ROOT\" && make ways" >&2
@@ -94,11 +109,15 @@ fi
 
 # Download binary + checksums
 echo "Downloading ${BIN_NAME}..." >&2
-gh release download "$RELEASE_TAG" \
-  --repo "$GH_REPO" \
-  --pattern "$BIN_NAME" \
-  --dir "$OUTPUT_DIR" \
-  --clobber
+if ! retry gh release download "$RELEASE_TAG" \
+    --repo "$GH_REPO" \
+    --pattern "$BIN_NAME" \
+    --dir "$OUTPUT_DIR" \
+    --clobber; then
+  echo "error: download of ${BIN_NAME} failed after retries — building from source instead." >&2
+  echo "  cd \"$REPO_ROOT\" && make ways" >&2
+  exit 1
+fi
 
 # Verify checksum
 CHECKSUMS_FILE="${OUTPUT_DIR}/checksums.txt"

--- a/tools/ways-cli/download-ways.sh
+++ b/tools/ways-cli/download-ways.sh
@@ -80,7 +80,7 @@ if [[ "$RELEASE_TAG" == "latest" ]]; then
     echo "  Falling back to build-from-source: cd \"$REPO_ROOT\" && make ways" >&2
     exit 1
   fi
-  RELEASE_TAG=$(echo "$release_tags" | grep '^ways-v' | head -1)
+  RELEASE_TAG=$(echo "$release_tags" | grep '^ways-v' | head -1 || true)
   if [[ -z "$RELEASE_TAG" ]]; then
     echo "No ways release found. Build from source:" >&2
     echo "  cd \"$REPO_ROOT\" && make ways" >&2
@@ -100,7 +100,7 @@ fi
 if ! echo "$release_assets" | grep -q "^${BIN_NAME}$"; then
   echo "No pre-built binary for ${PLATFORM} in release ${RELEASE_TAG}." >&2
   echo "Available binaries:" >&2
-  echo "$release_assets" | grep "ways-" | sed 's/^/  /' >&2
+  echo "$release_assets" | grep "^ways-" | sed 's/^/  /' >&2
   echo "" >&2
   echo "Build from source instead:" >&2
   echo "  cd \"$REPO_ROOT\" && make ways" >&2
@@ -119,14 +119,23 @@ if ! retry gh release download "$RELEASE_TAG" \
   exit 1
 fi
 
-# Verify checksum
+# Verify checksum. Whether the release HAS a checksums.txt is known from the
+# assets list, so a download failure here is a transient blip (retry), not
+# "absent" — and if it's present but unfetchable we refuse to install unverified
+# rather than silently skipping the integrity check.
 CHECKSUMS_FILE="${OUTPUT_DIR}/checksums.txt"
-if gh release download "$RELEASE_TAG" \
-    --repo "$GH_REPO" \
-    --pattern "checksums.txt" \
-    --dir "$OUTPUT_DIR" \
-    --clobber 2>/dev/null; then
-  expected_hash=$(grep "${BIN_NAME}" "$CHECKSUMS_FILE" | awk '{print $1}')
+if echo "$release_assets" | grep -q '^checksums\.txt$'; then
+  if ! retry gh release download "$RELEASE_TAG" \
+      --repo "$GH_REPO" \
+      --pattern "checksums.txt" \
+      --dir "$OUTPUT_DIR" \
+      --clobber; then
+    echo "error: checksums.txt is in ${RELEASE_TAG} but its download failed after retries —" >&2
+    echo "  refusing to install ${BIN_NAME} unverified. Build from source: cd \"$REPO_ROOT\" && make ways" >&2
+    rm -f "$PLATFORM_FILE"
+    exit 1
+  fi
+  expected_hash=$(grep "${BIN_NAME}" "$CHECKSUMS_FILE" | awk '{print $1}' || true)
   if [[ -n "$expected_hash" ]]; then
     actual_hash=$(sha256sum "$PLATFORM_FILE" 2>/dev/null | cut -d' ' -f1 \
       || shasum -a 256 "$PLATFORM_FILE" 2>/dev/null | cut -d' ' -f1)
@@ -141,7 +150,7 @@ if gh release download "$RELEASE_TAG" \
   fi
   rm -f "$CHECKSUMS_FILE"
 else
-  echo "WARNING: checksums.txt not found in release — skipping verification" >&2
+  echo "WARNING: no checksums.txt in ${RELEASE_TAG} — skipping verification" >&2
 fi
 
 # Make executable and install


### PR DESCRIPTION
## Symptom
On `ways update`, **attend** built from source ("No pre-built binary, building attend from source...") even though `attend-v0.7.1` is published with the `attend-linux-x86_64` asset — while `ways-audit` and `attend-chat` installed pre-built in the **same** run. Every component's binary is in fact posted (release-completeness verified); the update degraded for no good reason.

## Root cause
The four component download scripts resolved the release with:
```sh
RELEASE_TAG=$(gh release list ... 2>/dev/null | grep '^attend-v' | head -1)
[[ -z "$RELEASE_TAG" ]] && { echo "No attend release found"; exit 1; }
```
A **transient** GitHub API / network blip makes that `gh` call fail; the `2>/dev/null` swallows the error, the empty result reads as *"no release found"*, the script exits 1, and the Makefile — which **also** ran the script under `2>/dev/null` — falls straight to a from-source build. One hiccup on one component's `gh` call = a needless compile, with the reason hidden. (The scripts are structurally identical, so this was luck-of-the-draw per component per run.)

## Fix
- **Retry**: shared `retry()` helper (`tools/scripts/prebuilt-lib.sh`, exponential backoff) wrapping the three network `gh` calls — release *list*, *view*, and binary *download* — in all four scripts (attend, attend-chat, ways, ways-audit).
- **Honest classification**: distinguish *"couldn't reach the API"* (retries exhausted → explicit error + fall back) from *"reached it, no matching release"* (empty) — the old code conflated them.
- **Surface it**: the Makefile no longer swallows the scripts' stderr, and the fallback now reads *"Pre-built unavailable (see above) — building from source"* so a real failure is attributable.

## Verification
- All four scripts download + checksum-verify their **own** component's binary end-to-end (ways→`ways-v1.0.8`, not ways-audit; each isolated correctly).
- A simulated `gh` failure now **retries** (`attempt 1/2 failed; retrying...`) then reports *"could not reach GitHub Releases after retries (network/gh/auth?)"* instead of silently source-building.
- `bash -n` clean on all; Makefile parses. mmaid's separate (non-update-path) script left untouched.

Follow-up (not in this PR): a coordinated-release check so cutting one component's release verifies the others' published binaries still match source.

https://claude.ai/code/session_013LujXMCgxspdXURWvTWSaz