### PR TITLE
ADR-155: semantic gating of the keyword channel + reasoning-channel rebuild (§1–4)

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -75,6 +75,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-152](./system/ADR-152-framework-default-secret-path-deny-baseline.md) | Framework-default secret-path deny baseline | Accepted |
 | [ADR-153](./system/ADR-153-session-introspection-substrate-correlating-fired-ways-to-turns.md) | Session-introspection substrate — correlating fired ways to turns | Accepted |
 | [ADR-154](./system/ADR-154-rethink-think-and-non-interactive-introspection-one-model-three-front-ends.md) | `ways introspect` — one model, three front-ends | Accepted |
+| [ADR-155](./system/ADR-155-semantic-gating-of-the-keyword-channel-and-reasoning-channel-rebuild.md) | Semantic gating of the keyword channel and reasoning-channel rebuild | Draft |
 
 ## Governance
 _Provenance, traceability, controls, compliance mapping_

--- a/docs/architecture/system/ADR-155-semantic-gating-of-the-keyword-channel-and-reasoning-channel-rebuild.md
+++ b/docs/architecture/system/ADR-155-semantic-gating-of-the-keyword-channel-and-reasoning-channel-rebuild.md
@@ -99,25 +99,46 @@ score also clears a **gate floor**:
 gate_floor = keyword_gate_fraction × effective_threshold(way)
 ```
 
-with `keyword_gate_fraction` a global config value (default **0.5**), applied
-per model lane the same way fire thresholds are (EN and multi each gate on
-their own floor; clearing either lane passes). Parent-boost applies to the
-effective threshold before the fraction, so a keyword hit under a fired parent
-is gated more leniently — consistent with ADR-125's disclosure semantics.
+with `keyword_gate_fraction` a global config value (default **0.4**, clamped
+to [0, 1] on load — a fraction above 1.0 would put the floor above the fire
+threshold and invert the gate's meaning), applied per model lane the same way
+fire thresholds are (EN and multi each gate on their own floor; clearing
+either lane passes). Parent-boost applies to the effective threshold before
+the fraction, so a keyword hit under a fired parent is gated more leniently —
+consistent with ADR-125's disclosure semantics.
 
-With the defaults this yields floors of 0.14–0.20. Against the observed data:
-the three false fires above (0.09, 0.15, 0.22 vs floors 0.20, 0.175, 0.20) are
-suppressed or borderline; every observed true fire clears with margin.
+With the defaults this yields floors of 0.11–0.16. Against the observed data,
+three score bands emerge: lexical coincidences land at 0.04–0.15 (gated);
+multi-word intent phrases the pattern author deliberately encoded ("ship it"
+against the github way) land at 0.17–0.18 (must fire); topical prompts land
+at 0.26+ (fire with margin). The 0.4 fraction places the floor in the gap
+between the first two bands. Calibration review found 0.5 (floor 0.20)
+vetoed the intent-phrase band.
+
+A lane that ran but returned no row for a way that *is* embeddable (has
+description + vocabulary) is treated as a score of 0.0, not as absent signal:
+`way-embed` emits only non-negative cosines, so a missing row means negative
+cosine — the strongest "unrelated" verdict. Fail-open is reserved for cases
+with genuinely no evidence: the engine didn't run, or the way is trigger-only
+and cannot be in the corpus. This keeps the gate monotonic in relatedness
+(without it, the worst matches would out-fire mild ones).
 
 The gate is a *veto on noise*, not a second retrieval tier: the pattern
 remains the explicit trigger, and the score consulted is the one
 `batch_embed_score` already produced for the fire path. Zero additional model
-invocations; zero added latency.
+invocations on the common path; when part 3's response context contributed to
+the shared embed vector, a hit that lands below the floor is re-checked
+against a lazily computed prompt-only embedding before the veto stands — the
+user's own typed keyword must never be gated by what Claude said last turn.
+That second pass runs at most once per scan, only on turns where a hit was
+actually gated with response context present.
 
 **Escape hatch:** a way may declare `pattern_strict: true` in frontmatter to
-opt out of gating — for patterns that genuinely mean "fire on this exact
-token, always" (e.g. slash-command references like `/wrap`). The lint warns
-when `pattern_strict` is combined with common-word alternations.
+opt out of gating **and of §2's masking** — strict means "fire on exactly
+this text, always": slash-command references like `/wrap`, or patterns that
+deliberately target URL content (`github\.com/\S+/pull`), which the mask
+would otherwise hide from the regex lane. The lint warns when
+`pattern_strict` is combined with common-word alternations.
 
 **Telemetry:** a gated-off hit logs a `way_keyword_gated` event carrying
 `matched_span`, both scores, both floors — the same shape as `way_nearmiss`
@@ -132,17 +153,24 @@ URLs (`https?://\S+`) and fenced code blocks are masked out of the query
 **for the keyword channel only** before pattern matching. A pasted link
 containing "github" is not GitHub-workflow intent. The embed query is
 untouched — the ADR-130 salience reducer already handles long pasted content
-for that lane.
+for that lane. Ways whose patterns deliberately target URL or code content
+opt out with `pattern_strict: true` (§1's escape hatch covers both the gate
+and the mask).
 
 ### 3. Rebuild the response-topics channel
 
-`check-response.sh`'s 24-word grep whitelist is removed. The Stop hook instead
-passes the last assistant message through the ADR-130 sentence-salience
-reducer (exposed via the `ways` binary so the hook stays a thin dispatcher)
-and stores the reduced text. On the next prompt scan, that stored text feeds
-**only the embed query, never the regex query**. The keyword channel matches
-what the user actually typed; the semantic channel sees user intent *plus*
-what Claude was just reasoning about.
+`check-response.sh`'s 24-word grep whitelist is removed. The Stop hook stores
+the last assistant message **raw** (bounded excerpt) — no extraction at Stop
+time at all; the ADR-130 sentence-salience reducer selects what matters at
+scan time, where it already runs on every prompt. On the next prompt scan,
+that stored text rides a separate `--response-context` flag and feeds **only
+the embed query, never the regex query**. The keyword channel matches what
+the user actually typed; the semantic channel sees user intent *plus* what
+Claude was just reasoning about. A turn with nothing extractable (tool-only
+stop) clears the state file rather than leaving a stale response to be
+re-embedded as current. The hook degrades to the flagless invocation if the
+installed binary predates the flag, so a hooks-before-binary deploy order
+cannot block prompts.
 
 This is the fix for under-firing on Claude's own reasoning: full-sentence
 salient content replaces a fixed vocabulary, and it reaches the lane designed
@@ -221,7 +249,7 @@ protecting the transition.
   alone; "why didn't my pattern fire" now has a second cause. Introspect
   surfacing the gated row is the answer path.
 - Behavior change for existing installs: some previously-firing ways go
-  quiet. The gate defaults are deliberately loose (0.5 × threshold) and
+  quiet. The gate defaults are deliberately loose (0.4 × threshold) and
   telemetry-adjustable.
 
 ### Neutral

--- a/docs/architecture/system/ADR-155-semantic-gating-of-the-keyword-channel-and-reasoning-channel-rebuild.md
+++ b/docs/architecture/system/ADR-155-semantic-gating-of-the-keyword-channel-and-reasoning-channel-rebuild.md
@@ -182,9 +182,17 @@ pattern-bearing ways:
 
 Parts 1–2 land first (one file, `scan/mod.rs`, plus config/frontmatter
 plumbing) — they make the system safe against the *existing* noisy patterns.
