### PR TITLE
ADR-155 §5: calibrated pattern-hygiene sweep + pattern_keep lint exemption

### DIFF
--- a/hooks/ways/collaboration/onboarding-share/onboarding-share.md
+++ b/hooks/ways/collaboration/onboarding-share/onboarding-share.md
@@ -1,7 +1,7 @@
 ---
 description: When to surface publishing a repo's onboarding guide as a share link a teammate's own agent can open directly, instead of asking them to clone the repo and hunt for the file
 vocabulary: onboarding share link teammate colleague new engineer collaborator handoff hand off bring up to speed get started repo working model share guide invite agent context publish onboard
-pattern: onboard|onboarding guide|share .*(guide|link)|bring .* up to speed|hand(ing)? off|get .* started on (the|this) repo
+pattern: onboard|onboarding guide|share .{0,30}(guide|link)|bring .{0,30} up to speed|hand(ing)? off|get .{0,30} started on (the|this) repo
 scope: agent, subagent
 refire: 0.15
 ---

--- a/hooks/ways/data/documentation/documentation.md
+++ b/hooks/ways/data/documentation/documentation.md
@@ -1,7 +1,7 @@
 ---
 description: generating database documentation from the schema — a reference page and an entity-relationship diagram derived from the DDL, kept in sync in CI
 vocabulary: schema documentation erd entity relationship diagram dbml docgen generate ddl reference data dictionary table column pg_dump introspect catalog
-pattern: erd|entity.?relationship|dbml|schema.?(doc|diagram|reference|dictionary)|data.?dictionary|pg_dump.*(doc|diagram)
+pattern: \berd\b|entity.?relationship|\bdbml\b|schema.?(doc|diagram|reference|dictionary)|data.?dictionary|pg_dump.{0,30}(doc|diagram)
 scope: agent, subagent
 refire: 0.15
 ---

--- a/hooks/ways/data/documentation/documentation.md
+++ b/hooks/ways/data/documentation/documentation.md
@@ -1,7 +1,7 @@
 ---
 description: generating database documentation from the schema — a reference page and an entity-relationship diagram derived from the DDL, kept in sync in CI
 vocabulary: schema documentation erd entity relationship diagram dbml docgen generate ddl reference data dictionary table column pg_dump introspect catalog
-pattern: \berd\b|entity.?relationship|\bdbml\b|schema.?(doc|diagram|reference|dictionary)|data.?dictionary|pg_dump.{0,30}(doc|diagram)
+pattern: (?i)\berd\b|entity.?relationship|\bdbml\b|schema.?(doc|diagram|reference|dictionary)|data.?dictionary|pg_dump.{0,30}(doc|diagram)
 scope: agent, subagent
 refire: 0.15
 ---

--- a/hooks/ways/data/migrations/idempotent/idempotent.md
+++ b/hooks/ways/data/migrations/idempotent/idempotent.md
@@ -1,7 +1,7 @@
 ---
 description: writing idempotent, re-runnable schema migrations that survive a retry or partial failure without erroring on the second pass
 vocabulary: idempotent rerun retry replay guard conditional if not exists create or replace on conflict drop if exists partial failure resume safe reentrant
-pattern: idempoten|if not exists|create or replace|on conflict|re-?runnable|re-?run|drop .*if exists
+pattern: idempoten|if not exists|create or replace|on conflict|re-?runnable|re-?run|drop .{0,30}if exists
 scope: agent, subagent
 refire: 0.15
 ---

--- a/hooks/ways/documentation/diataxis/diataxis.md
+++ b/hooks/ways/documentation/diataxis/diataxis.md
@@ -1,7 +1,7 @@
 ---
 description: choosing a documentation mode — Diátaxis classification (tutorial / how-to / reference / explanation) for a catalog page
-vocabulary: diataxis tutorial how-to reference explanation mode classify learning working practical theoretical study newcomer goal information understanding catalog page
-pattern: di[aá]taxis|which (mode|kind of (doc|page))|tutorial vs|reference vs|explanation vs|classif.*(doc|page)|what mode
+vocabulary: diataxis tutorial how-to reference explanation mode classify learning working practical theoretical study newcomer goal information understanding catalog page classification document
+pattern: di[aá]taxis|which (mode|kind of (doc|page))|tutorial vs|reference vs|explanation vs|what mode
 scope: agent, subagent
 refire: 0.15
 ---

--- a/hooks/ways/documentation/documentation.md
+++ b/hooks/ways/documentation/documentation.md
@@ -1,7 +1,7 @@
 ---
 description: documentation as a typed graph — taxonomy, catalog frontmatter, linting, and how docs are organized and serialized for readers
 vocabulary: documentation docs catalog taxonomy diataxis frontmatter markdown linting graph node edge serialization readme reference tutorial how-to explanation mode domain mkdocs obsidian
-pattern: documentation|docs|catalog|diataxis|taxonomy|doclint|document.*(structure|model|graph|classif)
+pattern: catalog|diataxis|taxonomy|doclint|document.{0,30}(structure|model|graph|classif)
 files: README\.md$|docs/.*\.md$|mkdocs\.ya?ml$
 macro: prepend
 scope: agent, subagent

--- a/hooks/ways/frontmatter-schema.yaml
+++ b/hooks/ways/frontmatter-schema.yaml
@@ -49,6 +49,17 @@ way:
         always — reserve it for exact tokens (slash-command names, patterns
         that deliberately target URLs). Do not combine with common-word
         alternations; that reintroduces the noise the gate exists to veto.
+    pattern_keep:
+      type: string
+      required: optional
+      role: >
+        Whitespace-separated bare words in pattern: that the pattern-hygiene
+        lint should NOT flag as common/short (ADR-155 §5). Each is a measured,
+        calibration-backed exception (ADR-156): the keyword is load-bearing and
+        its off-sense noise scores below the keyword floor τ_k, so the heuristic
+        flag is a known false alarm. Annotate with an inline `# reason` comment.
+        Only silences the common-word and short-token rules — never the
+        unbounded `.*` rule, which is a structural defect, not a judgement call.
     files:
       type: regex
       required: optional

--- a/hooks/ways/itops/incident/incident.md
+++ b/hooks/ways/itops/incident/incident.md
@@ -1,7 +1,7 @@
 ---
 description: Incident response tiers, escalation paths, MTTR targets, alert triage, and remediation workflows
 vocabulary: incident response escalation support tier l0 l1 l2 mttr mean time alert triage remediate on-call outage severity page production down broken
-pattern: incident.?response|l0.?support|l1.?support|l2.?support|escalat|mttr|mean.?time|alert.?(response|triage)|remediat
+pattern: incident.?response|l0.?support|l1.?support|l2.?support|escalat|mean.?time|alert.?(response|triage)|remediat
 scope: agent, subagent
 refire: 0.15
 ---

--- a/hooks/ways/meta/choices/choices.md
+++ b/hooks/ways/meta/choices/choices.md
@@ -1,7 +1,7 @@
 ---
 description: presenting genuine decisions to the human as explicit choices rather than burying options in prose or deciding silently
 vocabulary: choice option decision present ask user select alternatives branch point recommend tradeoff prefer fork pick which clarify
-pattern: which (one|option|approach)|present.*(option|choice)|ask the user|let.*decide|how (should|do) (we|you|i)|prefer.*(or|over)
+pattern: which (one|option|approach)|ask the user|let (the user|the human|me|you) decide|how (should|do) (we|you|i)
 scope: agent, subagent
 refire: 0.15
 ---

--- a/hooks/ways/meta/choices/choices.md
+++ b/hooks/ways/meta/choices/choices.md
@@ -1,7 +1,7 @@
 ---
 description: presenting genuine decisions to the human as explicit choices rather than burying options in prose or deciding silently
 vocabulary: choice option decision present ask user select alternatives branch point recommend tradeoff prefer fork pick which clarify
