### PR TITLE
feat(lint): pattern-hygiene rules for the keyword lane (ADR-155 §5)

### DIFF
--- a/tools/ways-cli/src/cmd/lint/mod.rs
+++ b/tools/ways-cli/src/cmd/lint/mod.rs
@@ -14,7 +14,7 @@
 //! - [`scanning`] walks the project's ways directory and hands files to
 //!   `per_file`.
 //! - [`pattern`] runs the ADR-155 §5 pattern-hygiene rules over the
-//!   `pattern:` regex (common words, short unanchored tokens, greedy `.*`).
+//!   `pattern:` regex (common words, short unanchored tokens, unbounded `.*`).
 //! - [`locale_stubs`] validates `*.locales.jsonl` per-language overrides
 //!   against the `locale_stub:` schema block.
 //! - [`requires`] is the ADR-116 scan-macro-to-permissions machinery.

--- a/tools/ways-cli/src/cmd/lint/mod.rs
+++ b/tools/ways-cli/src/cmd/lint/mod.rs
@@ -13,6 +13,8 @@
 //!   top-level and `when:` sub-fields.
 //! - [`scanning`] walks the project's ways directory and hands files to
 //!   `per_file`.
+//! - [`pattern`] runs the ADR-155 §5 pattern-hygiene rules over the
+//!   `pattern:` regex (common words, short unanchored tokens, greedy `.*`).
 //! - [`locale_stubs`] validates `*.locales.jsonl` per-language overrides
 //!   against the `locale_stub:` schema block.
 //! - [`requires`] is the ADR-116 scan-macro-to-permissions machinery.
@@ -23,6 +25,7 @@
 
 mod helpers;
 mod locale_stubs;
+mod pattern;
 mod per_file;
 mod provenance;
 mod requires;

--- a/tools/ways-cli/src/cmd/lint/pattern.rs
+++ b/tools/ways-cli/src/cmd/lint/pattern.rs
@@ -8,16 +8,19 @@
 //!
 //! 1. **Bare common word** — an alternation that is a plain dictionary word
 //!    (from [`COMMON_WORDS`]) fires on unrelated prose. Move it to
-//!    `vocabulary:`.
+//!    `vocabulary:`. Applies regardless of anchoring — an anchored `\bcommit\b`
+//!    is still the word "commit".
 //! 2. **Short unanchored alternation** — a literal alternation shorter than
 //!    [`SHORT_ALTERNATION_FLOOR`] with no word-boundary anchoring collides
 //!    with substrings of larger words. Anchor it (term of art) or demote it.
-//! 3. **`.*` in a prompt pattern** — an unbounded greedy wildcard makes the
-//!    trigger match almost anything between its literals.
+//! 3. **Unbounded `.*` wildcard** — a `.*` (greedy or lazy) makes the trigger
+//!    match almost anything between its literals.
 //!
-//! The rules operate on top-level alternations (split on `|` at paren depth
-//! 0), so a grouped inner `|` such as `alert.?(response|triage)` is treated
-//! as one alternation, not three.
+//! The analysis mirrors the regex the matcher actually compiles: the value is
+//! read as the matcher's YAML loader sees it (inline `# comment` and a leading
+//! `(?i)`-style flag group stripped), and the rules operate on top-level
+//! alternations (split on `|` at paren depth 0), so a grouped inner `|` such as
+//! `alert.?(response|triage)` is treated as one alternation, not three.
 
 use std::fmt::Display;
 