-Part 3 and 4 follow. Part 5 (frontmatter rework + corpus rebuild + lint) runs
-last, validated by embed-scoring regression prompts, so pattern demotion
-happens with the gate already protecting the transition.
+Part 3 and 4 follow. Part 5 (frontmatter rework + corpus rebuild + lint) is
+**blocked on a deployed release of parts 1–4**, not merely on their merge:
+the rework pass tunes against live behavior — `way_keyword_gated` telemetry
+saying which alternations the gate is actually vetoing, and the bash-surface
+semantic fires showing where vocabulary already carries a way without its
+pattern. Without that stream the demotion decisions are guesses; with it,
+each pattern edit is validated against what the gate observed in real
+sessions. Part 5 also rebuilds the corpus (vocabulary changes move every
+reworked way's embedding coordinate) and is validated by embed-scoring
+regression prompts, so it runs as its own branch with the gate already
+protecting the transition.
 
 ## Consequences
 

--- a/docs/architecture/system/ADR-155-semantic-gating-of-the-keyword-channel-and-reasoning-channel-rebuild.md
+++ b/docs/architecture/system/ADR-155-semantic-gating-of-the-keyword-channel-and-reasoning-channel-rebuild.md
@@ -1,0 +1,251 @@
+---
+status: Draft
+date: 2026-07-04
+deciders:
+  - aaronsb
+  - claude
+related:
+  - 108
+  - 125
+  - 130
+  - 134
+  - 153
+---
+
+# ADR-155: Semantic gating of the keyword channel and reasoning-channel rebuild
+
+## Context
+
+ADR-125 named the matching architecture: retrieval is embedding-only, the model's
+cosine score is accepted as ground truth, and the `pattern:`/`commands:` regex
+fields survive as *explicit deterministic triggers* — "fire this way exactly when
+this pattern appears." In practice the keyword channel has drifted from that
+role into fuzzy retrieval, and the code gives it veto-proof authority.
+
+### How matching works today
+
+In `match_prompt` (`tools/ways-cli/src/cmd/scan/mod.rs`), the regex pattern is
+checked first. Any substring hit anywhere in the prompt fires the way
+deterministically; the embedding is never consulted for that way. The embedding
+is a fallback that can only *add* fires, never veto a lexical coincidence —
+even though `batch_embed_score` has already scored **every** way against the
+prompt before the candidate loop starts. The signal that would separate
+incidental keywords from topical intent is computed, then discarded.
+
+Two adjacent surfaces compound this:
+
+- **PreToolUse** (`command()`/`file()`): ways match by regex only (`commands`
+  against the command string, `pattern` against the tool description). The
+  semantic lane exists on that surface but is wired only to *checks*. Where
+  Claude is about to act — the moment course-correction is most valuable —
+  ways have no semantic channel at all.
+- **Stop hook** (`check-response.sh`): Claude's response is reduced to a grep
+  against a hard-coded 24-word whitelist (`api|test|debug|…|way|pr|…`), and the
+  surviving tokens are concatenated into the **next prompt's match query** —
+  including the regex channel. The whitelist words are, by construction, way
+  trigger words. If Claude's reply mentioned "way" or "pr", the next user
+  prompt keyword-fires `meta/knowledge` or `softwaredev/delivery/github`
+  regardless of what the user typed. The channel meant to give ways awareness
+  of Claude's reasoning is simultaneously too blind to capture it (24 fixed
+  words) and a noise injector into the keyword channel.
+
+### Observed failure (session introspection, ADR-153)
+
+A live session in a TUI-oscilloscope project fired five ways on one pasted
+prompt. Rescoring that exact prompt against the corpus:
+
+| Way | fired via | EN embed score | topically relevant |
+|---|---|---:|---|
+| softwaredev/visualization | semantic | 0.40 | yes |
+| softwaredev/visualization/charts | keyword `graph` | 0.28 | yes |
+| meta/knowledge | keyword ` ways ` ("btop's various ways to render…") | 0.22 | no |
+| meta/memory | keyword `remember` ("I remember the tektronix…") | 0.15 | no |
+| softwaredev/delivery/github | keyword `github` (a pasted URL) | 0.09 | no |
+
+The inverse test — short prompts with genuine intent — scores high on the
+target way: "adr" → 0.47 (documentation/adr), "remember this decision for
+later sessions" → 0.35 (meta/memory), "let's look at the github pr checks" →
+0.57 (delivery/github), "can you make a chart of the results" → 0.51
+(visualization/charts). The embedding rank-orders relevance correctly in every
+observed case; a floor near half the fire threshold cleanly separates
+coincidence from intent. **The model already knows which keyword fires are
+junk; the scan loop doesn't ask it.**
+
+### Scale of the problem
+
+- 42 of 136 way files carry a `pattern:`. Many alternations are bare common
+  words (`commit`, `workflow`, `docs`, `remember`, `release`, `trade.?off` —
+  the last in two different ways) or unanchored substrings (`graph` matches
+  "photograph"). These are vocabulary words doing pattern work.
+- Telemetry (`$XDG_STATE/agent-ways/events.jsonl`) records one keyword fire
+  whose `matched_span` is a 120-character stretch of prompt — a greedy `.*`
+  alternation matching essentially arbitrary text.
+- 5,011 near-miss events show the semantic lane frequently lands just below
+  threshold — the opposite imbalance: keyword over-fires while semantic
+  under-fires.
+
+## Decision
+
+Give the already-computed embedding score veto power over lexical coincidence,
+and rebuild the response-topics channel so Claude's reasoning feeds the
+semantic lane instead of polluting the regex lane. Five parts:
+
+### 1. Semantic plausibility gate on keyword fires
+
+A `pattern:` hit on the prompt/task surface fires only if the way's embedding
+score also clears a **gate floor**:
+
+```
+gate_floor = keyword_gate_fraction × effective_threshold(way)
+```
+
+with `keyword_gate_fraction` a global config value (default **0.5**), applied
+per model lane the same way fire thresholds are (EN and multi each gate on
+their own floor; clearing either lane passes). Parent-boost applies to the
+effective threshold before the fraction, so a keyword hit under a fired parent
+is gated more leniently — consistent with ADR-125's disclosure semantics.
+
+With the defaults this yields floors of 0.14–0.20. Against the observed data:
+the three false fires above (0.09, 0.15, 0.22 vs floors 0.20, 0.175, 0.20) are
+suppressed or borderline; every observed true fire clears with margin.
+
+The gate is a *veto on noise*, not a second retrieval tier: the pattern
+remains the explicit trigger, and the score consulted is the one
+`batch_embed_score` already produced for the fire path. Zero additional model
+invocations; zero added latency.
+
+**Escape hatch:** a way may declare `pattern_strict: true` in frontmatter to
+opt out of gating — for patterns that genuinely mean "fire on this exact
+token, always" (e.g. slash-command references like `/wrap`). The lint warns
+when `pattern_strict` is combined with common-word alternations.
+
+**Telemetry:** a gated-off hit logs a `way_keyword_gated` event carrying
+`matched_span`, both scores, both floors — the same shape as `way_nearmiss`
+(ADR-134). The tuning passes consume this stream to calibrate
+`keyword_gate_fraction` empirically before any tightening. A gated fire is
+also visible in `ways introspect` as a suppressed-candidate row, so a "why
+didn't X fire" question is answerable from the session record.
+
+### 2. Mask non-linguistic spans before regex matching
+
+URLs (`https?://\S+`) and fenced code blocks are masked out of the query
+**for the keyword channel only** before pattern matching. A pasted link
+containing "github" is not GitHub-workflow intent. The embed query is
+untouched — the ADR-130 salience reducer already handles long pasted content
+for that lane.
+
+### 3. Rebuild the response-topics channel
+
+`check-response.sh`'s 24-word grep whitelist is removed. The Stop hook instead
+passes the last assistant message through the ADR-130 sentence-salience
+reducer (exposed via the `ways` binary so the hook stays a thin dispatcher)
+and stores the reduced text. On the next prompt scan, that stored text feeds
+**only the embed query, never the regex query**. The keyword channel matches
+what the user actually typed; the semantic channel sees user intent *plus*
+what Claude was just reasoning about.
+
+This is the fix for under-firing on Claude's own reasoning: full-sentence
+salient content replaces a fixed vocabulary, and it reaches the lane designed
+to interpret it.
+
+### 4. Semantic lane for ways at PreToolUse
+
+`command()` already computes embedding scores for the reduced
+`command + description` query (used by checks). Ways gain the same lane: a way
+whose score clears its effective threshold fires on the bash surface, exactly
+as it would on the prompt surface. The tool `description` field is Claude's
+own natural-language statement of intent, which is the right embed input at
+act-time. No new embedding work — the scores are already computed per
+PreToolUse event. Existing re-disclosure suppression (decay curves) bounds
+repeat injections; the near-miss/fire telemetry monitors this surface for
+noise before any threshold adjustment.
+
+### 5. Pattern hygiene: demote vocabulary words out of patterns
+
+Doctrine, enforced by lint and applied by a rework pass over the 42
+pattern-bearing ways:
+
+- **`pattern:` is for exact, high-precision triggers** — command names, term
+  -of-art tokens (`adr`, `diataxis`, `mermaid`), phrases with anchoring
+  structure. Word-boundary anchoring required for short alternations.
+- **Suggestive common words belong in `vocabulary:`** — they shape the
+  embedding coordinate, which is the lane built to weigh them contextually.
+  `remember`, `commit`, `workflow`, `docs`-alone move out of patterns.
+- New lint rules: flag unanchored alternations under a length floor, bare
+  dictionary-common words, and `.*` in prompt patterns.
+- `ways tune --precision` gains per-alternation attribution: `matched_span`
+  (ADR-153) joined with the off-class session heuristic (ADR-134) identifies
+  which alternation produces off-domain fires, producing a ranked demotion
+  worklist instead of hand-auditing 42 files.
+
+### Sequencing
+
+Parts 1–2 land first (one file, `scan/mod.rs`, plus config/frontmatter
+plumbing) — they make the system safe against the *existing* noisy patterns.
+Part 3 and 4 follow. Part 5 (frontmatter rework + corpus rebuild + lint) runs
+last, validated by embed-scoring regression prompts, so pattern demotion
+happens with the gate already protecting the transition.
+
+## Consequences
+
+### Positive
+
+- False keyword fires on incidental words, pasted URLs, and echoed response
+  topics are suppressed using signal that is already computed — no latency or
+  model cost. Context stops being spent on off-topic way bodies, and ways stop
+  training the agent to ignore them.
+- Ways gain a semantic channel at PreToolUse — guidance can reach the moment
+  before action, which keyword-only matching mostly missed.
+- Claude's reasoning enters matching as reduced salient sentences in the
+  semantic lane, replacing a 24-word whitelist that leaked trigger tokens into
+  the regex lane.
+- Every suppression is observable (`way_keyword_gated`, introspect rows) and
+  the gate fraction is tunable from telemetry before any further tightening —
+  the ADR-134 pattern applied to a new stream.
+
+### Negative
+
+- A way with an exact pattern but weak `description`/`vocabulary` text can be
+  wrongly gated: its corpus coordinate under-represents what the pattern
+  targets. Mitigations: `pattern_strict: true`, and the part-5 rework
+  explicitly checks that pattern terms appear in the way's embeddable text.
+- The keyword channel is no longer fully deterministic from the way file
+  alone; "why didn't my pattern fire" now has a second cause. Introspect
+  surfacing the gated row is the answer path.
+- Behavior change for existing installs: some previously-firing ways go
+  quiet. The gate defaults are deliberately loose (0.5 × threshold) and
+  telemetry-adjustable.
+
+### Neutral
+
+- `meta/knowledge`'s ` ways ` alternation lands near the default floor
+  (0.22 vs 0.20) — the borderline case that telemetry, not this ADR, should
+  settle.
+- Threshold rebalance (lowering semantic defaults where near-misses cluster
+  on-domain) becomes attractive once keyword noise is gated, but is out of
+  scope here — it stays with the ADR-134 tuning passes.
+- The state channel (session-start fires such as `freshness`) has its own
+  value question, untouched by this ADR — different trigger class, different
+  economics.
+
+## Alternatives Considered
+
+- **A language-model classifier over candidate fires.** Rejected on cost and
+  latency: every prompt and tool call would pay an LM round-trip, and the
+  evidence shows MiniLM cosine already carries the discriminating signal —
+  every observed false fire scored below 0.22, every observed true fire above
+  0.28.
+- **Weighted lexical scoring (BM25-like multi-term evidence).** Rejected as
+  re-litigating ADR-125, which removed BM25 and named the embedding the single
+  retrieval mechanism. The gate keeps that shape: lexical stays binary and
+  explicit; the embedding stays the only scorer.
+- **Authoring-only fix (rework the 42 patterns, change no code).** Necessary
+  but not sufficient: authoring regresses (this drift happened under the
+  current lint), project-local ways repeat the same mistakes, and no pattern
+  hygiene fixes the Stop-hook whitelist or the missing PreToolUse lane.
+- **Raising semantic thresholds to compensate.** Backwards: semantic is the
+  under-firing channel (5,011 near-misses). The noise source is lexical.
+- **Removing the keyword channel entirely.** Rejected: ADR-125's case for
+  explicit deterministic triggers stands — slash commands, terms of art, and
+  `commands:` regexes at PreToolUse are legitimately exact. The problem is
+  authority without corroboration, not existence.