-pattern: which (one|option|approach)|ask the user|let (the user|the human|me|you) decide|how (should|do) (we|you|i)
+pattern: which (one|option|approach)|ask the user|let.{0,15}decide|how (should|do) (we|you|i)
 scope: agent, subagent
 refire: 0.15
 ---

--- a/hooks/ways/meta/introspection/introspection.md
+++ b/hooks/ways/meta/introspection/introspection.md
@@ -1,7 +1,7 @@
 ---
 description: PR creation as a reflection point — pause and consider what was learned this session
 vocabulary: pull request create pr open pr ship merge review reflect session learning introspection
-pattern: pull.?request|create.{0,20}\bpr\b|\bpr\b.{0,20}create|write.{0,20}\bpr\b|open.{0,20}\bpr\b
+pattern: (?i)pull.?request|create.{0,20}\bpr\b|\bpr\b.{0,20}create|write.{0,20}\bpr\b|open.{0,20}\bpr\b
 commands: gh\ pr\ create
 macro: prepend
 scope: agent

--- a/hooks/ways/meta/introspection/introspection.md
+++ b/hooks/ways/meta/introspection/introspection.md
@@ -1,7 +1,7 @@
 ---
 description: PR creation as a reflection point — pause and consider what was learned this session
 vocabulary: pull request create pr open pr ship merge review reflect session learning introspection
-pattern: pull.?request|create.*pr|pr.*create|write.*pr|open.*pr
+pattern: pull.?request|create.{0,20}\bpr\b|\bpr\b.{0,20}create|write.{0,20}\bpr\b|open.{0,20}\bpr\b
 commands: gh\ pr\ create
 macro: prepend
 scope: agent

--- a/hooks/ways/meta/memory/memory.md
+++ b/hooks/ways/meta/memory/memory.md
@@ -3,7 +3,7 @@ description: Persistent memory system — MEMORY.md, topic files, what to record
 vocabulary: remember memory save note forget recall persist session learning gotcha pattern
 trigger: context-threshold
 threshold: 80
-pattern: remember|save.*(to|this|that).*memory|note.*(for|this).*(later|next)|don't forget|keep.*in.*mind
+pattern: save.{0,30}(to|this|that).{0,30}memory|note.{0,30}(for|this).{0,30}(later|next)|don't forget|keep.{0,20}in.{0,10}mind
 files: projects/[^/]+/memory/.*\.md$
 macro: prepend
 scope: agent

--- a/hooks/ways/meta/skills/skills.md
+++ b/hooks/ways/meta/skills/skills.md
@@ -1,7 +1,7 @@
 ---
 description: How we write Claude Code skills in this repo — when a skill vs a way vs a slash command, naming and scope conventions, the global-scope caveat; defers SKILL.md mechanics to the official docs
 vocabulary: skill slash command SKILL.md create author write invoke user-invocable plugin convention scope global
-pattern: skill|SKILL\.md|skill.?(creation|author|write)|claude.?code.?skill|~\/\.claude\/skills
+pattern: SKILL\.md|skill.?(creation|author|write)|claude.?code.?skill|~\/\.claude\/skills
 scope: agent, subagent
 refire: 0.15
 ---

--- a/hooks/ways/meta/subagents/subagents.md
+++ b/hooks/ways/meta/subagents/subagents.md
@@ -1,7 +1,7 @@
 ---
 description: Sub-agent delegation — when and how to spawn specialized sub-agents for token-intensive work
-vocabulary: subagent delegate spawn background task parallel worker teammate
-pattern: subagent|delegat|spawn.*agent|review.*pr|plan.*task|organiz.*docs
+vocabulary: subagent delegate spawn background task parallel worker teammate planner
+pattern: subagent|delegat|spawn.{0,30}agent|review.{0,30}pr|organiz.{0,30}docs
 scope: agent
 refire: 0.15
 ---

--- a/hooks/ways/meta/subagents/subagents.md
+++ b/hooks/ways/meta/subagents/subagents.md
@@ -1,7 +1,7 @@
 ---
 description: Sub-agent delegation — when and how to spawn specialized sub-agents for token-intensive work
 vocabulary: subagent delegate spawn background task parallel worker teammate planner
-pattern: subagent|delegat|spawn.{0,30}agent|review.{0,30}pr|organiz.{0,30}docs
+pattern: (?i)subagent|delegat|spawn.{0,30}agent|review.{0,30}\bpr\b|organiz.{0,30}docs
 scope: agent
 refire: 0.15
 ---

--- a/hooks/ways/meta/think/think.md
+++ b/hooks/ways/meta/think/think.md
@@ -1,7 +1,7 @@
 ---
 description: structured reasoning, thinking frameworks, cognitive scaffolding for complex decisions
 vocabulary: explore options approaches trade-off balance alternatives stuck principle abstract reasoning framework systematic
-pattern: explore.*(option|approach|alternativ)|weigh.*(option|trade|alternativ)|trade.?off|several (option|approach|alternativ|way)|competing (objective|priorit|concern|goal)|first principle|step.?back|i'?m stuck|which (approach|option)
+pattern: explore.{0,30}(option|approach|alternativ)|weigh.{0,30}(option|trade|alternativ)|trade.?off|several (option|approach|alternativ|way)|competing (objective|priorit|concern|goal)|first principle|step.?back|i'?m stuck|which (approach|option)
 scope: agent, subagent
 refire: 0.15
 ---

--- a/hooks/ways/meta/workflows/workflows.md
+++ b/hooks/ways/meta/workflows/workflows.md
@@ -1,7 +1,7 @@
 ---
 description: When to reach for the Workflow tool — deterministic multi-agent orchestration, versus a single agent, a skill, or a plain task list
 vocabulary: workflow orchestrate orchestration fan out pipeline multi-agent parallel stage deterministic deliver decompose verify synthesize substrate gate remediate adversarially scale
-pattern: workflow|orchestrat|fan.?out|pipeline|multi.?agent
+pattern: orchestrat|fan.?out|pipeline|multi.?agent
 scope: agent
 refire: 0.15
 ---

--- a/hooks/ways/softwaredev/code/errors/errors.md
+++ b/hooks/ways/softwaredev/code/errors/errors.md
@@ -1,7 +1,7 @@
 ---
 description: error handling patterns, exception management, try-catch boundaries, error wrapping and propagation
 vocabulary: exception handling catch throw boundary wrap rethrow fallback graceful recovery propagate unhandled
-pattern: error.?handl|exception|try.?catch|throw
+pattern: error.?handl|try.?catch|throw
 scope: agent, subagent
 refire: 0.2
 ---

--- a/hooks/ways/softwaredev/code/performance/performance.md
+++ b/hooks/ways/softwaredev/code/performance/performance.md
@@ -1,7 +1,8 @@
 ---
 description: performance optimization, profiling, benchmarking, latency
-vocabulary: optimize profile benchmark latency throughput memory cache bottleneck flamegraph allocation heap speed slow
-pattern: slow|optimi|latency|cpu.?profil|flamegraph|performance|speed.?up|benchmark|bottleneck|throughput|memory.?leak
+vocabulary: optimize profile benchmark latency throughput memory cache bottleneck flamegraph allocation heap speed slow performance
+pattern: slow|optimi|latency|cpu.?profil|flamegraph|speed.?up|benchmark|bottleneck|throughput|memory.?leak
+pattern_keep: slow  # measured (ADR-155 §5): floor-band load-bearing ('this is slow' g=0.22, keyword-only); noise floor-gated (slow cooker g=0.003)
 scope: agent, subagent
 refire: 0.2
 ---