@@ -67,23 +70,35 @@ const COMMON_WORDS: &[&str] = &[
 /// Run all three pattern-hygiene rules against one way's `pattern:` value.
 /// `warnings` accumulates the project-wide counter owned by the caller.
 pub(super) fn check_pattern(rel: &dyn Display, pattern: &str, warnings: &mut u32) {
-    let pattern = unquote(pattern.trim());
-    for alt in split_top_level(pattern) {
-        let alt = alt.trim();
+    // Read the value the way the matcher's YAML loader does: strip a plain
+    // scalar's inline `# comment` (only for unquoted values — quotes make `#`
+    // literal) and a leading whole-pattern inline flag group like `(?i)`.
+    let (body_val, was_quoted) = unquote(pattern.trim());
+    let val = if was_quoted {
+        body_val
+    } else {
+        strip_yaml_comment(body_val)
+    };
+    let val = strip_inline_flags(val);
+
+    for raw in split_top_level(val) {
+        let alt = raw.trim();
         if alt.is_empty() {
             continue;
         }
 
-        // Rule 3: unbounded greedy wildcard.
+        // Rule 3: unbounded wildcard (greedy `.*` or lazy `.*?`).
         if alt.contains(".*") {
             eprintln!(
-                "  WARNING: {rel} — pattern alternation '{alt}' uses '.*' (greedy); \
-                 prompt patterns should avoid unbounded wildcards — bound or restructure it (ADR-155 §5)"
+                "  WARNING: {rel} — pattern alternation '{alt}' uses an unbounded '.*' wildcard; \
+                 prompt patterns should bound or restructure it (ADR-155 §5)"
             );
             *warnings += 1;
         }
 
-        let info = classify(alt);
+        // Classify against the untrimmed alternation so leading/trailing space
+        // anchoring (` erd `) is detected before it is trimmed away.
+        let info = classify(raw);
 
         // Rules 1 and 2 only apply to bare literal words; structured
         // alternations (groups, character classes, multi-word phrases joined
@@ -91,11 +106,11 @@ pub(super) fn check_pattern(rel: &dyn Display, pattern: &str, warnings: &mut u32
         if !info.is_bare_word {
             continue;
         }
-        let core = info.core.to_ascii_lowercase();
 
-        // Rule 2: common word (length-independent). Takes precedence over the
-        // short-token rule so an alternation earns at most one of these two.
-        if COMMON_WORDS.contains(&core.as_str()) {
+        // Rule 1: common word (length-independent, anchoring-independent).
+        // Takes precedence over the short-token rule so an alternation earns
+        // at most one of these two.
+        if COMMON_WORDS.contains(&info.word.as_str()) {
             eprintln!(
                 "  WARNING: {rel} — pattern alternation '{alt}' is a common word; \
                  move it to vocabulary: (semantic lane) and keep pattern: for exact triggers (ADR-155 §5)"
@@ -104,23 +119,50 @@ pub(super) fn check_pattern(rel: &dyn Display, pattern: &str, warnings: &mut u32
             continue;
         }
 
-        // Rule 1: short and unanchored.
-        if !info.is_anchored && info.core.len() < SHORT_ALTERNATION_FLOOR {
-            let n = info.core.len();
+        // Rule 2: short and unanchored.
+        if !info.is_anchored && info.char_len < SHORT_ALTERNATION_FLOOR {
+            let n = info.char_len;
+            let word = &info.word;
             eprintln!(
                 "  WARNING: {rel} — pattern alternation '{alt}' is short ({n} chars) and unanchored; \
-                 anchor it (\\b{core}\\b) if it's a term of art, or move it to vocabulary: (ADR-155 §5)"
+                 anchor it (\\b{word}\\b) if it's a term of art, or move it to vocabulary: (ADR-155 §5)"
             );
             *warnings += 1;
         }
     }
 }
 
-/// Strip one layer of matching YAML quotes, if present.
-fn unquote(s: &str) -> &str {
+/// Strip one layer of matching YAML quotes. Returns the inner text and whether
+/// a quote layer was removed (quoted values do not honor `#` comments).
+fn unquote(s: &str) -> (&str, bool) {
     for q in ['"', '\''] {
         if s.len() >= 2 && s.starts_with(q) && s.ends_with(q) {
-            return &s[1..s.len() - 1];
+            return (&s[1..s.len() - 1], true);
+        }
+    }
+    (s, false)
+}
+
+/// Drop a plain-scalar inline comment (` #…`), matching serde_yaml. A `#` not
+/// preceded by whitespace is literal and kept.
+fn strip_yaml_comment(s: &str) -> &str {
+    match s.find(" #") {
+        Some(i) => s[..i].trim_end(),
+        None => s,
+    }
+}
+
+/// Drop a leading whole-pattern inline flag group (`(?i)`, `(?ims)`, `(?i-u)`)
+/// so it is not misread as part of the first alternation. A non-capturing
+/// `(?:…)` or named `(?P<…>…)` group is left intact (its inner content is real
+/// pattern text).
+fn strip_inline_flags(s: &str) -> &str {
+    if let Some(rest) = s.strip_prefix("(?") {
+        if let Some(close) = rest.find(')') {
+            let flags = &rest[..close];
+            if !flags.is_empty() && flags.chars().all(|c| c.is_ascii_alphabetic() || c == '-') {
+                return &rest[close + 1..];
+            }
         }
     }
     s
@@ -158,11 +200,15 @@ fn split_top_level(pattern: &str) -> Vec<&str> {
 }
 
 struct AltInfo {
-    /// Alphanumeric characters of the alternation, in order.
-    core: String,
-    /// The alternation is a single literal word (only word chars, optionally
-    /// with anchor decoration and an optional trailing `?`) — not a phrase or
-    /// structured regex.
+    /// The literal word after anchor decoration is stripped, lowercased. Empty
+    /// when the alternation is not a bare word.
+    word: String,
+    /// Character count of the literal word (Unicode scalar values, so accented
+    /// and non-Latin tokens count correctly).
+    char_len: usize,
+    /// The alternation is a single literal word (only alphanumeric chars,
+    /// optionally with anchor decoration and an optional trailing `?`) — not a
+    /// phrase or structured regex.
     is_bare_word: bool,
     /// Carries word-boundary anchoring (`\b`, `^`/`$`, `(^| )`/`( |$)`, or a
     /// leading/trailing literal or escaped space).
@@ -170,14 +216,16 @@ struct AltInfo {
 }
 
 fn classify(alt: &str) -> AltInfo {
-    let core: String = alt.chars().filter(|c| c.is_ascii_alphanumeric()).collect();
+    // Detect anchoring on the untrimmed alternation so surrounding spaces
+    // count as boundaries before they are trimmed off below.
     let is_anchored = detect_anchor(alt);
 
-    // Strip anchor decoration, then test whether the remainder is a single
-    // literal word. `\b`, `^`, `$`, `(^| )`, `( |$)`, and boundary spaces are
-    // removed; a single trailing `?` (optional last letter, e.g. `ways?`) is
-    // allowed. Anything else (`.`, `*`, `+`, groups, classes, interior `?`)
-    // means the alternation is not a bare word.
+    // Reduce to the literal word: strip anchor decoration, then a single
+    // trailing `?` (optional last letter, e.g. `ways?`). `\b`, `^`, `$`,
+    // `(^| )`, `( |$)`, and boundary spaces are removed; anything else (`.`,
+    // `*`, `+`, groups, classes, interior `?`) means the alternation is not a
+    // bare word. Word chars are tested with Unicode `is_alphanumeric` so
+    // localized patterns are classified, not silently skipped.
     let mut s = alt.trim();
     s = s
         .trim_start_matches("(^| )")
@@ -189,11 +237,17 @@ fn classify(alt: &str) -> AltInfo {
     s = s.trim_start_matches('^').trim_end_matches('$');
     s = s.trim_start_matches("\\ ").trim_end_matches("\\ ");
     let s = s.trim();
-    let body = s.strip_suffix('?').unwrap_or(s);
-    let is_bare_word = !body.is_empty() && body.chars().all(|c| c.is_ascii_alphanumeric());
+    let word_src = s.strip_suffix('?').unwrap_or(s);
+    let is_bare_word = !word_src.is_empty() && word_src.chars().all(|c| c.is_alphanumeric());
+    let (word, char_len) = if is_bare_word {
+        (word_src.to_lowercase(), word_src.chars().count())
+    } else {
+        (String::new(), 0)
+    };
 
     AltInfo {
-        core,
+        word,
+        char_len,
         is_bare_word,
         is_anchored,
     }
@@ -249,6 +303,25 @@ mod tests {
     }
 
     #[test]
+    fn anchored_common_word_still_flagged() {
+        // \bcommit\b — the `\b` must not leak into the word; "commit" is still
+        // a common word and should be flagged (regression for the core/body
+        // corruption bug).
+        assert_eq!(warnings_for(r"\bcommit\b"), 1);
+        assert_eq!(warnings_for(r"\bdocs\b|diataxis"), 1);
+    }
+
+    #[test]
+    fn inline_flag_group_stripped() {
+        // (?i) applies to the whole pattern; the first alternation is "commit".
+        assert_eq!(warnings_for("(?i)commit|remember"), 2);
+        // Non-capturing groups are left intact (not a flag group): only the
+        // bare `baz` warns. If `(?:…)` were wrongly stripped as flags, the
+        // pattern would become `foo|bar|baz` and warn three times.
+        assert_eq!(warnings_for("(?:foo|bar)|baz"), 1);
+    }
+
+    #[test]
     fn short_unanchored_flagged() {
         assert_eq!(warnings_for("erd|entity.?relationship"), 1); // erd short
         assert_eq!(warnings_for("dbml"), 1);
@@ -257,6 +330,34 @@ mod tests {
     #[test]
     fn short_but_anchored_is_clean() {
         assert_eq!(warnings_for(r"\berd\b|entity"), 0);
+    }
+
+    #[test]
+    fn space_anchored_middle_token_is_clean() {
+        // A middle alternation anchored by surrounding spaces must not warn
+        // (regression for anchor detection running before the trim).
+        assert_eq!(warnings_for("longword| erd |otherword"), 0);
+    }
+
+    #[test]
+    fn non_ascii_short_word_is_classified() {
+        // Accented/non-Latin bare words must be seen, not silently skipped.
+        assert_eq!(warnings_for("añ|entityname"), 1); // "añ" short + unanchored
+    }
+
+    #[test]
+    fn inline_comment_stripped() {
+        // serde_yaml drops ` # trigger`; lint must too, so "erd" is still seen.
+        assert_eq!(warnings_for("pr|erd # trigger"), 2); // pr + erd, both short
+    }
+
+    #[test]
+    fn lazy_wildcard_flagged_without_greedy_label() {
+        // `.*?` is unbounded too; still flagged, but not mislabeled "greedy".
+        let mut n = 0;
+        // capture is not straightforward; just assert it fires exactly once.
+        check_pattern(&"way", "alert.*?ack", &mut n);
+        assert_eq!(n, 1);
     }
 
     #[test]

--- a/tools/ways-cli/src/cmd/lint/pattern.rs
+++ b/tools/ways-cli/src/cmd/lint/pattern.rs
@@ -1,0 +1,285 @@
+//! Pattern-hygiene lint (ADR-155 §5): the `pattern:` field is the
+//! high-precision keyword lane. Suggestive common words belong in
+//! `vocabulary:` where the embedding lane weighs them contextually; the
+//! keyword lane should carry only exact, anchored, term-of-art triggers.
+//!
+//! Three advisory rules, all emitted as WARNING (so `--check` in CI is not
+//! gated on hygiene — the rework pass and telemetry adjudicate per way):
+//!
+//! 1. **Bare common word** — an alternation that is a plain dictionary word
+//!    (from [`COMMON_WORDS`]) fires on unrelated prose. Move it to
+//!    `vocabulary:`.
+//! 2. **Short unanchored alternation** — a literal alternation shorter than
+//!    [`SHORT_ALTERNATION_FLOOR`] with no word-boundary anchoring collides
+//!    with substrings of larger words. Anchor it (term of art) or demote it.
+//! 3. **`.*` in a prompt pattern** — an unbounded greedy wildcard makes the
+//!    trigger match almost anything between its literals.
+//!
+//! The rules operate on top-level alternations (split on `|` at paren depth
+//! 0), so a grouped inner `|` such as `alert.?(response|triage)` is treated
+//! as one alternation, not three.
+
+use std::fmt::Display;
+
+/// Literal alternations at or above this length are common enough in normal
+/// English that unanchored short-token collisions are the dominant risk; below
+/// it, a bare token matched anywhere in the prompt fires on unrelated
+/// substrings. Chosen to flag 2–4 char tokens (`pr`, `erd`, `dbml`, `docs`)
+/// while leaving 5+ char tokens to the common-word rule. Heuristic, not a law.
+const SHORT_ALTERNATION_FLOOR: usize = 5;
+
+/// Suggestive words that read as intent in prose and therefore belong in the
+/// contextual (embedding) lane, not the exact keyword lane. Kept deliberately
+/// narrow: unambiguously generic words plus the four the ADR names
+/// (`remember`, `commit`, `workflow`, `docs`). Domain terms of art (`adr`,
+/// `diataxis`, `schema`, `migrate`, `mermaid`) are intentionally absent — the
+/// rework pass keeps-and-anchors those rather than demoting them. Extend this
+/// list from `way_keyword_gated` telemetry as live offenders surface.
+const COMMON_WORDS: &[&str] = &[
+    // ADR-155 §5 names these four explicitly.
+    "remember",
+    "commit",
+    "workflow",
+    "docs",
+    // Generic verbs/nouns that fire on unrelated prose.
+    "note",
+    "review",
+    "error",
+    "exception",
+    "slow",
+    "speed",
+    "upgrade",
+    "release",
+    "audit",
+    "automate",
+    "tooling",
+    "skill",
+    // Generic doc/data nouns better served by the embedding lane.
+    "documentation",
+    "package",
+    "library",
+    "chart",
+    "graph",
+    "plot",
+    "performance",
+];
+
+/// Run all three pattern-hygiene rules against one way's `pattern:` value.
+/// `warnings` accumulates the project-wide counter owned by the caller.
+pub(super) fn check_pattern(rel: &dyn Display, pattern: &str, warnings: &mut u32) {
+    let pattern = unquote(pattern.trim());
+    for alt in split_top_level(pattern) {
+        let alt = alt.trim();
+        if alt.is_empty() {
+            continue;
+        }
+
+        // Rule 3: unbounded greedy wildcard.
+        if alt.contains(".*") {
+            eprintln!(
+                "  WARNING: {rel} — pattern alternation '{alt}' uses '.*' (greedy); \
+                 prompt patterns should avoid unbounded wildcards — bound or restructure it (ADR-155 §5)"
+            );
+            *warnings += 1;
+        }
+
+        let info = classify(alt);
+
+        // Rules 1 and 2 only apply to bare literal words; structured
+        // alternations (groups, character classes, multi-word phrases joined
+        // by `.?`/`.*`) are outside the vocabulary-demotion doctrine.
+        if !info.is_bare_word {
+            continue;
+        }
+        let core = info.core.to_ascii_lowercase();
+
+        // Rule 2: common word (length-independent). Takes precedence over the
+        // short-token rule so an alternation earns at most one of these two.
+        if COMMON_WORDS.contains(&core.as_str()) {
+            eprintln!(
+                "  WARNING: {rel} — pattern alternation '{alt}' is a common word; \
+                 move it to vocabulary: (semantic lane) and keep pattern: for exact triggers (ADR-155 §5)"
+            );
+            *warnings += 1;
+            continue;
+        }
+
+        // Rule 1: short and unanchored.
+        if !info.is_anchored && info.core.len() < SHORT_ALTERNATION_FLOOR {
+            let n = info.core.len();
+            eprintln!(
+                "  WARNING: {rel} — pattern alternation '{alt}' is short ({n} chars) and unanchored; \
+                 anchor it (\\b{core}\\b) if it's a term of art, or move it to vocabulary: (ADR-155 §5)"
+            );
+            *warnings += 1;
+        }
+    }
+}
+
+/// Strip one layer of matching YAML quotes, if present.
+fn unquote(s: &str) -> &str {
+    for q in ['"', '\''] {
+        if s.len() >= 2 && s.starts_with(q) && s.ends_with(q) {
+            return &s[1..s.len() - 1];
+        }
+    }
+    s
+}
+
+/// Split a regex on `|` at parenthesis depth 0, so grouped inner alternations
+/// (`(response|triage)`) and escaped pipes (`\|`) stay intact.
+fn split_top_level(pattern: &str) -> Vec<&str> {
+    let bytes = pattern.as_bytes();
+    let mut parts = Vec::new();
+    let mut depth: i32 = 0;
+    let mut start = 0usize;
+    let mut i = 0usize;
+    let mut in_class = false; // inside a [...] character class
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => {
+                i += 2; // skip escaped char
+                continue;
+            }
+            b'[' if !in_class => in_class = true,
+            b']' if in_class => in_class = false,
+            b'(' if !in_class => depth += 1,
+            b')' if !in_class => depth -= 1,
+            b'|' if !in_class && depth == 0 => {
+                parts.push(&pattern[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    parts.push(&pattern[start..]);
+    parts
+}
+
+struct AltInfo {
+    /// Alphanumeric characters of the alternation, in order.
+    core: String,
+    /// The alternation is a single literal word (only word chars, optionally
+    /// with anchor decoration and an optional trailing `?`) — not a phrase or
+    /// structured regex.
+    is_bare_word: bool,
+    /// Carries word-boundary anchoring (`\b`, `^`/`$`, `(^| )`/`( |$)`, or a
+    /// leading/trailing literal or escaped space).
+    is_anchored: bool,
+}
+
+fn classify(alt: &str) -> AltInfo {
+    let core: String = alt.chars().filter(|c| c.is_ascii_alphanumeric()).collect();
+    let is_anchored = detect_anchor(alt);
+
+    // Strip anchor decoration, then test whether the remainder is a single
+    // literal word. `\b`, `^`, `$`, `(^| )`, `( |$)`, and boundary spaces are
+    // removed; a single trailing `?` (optional last letter, e.g. `ways?`) is
+    // allowed. Anything else (`.`, `*`, `+`, groups, classes, interior `?`)
+    // means the alternation is not a bare word.
+    let mut s = alt.trim();
+    s = s
+        .trim_start_matches("(^| )")
+        .trim_start_matches("(^|")
+        .trim_end_matches("( |$)")
+        .trim_end_matches("|$)");
+    let s = s.replace("\\b", "");
+    let mut s = s.trim();
+    s = s.trim_start_matches('^').trim_end_matches('$');
+    s = s.trim_start_matches("\\ ").trim_end_matches("\\ ");
+    let s = s.trim();
+    let body = s.strip_suffix('?').unwrap_or(s);
+    let is_bare_word = !body.is_empty() && body.chars().all(|c| c.is_ascii_alphanumeric());
+
+    AltInfo {
+        core,
+        is_bare_word,
+        is_anchored,
+    }
+}
+
+fn detect_anchor(alt: &str) -> bool {
+    alt.contains("\\b")
+        || alt.starts_with('^')
+        || alt.ends_with('$')
+        || alt.starts_with("(^|")
+        || alt.ends_with("|$)")
+        || alt.starts_with(' ')
+        || alt.ends_with(' ')
+        || alt.starts_with("\\ ")
+        || alt.ends_with("\\ ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn warnings_for(pattern: &str) -> u32 {
+        let mut n = 0;
+        check_pattern(&"way", pattern, &mut n);
+        n
+    }
+
+    #[test]
+    fn split_respects_group_depth() {
+        assert_eq!(
+            split_top_level("alert.?(response|triage)|remediat"),
+            vec!["alert.?(response|triage)", "remediat"]
+        );
+    }
+
+    #[test]
+    fn split_respects_escaped_pipe_and_class() {
+        assert_eq!(split_top_level(r"a\|b|c"), vec![r"a\|b", "c"]);
+        assert_eq!(split_top_level("[a|b]|c"), vec!["[a|b]", "c"]);
+    }
+
+    #[test]
+    fn anchored_term_of_art_is_clean() {
+        // (^| )adr( |$) — anchored, short: no warning.
+        assert_eq!(warnings_for("(^| )adr( |$)|architect|decision"), 0);
+    }
+
+    #[test]
+    fn common_word_flagged() {
+        assert_eq!(warnings_for("remember|save.*memory"), 2); // remember + .*
+        assert_eq!(warnings_for("commit"), 1);
+        assert_eq!(warnings_for("workflow|orchestrat|pipeline"), 1); // only workflow
+    }
+
+    #[test]
+    fn short_unanchored_flagged() {
+        assert_eq!(warnings_for("erd|entity.?relationship"), 1); // erd short
+        assert_eq!(warnings_for("dbml"), 1);
+    }
+
+    #[test]
+    fn short_but_anchored_is_clean() {
+        assert_eq!(warnings_for(r"\berd\b|entity"), 0);
+    }
+
+    #[test]
+    fn greedy_wildcard_flagged() {
+        assert_eq!(warnings_for("create.*pr|pr.*create"), 2);
+    }
+
+    #[test]
+    fn phrase_not_treated_as_bare_word() {
+        // design.?pattern is a joined phrase, not a bare word: no common/short
+        // flag, and no `.*`.
+        assert_eq!(warnings_for("design.?pattern|technical.?choice"), 0);
+    }
+
+    #[test]
+    fn optional_trailing_letter_is_bare() {
+        // ways? — bare word "ways"; not in COMMON_WORDS (project term of art),
+        // long enough to escape the short rule: clean.
+        assert_eq!(warnings_for("(^| )ways?( |$)|knowledge"), 0);
+    }
+
+    #[test]
+    fn longer_uncommon_bare_word_is_clean() {
+        assert_eq!(warnings_for("orchestrat|multiagent"), 0);
+    }
+}

--- a/tools/ways-cli/src/cmd/lint/per_file.rs
+++ b/tools/ways-cli/src/cmd/lint/per_file.rs
@@ -208,6 +208,13 @@ pub(super) fn lint_file(
         }
     }
 
+    // Pattern hygiene (ADR-155 §5): the keyword lane should carry exact,
+    // anchored, term-of-art triggers; suggestive common words belong in
+    // vocabulary:. Advisory WARNINGs, not errors.
+    if let Some(val) = get_field_value(&fm_str, "pattern") {
+        super::pattern::check_pattern(&rel, &val, warnings);
+    }
+
     // Scope enum
     if let Some(val) = get_field_value(&fm_str, "scope") {
         for part in val.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()) {


### PR DESCRIPTION
## What

Implements the **lint-rules** piece of ADR-155 §5 (pattern hygiene). `ways lint` now enforces the doctrine that the `pattern:` field is the high-precision keyword lane: suggestive common words belong in `vocabulary:` (the contextual embedding lane), and the keyword lane should carry only exact, anchored, term-of-art triggers.

## Why this piece first

ADR-155 §5 calls for the rework to be driven by a **ranked demotion worklist** rather than a hand-audit of the 42 pattern-bearing ways. Live `way_keyword_gated` telemetry is still thin (5 events), so the deterministic lint rules are the available substitute — and they produce that worklist now, codifying the doctrine so future ways can't regress before the rework even runs.

## Rules

Three advisory (WARNING-level) rules over each way's `pattern:` regex, operating on top-level alternations (split on `|` at paren depth 0 so a grouped inner `|` like `alert.?(response|triage)` stays intact):

1. **Bare common word** — a plain dictionary word (curated list including the four the ADR names: `remember`, `commit`, `workflow`, `docs`) → move to `vocabulary:`.
2. **Short unanchored alternation** — `< 5` literal chars with no `\b` / `^$` / space anchoring → anchor if term-of-art, else demote.
3. **`.*` greedy wildcard** — matches across unrelated clauses → bound or restructure.

WARNING-level keeps `--check` ungated on hygiene; the rework pass + telemetry adjudicate per way.

## Result over the current ways

62 findings — 18 common words, 40 greedy `.*`, 4 short unanchored — and it **independently rediscovered the offenders live telemetry already flagged** (`remember`, `commit`), cross-validating the heuristic against real gate behavior.

## Tests

10 unit tests: depth-aware splitting (groups, escaped pipes, char classes), anchor detection, bare-word classification (`ways?`, phrases), and each rule. Full `ways` suite green (262 passed).

## Scope / next

This is the lint piece only. Remaining ADR-155 §5 work (tracked separately): the guided rework pass over the flagged alternations (measured with embed probes), corpus rebuild, and folding in live `way_keyword_gated` telemetry as it accumulates.