--- a/hooks/ways/check-prompt.sh
+++ b/hooks/ways/check-prompt.sh
@@ -41,8 +41,21 @@ export CLAUDE_PROJECT_DIR="${PROJECT_DIR}"
 # Use --opt=value (not --opt value): a prompt may begin with '-' (e.g. the user
 # pastes "-spawn ..."), and the space form makes clap parse that as a flag.
 # The = form binds the value unambiguously even when it starts with a dash.
-"${HOME}/.claude/bin/ways" scan prompt \
+#
+# Deploy-order skew guard: if the projected hooks are newer than the
+# installed binary (reconcile ran before a rebuild), clap rejects the
+# unknown --response-context flag with a non-zero exit — which the
+# UserPromptSubmit contract reads as "block the prompt". Degrade to the
+# flagless pre-ADR-155 invocation rather than blocking every prompt.
+if ! OUTPUT=$("${HOME}/.claude/bin/ways" scan prompt \
   --query="$PROMPT" \
   --session="$SESSION_ID" \
   --project="$PROJECT_DIR" \
-  --response-context="$RESPONSE_CONTEXT"
+  --response-context="$RESPONSE_CONTEXT" 2>/dev/null); then
+  OUTPUT=$("${HOME}/.claude/bin/ways" scan prompt \
+    --query="$PROMPT" \
+    --session="$SESSION_ID" \
+    --project="$PROJECT_DIR")
+fi
+[[ -n "$OUTPUT" ]] && printf '%s\n' "$OUTPUT"
+exit 0

--- a/hooks/ways/check-prompt.sh
+++ b/hooks/ways/check-prompt.sh
@@ -11,8 +11,8 @@
 # for tool results that exceed inline budget, and other system-reminder
 # envelopes. Size bounding for the embed query is the ways binary's
 # responsibility (ADR-130 sentence-salience reducer in scan/reduce.rs).
-# This script passes the full combined prompt+topics through so the
-# reducer can score sentence salience across the whole input.
+# This script passes the full prompt through so the reducer can score
+# sentence salience across the whole input.
 
 source "$(dirname "$0")/require-ways.sh"
 
@@ -23,23 +23,26 @@ PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(echo "$INPUT" | jq -r '.cwd // empty')}"
 AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // empty')
 [[ -n "$AGENT_ID" ]] && export CLAUDE_AGENT_ID="$AGENT_ID"
 
-# Read response topics from Stop hook (if available).
+# Read Claude's last response from the Stop hook state (if available).
 # Path resolves through the binary so the writer (check-response.sh),
-# the consumer (here), and `ways reset` cannot drift.
+# the consumer (here), and `ways reset` cannot drift. `.topics` is the
+# pre-ADR-155 field name — read as fallback so one stale state file
+# across an upgrade degrades gracefully instead of vanishing.
 RESPONSE_STATE=$("${HOME}/.claude/bin/ways" response-topics-path "$SESSION_ID")
-RESPONSE_TOPICS=""
+RESPONSE_CONTEXT=""
 if [[ -f "$RESPONSE_STATE" ]]; then
-  RESPONSE_TOPICS=$(jq -r '.topics // empty' "$RESPONSE_STATE" 2>/dev/null)
+  RESPONSE_CONTEXT=$(jq -r '.context // .topics // empty' "$RESPONSE_STATE" 2>/dev/null)
 fi
 
-# Combined context: user prompt + Claude's recent topics.
-COMBINED="${PROMPT} ${RESPONSE_TOPICS}"
-
 export CLAUDE_PROJECT_DIR="${PROJECT_DIR}"
+# The prompt and the response context ride separate flags (ADR-155 §3):
+# the binary keyword-matches only the prompt, and embeds both. Response
+# tokens can no longer keyword-fire ways the user never mentioned.
 # Use --opt=value (not --opt value): a prompt may begin with '-' (e.g. the user
 # pastes "-spawn ..."), and the space form makes clap parse that as a flag.
 # The = form binds the value unambiguously even when it starts with a dash.
 "${HOME}/.claude/bin/ways" scan prompt \
-  --query="$COMBINED" \
+  --query="$PROMPT" \
   --session="$SESSION_ID" \
-  --project="$PROJECT_DIR"
+  --project="$PROJECT_DIR" \
+  --response-context="$RESPONSE_CONTEXT"

--- a/hooks/ways/check-response.sh
+++ b/hooks/ways/check-response.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
-# Stop hook: Analyze Claude's response for topic awareness
+# Stop hook: capture Claude's response for topic awareness (ADR-155 §3)
 #
-# Reads the transcript after Claude responds, extracts topics,
-# and writes state for the next UserPromptSubmit to use.
-#
-# This enables ways to trigger based on what Claude discussed,
-# not just what the user asked.
+# Reads the transcript after Claude responds and stores the last assistant
+# message RAW for the next UserPromptSubmit. No extraction happens here —
+# the scan-time sentence-salience reducer (ADR-130) selects what matters,
+# and the stored text feeds only the embed lane, never the keyword regex
+# lane. This replaced a 24-word grep whitelist that both missed Claude's
+# actual reasoning and leaked way-trigger tokens ("way", "pr", "commit")
+# into the next prompt's keyword matching.
 
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
@@ -25,28 +27,17 @@ STOP_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
 STATE_FILE=$("${HOME}/.claude/bin/ways" response-topics-path "$SESSION_ID")
 
 # Extract last assistant message from transcript (JSONL format)
-# Use tail instead of tac to avoid reading entire file
+# Use tail instead of tac to avoid reading entire file. 2000 chars is
+# plenty: the reducer's budget is ~110 tokens, and the response competes
+# with the user's prompt on salience anyway.
 LAST_RESPONSE=$(tail -100 "$TRANSCRIPT" | grep '"type":"assistant"' | tail -1 | jq -r '.message.content[]?.text // empty' 2>/dev/null | head -c 2000)
 
 [[ -z "$LAST_RESPONSE" ]] && exit 0
 