--- a/hooks/ways/softwaredev/delivery/commits/commits.md
+++ b/hooks/ways/softwaredev/delivery/commits/commits.md
@@ -1,7 +1,7 @@
 ---
 description: git commit messages, branch naming, conventional commits, atomic changes
 vocabulary: commit message branch conventional feat fix refactor scope atomic squash amend stash rebase cherry
-pattern: commit|push.*(remote|origin|upstream)
+pattern: push.{0,30}(remote|origin|upstream)
 commands: git\ commit
 refire: 0.15
 scope: agent, subagent

--- a/hooks/ways/softwaredev/delivery/release/release.md
+++ b/hooks/ways/softwaredev/delivery/release/release.md
@@ -3,6 +3,7 @@ description: software releases, changelog generation, version bumping, semantic 
 vocabulary: release changelog version bump semver tag publish ship major minor breaking
 refire: 0.15
 pattern: release|changelog|semver|git.?tag|release.?(notes|candidate)|npm.?publish|cargo.?publish
+pattern_keep: release  # measured (ADR-155 §5): load-bearing ('github release with binaries' g=0.46, keyword-only); noise floor-gated (median g=0.01)
 scope: agent, subagent
 ---
 <!-- epistemic: heuristic -->

--- a/hooks/ways/softwaredev/environment/deps/deps.md
+++ b/hooks/ways/softwaredev/environment/deps/deps.md
@@ -1,7 +1,8 @@
 ---
 description: dependency management, package installation, library evaluation, security auditing of third-party code
 vocabulary: dependency package library install upgrade outdated audit vulnerability license bundle npm pip cargo
-pattern: dependenc|package|library|npm.?install|pip.?install|upgrade.*version
+pattern: dependenc|package|library|npm.?install|pip.?install|upgrade.{0,30}version
+pattern_keep: package library  # measured (ADR-155 §5): floor-band load-bearing ('install the react package' g=0.22); off-sense noise floor-gated (public library g=0.01, delivery package g=0.13)
 commands: npm\ install|yarn\ add|pip\ install|cargo\ add|go\ get
 refire: 0.15
 scope: agent, subagent

--- a/hooks/ways/softwaredev/environment/ssh/ssh.md
+++ b/hooks/ways/softwaredev/environment/ssh/ssh.md
@@ -1,7 +1,7 @@
 ---
 description: SSH remote access, key management, secure file transfer, non-interactive authentication
 vocabulary: ssh remote key scp rsync bastion jumphost tunnel forwarding batchmode noninteractive
-pattern: \bssh\b|remote.?server|remote.?host|sshpass
+pattern: (?i)\bssh\b|remote.?server|remote.?host|sshpass
 commands: ^ssh\ |^scp\ |^rsync.*:|\bsshpass\b
 scope: agent, subagent
 refire: 0.15

--- a/hooks/ways/softwaredev/environment/ssh/ssh.md
+++ b/hooks/ways/softwaredev/environment/ssh/ssh.md
@@ -1,7 +1,7 @@
 ---
 description: SSH remote access, key management, secure file transfer, non-interactive authentication
 vocabulary: ssh remote key scp rsync bastion jumphost tunnel forwarding batchmode noninteractive
-pattern: ssh|remote.?server|remote.?host|sshpass
+pattern: \bssh\b|remote.?server|remote.?host|sshpass
 commands: ^ssh\ |^scp\ |^rsync.*:|\bsshpass\b
 scope: agent, subagent
 refire: 0.15

--- a/hooks/ways/softwaredev/freshness/groundtruth/groundtruth.md
+++ b/hooks/ways/softwaredev/freshness/groundtruth/groundtruth.md
@@ -1,7 +1,7 @@
 ---
 description: when describing how a system actually behaves, derive ground truth from executable artifacts (code, migrations, runtime config) and treat design docs / ADRs / specs as claims to verify
 vocabulary: source of truth ground truth authoritative audit security review reconcile docs vs code spec vs implementation adr design doc stale proposal what does the system actually do how does this really work migrations schema enforcement code drift baseline supersede
-pattern: source.?of.?truth|ground.?truth|audit|security.?review|reconcile|docs?.vs.?code|spec.vs.?implementation|actually (do|behave|work|enforce)|is (this|the|that).*(up.?to.?date|still (true|accurate|current))|stale (adr|doc|spec)
+pattern: source.?of.?truth|ground.?truth|security.?review|reconcile|docs?.vs.?code|spec.vs.?implementation|actually (do|behave|work|enforce)|is (this|the|that).{0,30}(up.?to.?date|still (true|accurate|current))|stale (adr|doc|spec)
 scope: agent, subagent
 refire: 0.2
 ---

--- a/hooks/ways/softwaredev/tooling/tooling.md
+++ b/hooks/ways/softwaredev/tooling/tooling.md
@@ -1,7 +1,7 @@
 ---
 description: building and maintaining a project's own CLI tooling — encoding repeated operations as commands rather than manual shell sequences
 vocabulary: tool tooling cli script subcommand automate automation repeated manual incantation workflow efficiency wrapper helper scaffold makefile
-pattern: build.?a.?(tool|script|cli)|tooling|subcommand|automate|manual.?(step|process)|shell.?(script|incantation)|repeated.?(command|operation)
+pattern: build.?a.?(tool|script|cli)|subcommand|manual.?(step|process)|shell.?(script|incantation)|repeated.?(command|operation)
 files: (scripts|tools|bin)/.*|Makefile$
 scope: agent, subagent
 refire: 0.2

--- a/hooks/ways/softwaredev/visualization/charts/charts.md
+++ b/hooks/ways/softwaredev/visualization/charts/charts.md
@@ -1,7 +1,8 @@
 ---
 description: Render ANSI terminal charts from data — bar, line, sparkline, histogram, table
 vocabulary: chart visualize graph sparkline histogram plot trend metric compare bar line table render data display summary distribution hbar spark values series braille ansi terminal
-pattern: chart|visuali[sz]|graph|sparkline|histogram|plot|bar.?chart|trend|metric
+pattern: visuali[sz]|sparkline|histogram|plot|bar.?chart|trend|metric
+pattern_keep: plot  # measured (ADR-155 §5): load-bearing ('plot these numbers' g=0.46, keyword-only); noise floor-gated (plot twist g=0.001)
 scope: agent, subagent
 refire: 0.15
 ---

--- a/hooks/ways/softwaredev/visualization/diagrams/diagrams.md
+++ b/hooks/ways/softwaredev/visualization/diagrams/diagrams.md
@@ -1,7 +1,7 @@
 ---
 description: Render Mermaid diagrams as terminal art using mmaid — flowcharts, sequences, state machines, ER diagrams, pie charts, gantt, git graphs, and more
 vocabulary: mermaid diagram flowchart sequence state class er entity relationship pie chart gantt timeline kanban mindmap git graph block treemap quadrant render terminal visualize architecture
-pattern: mermaid|diagram|flowchart|sequence.*diagram|state.*diagram|er.*diagram|class.*diagram|gantt|mindmap|visuali[sz]e.*architecture
+pattern: mermaid|diagram|flowchart|gantt|mindmap
 scope: agent, subagent
 refire: 0.15
 ---

--- a/hooks/ways/softwaredev/visualization/visualization.md
+++ b/hooks/ways/softwaredev/visualization/visualization.md
@@ -1,7 +1,7 @@
 ---
 description: Suggest visual representations when explaining, walking through, or describing systems, flows, and relationships
 vocabulary: walk me through explain how show me describe overview understand flow process step by step architecture workflow pipeline relationship lifecycle sequence interaction dependency diagram visual how it works system
