### PR TITLE
release: ways v1.0.9

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "ways"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "agent-fmt",
  "anyhow",

--- a/tools/ways-cli/Cargo.toml
+++ b/tools/ways-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ways"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 description = "Unified CLI for ways — knowledge guidance for Claude Code"
 license = "MIT"


### PR DESCRIPTION
Patch release carrying ADR-155 §1–4: semantic gate on keyword fires (default fraction 0.4, pattern_strict opt-out, way_keyword_gated telemetry), URL/code-fence masking of the regex lane, raw response context on the embed lane only, and the semantic:bash:* lane at PreToolUse. Deploy note: hooks degrade gracefully against an older binary, and part 5 (pattern rework) is blocked on this release reaching installs.