### PR TITLE
release(ways): v1.2.0 — calibrated pattern-hygiene sweep + docs alignment; defer migrator to 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An LLM session cannot internalize norms — no weight updates, no carried memory
 
 > **Current status:** Agent Ways ships with full support for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Support for additional CLI-based coding agents is in development.
 
-> ⚠️ **Breaking change in 1.0 — existing installs must migrate.** Before 1.0, the repo *was* your install (`~/.claude` was the clone). 1.0 turns `~/.claude` into a thin **projection** of an XDG application whose source lives in `$XDG_DATA_HOME/agent-ways`. A pre-1.0 in-place clone moves over with one gated, backup-first command — `ways migrate --execute` — after upgrading (`cd ~/.claude && git pull && make update`). Your `projects/` and `settings.json` are preserved. The migrator is **transitional**: it ships through the 1.0.x line and is **removed in 1.1**, after which migrating means checking out a pre-1.1 release first. **See the [Migration Guide](docs/migration-1.0.md).**
+> ⚠️ **Breaking change in 1.0 — existing installs must migrate.** Before 1.0, the repo *was* your install (`~/.claude` was the clone). 1.0 turns `~/.claude` into a thin **projection** of an XDG application whose source lives in `$XDG_DATA_HOME/agent-ways`. A pre-1.0 in-place clone moves over with one gated, backup-first command — `ways migrate --execute` — after upgrading (`cd ~/.claude && git pull && make update`). Your `projects/` and `settings.json` are preserved. The migrator is **transitional**: it ships through the 1.2.x line and is **removed in 1.3**, after which migrating means checking out a pre-1.3 release first. **See the [Migration Guide](docs/migration-1.0.md).**
 
 ```mermaid
 sequenceDiagram

--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -42,7 +42,7 @@ ways migrate --what-if     # preview (read-only)
 ways migrate --execute     # relocate the clone to $XDG_DATA, build the projection
 ```
 
-See the [Migration Guide](migration-1.0.md) for the full walkthrough and the deprecation window (the migrator ships through 1.0.x and is removed at 1.1).
+See the [Migration Guide](migration-1.0.md) for the full walkthrough and the deprecation window (the migrator ships through 1.2.x and is removed at 1.3).
 
 ## Scenario: you want a fork
 

--- a/docs/migration-1.0.md
+++ b/docs/migration-1.0.md
@@ -117,16 +117,18 @@ did before 1.0.0 shipped.
 
 | Version | `ways migrate` |
 |---|---|
-| **1.0.0 → final 1.0.x** | Present. Migrate anytime in this window. |
-| **1.1.0 and later** | **Removed.** The binary no longer carries the migrator. |
+| **1.0.0 → 1.2.x** | Present. Migrate anytime in this window. |
+| **1.3.0 and later** | **Removed.** The binary no longer carries the migrator. |
 
-After 1.1, an un-migrated install can still migrate — but only by first checking out a
-**pre-1.1 release** that still ships the command (the last `ways-v1.0.x` tag), running
+(The removal was originally slated for 1.1 and **deferred to 1.3** to widen the migration window — the migrator is still present in 1.1.x and 1.2.x.)
+
+After 1.3, an un-migrated install can still migrate — but only by first checking out a
+**pre-1.3 release** that still ships the command (the last `ways-v1.2.x` tag), running
 `ways migrate --execute`, and *then* updating to current:
 
 ```bash
-# After 1.1, to migrate a still-legacy install:
-git checkout ways-v1.0.x   # the last release that carries `ways migrate`
+# After 1.3, to migrate a still-legacy install:
+git checkout ways-v1.2.x   # the last release that carries `ways migrate`
 make update
 ways migrate --execute
 # then update to the current release

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "ways"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "agent-fmt",
  "anyhow",

--- a/tools/ways-cli/Cargo.toml
+++ b/tools/ways-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ways"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 description = "Unified CLI for ways — knowledge guidance for Claude Code"
 license = "MIT"


### PR DESCRIPTION
Release v1.2.0 (minor). Captures this session's ADR-155 §5 calibrated pattern-hygiene work and the documentation overhaul, and corrects + extends the migrator deprecation window.

## What ships in 1.2.0

- **`pattern_keep` lint feature** (new frontmatter field + rule) — exempts *measured* common-word keeps from the pattern-hygiene lint (PR #301).
- **Calibrated pattern-corpus rework** — 62 lint findings across 24 ways resolved by measurement through the ADR-156 calibration (remove/keep/anchor/bound), review-adjudicated and live-tested (PR #301).
- **Documentation alignment** — the whole ways doc surface now states one calibrated model, anchored by the new source-cited `docs/hooks-and-ways/engine-reference.md` (PRs #302, #303, #304).

## Migrator window: deferred to 1.3.0

The docs claimed `ways migrate` was "removed in 1.1.0", but **1.1.0 shipped with the migrator still present** (`migrate.rs` / `migrate_exec.rs`) — the doc had drifted from the code. Rather than execute the removal now, the window is **deferred to 1.3.0** to give adopters more time. Corrected in `README.md`, `docs/install-guide.md`, and `docs/migration-1.0.md`: migrator present through **1.2.x**, removed in **1.3.0**.

## Verified

- `tools/ways-cli/Cargo.toml` + `Cargo.lock` at 1.2.0.
- ways-bin 274 tests + ways-core 109 green, clippy clean, `ways lint` 0/0.

After merge: annotated tag `ways-v1.2.0` → CI publishes binaries.

https://claude.ai/code/session_017bpbXScJHd91buptnw7piy