-pattern: step.by.step
+pattern: walk.{0,20}through|step.by.step
 scope: agent, subagent
 refire: 0.15
 ---

--- a/hooks/ways/softwaredev/visualization/visualization.md
+++ b/hooks/ways/softwaredev/visualization/visualization.md
@@ -1,7 +1,7 @@
 ---
 description: Suggest visual representations when explaining, walking through, or describing systems, flows, and relationships
-vocabulary: walk me through explain how show me describe overview understand flow process step by step architecture workflow pipeline relationship lifecycle sequence interaction dependency diagram visual
-pattern: walk.*through|explain.*how|show.*how|describe.*flow|step.by.step|how.*work|overview.*system
+vocabulary: walk me through explain how show me describe overview understand flow process step by step architecture workflow pipeline relationship lifecycle sequence interaction dependency diagram visual how it works system
+pattern: step.by.step
 scope: agent, subagent
 refire: 0.15
 ---

--- a/hooks/ways/workstation/pkghistory/pkghistory.md
+++ b/hooks/ways/workstation/pkghistory/pkghistory.md
@@ -1,7 +1,7 @@
 ---
 description: going over the stuff you have added to a machine over time and deciding what you no longer need — auditing a workstation for forgotten, unused, or leftover software you installed and stopped using, reviewing what accumulated, grouping it by subject, and trimming the cruft. The retrospective audit-and-cull side of installing software, distinct from project dependency management.
-vocabulary: stuff I added installation machine workstation unneeded dont need anymore no longer use forgotten unused leftover smelly leftovers cruft accumulated go over review audit clean up trim prune get rid of remove uninstall what did I add what have I installed group by subject still need AUR yay
-pattern: (?i)go over .*(stuff|things|packages|what).*(added|install)|stuff i.?ve added|what (did|have) i install|(unneeded|leftover|forgotten|unused) (things|stuff|packages|software)|(don.?t|do not) (need|want) (it|them|this|that|th[eo]se|any ?more)|no longer (use|need)|(clean up|get rid of|trim|prune|cull).*(cruft|leftover|smelly|packages)|smelly .*leftover
+vocabulary: stuff I added installation machine workstation unneeded dont need anymore no longer use forgotten unused leftover smelly leftovers cruft accumulated go over review audit clean up trim prune get rid of remove uninstall what did I add what have I installed group by subject still need AUR yay go over the stuff I added go over what I installed
+pattern: (?i)stuff i.?ve added|what (did|have) i install|(unneeded|leftover|forgotten|unused) (things|stuff|packages|software)|(don.?t|do not) (need|want) (it|them|this|that|th[eo]se|any ?more)|no longer (use|need)|(clean up|get rid of|trim|prune|cull).{0,30}(cruft|leftover|smelly|packages)|smelly .{0,20}leftover
 scope: agent
 refire: 0.12
 ---

