### PR TITLE
release(ways): 1.1.0 — ADR-156 calibrated scoring

### DIFF
--- a/docs/architecture/system/ADR-156-calibrated-relevance-scoring-for-the-semantic-lane.md
+++ b/docs/architecture/system/ADR-156-calibrated-relevance-scoring-for-the-semantic-lane.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-07-04
 deciders:
   - aaronsb

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "ways"
-version = "1.0.9"
+version = "1.1.0"
 dependencies = [
  "agent-fmt",
  "anyhow",

--- a/tools/ways-cli/Cargo.toml
+++ b/tools/ways-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ways"
-version = "1.0.9"
+version = "1.1.0"
 edition = "2021"
 description = "Unified CLI for ways — knowledge guidance for Claude Code"
 license = "MIT"


### PR DESCRIPTION
Bumps `ways` to **1.1.0** and marks ADR-156 Accepted.

Minor bump (vs. ADR-155's patch) because this is a **clean cutover with a behaviour change**:
- raw-cosine thresholding → calibrated probability space (`g(s)`, `τ_s`/`τ_k`)
- removed: per-way `embed_threshold` (schema + frontmatter + 18 way files), and the `keyword_gate_fraction` / `default_embed_threshold` / `default_multi_embed_threshold` config keys (now warn if set)
- requires a corpus regeneration to fit the calibration (a deliberate operator deploy); until then the semantic lane degrades to keyword-only, surfaced in `ways status`

Merging tags `ways-v1.1.0` → CI publishes binaries.

https://claude.ai/code/session_017bpbXScJHd91buptnw7piy