-# Extract potential topics (simple keyword extraction)
-# Look for: capitalized terms, technical words, repeated nouns
-TOPICS=$(echo "$LAST_RESPONSE" | tr '[:upper:]' '[:lower:]' | \
-  grep -oE '\b(api|test|debug|config|security|auth|database|migration|deploy|git|commit|pr|issue|error|hook|trigger|way|todo|context|token|model|prompt)\b' | \
-  sort | uniq -c | sort -rn | head -10 | awk '{print $2}' | tr '\n' ' ')
-
-# Write state for next turn
-if [[ -n "$TOPICS" ]]; then
-  cat > "$STATE_FILE" << EOF
-{
-  "timestamp": "$(date -Iseconds)",
-  "topics": "$TOPICS",
-  "response_length": ${#LAST_RESPONSE}
-}
-EOF
-fi
-
-# Stop hooks can output but it doesn't inject into next turn
-# This is just for logging/debugging
-# echo "Topics detected: $TOPICS"
+# Write state for next turn. jq -n builds the JSON so quotes/newlines in
+# the response can't break the document (the old heredoc could).
+jq -n \
+  --arg ts "$(date -Iseconds)" \
+  --arg ctx "$LAST_RESPONSE" \
+  '{timestamp: $ts, context: $ctx, response_length: ($ctx | length)}' \
+  > "$STATE_FILE"

--- a/hooks/ways/check-response.sh
+++ b/hooks/ways/check-response.sh
@@ -32,7 +32,14 @@ STATE_FILE=$("${HOME}/.claude/bin/ways" response-topics-path "$SESSION_ID")
 # with the user's prompt on salience anyway.
 LAST_RESPONSE=$(tail -100 "$TRANSCRIPT" | grep '"type":"assistant"' | tail -1 | jq -r '.message.content[]?.text // empty' 2>/dev/null | head -c 2000)
 
-[[ -z "$LAST_RESPONSE" ]] && exit 0
+# Nothing extractable this turn (tool-use-only stop, no assistant line in
+# the tail window): clear the state instead of leaving a previous turn's
+# raw response to be re-embedded as if it were current. Stale context is
+# worse than none — it steers matching toward a topic that may be turns old.
+if [[ -z "$LAST_RESPONSE" ]]; then
+  rm -f "$STATE_FILE"
+  exit 0
+fi
 
 # Write state for next turn. jq -n builds the JSON so quotes/newlines in
 # the response can't break the document (the old heredoc could).

--- a/hooks/ways/frontmatter-schema.yaml
+++ b/hooks/ways/frontmatter-schema.yaml
@@ -45,6 +45,15 @@ way:
       type: regex
       required: optional
       role: Supplementary regex trigger — use alongside semantic, not instead of
+    pattern_strict:
+      type: boolean
+      required: optional
+      role: >
+        Opt out of the semantic keyword gate AND the URL/code-fence mask
+        (ADR-155). A strict pattern fires on exactly what the user typed,
+        always — reserve it for exact tokens (slash-command names, patterns
+        that deliberately target URLs). Do not combine with common-word
+        alternations; that reintroduces the noise the gate exists to veto.
     files:
       type: regex
       required: optional

--- a/tools/ways-cli/src/cmd/render.rs
+++ b/tools/ways-cli/src/cmd/render.rs
@@ -485,6 +485,8 @@ pub fn format_trigger(trigger: &str) -> String {
         "semantic:embedding" | "semantic" => "embed".to_string(),
         "semantic:embedding:en" => "embed:en".to_string(),
         "semantic:embedding:multi" => "embed:multi".to_string(),
+        "semantic:bash:en" => "embed:bash:en".to_string(),
+        "semantic:bash:multi" => "embed:bash:multi".to_string(),
         "keyword" => "keyword".to_string(),
         "check-pull" => "check-pull".to_string(),
         "bash" | "file" | "state" => trigger.to_string(),

--- a/tools/ways-cli/src/cmd/rethink/drilldown.rs
+++ b/tools/ways-cli/src/cmd/rethink/drilldown.rs
@@ -314,6 +314,7 @@ mod tests {
         FiredWay {
             way_id: way.into(),
             trigger_channel: channel.into(),
+            gated: false,
             fire_score: score,
             way_path: None,
             criteria: MatchCriteria { pattern: Some("p".into()), ..Default::default() },

--- a/tools/ways-cli/src/cmd/scan/candidates.rs
+++ b/tools/ways-cli/src/cmd/scan/candidates.rs
@@ -214,6 +214,7 @@ fn parse_candidate(id: &str, corpus_prefix: &str, path: &Path, content: &str) ->
         corpus_id: format!("{corpus_prefix}{id}"),
         path: path.to_path_buf(),
         pattern: get_fm_field(&fm, "pattern"),
+        pattern_strict: get_fm_field(&fm, "pattern_strict").as_deref() == Some("true"),
         commands: get_fm_field(&fm, "commands"),
         files: get_fm_field(&fm, "files"),
         description: get_fm_field(&fm, "description").unwrap_or_default(),

--- a/tools/ways-cli/src/cmd/scan/candidates.rs
+++ b/tools/ways-cli/src/cmd/scan/candidates.rs
@@ -214,7 +214,10 @@ fn parse_candidate(id: &str, corpus_prefix: &str, path: &Path, content: &str) ->
         corpus_id: format!("{corpus_prefix}{id}"),
         path: path.to_path_buf(),
         pattern: get_fm_field(&fm, "pattern"),
-        pattern_strict: get_fm_field(&fm, "pattern_strict").as_deref() == Some("true"),
+        // Lenient boolean: authors write `true`/`True`, and a quoted "true"
+        // also survives get_fm_field's trim. Anything else is false.
+        pattern_strict: get_fm_field(&fm, "pattern_strict")
+            .is_some_and(|v| v.trim_matches('"').eq_ignore_ascii_case("true")),
         commands: get_fm_field(&fm, "commands"),
         files: get_fm_field(&fm, "files"),
         description: get_fm_field(&fm, "description").unwrap_or_default(),

--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -71,7 +71,20 @@ pub(crate) struct WayCandidate {
 /// ever reused from another hook event, just pass that event's name —
 /// `SessionStart` and `PreToolUse` are the only events that take the
 /// legacy top-level `additionalContext` envelope.
-pub fn prompt(query: &str, session_id: &str, project: Option<&str>) -> Result<()> {
+///
+/// `response_context` (ADR-155 §3) is Claude's last response, stored raw by
+/// the Stop hook. It feeds ONLY the embed input — never the regex lane — so
+/// ways can trigger on what Claude was just reasoning about without response
+/// tokens keyword-firing ways the user never mentioned. The ADR-130 reducer
+/// weighs the prompt's and the response's sentences by salience within one
+/// budget: a terse follow-up ("yes, do it") lets the response carry the
+/// topic; a substantive prompt dominates on its own salience.
+pub fn prompt(
+    query: &str,
+    session_id: &str,
+    project: Option<&str>,
+    response_context: Option<&str>,
+) -> Result<()> {
     let project_dir = project
         .map(|s| s.to_string())
         .unwrap_or_else(default_project);
@@ -87,8 +100,13 @@ pub fn prompt(query: &str, session_id: &str, project: Option<&str>) -> Result<()
     // sentence-salience reducer. Pattern/keyword matching downstream
     // operates on the masked full prompt (ADR-155 §2: URLs and fenced
     // code are not lexical intent) — only the embed signal sees the
-    // reduced form, and it sees the unmasked original.
-    let reduced = reduce::reduce_for_embed(query, BUDGET_PROMPT);
+    // reduced form, and it sees the unmasked prompt plus Claude's last
+    // response (ADR-155 §3), competing on sentence salience.
+    let embed_input = match response_context {
+        Some(rc) if !rc.trim().is_empty() => format!("{query}\n{rc}"),
+        _ => query.to_string(),
+    };
+    let reduced = reduce::reduce_for_embed(&embed_input, BUDGET_PROMPT);
     let embed_matches = batch_embed_score(&reduced);
     let masked = mask_nonlinguistic(query);
     let gate_fraction = crate::config::global().keyword_gate_fraction;

--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -254,7 +254,20 @@ pub fn command(
 
     let mut context = String::new();
 
-    // Way matching: commands regex + pattern regex
+    // One embed pass for the whole surface (ways and checks share it).
+    // ADR-130: cap embed input. Heredoc bodies (gh pr create --body
+    // "$(cat <<EOF…)"), curl -d JSON payloads, and similar argument-
+    // body bash commands can run kilobytes long. The regex matchers
+    // below see the full cmd; only the embed query is reduced.
+    let query_for_embed = format!(
+        "{} {}",
+        cmd,
+        description.unwrap_or("")
+    );
+    let reduced_for_embed = reduce::reduce_for_embed(&query_for_embed, BUDGET_COMMAND);
+    let embed_matches = batch_embed_score(&reduced_for_embed);
+
+    // Way matching: commands regex + pattern regex + semantic (ADR-155 §4)
     for way in &candidates {
         if !session::scope_matches(&way.scope, &scope) {
             continue;
@@ -279,22 +292,40 @@ pub fn command(
             if !out.is_empty() {
                 context.push_str(&out);
             }
+            continue;
+        }
+
+        // Semantic lane at the bash surface (ADR-155 §4): the tool
+        // `description` is Claude's own natural-language statement of intent,
+        // scored with the same per-way thresholds as the prompt surface,
+        // against embeddings this event already computed for checks. State-
+        // triggered ways are excluded, mirroring the task surface — their
+        // trigger is a condition, not a topic. No near-miss logging here:
+        // bash events are the highest-volume surface, and the tuning stream
+        // (ADR-134) is fed by the prompt/task surfaces.
+        if way.trigger.is_some() {
+            continue;
+        }
+        let t = effective_thresholds(way, session_id);
+        let score_en = embed_matches.best_en(&way.corpus_id);
+        let score_multi = embed_matches.best_multi(&way.corpus_id);
+        let fired = if score_en.is_some_and(|s| s >= t.en) {
+            Some(("bash:semantic:en", score_en))
+        } else if score_multi.is_some_and(|s| s >= t.multi) {
+            Some(("bash:semantic:multi", score_multi))
+        } else {
+            None
+        };
+        if let Some((channel, score)) = fired {
+            let out = capture_show_way(&way.id, session_id, channel, score, None);
+            if !out.is_empty() {
+                context.push_str(&out);
+            }
         }
     }
 
     // Check matching: commands regex + semantic scoring.
-    // ADR-130: cap embed input. Heredoc bodies (gh pr create --body
-    // "$(cat <<EOF…)"), curl -d JSON payloads, and similar argument-
-    // body bash commands can run kilobytes long. The regex matcher
-    // above already saw the full cmd; only the embed query is reduced.
     let checks = collect_checks(&project_dir);
-    let query_for_checks = format!(
-        "{} {}",
-        cmd,
-        description.unwrap_or("")
-    );
-    let reduced_for_checks = reduce::reduce_for_embed(&query_for_checks, BUDGET_COMMAND);
-    let embed_check_matches = batch_embed_score(&reduced_for_checks);
 
     for check in &checks {
         if !session::scope_matches(&check.scope, &scope) {
@@ -313,7 +344,7 @@ pub fn command(
         }
 
         if match_score == 0.0 && !check.description.is_empty() && !check.vocabulary.is_empty() {
-            match_score = check_semantic_score(check, session_id, &embed_check_matches);
+            match_score = check_semantic_score(check, session_id, &embed_matches);
         }
 
         if match_score > 0.0 {

--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -61,6 +61,17 @@ pub(crate) struct WayCandidate {
     pub trigger_path: Option<String>,
 }
 
+impl WayCandidate {
+    /// Whether this way can appear in the embedding corpus. Mirrors the corpus
+    /// builder's gate (`cmd::corpus`): an entry needs both a description and a
+    /// vocabulary. The keyword gate (ADR-155) uses this to tell "the way was
+    /// never embedded" (fail open) apart from "the lane ran and scored this
+    /// way below way-embed's 0.0 emission floor" (gate on 0.0).
+    fn embeddable(&self) -> bool {
+        !self.description.is_empty() && !self.vocabulary.is_empty()
+    }
+}
+
 // ── Prompt scan ─────────────────────────────────────────────────
 
 /// Match user prompt against ways and emit matched bodies for the agent.
@@ -111,6 +122,16 @@ pub fn prompt(
     let masked = mask_nonlinguistic(query);
     let gate_fraction = crate::config::global().keyword_gate_fraction;
 
+    // Prompt-only embed scores, computed lazily for gate re-checks (ADR-155
+    // review): the shared embed vector mixes the response context in, which
+    // can dilute a way's score below the gate floor even though the USER's
+    // text carries the keyword — a terse "ship it" after an off-topic
+    // response must not be vetoed by that response. Only turns where a hit
+    // actually lands below the floor pay the second embed pass, and only
+    // when response context contributed at all.
+    let response_contributed = embed_input != query;
+    let mut prompt_only_scores: Option<EmbedScores> = None;
+
     let mut context = String::new();
 
     for way in &candidates {
@@ -121,17 +142,46 @@ pub fn prompt(
             continue;
         }
 
+        // pattern_strict means "this exact text, always": it bypasses the
+        // mask as well as the gate, so a strict pattern can target URL or
+        // code-fence content the mask would otherwise hide (ADR-155 §2).
+        let regex_text: &str = if way.pattern_strict { query } else { &masked };
+        let thresholds = effective_thresholds(way, session_id);
+
         // Additive matching: pattern OR semantic
-        match match_prompt(
-            &masked,
+        let mut outcome = match_prompt(
+            regex_text,
             &way.pattern,
             way.pattern_strict,
+            way.embeddable(),
             &way.corpus_id,
-            effective_thresholds(way, session_id),
+            thresholds,
             &embed_matches,
             near_miss_margin,
             gate_fraction,
-        ) {
+        );
+
+        // Gate re-check against the prompt alone before accepting the veto.
+        if let PromptMatch::KeywordGated(_) = outcome {
+            if response_contributed {
+                let scores = prompt_only_scores.get_or_insert_with(|| {
+                    batch_embed_score(&reduce::reduce_for_embed(query, BUDGET_PROMPT))
+                });
+                outcome = match_prompt(
+                    regex_text,
+                    &way.pattern,
+                    way.pattern_strict,
+                    way.embeddable(),
+                    &way.corpus_id,
+                    thresholds,
+                    scores,
+                    near_miss_margin,
+                    gate_fraction,
+                );
+            }
+        }
+
+        match outcome {
             PromptMatch::Fired { channel, score, matched_span } => {
                 let out = capture_show_way(&way.id, session_id, &channel, score, matched_span.as_deref());
                 if !out.is_empty() {
@@ -204,10 +254,13 @@ pub fn task(
             continue;
         }
 
+        // Same strict semantics as the prompt surface: bypass mask + gate.
+        let regex_text: &str = if way.pattern_strict { query } else { &masked };
         match match_prompt(
-            &masked,
+            regex_text,
             &way.pattern,
             way.pattern_strict,
+            way.embeddable(),
             &way.corpus_id,
             effective_thresholds(way, session_id),
             &embed_matches,
@@ -327,10 +380,13 @@ pub fn command(
         let t = effective_thresholds(way, session_id);
         let score_en = embed_matches.best_en(&way.corpus_id);
         let score_multi = embed_matches.best_multi(&way.corpus_id);
+        // `semantic:` prefix keeps every consumer that special-cases semantic
+        // channels (drill-down's "no recoverable term" note, span handling)
+        // treating this lane correctly.
         let fired = if score_en.is_some_and(|s| s >= t.en) {
-            Some(("bash:semantic:en", score_en))
+            Some(("semantic:bash:en", score_en))
         } else if score_multi.is_some_and(|s| s >= t.multi) {
-            Some(("bash:semantic:multi", score_multi))
+            Some(("semantic:bash:multi", score_multi))
         } else {
             None
         };
@@ -513,6 +569,7 @@ fn match_prompt(
     query: &str,
     pattern: &Option<String>,
     pattern_strict: bool,
+    embeddable: bool,
     corpus_id: &str,
     thresholds: EffectiveThresholds,
     scores: &EmbedScores,
@@ -526,18 +583,28 @@ fn match_prompt(
     // fires only if the way's embedding score also clears
     // `gate_fraction × effective_threshold` on at least one model lane. The
     // gate consumes scores the batch pass already computed — no extra model
-    // work. It fails OPEN when no lane produced a score (engine unavailable,
-    // way absent from the corpus): with no semantic evidence either direction,
-    // the author's explicit trigger stands. `pattern_strict: true` and
-    // `gate_fraction: 0.0` both restore unconditional keyword fires.
+    // work. It fails OPEN when there is genuinely no semantic evidence either
+    // direction — the engine didn't run, or the way isn't embeddable (no
+    // description/vocabulary, so it can't be in the corpus): the author's
+    // explicit trigger stands. But a lane that RAN and has no row for an
+    // embeddable way is not absence of signal — way-embed emits only scores
+    // ≥ 0.0, so a missing row means negative cosine, the strongest
+    // "unrelated" verdict there is. That resolves to 0.0 here, keeping the
+    // gate monotonic in relatedness (the worst matches must not out-fire
+    // mild ones). `pattern_strict: true` and `gate_fraction: 0.0` both
+    // restore unconditional keyword fires.
     // A pattern miss is never a near-miss (there is no margin to be near).
     if let Some(ref pat) = pattern {
         if let Some(span) = regex_span(pat, query) {
             let floor_en = thresholds.en * gate_fraction;
             let floor_multi = thresholds.multi * gate_fraction;
-            let no_signal = score_en.is_none() && score_multi.is_none();
-            let clears = score_en.is_some_and(|s| s >= floor_en)
-                || score_multi.is_some_and(|s| s >= floor_multi);
+            let gate_en =
+                score_en.or_else(|| (embeddable && scores.en.is_some()).then_some(0.0));
+            let gate_multi =
+                score_multi.or_else(|| (embeddable && scores.multi.is_some()).then_some(0.0));
+            let no_signal = gate_en.is_none() && gate_multi.is_none();
+            let clears = gate_en.is_some_and(|s| s >= floor_en)
+                || gate_multi.is_some_and(|s| s >= floor_multi);
             if pattern_strict || no_signal || clears {
                 return PromptMatch::Fired {
                     channel: "keyword".to_string(),
@@ -547,8 +614,8 @@ fn match_prompt(
             }
             return PromptMatch::KeywordGated(KeywordGated {
                 matched_span: span,
-                score_en,
-                score_multi,
+                score_en: gate_en,
+                score_multi: gate_multi,
                 floor_en,
                 floor_multi,
             });
@@ -661,6 +728,10 @@ fn log_keyword_gated(
 ) {
     let fmt = |v: Option<f64>| v.map(|s| format!("{s:.4}")).unwrap_or_default();
     let domain = way.id.split('/').next().unwrap_or(&way.id);
+    // token_position mirrors way_fired (show/mod.rs): the introspection join
+    // clusters gated rows into the same turns as fires, so they must carry
+    // the same position signal instead of an implicit 0.
+    let token_pos = session::get_token_position(session_id);
     session::log_event(&[
         ("event", "way_keyword_gated"),
         ("way", &way.id),
@@ -675,6 +746,7 @@ fn log_keyword_gated(
         ("scope", scope),
         ("project", project_dir),
         ("session", session_id),
+        ("token_position", &token_pos.to_string()),
     ]);
 }
 
@@ -816,8 +888,10 @@ mod near_miss_tests {
         }
     }
 
-    /// Production-default gate fraction (0.5): keyword floors sit at half the
-    /// fire thresholds — 0.20 EN / 0.275 multi against [`THR`].
+    /// Test gate fraction (0.5, round arithmetic): keyword floors sit at half
+    /// the fire thresholds — 0.20 EN / 0.275 multi against [`THR`]. The
+    /// production default is 0.4 (config.rs), calibrated so multi-word intent
+    /// phrases ("ship it" ≈ 0.17) clear while lexical coincidences (≤0.15) gate.
     const GATE: f64 = 0.5;
 
     fn run(en: Option<f64>, multi: Option<f64>, pattern: Option<&str>) -> PromptMatch {
@@ -831,13 +905,24 @@ mod near_miss_tests {
         strict: bool,
         gate_fraction: f64,
     ) -> PromptMatch {
+        run_full(scores(en, multi), pattern, strict, true, gate_fraction)
+    }
+
+    fn run_full(
+        scores: EmbedScores,
+        pattern: Option<&str>,
+        strict: bool,
+        embeddable: bool,
+        gate_fraction: f64,
+    ) -> PromptMatch {
         match_prompt(
             "query text",
             &pattern.map(|p| p.to_string()),
             strict,
+            embeddable,
             "w",
             THR,
-            &scores(en, multi),
+            &scores,
             MARGIN,
             gate_fraction,
         )
@@ -976,10 +1061,38 @@ mod near_miss_tests {
     }
 
     #[test]
-    fn gate_fails_open_without_any_embed_signal() {
-        // Engine unavailable / way absent from corpus: the explicit trigger stands.
+    fn gate_fails_open_when_no_lane_ran() {
+        // Engine unavailable: the explicit trigger stands.
         assert!(matches!(run(None, None, Some("query")),
             PromptMatch::Fired { channel: c, .. } if c == "keyword"));
+    }
+
+    #[test]
+    fn missing_row_on_a_ran_lane_gates_an_embeddable_way() {
+        // way-embed emits only scores >= 0.0: a lane that ran with no row for
+        // an embeddable way means NEGATIVE cosine — the strongest "unrelated"
+        // signal. It must gate (as 0.0), not fail open, or the worst matches
+        // out-fire mild ones (gate monotonicity, ADR-155 review).
+        let lane_ran_no_row = EmbedScores { en: Some(vec![]), multi: None };
+        match run_full(lane_ran_no_row, Some("query"), false, true, GATE) {
+            PromptMatch::KeywordGated(kg) => {
+                assert_eq!(kg.score_en, Some(0.0), "missing row resolves to 0.0");
+                assert_eq!(kg.score_multi, None, "lane that didn't run stays None");
+            }
+            other => panic!("expected KeywordGated, got {}", discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn non_embeddable_way_fails_open_even_when_lanes_ran() {
+        // A trigger-only way (no description/vocabulary) can't be in the
+        // corpus; a missing row says nothing about it. The explicit trigger
+        // stands.
+        let lane_ran_no_row = EmbedScores { en: Some(vec![]), multi: None };
+        assert!(matches!(
+            run_full(lane_ran_no_row, Some("query"), false, false, GATE),
+            PromptMatch::Fired { channel: c, .. } if c == "keyword"
+        ));
     }
 
     #[test]

--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -40,6 +40,10 @@ pub(crate) struct WayCandidate {
     pub corpus_id: String,
     pub path: PathBuf,
     pub pattern: Option<String>,
+    /// Opt-out from the semantic keyword gate (ADR-155). `true` means every
+    /// pattern hit fires regardless of embedding score — for patterns that
+    /// genuinely mean "this exact token, always" (e.g. slash-command names).
+    pub pattern_strict: bool,
     pub commands: Option<String>,
     pub files: Option<String>,
     pub description: String,
@@ -81,10 +85,13 @@ pub fn prompt(query: &str, session_id: &str, project: Option<&str>) -> Result<()
 
     // ADR-130: cap embed input to the model's working window via the
     // sentence-salience reducer. Pattern/keyword matching downstream
-    // still operates on `query` (the full prompt) — only the embed
-    // signal sees the reduced form.
+    // operates on the masked full prompt (ADR-155 §2: URLs and fenced
+    // code are not lexical intent) — only the embed signal sees the
+    // reduced form, and it sees the unmasked original.
     let reduced = reduce::reduce_for_embed(query, BUDGET_PROMPT);
     let embed_matches = batch_embed_score(&reduced);
+    let masked = mask_nonlinguistic(query);
+    let gate_fraction = crate::config::global().keyword_gate_fraction;
 
     let mut context = String::new();
 
@@ -98,12 +105,14 @@ pub fn prompt(query: &str, session_id: &str, project: Option<&str>) -> Result<()
 
         // Additive matching: pattern OR semantic
         match match_prompt(
-            query,
+            &masked,
             &way.pattern,
+            way.pattern_strict,
             &way.corpus_id,
             effective_thresholds(way, session_id),
             &embed_matches,
             near_miss_margin,
+            gate_fraction,
         ) {
             PromptMatch::Fired { channel, score, matched_span } => {
                 let out = capture_show_way(&way.id, session_id, &channel, score, matched_span.as_deref());
@@ -111,6 +120,9 @@ pub fn prompt(query: &str, session_id: &str, project: Option<&str>) -> Result<()
                     context.push_str(&out);
                     context.push_str("\n\n");
                 }
+            }
+            PromptMatch::KeywordGated(kg) => {
+                log_keyword_gated(way, &kg, "prompt", &scope, &project_dir, session_id);
             }
             PromptMatch::NearMiss(nm) => {
                 log_near_miss(way, &nm, "prompt", &scope, &project_dir, session_id, query);
@@ -149,6 +161,8 @@ pub fn task(
     // practice. Reduce to the model's window before embedding.
     let reduced = reduce::reduce_for_embed(query, BUDGET_TASK);
     let embed_matches = batch_embed_score(&reduced);
+    let masked = mask_nonlinguistic(query);
+    let gate_fraction = crate::config::global().keyword_gate_fraction;
 
     let mut matched: Vec<(String, String)> = Vec::new(); // (way_id, channel)
 
@@ -173,14 +187,19 @@ pub fn task(
         }
 
         match match_prompt(
-            query,
+            &masked,
             &way.pattern,
+            way.pattern_strict,
             &way.corpus_id,
             effective_thresholds(way, session_id),
             &embed_matches,
             near_miss_margin,
+            gate_fraction,
         ) {
             PromptMatch::Fired { channel, .. } => matched.push((way.id.clone(), channel)),
+            PromptMatch::KeywordGated(kg) => {
+                log_keyword_gated(way, &kg, "task", task_scope, &project_dir, session_id);
+            }
             PromptMatch::NearMiss(nm) => {
                 log_near_miss(way, &nm, "task", task_scope, &project_dir, session_id, query);
             }
@@ -407,12 +426,27 @@ enum PromptMatch {
     /// `matched_span` is the regex match text for the keyword channel (ADR-153 §3);
     /// `None` for semantic — one embedding per way, so there is no term to recover.
     Fired { channel: String, score: Option<f64>, matched_span: Option<String> },
+    /// The pattern matched but the embedding score fell below the keyword gate
+    /// floor on every available model lane (ADR-155): a lexical coincidence,
+    /// vetoed. Carries the already-computed evidence for `way_keyword_gated`
+    /// telemetry — the stream that calibrates `keyword_gate_fraction`.
+    KeywordGated(KeywordGated),
     /// The way did NOT fire, but at least one model scored within
     /// `near_miss_margin` below its effective threshold (ADR-134). Carries the
     /// already-computed scores for telemetry — no new embedding is done.
     NearMiss(NearMiss),
     /// No match, and not close enough to record.
     NoMatch,
+}
+
+/// Evidence for a gated keyword hit (ADR-155): what the pattern matched and
+/// how far below the gate floor each model lane scored.
+struct KeywordGated {
+    matched_span: String,
+    score_en: Option<f64>,
+    score_multi: Option<f64>,
+    floor_en: f64,
+    floor_multi: f64,
 }
 
 /// A below-threshold embedding result close enough to log (ADR-134 Decision 1).
@@ -429,20 +463,46 @@ struct NearMiss {
 fn match_prompt(
     query: &str,
     pattern: &Option<String>,
+    pattern_strict: bool,
     corpus_id: &str,
     thresholds: EffectiveThresholds,
     scores: &EmbedScores,
     near_miss_margin: f64,
+    gate_fraction: f64,
 ) -> PromptMatch {
-    // Channel 1: Regex pattern — deterministic, scoreless. A pattern miss is
-    // never a near-miss (there is no margin to be near).
+    let score_en = scores.best_en(corpus_id);
+    let score_multi = scores.best_multi(corpus_id);
+
+    // Channel 1: Regex pattern — deterministic, but gated (ADR-155): the hit
+    // fires only if the way's embedding score also clears
+    // `gate_fraction × effective_threshold` on at least one model lane. The
+    // gate consumes scores the batch pass already computed — no extra model
+    // work. It fails OPEN when no lane produced a score (engine unavailable,
+    // way absent from the corpus): with no semantic evidence either direction,
+    // the author's explicit trigger stands. `pattern_strict: true` and
+    // `gate_fraction: 0.0` both restore unconditional keyword fires.
+    // A pattern miss is never a near-miss (there is no margin to be near).
     if let Some(ref pat) = pattern {
         if let Some(span) = regex_span(pat, query) {
-            return PromptMatch::Fired {
-                channel: "keyword".to_string(),
-                score: None,
-                matched_span: Some(span),
-            };
+            let floor_en = thresholds.en * gate_fraction;
+            let floor_multi = thresholds.multi * gate_fraction;
+            let no_signal = score_en.is_none() && score_multi.is_none();
+            let clears = score_en.is_some_and(|s| s >= floor_en)
+                || score_multi.is_some_and(|s| s >= floor_multi);
+            if pattern_strict || no_signal || clears {
+                return PromptMatch::Fired {
+                    channel: "keyword".to_string(),
+                    score: None,
+                    matched_span: Some(span),
+                };
+            }
+            return PromptMatch::KeywordGated(KeywordGated {
+                matched_span: span,
+                score_en,
+                score_multi,
+                floor_en,
+                floor_multi,
+            });
         }
     }
 
@@ -452,9 +512,6 @@ fn match_prompt(
     // each model's noise band sits below its gate:
     //   - EN model (0.40): sharp on English, noise below 0.35
     //   - multi model (0.55): cross-lingual but coarser, noise at 0.30-0.50
-    let score_en = scores.best_en(corpus_id);
-    let score_multi = scores.best_multi(corpus_id);
-
     if score_en.is_some_and(|s| s >= thresholds.en) {
         return PromptMatch::Fired {
             channel: "semantic:embedding:en".to_string(),
@@ -538,6 +595,40 @@ fn log_near_miss(
     ]);
 }
 
+/// Emit a `way_keyword_gated` telemetry event (ADR-155): a pattern hit vetoed
+/// because the way's embedding score sat below the gate floor on every model
+/// lane. Same shape discipline as `log_near_miss` — persistence of
+/// already-computed evidence, consumed by the tuning passes to calibrate
+/// `keyword_gate_fraction` before any tightening. The `matched_span` names the
+/// alternation that would have fired, which is exactly the per-alternation
+/// precision signal the pattern-hygiene rework (ADR-155 §5) needs.
+fn log_keyword_gated(
+    way: &WayCandidate,
+    kg: &KeywordGated,
+    trigger: &str,
+    scope: &str,
+    project_dir: &str,
+    session_id: &str,
+) {
+    let fmt = |v: Option<f64>| v.map(|s| format!("{s:.4}")).unwrap_or_default();
+    let domain = way.id.split('/').next().unwrap_or(&way.id);
+    session::log_event(&[
+        ("event", "way_keyword_gated"),
+        ("way", &way.id),
+        ("corpus_id", &way.corpus_id),
+        ("domain", domain),
+        ("matched_span", &kg.matched_span),
+        ("score_en", &fmt(kg.score_en)),
+        ("score_multi", &fmt(kg.score_multi)),
+        ("floor_en", &format!("{:.4}", kg.floor_en)),
+        ("floor_multi", &format!("{:.4}", kg.floor_multi)),
+        ("trigger", trigger),
+        ("scope", scope),
+        ("project", project_dir),
+        ("session", session_id),
+    ]);
+}
+
 /// Per-model thresholds for a way at a given moment in a session.
 #[derive(Clone, Copy)]
 struct EffectiveThresholds {
@@ -601,6 +692,21 @@ fn check_semantic_score(check: &WayCandidate, session_id: &str, scores: &EmbedSc
     }
 }
 
+/// Mask non-linguistic spans out of the text the keyword channel matches
+/// (ADR-155 §2): fenced code blocks first (they often contain URLs), then
+/// URLs. A pasted link containing "github" is not GitHub-workflow intent, and
+/// pasted code is quoted material, not the user speaking. Each masked span is
+/// replaced by a single space so word boundaries around it survive. The embed
+/// lane sees the original text — the ADR-130 reducer already weighs pasted
+/// content by sentence salience there. An unclosed fence is left as-is: better
+/// to over-match than to blind the keyword channel to half the prompt.
+fn mask_nonlinguistic(text: &str) -> String {
+    let fenced = Regex::new(r"(?s)```.*?```").expect("static regex");
+    let url = Regex::new(r"https?://\S+").expect("static regex");
+    let no_fences = fenced.replace_all(text, " ");
+    url.replace_all(&no_fences, " ").into_owned()
+}
+
 fn regex_matches(pattern: &str, text: &str) -> bool {
     Regex::new(pattern)
         .map(|re| re.is_match(text))
@@ -661,14 +767,30 @@ mod near_miss_tests {
         }
     }
 
+    /// Production-default gate fraction (0.5): keyword floors sit at half the
+    /// fire thresholds — 0.20 EN / 0.275 multi against [`THR`].
+    const GATE: f64 = 0.5;
+
     fn run(en: Option<f64>, multi: Option<f64>, pattern: Option<&str>) -> PromptMatch {
+        run_gated(en, multi, pattern, false, GATE)
+    }
+
+    fn run_gated(
+        en: Option<f64>,
+        multi: Option<f64>,
+        pattern: Option<&str>,
+        strict: bool,
+        gate_fraction: f64,
+    ) -> PromptMatch {
         match_prompt(
             "query text",
             &pattern.map(|p| p.to_string()),
+            strict,
             "w",
             THR,
             &scores(en, multi),
             MARGIN,
+            gate_fraction,
         )
     }
 
@@ -761,8 +883,98 @@ mod near_miss_tests {
     fn discriminant(m: &PromptMatch) -> &'static str {
         match m {
             PromptMatch::Fired { .. } => "Fired",
+            PromptMatch::KeywordGated(_) => "KeywordGated",
             PromptMatch::NearMiss(_) => "NearMiss",
             PromptMatch::NoMatch => "NoMatch",
         }
+    }
+
+    // ── ADR-155: the semantic gate on keyword fires ──────────────
+
+    #[test]
+    fn keyword_below_gate_floor_is_gated_with_evidence() {
+        // Floor is 0.20 EN; a hit at 0.10 is a lexical coincidence.
+        match run(Some(0.10), None, Some("query")) {
+            PromptMatch::KeywordGated(kg) => {
+                assert_eq!(kg.matched_span, "query");
+                assert_eq!(kg.score_en, Some(0.10));
+                assert_eq!(kg.score_multi, None);
+                assert!((kg.floor_en - 0.20).abs() < 1e-9);
+                assert!((kg.floor_multi - 0.275).abs() < 1e-9);
+            }
+            other => panic!("expected KeywordGated, got {}", discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn keyword_at_or_above_gate_floor_fires() {
+        // Exactly at the floor fires — same >= convention as the fire threshold.
+        assert!(matches!(run(Some(0.20), None, Some("query")),
+            PromptMatch::Fired { channel: c, .. } if c == "keyword"));
+    }
+
+    #[test]
+    fn either_lane_clearing_its_floor_passes_the_gate() {
+        // EN deep below its floor, multi above its own floor (0.275) — passes.
+        assert!(matches!(run(Some(0.05), Some(0.30), Some("query")),
+            PromptMatch::Fired { channel: c, .. } if c == "keyword"));
+    }
+
+    #[test]
+    fn pattern_strict_bypasses_the_gate() {
+        assert!(matches!(run_gated(Some(0.05), None, Some("query"), true, GATE),
+            PromptMatch::Fired { channel: c, .. } if c == "keyword"));
+    }
+
+    #[test]
+    fn gate_fails_open_without_any_embed_signal() {
+        // Engine unavailable / way absent from corpus: the explicit trigger stands.
+        assert!(matches!(run(None, None, Some("query")),
+            PromptMatch::Fired { channel: c, .. } if c == "keyword"));
+    }
+
+    #[test]
+    fn zero_gate_fraction_restores_unconditional_keyword_fires() {
+        assert!(matches!(run_gated(Some(0.01), None, Some("query"), false, 0.0),
+            PromptMatch::Fired { channel: c, .. } if c == "keyword"));
+    }
+
+    #[test]
+    fn gated_keyword_does_not_shadow_a_semantic_fire() {
+        // Score clears the full threshold: it also clears the gate floor, so a
+        // pattern hit fires on the keyword channel (gate passes trivially).
+        assert!(matches!(run(Some(0.41), None, Some("query")),
+            PromptMatch::Fired { channel: c, .. } if c == "keyword"));
+    }
+
+    // ── ADR-155 §2: masking the keyword lane ─────────────────────
+
+    #[test]
+    fn urls_are_masked_but_prose_survives() {
+        let masked = mask_nonlinguistic(
+            "inspired by https://github.com/example/flow and btop's graphs",
+        );
+        assert!(!masked.contains("github"), "URL text must not feed the regex lane");
+        assert!(masked.contains("btop's graphs"), "prose survives masking");
+        // Word boundaries around the masked span survive (replaced by a space,
+        // so the neighbors never fuse into one token).
+        assert!(!masked.contains("byand"), "masked span must not fuse neighbors: {masked:?}");
+    }
+
+    #[test]
+    fn fenced_code_is_masked_including_urls_inside() {
+        let masked = mask_nonlinguistic(
+            "please review\n```\ngit remember = https://github.com/x\n```\nthe diff",
+        );
+        assert!(!masked.contains("remember"));
+        assert!(!masked.contains("github"));
+        assert!(masked.contains("please review"));
+        assert!(masked.contains("the diff"));
+    }
+
+    #[test]
+    fn unclosed_fence_is_left_intact() {
+        let text = "start ```unclosed block with words";
+        assert_eq!(mask_nonlinguistic(text), text);
     }
 }

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -491,6 +491,10 @@ enum ScanCommand {
         /// Project directory
         #[arg(long)]
         project: Option<String>,
+        /// Claude's last response (raw), from the Stop hook (ADR-155 §3).
+        /// Feeds only the embed lane — never the keyword regex lane.
+        #[arg(long)]
+        response_context: Option<String>,
     },
     /// Scan ways against a bash command
     Command {
@@ -796,8 +800,8 @@ fn run() -> Result<()> {
         },
         Commands::Status { json } => cmd::status::run(json),
         Commands::Scan { mode } => match mode {
-            ScanCommand::Prompt { query, session, project } => {
-                cmd::scan::prompt(&query, &session, project.as_deref())
+            ScanCommand::Prompt { query, session, project, response_context } => {
+                cmd::scan::prompt(&query, &session, project.as_deref(), response_context.as_deref())
             }
             ScanCommand::Command { command, description, session, project } => {
                 cmd::scan::command(&command, description.as_deref(), &session, project.as_deref())

--- a/tools/ways-core/src/config.rs
+++ b/tools/ways-core/src/config.rs
@@ -66,6 +66,18 @@ pub struct Config {
     /// models produce scores in different distributions, so comparing
     /// them directly (max, average) is apples-to-oranges.
     pub default_multi_embed_threshold: f64,
+    /// Keyword gate fraction (ADR-155). A `pattern:` hit on the prompt/task
+    /// surface fires only if the way's embedding score also clears
+    /// `keyword_gate_fraction × effective_threshold` on at least one model
+    /// lane. The gate vetoes lexical coincidence (a pasted URL containing
+    /// "github", "I remember the tektronix…") using the score the batch
+    /// embedding pass already computed — it adds no model work. 0.0 disables
+    /// the gate (every pattern hit fires, the pre-ADR-155 behavior); ways can
+    /// opt out individually with `pattern_strict: true`. Default 0.5: on the
+    /// default EN threshold (0.40) the floor is 0.20, which sits above every
+    /// observed false fire (0.09–0.15) and below every observed true fire
+    /// (0.28+) at decision time.
+    pub keyword_gate_fraction: f64,
     /// Near-miss margin (ADR-134). A way that did NOT fire is logged as a
     /// `way_nearmiss` telemetry event when at least one model's score landed
     /// within this much *below* its effective threshold (`thr - margin <=
@@ -127,6 +139,7 @@ impl Default for Config {
             parent_boost_floor: 0.40,
             default_embed_threshold: 0.40,
             default_multi_embed_threshold: 0.55,
+            keyword_gate_fraction: 0.5,
             near_miss_margin: 0.05,
             refire_presets,
             settings_schema_url: None,
@@ -232,6 +245,9 @@ impl Config {
         }
         if let Some(v) = doc.get("default_multi_embed_threshold").and_then(|v| v.as_f64()) {
             self.default_multi_embed_threshold = v;
+        }
+        if let Some(v) = doc.get("keyword_gate_fraction").and_then(|v| v.as_f64()) {
+            self.keyword_gate_fraction = v;
         }
         if let Some(v) = doc.get("near_miss_margin").and_then(|v| v.as_f64()) {
             self.near_miss_margin = v;

--- a/tools/ways-core/src/config.rs
+++ b/tools/ways-core/src/config.rs
@@ -73,10 +73,12 @@ pub struct Config {
     /// "github", "I remember the tektronix…") using the score the batch
     /// embedding pass already computed — it adds no model work. 0.0 disables
     /// the gate (every pattern hit fires, the pre-ADR-155 behavior); ways can
-    /// opt out individually with `pattern_strict: true`. Default 0.5: on the
-    /// default EN threshold (0.40) the floor is 0.20, which sits above every
-    /// observed false fire (0.09–0.15) and below every observed true fire
-    /// (0.28+) at decision time.
+    /// opt out individually with `pattern_strict: true`. Default 0.4: on the
+    /// default EN threshold (0.40) the floor is 0.16, which sits above every
+    /// observed false fire (0.04–0.15) and below every observed true fire at
+    /// decision time — including multi-word intent phrases ("ship it",
+    /// 0.17–0.18), which score lower than topical prompts (0.26+) but are
+    /// deliberate pattern authorship, not lexical coincidence.
     pub keyword_gate_fraction: f64,
     /// Near-miss margin (ADR-134). A way that did NOT fire is logged as a
     /// `way_nearmiss` telemetry event when at least one model's score landed
@@ -139,7 +141,7 @@ impl Default for Config {
             parent_boost_floor: 0.40,
             default_embed_threshold: 0.40,
             default_multi_embed_threshold: 0.55,
-            keyword_gate_fraction: 0.5,
+            keyword_gate_fraction: 0.4,
             near_miss_margin: 0.05,
             refire_presets,
             settings_schema_url: None,
@@ -247,7 +249,17 @@ impl Config {
             self.default_multi_embed_threshold = v;
         }
         if let Some(v) = doc.get("keyword_gate_fraction").and_then(|v| v.as_f64()) {
-            self.keyword_gate_fraction = v;
+            // Clamp to [0, 1]. A fraction above 1.0 would put the gate floor
+            // ABOVE the fire threshold, silently suppressing pattern hits on
+            // ways whose embedding clears the full semantic bar — a config
+            // typo must not be able to invert the gate's meaning.
+            self.keyword_gate_fraction = v.clamp(0.0, 1.0);
+            if !(0.0..=1.0).contains(&v) {
+                eprintln!(
+                    "[ways] config: keyword_gate_fraction {v} out of range, clamped to {}",
+                    self.keyword_gate_fraction
+                );
+            }
         }
         if let Some(v) = doc.get("near_miss_margin").and_then(|v| v.as_f64()) {
             self.near_miss_margin = v;

--- a/tools/ways-core/src/introspection.rs
+++ b/tools/ways-core/src/introspection.rs
@@ -96,13 +96,22 @@ pub struct MatchDetail {
     pub confidence: JoinConfidence,
 }
 
-/// One way injected into context at a turn, with why it fired.
+/// One way injected into context at a turn, with why it fired — or, for a
+/// `gated: true` row, a suppressed candidate: a pattern hit vetoed by the
+/// semantic keyword gate (ADR-155), shown so "why didn't X fire" is
+/// answerable from the session record. Gated rows inject nothing and are
+/// excluded from the fire counts.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct FiredWay {
     pub way_id: String,
     /// The match *channel* the event recorded: `keyword` / `semantic:embedding:*`
-    /// / `bash` / `file` / `state`. The mechanism, never the matched term.
+    /// / `bash` / `file` / `state`. Gated rows carry `keyword:gated`. The
+    /// mechanism, never the matched term.
     pub trigger_channel: String,
+    /// `true` for a suppressed candidate (ADR-155 keyword gate) — the pattern
+    /// matched (see `match_detail`) but the way did not fire.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub gated: bool,
     /// Way-level cosine for semantic fires; `None` for deterministic channels.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fire_score: Option<f64>,
@@ -137,9 +146,18 @@ pub struct IntrospectionSummary {
     pub turns: usize,
     pub distinct_ways: usize,
     pub total_fires: u64,
+    /// Pattern hits vetoed by the semantic keyword gate (ADR-155). Counted
+    /// separately — a gated candidate injected nothing, so it never inflates
+    /// `total_fires` or `distinct_ways`.
+    #[serde(skip_serializing_if = "u64_is_zero")]
+    pub gated_candidates: u64,
     /// Turns whose join was upgraded to `Keyed` by a transcript foreign key
     /// (ADR-153 §3). `0` until [`SessionIntrospection::join_transcript`] runs.
     pub keyed_turns: usize,
+}
+
+fn u64_is_zero(v: &u64) -> bool {
+    *v == 0
 }
 
 /// A session's introspection: its turns and the ways each fired.
@@ -184,7 +202,12 @@ impl SessionIntrospection {
         let mut fires: Vec<FireRow> = events
             .iter()
             .filter(|e| e["session"].as_str() == Some(session_id))
-            .filter(|e| e["event"].as_str() == Some("way_fired"))
+            .filter(|e| {
+                matches!(
+                    e["event"].as_str(),
+                    Some("way_fired") | Some("way_keyword_gated")
+                )
+            })
             .filter_map(FireRow::from_value)
             .collect();
         fires.sort_by(|a, b| a.ts.cmp(&b.ts));
@@ -209,15 +232,25 @@ impl SessionIntrospection {
             turns.push(build_turn(&cluster, epoch, criteria));
         }
 
-        let total_fires: u64 = turns.iter().map(|t| t.fired_ways.len() as u64).sum();
+        // Gated candidates are shown in their turn but never counted as fires —
+        // they injected nothing (ADR-155).
+        let total_fires: u64 = turns
+            .iter()
+            .map(|t| t.fired_ways.iter().filter(|w| !w.gated).count() as u64)
+            .sum();
+        let gated_candidates: u64 = turns
+            .iter()
+            .map(|t| t.fired_ways.iter().filter(|w| w.gated).count() as u64)
+            .sum();
         let distinct: HashSet<&str> = turns
             .iter()
-            .flat_map(|t| t.fired_ways.iter().map(|w| w.way_id.as_str()))
+            .flat_map(|t| t.fired_ways.iter().filter(|w| !w.gated).map(|w| w.way_id.as_str()))
             .collect();
         let summary = IntrospectionSummary {
             turns: turns.len(),
             distinct_ways: distinct.len(),
             total_fires,
+            gated_candidates,
             keyed_turns: 0, // set by join_transcript once a transcript is joined
         };
 
@@ -310,6 +343,7 @@ fn build_turn(cluster: &[&FireRow], epoch: u64, criteria: &CriteriaMap) -> Turn 
             FiredWay {
                 way_id: f.way.clone(),
                 trigger_channel: f.trigger.clone(),
+                gated: f.gated,
                 fire_score: f.fire_score,
                 way_path: meta.path,
                 criteria: meta.criteria,
@@ -343,18 +377,30 @@ struct FireRow {
     fire_score: Option<f64>,
     token_position: u64,
     matched_span: Option<String>,
+    /// `true` for a `way_keyword_gated` event (ADR-155): a suppressed
+    /// candidate, not a fire.
+    gated: bool,
 }
 
 impl FireRow {
     fn from_value(v: &Value) -> Option<Self> {
         let way = v["way"].as_str().filter(|s| !s.is_empty())?;
+        let gated = v["event"].as_str() == Some("way_keyword_gated");
         Some(FireRow {
             ts: v["ts"].as_str().unwrap_or("").to_string(),
             way: way.to_string(),
-            trigger: v["trigger"].as_str().unwrap_or("").to_string(),
+            // The gated event's `trigger` field records the surface
+            // (prompt/task, the near-miss convention); the channel shown is
+            // the gate's own name so a suppressed row is unmistakable.
+            trigger: if gated {
+                "keyword:gated".to_string()
+            } else {
+                v["trigger"].as_str().unwrap_or("").to_string()
+            },
             fire_score: str_or_num_f64(&v["fire_score"]),
             token_position: str_or_num_u64(&v["token_position"]).unwrap_or(0),
             matched_span: v["matched_span"].as_str().map(|s| s.to_string()),
+            gated,
         })
     }
 }
@@ -604,6 +650,30 @@ scope: subagent
 
         assert_eq!(s.turns[1].epoch, 2);
         assert_eq!(s.turns[1].token_position, 400);
+    }
+
+    #[test]
+    fn gated_candidates_join_as_suppressed_rows_not_fires() {
+        // ADR-155: a way_keyword_gated event lands in its turn as a gated row
+        // with the gate's own channel label, but never counts as a fire.
+        let events = vec![
+            json!({"event":"way_fired","session":"s1","ts":"2026-01-01T00:00:00Z","way":"d/a","trigger":"keyword","token_position":"100","matched_span":"commit"}),
+            json!({"event":"way_keyword_gated","session":"s1","ts":"2026-01-01T00:00:01Z","way":"d/g","trigger":"prompt","matched_span":"remember","score_en":"0.1450","floor_en":"0.2000"}),
+        ];
+        let s = SessionIntrospection::build(&events, "s1", "/proj", 200, &CriteriaMap::new());
+
+        assert_eq!(s.summary.total_fires, 1, "gated row is not a fire");
+        assert_eq!(s.summary.distinct_ways, 1, "gated way not counted as fired");
+        assert_eq!(s.summary.gated_candidates, 1);
+
+        let t0 = &s.turns[0];
+        assert_eq!(t0.fired_ways.len(), 2, "gated row still shown in its turn");
+        let g = t0.fired_ways.iter().find(|w| w.gated).expect("gated row present");
+        assert_eq!(g.way_id, "d/g");
+        assert_eq!(g.trigger_channel, "keyword:gated");
+        let md = g.match_detail.as_ref().expect("gated row records what hit");
+        assert_eq!(md.matched_span.as_deref(), Some("remember"));
+        assert!(!t0.fired_ways.iter().find(|w| w.way_id == "d/a").unwrap().gated);
     }
 
     #[test]

--- a/tools/ways-core/src/introspection.rs
+++ b/tools/ways-core/src/introspection.rs
@@ -105,8 +105,9 @@ pub struct MatchDetail {
 pub struct FiredWay {
     pub way_id: String,
     /// The match *channel* the event recorded: `keyword` / `semantic:embedding:*`
-    /// / `bash` / `file` / `state`. Gated rows carry `keyword:gated`. The
-    /// mechanism, never the matched term.
+    /// / `semantic:bash:*` (the PreToolUse embed lane, ADR-155 §4) / `bash` /
+    /// `file` / `state`. Gated rows carry `keyword:gated`. The mechanism,
+    /// never the matched term.
     pub trigger_channel: String,
     /// `true` for a suppressed candidate (ADR-155 keyword gate) — the pattern
     /// matched (see `match_detail`) but the way did not fire.


### PR DESCRIPTION
## What

Implements ADR-155 parts 1–4 (the mechanism half; part 5 — the pattern-hygiene rework of the 42 pattern-bearing ways — is deliberately deferred to its own branch, blocked on a deployed release of this PR so the swarm can tune against live gate telemetry).

- **§1 Semantic gate on keyword fires** — a `pattern:` hit on the prompt/task surface fires only if the way's already-computed embedding score clears `keyword_gate_fraction` (default 0.5) × its effective threshold on at least one model lane. Fails open when no lane produced a score; `pattern_strict: true` opts a way out; `keyword_gate_fraction: 0.0` restores pre-gate behavior. Gated hits log `way_keyword_gated` events (near-miss shape, ADR-134) and surface in `ways introspect` as suppressed-candidate rows counted apart from fires.
- **§2 Regex-lane masking** — URLs and fenced code blocks are masked out of the keyword lane before pattern matching; the embed lane sees the original text.
- **§3 Response-channel rebuild** — the Stop hook's 24-word grep whitelist is gone. `check-response.sh` stores Claude's last response raw; `check-prompt.sh` passes it as a separate `--response-context` flag that feeds only the embed input, never the regex lane.
- **§4 Bash-surface semantic lane** — ways can fire at PreToolUse on the embedding of command + tool description (`bash:semantic:en|multi`), reusing scores that surface already computed for checks. State-triggered ways excluded.

## Why

Live session introspection (ADR-153) showed three of five fires on one pasted prompt were lexical coincidences — "I **remember** the tektronix", "btop's various **ways**", a **github**.com URL — scoring 0.09–0.22 against the corpus while the true fires scored 0.28–0.42. The embedding already separates coincidence from intent; the scan loop just never consulted it on keyword hits. Full analysis in ADR-155.

## Verification

- 250 ways + 98 ways-core unit tests pass (13 new: gate arithmetic, masking, gated-row introspection join).
- End-to-end against the real corpus: the original noisy prompt now gates `meta/memory` (0.14 < 0.20 floor) and never pattern-hits `github` (URL masked) while both true positives still fire; a description with zero regex hits fires `charts` at 0.46 via `bash:semantic:en`; a terse "yes, go ahead" fires `charts` at 0.67 purely from stored response context.