--- a/tools/scripts/pattern-hygiene-fanout.mjs
+++ b/tools/scripts/pattern-hygiene-fanout.mjs
@@ -1,0 +1,177 @@
+export const meta = {
+  name: 'pattern-hygiene-sweep',
+  description: 'ADR-155 §5: measure each flagged pattern keyword through the live ADR-156 calibration and propose remove/keep/anchor/bound (no file edits)',
+  phases: [
+    { title: 'Propose', detail: 'one proposer per flagged way file; measures probes through g(s)' },
+  ],
+}
+
+const REPO = '/home/aaron/Projects/ai/agent-ways'
+// Findings manifest inlined (see scratchpad/findings-manifest.json) — avoids the
+// fragile args-passing path that reached the script as a non-array.
+const ways = [
+  {"file":"hooks/ways/collaboration/onboarding-share/onboarding-share.md","id":"collaboration/onboarding-share","common":[],"short":[],"greedy":["share .*(guide|link)","bring .* up to speed","get .* started on (the|this) repo"],"needs_measure":false},
+  {"file":"hooks/ways/data/documentation/documentation.md","id":"data/documentation","common":[],"short":["erd","dbml"],"greedy":["pg_dump.*(doc|diagram)"],"needs_measure":true},
+  {"file":"hooks/ways/data/migrations/idempotent/idempotent.md","id":"data/migrations/idempotent","common":[],"short":[],"greedy":["drop .*if exists"],"needs_measure":false},
+  {"file":"hooks/ways/documentation/diataxis/diataxis.md","id":"documentation/diataxis","common":[],"short":[],"greedy":["classif.*(doc|page)"],"needs_measure":false},
+  {"file":"hooks/ways/documentation/documentation.md","id":"documentation","common":["documentation","docs"],"short":[],"greedy":["document.*(structure|model|graph|classif)"],"needs_measure":true},
+  {"file":"hooks/ways/itops/incident/incident.md","id":"itops/incident","common":[],"short":["mttr"],"greedy":[],"needs_measure":true},
+  {"file":"hooks/ways/meta/choices/choices.md","id":"meta/choices","common":[],"short":[],"greedy":["present.*(option|choice)","let.*decide","prefer.*(or|over)"],"needs_measure":false},
+  {"file":"hooks/ways/meta/introspection/introspection.md","id":"meta/introspection","common":[],"short":[],"greedy":["create.*pr","pr.*create","write.*pr","open.*pr"],"needs_measure":false},
+  {"file":"hooks/ways/meta/memory/memory.md","id":"meta/memory","common":["remember"],"short":[],"greedy":["save.*(to|this|that).*memory","note.*(for|this).*(later|next)","keep.*in.*mind"],"needs_measure":true},
+  {"file":"hooks/ways/meta/skills/skills.md","id":"meta/skills","common":["skill"],"short":[],"greedy":[],"needs_measure":true},
+  {"file":"hooks/ways/meta/subagents/subagents.md","id":"meta/subagents","common":[],"short":[],"greedy":["spawn.*agent","review.*pr","plan.*task","organiz.*docs"],"needs_measure":false},
+  {"file":"hooks/ways/meta/think/think.md","id":"meta/think","common":[],"short":[],"greedy":["explore.*(option|approach|alternativ)","weigh.*(option|trade|alternativ)"],"needs_measure":false},
+  {"file":"hooks/ways/meta/workflows/workflows.md","id":"meta/workflows","common":["workflow"],"short":[],"greedy":[],"needs_measure":true},
+  {"file":"hooks/ways/softwaredev/code/errors/errors.md","id":"softwaredev/code/errors","common":["exception"],"short":[],"greedy":[],"needs_measure":true},
+  {"file":"hooks/ways/softwaredev/code/performance/performance.md","id":"softwaredev/code/performance","common":["slow","performance"],"short":[],"greedy":[],"needs_measure":true},
+  {"file":"hooks/ways/softwaredev/delivery/commits/commits.md","id":"softwaredev/delivery/commits","common":["commit"],"short":[],"greedy":["push.*(remote|origin|upstream)"],"needs_measure":true},
+  {"file":"hooks/ways/softwaredev/delivery/release/release.md","id":"softwaredev/delivery/release","common":["release"],"short":[],"greedy":[],"needs_measure":true},
+  {"file":"hooks/ways/softwaredev/environment/deps/deps.md","id":"softwaredev/environment/deps","common":["package","library"],"short":[],"greedy":["upgrade.*version"],"needs_measure":true},
+  {"file":"hooks/ways/softwaredev/environment/ssh/ssh.md","id":"softwaredev/environment/ssh","common":[],"short":["ssh"],"greedy":[],"needs_measure":true},
+  {"file":"hooks/ways/softwaredev/freshness/groundtruth/groundtruth.md","id":"softwaredev/freshness/groundtruth","common":["audit"],"short":[],"greedy":["is (this|the|that).*(up.?to.?date|still (true|accurate|current))"],"needs_measure":true},
+  {"file":"hooks/ways/softwaredev/tooling/tooling.md","id":"softwaredev/tooling","common":["tooling","automate"],"short":[],"greedy":[],"needs_measure":true},
+  {"file":"hooks/ways/softwaredev/visualization/charts/charts.md","id":"softwaredev/visualization/charts","common":["chart","graph","plot"],"short":[],"greedy":[],"needs_measure":true},
+  {"file":"hooks/ways/softwaredev/visualization/diagrams/diagrams.md","id":"softwaredev/visualization/diagrams","common":[],"short":[],"greedy":["sequence.*diagram","state.*diagram","er.*diagram","class.*diagram","visuali[sz]e.*architecture"],"needs_measure":false},
+  {"file":"hooks/ways/softwaredev/visualization/visualization.md","id":"softwaredev/visualization","common":[],"short":[],"greedy":["walk.*through","explain.*how","show.*how","describe.*flow","how.*work","overview.*system"],"needs_measure":false},
+  {"file":"hooks/ways/workstation/pkghistory/pkghistory.md","id":"workstation/pkghistory","common":[],"short":[],"greedy":["go over .*(stuff|things|packages|what).*(added|install)","(clean up|get rid of|trim|prune|cull).*(cruft|leftover|smelly|packages)","smelly .*leftover"],"needs_measure":false},
+]
+
+const SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['way_id', 'way_file', 'current_pattern', 'proposed_pattern', 'findings', 'vocabulary_additions', 'measured', 'notes'],
+  properties: {
+    way_id: { type: 'string' },
+    way_file: { type: 'string' },
+    current_pattern: { type: 'string', description: 'the verbatim current pattern: field value' },
+    proposed_pattern: { type: 'string', description: 'the full rewritten pattern: field value (unchanged if no edit)' },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['flagged', 'kind', 'verdict', 'replacement', 'evidence'],
+        properties: {
+          flagged: { type: 'string', description: 'the flagged alternation, verbatim from lint' },
+          kind: { type: 'string', enum: ['common', 'short', 'greedy'] },
+          verdict: { type: 'string', enum: ['remove', 'keep', 'anchor', 'bound'] },
+          replacement: { type: 'string', description: 'new alternation text; empty string if removed' },
+          evidence: { type: 'string', description: 'measured g_en values for intent/noise probes, or regex rationale' },
+        },
+      },
+    },
+    vocabulary_additions: {
+      type: 'array', items: { type: 'string' },
+      description: 'terms to append to the way vocabulary: field for any keyword removed from pattern:',
+    },
+    measured: { type: 'boolean', description: 'true if probe-measure.py was run for this way' },
+    notes: { type: 'string' },
+  },
+}
+
+function prompt(w) {
+  const findingsBlock = [
+    w.common.length ? `  COMMON-WORD (flagged as too generic for pattern:): ${JSON.stringify(w.common)}` : null,
+    w.short.length ? `  SHORT-UNANCHORED (<4 chars, no \\b): ${JSON.stringify(w.short)}` : null,
+    w.greedy.length ? `  GREEDY-WILDCARD (unbounded .*): ${JSON.stringify(w.greedy)}` : null,
+  ].filter(Boolean).join('\n')
+
+  return `You are a pattern-hygiene proposer for the agent-ways project (ADR-155 §5, on the ADR-156
+calibrated ruler). You OWN one way file. PROPOSE fixes for its flagged pattern alternations,
+backed by MEASUREMENT. Do NOT edit any file — return a structured proposal only.
+
+WAY: ${w.id}
+FILE: ${REPO}/${w.file}
+
+LINT FINDINGS for this way:
+${findingsBlock}
+
+BACKGROUND — the matching engine (ADR-156). A prompt fires a way when, for the way's embedded
+alias text (= "{description} {vocabulary}"), the calibrated probability g(s)=σ(a·s+b) of the
+cosine s clears a threshold:
+    fire ⇔ g(s) ≥ τ_s   ∨   ( keyword_matches ∧ g(s) ≥ τ_k )
+Global thresholds: τ_s = 0.5 (semantic lane; EN cos ≥ 0.293) and τ_k = 0.15 (keyword floor; EN
+cos ≥ 0.228). The keyword lane ONLY fires when the semantic score already clears the low floor
+τ_k — so a keyword can NEVER drag in a prompt the embedding finds totally unrelated. There is NO
+per-way threshold knob anymore (embed_threshold was removed). Remedies are vocabulary/pattern
+edits only: remove / keep / anchor / bound.
+
+STEP 1 — read the file. Read ${REPO}/${w.file} and extract the CURRENT \`pattern:\` field value
+verbatim (it's a regex with top-level | alternations; may start with (?i)). Also note the
+\`vocabulary:\` field.
+
+STEP 2 — for each COMMON-WORD and SHORT finding, MEASURE. Write 8–12 INTENT probes (realistic
+prompts from a user who genuinely wants THIS way — varied phrasings, some that DON'T contain the
+flagged word so you can see whether the semantic lane alone catches the intent) and 8–12 NOISE
+probes (prompts that CONTAIN the flagged word but where the user does NOT want this way — the
+word used in an unrelated sense). Then run the shared instrument:
+
+    cd ${REPO} && python3 tools/scripts/probe-measure.py '${w.id}' \\
+      --intent "probe one" "probe two" ... \\
+      --noise "noise one" "noise two" ...
+
+It prints per-probe cosine, g_en, whether it fires the semantic lane (g≥τ_s) and clears the floor
+(g≥τ_k), plus a separation summary. Read the numbers. Decide per keyword:
+  • REMOVE (from pattern:, ADD to vocabulary:) if EITHER
+      (a) SEMANTIC-SAFE: the genuine intent already fires the semantic lane on its own — most
+          INTENT probes (incl. ones lacking the word) reach g ≥ τ_s. The keyword is redundant.
+      (b) INSEPARABLE: intent and noise g-distributions overlap so much the keyword can't
+          discriminate (noise leaks past τ_k about as often as intent clears it, or the summary
+          says distributions overlap and noise median ≈ intent median). No pattern can save it;
+          e.g. meta/memory 'remember'. Removing stops the false fires; the semantic lane keeps
+          the true ones.
+  • KEEP (in pattern:, unchanged) if the keyword is LOAD-BEARING and CLEAN: genuine intent needs
+      the floor (INTENT clears τ_k but often NOT τ_s, so semantic-alone would miss it) AND the
+      NOISE is gated (noise g mostly < τ_k — the floor already suppresses the generic-word
+      misfires). The calibration is doing its job; the lint flag is a false alarm here. (This is
+      the likely verdict for softwaredev/code/performance 'slow' — verify by measuring.)
+  • ANCHOR (\\bTERM\\b) for SHORT terms-of-art (erd, dbml, mttr, ssh): keep the keyword but wrap
+      in word boundaries so it can't match inside larger words. Measure to confirm the anchored
+      term still fires on real intent and the substring-collisions disappear.
+
+STEP 3 — for each GREEDY-WILDCARD finding, the default remedy is BOUND: replace the unbounded
+\`.*\` with a bounded, proximity-preserving quantifier (\`.{0,30}\` is a good default; tune 10–40
+to the intended phrase gap) or restructure to explicit tokens (e.g. \`push\\s+\\S+\\s+(remote|
+origin|upstream)\` → but simplest is bounding). Preserve the ORIGINAL matching intent — the fix
+is about killing the unbounded span, not changing what phrases match. If a bounded pattern would
+STILL be a generic-phrase leak (e.g. visualization 'how.*work', 'walk.*through' are near-universal
+phrasings), MEASURE it like a common word and consider REMOVE if the semantic lane covers the
+intent. Otherwise bound and move on.
+
+STEP 4 — assemble the full rewritten \`pattern:\` value: apply every verdict (drop removed
+alternations, swap anchored/bounded ones in place, keep the rest). Preserve the leading (?i) if
+present and the overall alternation structure. For every keyword you REMOVE, add it (or a better
+semantic phrasing of it) to vocabulary_additions so the term still contributes to the embedding.
+
+Return the structured proposal. evidence must cite the actual measured g_en numbers (e.g.
+"intent median g=0.71, noise median g=0.04, noise 0% past floor → keep" or "intent g 0.2–0.3 all
+below τ_s but clear τ_k; noise g<0.05 → keep, floor-protected"). Be decisive; when genuinely
+uncertain, prefer KEEP for load-bearing keywords and BOUND for wildcards, and say so in notes.`
+}
+
+phase('Propose')
+const proposals = await parallel(
+  ways.map((w) => () =>
+    agent(prompt(w), {
+      label: `propose:${w.id}`,
+      phase: 'Propose',
+      schema: SCHEMA,
+      agentType: 'general-purpose',
+    })
+  )
+)
+
+const ok = proposals.filter(Boolean)
+log(`${ok.length}/${ways.length} proposals returned`)
+
+// Roll up a compact decision ledger for central review.
+const ledger = ok.map((p) => ({
+  way: p.way_id,
+  measured: p.measured,
+  verdicts: (p.findings || []).map((f) => `${f.flagged} → ${f.verdict}`),
+  pattern_changed: p.current_pattern !== p.proposed_pattern,
+  vocab_adds: p.vocabulary_additions || [],
+}))
+
+return { count: ok.length, of: ways.length, proposals: ok, ledger }

--- a/tools/scripts/pattern-hygiene-fanout.mjs
+++ b/tools/scripts/pattern-hygiene-fanout.mjs
@@ -6,6 +6,8 @@ export const meta = {
   ],
 }
 
+// Session-specific absolute repo root (workflow scripts have no cwd/fs access to
+// derive it). Edit this if replaying the methodology from another checkout.
 const REPO = '/home/aaron/Projects/ai/agent-ways'
 // Findings manifest inlined (see scratchpad/findings-manifest.json) — avoids the
 // fragile args-passing path that reached the script as a non-array.
@@ -73,7 +75,7 @@ const SCHEMA = {
 function prompt(w) {
   const findingsBlock = [
     w.common.length ? `  COMMON-WORD (flagged as too generic for pattern:): ${JSON.stringify(w.common)}` : null,
-    w.short.length ? `  SHORT-UNANCHORED (<4 chars, no \\b): ${JSON.stringify(w.short)}` : null,
+    w.short.length ? `  SHORT-UNANCHORED (under 5 chars, no \\b): ${JSON.stringify(w.short)}` : null,
     w.greedy.length ? `  GREEDY-WILDCARD (unbounded .*): ${JSON.stringify(w.greedy)}` : null,
   ].filter(Boolean).join('\n')
 

--- a/tools/scripts/probe-measure.py
+++ b/tools/scripts/probe-measure.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Measure probes through the LIVE ADR-156 calibration.
+
+For each probe, computes cosine(probe, way_alias) via way-embed and maps it to a
+relevance probability g(s)=sigmoid(a*s+b) using the deployed calibration in the
+embed-manifest. The way alias is "{description} {vocabulary}" — the exact text
+the corpus embedded and the calibration was fit against.
+
+Usage:
+    probe-measure.py <way-id> --intent "probe" "probe" ... --noise "probe" ...
+    probe-measure.py <way-id> --json < probes.json   # {"intent":[...],"noise":[...]}
+
+Emits per-probe cosine, g_en, g_multi, and lane verdict against the global
+thresholds tau_s=0.5 (semantic fire) / tau_k=0.15 (keyword floor). Prints a
+separation summary (intent vs noise) used to decide remove/anchor/bound.
+"""
+import argparse, json, math, os, subprocess, sys
+from pathlib import Path
+
+HOME = Path.home()
+BIN_CANDIDATES = [
+    HOME / ".claude/bin/way-embed",
+    HOME / ".local/share/agent-ways/bin/way-embed",
+    HOME / ".cache/agent-ways/user/way-embed",
+]
+CACHE = HOME / ".cache/agent-ways/user"
+CORPUS = CACHE / "ways-corpus-en.jsonl"
+MANIFEST = CACHE / "embed-manifest.json"
+EN_MODEL = CACHE / "minilm-l6-v2.gguf"
+
+TAU_S = 0.5   # semantic fire probability (config: semantic_fire_probability)
+TAU_K = 0.15  # keyword floor probability (config: keyword_floor_probability)
+
+
+def die(msg):
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(2)
+
+
+def find_bin():
+    for c in BIN_CANDIDATES:
+        if c.exists():
+            return c
+    die("way-embed binary not found")
+
+
+def load_alias(way_id):
+    if not CORPUS.exists():
+        die(f"corpus missing: {CORPUS}")
+    for line in CORPUS.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            v = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if v.get("id") == way_id:
+            desc = v.get("description", "")
+            vocab = v.get("vocabulary", "")
+            return f"{desc} {vocab}".strip()
+    die(f"way id not found in corpus: {way_id}")
+
+
+def load_calibration():
+    if not MANIFEST.exists():
+        die(f"manifest missing: {MANIFEST}")
+    cal = json.loads(MANIFEST.read_text()).get("calibration") or {}
+    if "en" not in cal:
+        die("no EN calibration in manifest — corpus not fit")
+    return cal
+
+
+def sigmoid(x):
+    if x < -60:
+        return 0.0
+    if x > 60:
+        return 1.0
+    return 1.0 / (1.0 + math.exp(-x))
+
+
+def batch_similarity(bin_path, alias, probes):
+    """Return one cosine per probe (order preserved)."""
+    lines = []
+    for p in probes:
+        p = p.replace("\t", " ").replace("\n", " ")
+        lines.append(f"{p}\t{alias}")
+    proc = subprocess.run(
+        [str(bin_path), "similarity", "--model", str(EN_MODEL), "--batch"],
+        input="\n".join(lines) + "\n",
+        capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        die(f"way-embed failed: {proc.stderr}")
+    out = [l.strip() for l in proc.stdout.splitlines() if l.strip()]
+    if len(out) != len(probes):
+        die(f"expected {len(probes)} cosines, got {len(out)}")
+    return [float(x) for x in out]
+
+
+def measure(bin_path, alias, cal, probes, label):
+    if not probes:
+        return []
+    cosines = batch_similarity(bin_path, alias, probes)
+    en = cal["en"]
+    rows = []
+    for p, s in zip(probes, cosines):
+        g_en = sigmoid(en["a"] * s + en["b"])
+        fires_sem = g_en >= TAU_S
+        clears_floor = g_en >= TAU_K
+        rows.append({
+            "label": label, "probe": p, "cos": s, "g_en": g_en,
+            "fires_sem": fires_sem, "clears_floor": clears_floor,
+        })
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("way_id")
+    ap.add_argument("--intent", nargs="*", default=[])
+    ap.add_argument("--noise", nargs="*", default=[])
+    ap.add_argument("--json", action="store_true", help="read {intent,noise} from stdin")
+    args = ap.parse_args()
+
+    intent, noise = args.intent, args.noise
+    if args.json:
+        data = json.load(sys.stdin)
+        intent = data.get("intent", [])
+        noise = data.get("noise", [])
+
+    bin_path = find_bin()
+    alias = load_alias(args.way_id)
+    cal = load_calibration()
+
+    rows = measure(bin_path, alias, cal, intent, "INTENT") + \
+           measure(bin_path, alias, cal, noise, "NOISE")
+
+    print(f"# way: {args.way_id}")
+    print(f"# alias: {alias[:120]}{'...' if len(alias) > 120 else ''}")
+    print(f"# EN calibration: a={cal['en']['a']:.3f} b={cal['en']['b']:.3f} "
+          f"(tau_s={TAU_S} -> cos>={(math.log(TAU_S/(1-TAU_S)) - cal['en']['b'])/cal['en']['a']:.3f}, "
+          f"tau_k={TAU_K} -> cos>={(math.log(TAU_K/(1-TAU_K)) - cal['en']['b'])/cal['en']['a']:.3f})")
+    print(f"{'LABEL':7} {'cos':>6} {'g_en':>6} {'sem':>4} {'floor':>5}  probe")
+    for r in rows:
+        print(f"{r['label']:7} {r['cos']:6.3f} {r['g_en']:6.3f} "
+              f"{'Y' if r['fires_sem'] else '·':>4} {'Y' if r['clears_floor'] else '·':>5}  {r['probe'][:70]}")
+
+    ig = [r["g_en"] for r in rows if r["label"] == "INTENT"]
+    ng = [r["g_en"] for r in rows if r["label"] == "NOISE"]
+    if ig and ng:
+        # separation: fraction of intent above tau_s, fraction of noise below tau_k
+        intent_semantic_safe = sum(1 for g in ig if g >= TAU_S) / len(ig)
+        noise_leaks = sum(1 for g in ng if g >= TAU_K) / len(ng)
+        inseparable = (min(ig) <= max(ng))
+        print(f"\n# SUMMARY  intent median g={sorted(ig)[len(ig)//2]:.3f}  "
+              f"noise median g={sorted(ng)[len(ng)//2]:.3f}")
+        print(f"#   intent semantic-safe (g>=tau_s): {intent_semantic_safe:.0%}")
+        print(f"#   noise still leaks past floor (g>=tau_k): {noise_leaks:.0%}")
+        print(f"#   distributions overlap (min intent <= max noise): {inseparable}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/scripts/probe-measure.py
+++ b/tools/scripts/probe-measure.py
@@ -24,6 +24,9 @@ BIN_CANDIDATES = [
     HOME / ".cache/agent-ways/user/way-embed",
 ]
 CACHE = HOME / ".cache/agent-ways/user"
+# Override with --cache-dir to score against an isolated corpus build (e.g. a
+# `ways corpus --output <dir>` refit of an un-deployed branch). The model always
+# lives in the canonical cache.
 CORPUS = CACHE / "ways-corpus-en.jsonl"
 MANIFEST = CACHE / "embed-manifest.json"
 EN_MODEL = CACHE / "minilm-l6-v2.gguf"
@@ -121,7 +124,14 @@ def main():
     ap.add_argument("--intent", nargs="*", default=[])
     ap.add_argument("--noise", nargs="*", default=[])
     ap.add_argument("--json", action="store_true", help="read {intent,noise} from stdin")
+    ap.add_argument("--cache-dir", help="dir holding ways-corpus-en.jsonl + embed-manifest.json to use instead of the canonical cache")
     args = ap.parse_args()
+
+    global CORPUS, MANIFEST
+    if args.cache_dir:
+        d = Path(args.cache_dir)
+        CORPUS = d / "ways-corpus-en.jsonl"
+        MANIFEST = d / "embed-manifest.json"
 
     intent, noise = args.intent, args.noise
     if args.json:
@@ -136,11 +146,15 @@ def main():
     rows = measure(bin_path, alias, cal, intent, "INTENT") + \
            measure(bin_path, alias, cal, noise, "NOISE")
 
+    a, b = cal["en"]["a"], cal["en"]["b"]
+    # cos at which g(s)=tau: solve a*s+b = logit(tau). Guard a<=0 (a degenerate
+    # or missing fit that load_calibration let through) rather than dividing by 0.
+    def cos_at(tau):
+        return (math.log(tau / (1 - tau)) - b) / a if a > 0 else float("nan")
     print(f"# way: {args.way_id}")
     print(f"# alias: {alias[:120]}{'...' if len(alias) > 120 else ''}")
-    print(f"# EN calibration: a={cal['en']['a']:.3f} b={cal['en']['b']:.3f} "
-          f"(tau_s={TAU_S} -> cos>={(math.log(TAU_S/(1-TAU_S)) - cal['en']['b'])/cal['en']['a']:.3f}, "
-          f"tau_k={TAU_K} -> cos>={(math.log(TAU_K/(1-TAU_K)) - cal['en']['b'])/cal['en']['a']:.3f})")
+    print(f"# EN calibration: a={a:.3f} b={b:.3f} "
+          f"(tau_s={TAU_S} -> cos>={cos_at(TAU_S):.3f}, tau_k={TAU_K} -> cos>={cos_at(TAU_K):.3f})")
     print(f"{'LABEL':7} {'cos':>6} {'g_en':>6} {'sem':>4} {'floor':>5}  probe")
     for r in rows:
         print(f"{r['label']:7} {r['cos']:6.3f} {r['g_en']:6.3f} "

--- a/tools/ways-cli/src/cmd/lint/pattern.rs
+++ b/tools/ways-cli/src/cmd/lint/pattern.rs
@@ -22,6 +22,7 @@
 //! alternations (split on `|` at paren depth 0), so a grouped inner `|` such as
 //! `alert.?(response|triage)` is treated as one alternation, not three.
 
+use std::collections::HashSet;
 use std::fmt::Display;
 
 /// Literal alternations at or above this length are common enough in normal
@@ -67,9 +68,33 @@ const COMMON_WORDS: &[&str] = &[
     "performance",
 ];
 
+/// Parse a `pattern_keep:` value into the set of lowercased bare words the
+/// author has measured and deliberately kept in `pattern:` despite the
+/// common-word / short-token heuristics. Whitespace-separated; an inline
+/// `# reason` comment (plain scalar) is stripped so the value carries only the
+/// exempted tokens. Each entry documents a calibration-backed exception
+/// (ADR-155 §5 sweep, ADR-156 ruler): the keyword is load-bearing and its noise
+/// is floor-gated, so the heuristic flag is a known false alarm.
+pub(super) fn parse_keep(raw: &str) -> HashSet<String> {
+    let (body, was_quoted) = unquote(raw.trim());
+    let val = if was_quoted {
+        body
+    } else {
+        strip_yaml_comment(body)
+    };
+    val.split_whitespace().map(|w| w.to_lowercase()).collect()
+}
+
 /// Run all three pattern-hygiene rules against one way's `pattern:` value.
-/// `warnings` accumulates the project-wide counter owned by the caller.
-pub(super) fn check_pattern(rel: &dyn Display, pattern: &str, warnings: &mut u32) {
+/// `keep` lists bare words exempted from the common-word / short rules (see
+/// [`parse_keep`]); the structural `.*` rule is never exempted. `warnings`
+/// accumulates the project-wide counter owned by the caller.
+pub(super) fn check_pattern(
+    rel: &dyn Display,
+    pattern: &str,
+    keep: &HashSet<String>,
+    warnings: &mut u32,
+) {
     // Read the value the way the matcher's YAML loader does: strip a plain
     // scalar's inline `# comment` (only for unquoted values — quotes make `#`
     // literal) and a leading whole-pattern inline flag group like `(?i)`.
@@ -104,6 +129,14 @@ pub(super) fn check_pattern(rel: &dyn Display, pattern: &str, warnings: &mut u32
         // alternations (groups, character classes, multi-word phrases joined
         // by `.?`/`.*`) are outside the vocabulary-demotion doctrine.
         if !info.is_bare_word {
+            continue;
+        }
+
+        // Author-acknowledged exception: a measured, calibration-backed keep
+        // (`pattern_keep:`) exempts this bare word from the two heuristic
+        // rules. The structural `.*` rule above is intentionally not exemptable
+        // — a wildcard span is a defect, not a judgement call.
+        if keep.contains(&info.word) {
             continue;
         }
 
@@ -271,7 +304,13 @@ mod tests {
 
     fn warnings_for(pattern: &str) -> u32 {
         let mut n = 0;
-        check_pattern(&"way", pattern, &mut n);
+        check_pattern(&"way", pattern, &HashSet::new(), &mut n);
+        n
+    }
+
+    fn warnings_with_keep(pattern: &str, keep: &str) -> u32 {
+        let mut n = 0;
+        check_pattern(&"way", pattern, &parse_keep(keep), &mut n);
         n
     }
 
@@ -356,7 +395,7 @@ mod tests {
         // `.*?` is unbounded too; still flagged, but not mislabeled "greedy".
         let mut n = 0;
         // capture is not straightforward; just assert it fires exactly once.
-        check_pattern(&"way", "alert.*?ack", &mut n);
+        check_pattern(&"way", "alert.*?ack", &HashSet::new(), &mut n);
         assert_eq!(n, 1);
     }
 
@@ -382,5 +421,48 @@ mod tests {
     #[test]
     fn longer_uncommon_bare_word_is_clean() {
         assert_eq!(warnings_for("orchestrat|multiagent"), 0);
+    }
+
+    #[test]
+    fn pattern_keep_exempts_measured_common_word() {
+        // 'slow' is a common word but a measured keep: pattern_keep silences
+        // rule 1 for it, while other alternations stay checked.
+        assert_eq!(warnings_for("slow|optimi|latency"), 1);
+        assert_eq!(warnings_with_keep("slow|optimi|latency", "slow"), 0);
+        // Multiple kept words (deps: package + library), whitespace-separated.
+        assert_eq!(warnings_for("package|library|upgrade"), 3);
+        assert_eq!(
+            warnings_with_keep("package|library|upgrade", "package library"),
+            1 // only 'upgrade' remains
+        );
+    }
+
+    #[test]
+    fn pattern_keep_exempts_short_token() {
+        // A short unanchored term-of-art can be kept as-is if measured safe.
+        assert_eq!(warnings_for("erd|entity"), 1);
+        assert_eq!(warnings_with_keep("erd|entity", "erd"), 0);
+    }
+
+    #[test]
+    fn pattern_keep_does_not_exempt_wildcard() {
+        // The structural `.*` rule is never silenced, even if the word is kept.
+        assert_eq!(warnings_with_keep("slow|save.*memory", "slow save"), 1);
+    }
+
+    #[test]
+    fn pattern_keep_strips_inline_reason_comment() {
+        // Authors annotate the keep with a reason; the comment is not a token.
+        assert_eq!(
+            warnings_with_keep("slow|optimi", "slow # measured: floor-gated"),
+            0
+        );
+    }
+
+    #[test]
+    fn pattern_keep_is_case_insensitive_and_anchor_aware() {
+        // Keep matches the lowercased bare word, so an anchored/cased keyword
+        // is still exempted by its plain form.
+        assert_eq!(warnings_with_keep(r"\bCommit\b", "commit"), 0);
     }
 }

--- a/tools/ways-cli/src/cmd/lint/per_file.rs
+++ b/tools/ways-cli/src/cmd/lint/per_file.rs
@@ -212,7 +212,10 @@ pub(super) fn lint_file(
     // anchored, term-of-art triggers; suggestive common words belong in
     // vocabulary:. Advisory WARNINGs, not errors.
     if let Some(val) = get_field_value(&fm_str, "pattern") {
-        super::pattern::check_pattern(&rel, &val, warnings);
+        let keep = get_field_value(&fm_str, "pattern_keep")
+            .map(|k| super::pattern::parse_keep(&k))
+            .unwrap_or_default();
+        super::pattern::check_pattern(&rel, &val, &keep, warnings);
     }
 
     // Scope enum


### PR DESCRIPTION
Reworks every lint-flagged `pattern:` alternation on the **ADR-156 calibrated ruler** instead of by eye, and adds a `pattern_keep` lint exemption for the keywords measurement proves are safe to keep.

## What & why

The pattern-hygiene lint (#298) flagged **62 findings across 25 ways** (18 common-word, 4 short-unanchored, 40 greedy `.*`). ADR-155 §5 sequenced the rework pass *behind* ADR-156 so it could run against a real decision boundary rather than heuristics. This is that pass.

Each flagged common-word/short keyword was **measured** through the live calibration — `g(s)=σ(a·s+b)`, EN `a=26.86 b=-7.87` — with 8–12 intent + 8–12 noise probes scored against `τ_s=0.5` (semantic fire) and `τ_k=0.15` (keyword floor), then adjudicated. A 25-agent fanout proposed; verdicts were applied centrally after auditing every REMOVE for embedding-alias preservation.

## Outcome — 30 remove · 24 bound · 3 anchor · 5 keep

| Verdict | Meaning | Examples |
|---|---|---|
| **REMOVE** (30) | keyword redundant (intent clears τ_s semantically) or inseparable (intent/noise overlap; no floor discriminates) | `remember`, `skill`, `workflow`, `commit`, `chart` |
| **BOUND** (24) | unbounded `.*` → `.{0,N}`, phrase-proximity kept | `push.{0,30}(remote…)`, `is (this…).{0,30}(up.?to.?date…)` |
| **ANCHOR** (3) | short term-of-art wrapped in `\b` | `\berd\b`, `\bdbml\b`, `\bssh\b` |
| **KEEP** (5) | load-bearing **and** clean — floor-band intent needs the keyword, off-sense noise is floor-gated | `slow`, `release`, `package`, `library`, `plot` |

The heuristic sweep would have **wrongly stripped** `slow`/`release`/`plot` on sight; measurement flipped them to keep (`slow cooker` → g=0.003, gated by the floor). Every removed bare word is preserved in the embedding alias (its stem is already in `description`+`vocabulary`), so recall for genuine intent is unchanged — only the keyword-lane-only misfires stop.

## `pattern_keep` lint exemption

The 5 KEEPs are measured exceptions the heuristic lint would nag on forever. New `pattern_keep:` frontmatter field (whitespace-separated bare words + inline `# reason`) silences the common-word/short rules for named alternations — **never** the structural `.*` rule. Self-documents the calibration rationale at the point of use.

## Verification

- **Calibration holds**: isolated corpus refit against the swept ways → **EN AUC 0.955, multi 0.941** (was 0.956 / 0.941). Vocab edits didn't disturb the ruler.
- **Lint clean**: 0 warnings, 0 errors (was 62 warnings).
- **Tests**: ways 274 green (+5 `pattern_keep`), ways-core 109 green, clippy clean.

## Tooling (committed, reusable for the ADR-155 §5 telemetry follow-on)

- `tools/scripts/probe-measure.py` — scores intent/noise probes through the deployed calibration.
- `tools/scripts/pattern-hygiene-fanout.mjs` — the 25-agent measure-and-propose workflow.

## Follow-ons (not in this PR)

- Extend `calibration_probes.jsonl` with the reworked ways' probes as a committed regression asset (harvestable from the fanout).
- Propagate calibrated doctrine to way-authoring surfaces still teaching the removed `embed_threshold` knob (2 way bodies + README + `docs/hooks-and-ways/*` + the ways-tests skill).

https://claude.ai/code/session_017bpbXScJHd91buptnw7piy