### PR TITLE
feat(scan): case-insensitive trigger regex compilation (ADR-157)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -224,7 +224,7 @@ flowchart LR
     classDef output fill:#2E7D32,stroke:#1B5E20,color:#fff
 
     subgraph Input
-        Prompt["User prompt<br/>(lowercased)"]:::input
+        Prompt["User prompt<br/>(masked: fences/URLs stripped)"]:::input
         Cmd["Bash command"]:::input
         File["File path"]:::input
     end

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -76,7 +76,8 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-153](./system/ADR-153-session-introspection-substrate-correlating-fired-ways-to-turns.md) | Session-introspection substrate — correlating fired ways to turns | Accepted |
 | [ADR-154](./system/ADR-154-rethink-think-and-non-interactive-introspection-one-model-three-front-ends.md) | `ways introspect` — one model, three front-ends | Accepted |
 | [ADR-155](./system/ADR-155-semantic-gating-of-the-keyword-channel-and-reasoning-channel-rebuild.md) | Semantic gating of the keyword channel and reasoning-channel rebuild | Draft |
-| [ADR-156](./system/ADR-156-calibrated-relevance-scoring-for-the-semantic-lane.md) | Calibrated relevance scoring for the semantic lane | Draft |
+| [ADR-156](./system/ADR-156-calibrated-relevance-scoring-for-the-semantic-lane.md) | Calibrated relevance scoring for the semantic lane | Accepted |
+| [ADR-157](./system/ADR-157-case-insensitive-trigger-regex-compilation.md) | Case-insensitive trigger regex compilation | Accepted |
 
 ## Governance
 _Provenance, traceability, controls, compliance mapping_

--- a/docs/architecture/system/ADR-157-case-insensitive-trigger-regex-compilation.md
+++ b/docs/architecture/system/ADR-157-case-insensitive-trigger-regex-compilation.md
@@ -1,0 +1,114 @@
+---
+status: Accepted
+date: 2026-07-04
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-155
+  - ADR-156
+---
+
+# ADR-157: Case-insensitive trigger regex compilation
+
+## Context
+
+The keyword lane compiles each way's `pattern:` (and the `cmds:` / `files:`
+patterns) with `Regex::new(...)` and matches it against the **original-case**
+text. `mask_nonlinguistic` (ADR-155 §2) strips fences and URLs but does not
+lowercase, and the query path (`match_prompt`, `scan/mod.rs:596`) passes the
+masked query straight through. Only the tool-description path
+(`scan/mod.rs:354`) lowercases its input, and it does so on the *text*, not the
+pattern.
+
+The consequence: a lowercase author pattern silently misses the uppercase
+acronyms users actually type. `\bssh\b` misses `SSH`; `\berd\b` misses `ERD`;
+`\bpr\b`, `ADR`, `DBML`, `MTTR` all leak the same way. This surfaced in the
+PR #301 review, which patched the acute offenders by prepending an inline
+`(?i)` flag to five patterns:
+
+- `hooks/ways/meta/subagents/subagents.md`
+- `hooks/ways/meta/introspection/introspection.md`
+- `hooks/ways/workstation/pkghistory/pkghistory.md`
+- `hooks/ways/softwaredev/environment/ssh/ssh.md`
+- `hooks/ways/data/documentation/documentation.md`
+
+That is per-way cruft. It fixes the five patterns someone happened to notice and
+leaves every other acronym-bearing pattern latent — the next author who writes
+`\bpr\b` re-introduces the bug and won't know why their way never fires on `PR`.
+Case sensitivity is the wrong default for a trigger channel: an author writing a
+keyword means the *concept*, not a specific casing.
+
+**Blast-radius survey of the current corpus** (why a global fix is safe):
+
+| Lane | Cased patterns today | Effect of case-insensitivity |
+|------|----------------------|------------------------------|
+| `pattern:` (keyword) | 5× `(?i)` + `SKILL\.md` | Intended fix. `SKILL\.md` still matches `skill.md` — same concept. |
+| `cmds:` | none | No-op — no uppercase-bearing command patterns exist. |
+| `files:` | `README\.md$`, `Makefile$\|makefile$\|GNUmakefile$`, `Makefile$` | Desirable — READMEs and Makefiles have real casing variants; the `makefile$` alternation branch becomes redundant-but-harmless. |
+
+No pattern in the corpus relies on case-sensitivity to *avoid* a match. The
+helpers (`regex_matches`, `regex_span`) are private to `scan/mod.rs` and serve
+all three lanes, so the cleanest change lives in one place.
+
+## Decision
+
+Compile trigger regexes **case-insensitively** by building them with
+`regex::RegexBuilder::new(pattern).case_insensitive(true)` in the two shared
+helpers `regex_matches` and `regex_span` (`scan/mod.rs`). This applies uniformly
+to the keyword, command, and file lanes.
+
+Because the keyword regex now matches case-insensitively, the tool-description
+path no longer needs to pre-lowercase its text: `scan/mod.rs:354` changes from
+`regex_span(pat, &desc.to_lowercase())` to `regex_span(pat, desc)`, which also
+yields a truer original-case `matched_span` in telemetry (ADR-153 §3).
+
+Then **retire the five inline `(?i)` flags** — they become redundant. The
+patterns revert to their plain form; behavior is preserved by the global flag.
+
+The invariant, stated once so future authors inherit it: *the keyword lane
+matches case-insensitively; write patterns in lowercase and mean the concept.*
+This lands in the engine-reference and the authoring surfaces.
+
+## Consequences
+
+### Positive
+
+- Every acronym-bearing pattern (`PR`, `ADR`, `SSH`, `ERD`, `DBML`, `MTTR`, …)
+  matches the uppercase form users type — corpus-wide, not just the five noticed.
+- Removes per-way `(?i)` cruft and the latent-bug trap it papered over.
+- Truer `matched_span` telemetry on the description path (original case, not
+  lowercased).
+- One compile-site invariant replaces a convention every author had to remember.
+
+### Negative
+
+- An author who *wants* case-sensitive matching (e.g. to distinguish `OK` from
+  `ok`) can no longer get it via the shared helpers. No current pattern needs
+  this; if one ever does, it can carry an inline `(?-i)` scope — the regex crate
+  supports per-pattern override, so the global default is not a hard ceiling.
+- Marginally wider matching on `files:`/`cmds:` (e.g. `.ENV` now matches an
+  `\.env$` pattern). Reviewed as desirable, not a regression, for the current
+  corpus.
+
+### Neutral
+
+- The `makefile$|GNUmakefile$` explicit-casing alternations are now redundant;
+  they are left as-is (harmless) rather than churned in this ADR's scope.
+- `RegexBuilder` is already in the `regex` crate dependency — no new deps.
+
+## Alternatives Considered
+
+- **Lowercase the text instead of the pattern.** Rejected: globally lowercasing
+  the query breaks any deliberately-uppercase pattern (`SKILL\.md` would need
+  the text cased to match) and mangles the captured span. The regex flag matches
+  the *pattern* case-insensitively without touching the text — strictly safer.
+- **Keyword-lane-only case-insensitivity** (a separate helper used only at
+  `:596`, leaving `cmds:`/`files:` case-sensitive). Rejected: the same
+  `pattern:` field is consumed at both `:354` and `:596`, so splitting behavior
+  by call-site would make one field match two ways; and the survey shows
+  case-insensitivity is *desirable* for `files:` (READMEs, Makefiles) and a
+  no-op for `cmds:`. A uniform rule is simpler and correct.
+- **Keep patching per-way with `(?i)`.** Rejected: it is the status quo that
+  produced the bug — it fixes only noticed patterns and re-arms the trap for the
+  next author.

--- a/docs/hooks-and-ways.md
+++ b/docs/hooks-and-ways.md
@@ -175,7 +175,7 @@ commands: git\ commit         # matched against bash commands
 files: \.env$|config\.json    # matched against file paths
 ```
 
-Fast and precise. Most ways use this. Keyword matching is **case-sensitive** against the original-case prompt — only code fences and URLs are stripped, no lowercasing.
+Fast and precise. Most ways use this. Keyword matching is **case-insensitive** (ADR-157): the pattern is compiled case-insensitively so a lowercase pattern matches the uppercase acronyms users type (`\bssh\b` → `SSH`). The prompt text keeps its original case — only code fences and URLs are stripped — so write patterns in lowercase and mean the concept. See [engine-reference.md](hooks-and-ways/engine-reference.md).
 
 The prompt `pattern:` hit is **floor-gated**: it fires only when the way's calibrated probability also clears the keyword floor `τ_k` on at least one model lane, so a lexical coincidence can't drag in an unrelated prompt. Two carve-outs let the author's explicit trigger stand: the gate **fails open** when there is genuinely no calibrated signal (the engine didn't run, the way isn't embeddable, or no calibration is loaded), and `pattern_strict: true` forces an unconditional keyword fire by design (`scan/mod.rs` `match_prompt`).
 

--- a/docs/hooks-and-ways/engine-reference.md
+++ b/docs/hooks-and-ways/engine-reference.md
@@ -59,8 +59,14 @@ Per way, per prompt (`scan/mod.rs` `match_prompt`, ~583–623):
   semantic fire — the gated verdict is held and the semantic lane is checked first.
 - `pattern_strict: true` also bypasses the URL / code-fence mask (mod.rs:145).
 
-Keyword matching is **case-sensitive** against the original-case (masked) prompt — only
-code fences and URLs are stripped, no lowercasing (mod.rs:145, `mask_nonlinguistic`).
+Keyword matching is **case-insensitive** (ADR-157): every trigger regex — `pattern:`,
+`cmds:`, `files:` — is compiled with `RegexBuilder::case_insensitive(true)`
+(`compile_trigger`, shared by `regex_matches`/`regex_span`), so a lowercase pattern
+matches the uppercase acronyms users type (`\bssh\b` → `SSH`, `\bpr\b` → `PR`). The
+*text* is left in its original case — only code fences and URLs are stripped, no
+lowercasing (`mask_nonlinguistic`) — so the flag lives on the pattern, not the input, and
+`SKILL\.md` still matches. A pattern may opt back into case-sensitivity with an inline
+`(?-i)` scope. Authoring rule: **write patterns in lowercase and mean the concept.**
 
 ## Parent-boost — `tools/ways-cli/src/cmd/scan/mod.rs` `effective_thresholds` (753–782)
 

--- a/docs/hooks-and-ways/matching.md
+++ b/docs/hooks-and-ways/matching.md
@@ -139,7 +139,7 @@ The default and most common mode. Three fields can be tested independently:
 - `commands:` - tested against bash commands (PreToolUse:Bash)
 - `files:` - tested against file paths (PreToolUse:Edit|Write)
 
-A way can declare any combination. Each field is a standard regex evaluated case-insensitively against its input.
+A way can declare any combination. Each field is a standard regex evaluated case-insensitively against its input (ADR-157 — the pattern is compiled case-insensitively; the input keeps its original case).
 
 ### Why regex is the default
 

--- a/hooks/ways/data/documentation/documentation.md
+++ b/hooks/ways/data/documentation/documentation.md
@@ -1,7 +1,7 @@
 ---
 description: generating database documentation from the schema — a reference page and an entity-relationship diagram derived from the DDL, kept in sync in CI
 vocabulary: schema documentation erd entity relationship diagram dbml docgen generate ddl reference data dictionary table column pg_dump introspect catalog
-pattern: (?i)\berd\b|entity.?relationship|\bdbml\b|schema.?(doc|diagram|reference|dictionary)|data.?dictionary|pg_dump.{0,30}(doc|diagram)
+pattern: \berd\b|entity.?relationship|\bdbml\b|schema.?(doc|diagram|reference|dictionary)|data.?dictionary|pg_dump.{0,30}(doc|diagram)
 scope: agent, subagent
 refire: 0.15
 ---

--- a/hooks/ways/meta/introspection/introspection.md
+++ b/hooks/ways/meta/introspection/introspection.md
@@ -1,7 +1,7 @@
 ---
 description: PR creation as a reflection point — pause and consider what was learned this session
 vocabulary: pull request create pr open pr ship merge review reflect session learning introspection
-pattern: (?i)pull.?request|create.{0,20}\bpr\b|\bpr\b.{0,20}create|write.{0,20}\bpr\b|open.{0,20}\bpr\b
+pattern: pull.?request|create.{0,20}\bpr\b|\bpr\b.{0,20}create|write.{0,20}\bpr\b|open.{0,20}\bpr\b
 commands: gh\ pr\ create
 macro: prepend
 scope: agent

--- a/hooks/ways/meta/knowledge/authoring/authoring.md
+++ b/hooks/ways/meta/knowledge/authoring/authoring.md
@@ -37,7 +37,9 @@ only avoids leaking because the `τ_k` floor happens to gate it — don't rely o
 flags common-word, short-unanchored, and unbounded-`.*` alternations for exactly this reason
 (ADR-155 §5); fix them by moving the term to `vocabulary:`, anchoring a genuine term of art
 (`\berd\b`), or bounding the wildcard (`.{0,30}`). This keeps a way about a specific topic from
-firing during unrelated work — the semantic lane is the topic isolation.
+firing during unrelated work — the semantic lane is the topic isolation. The keyword lane is
+**case-insensitive** (ADR-157), so write patterns in lowercase and mean the concept — `\bpr\b`
+matches the `PR` a user types, no `(?i)` needed.
 
 **Other trigger types** (not prompt-based, semantic doesn't apply):
 - `files:` — regex matched against file paths (Edit/Write hooks)

--- a/hooks/ways/meta/subagents/subagents.md
+++ b/hooks/ways/meta/subagents/subagents.md
@@ -1,7 +1,7 @@
 ---
 description: Sub-agent delegation — when and how to spawn specialized sub-agents for token-intensive work
 vocabulary: subagent delegate spawn background task parallel worker teammate planner
-pattern: (?i)subagent|delegat|spawn.{0,30}agent|review.{0,30}\bpr\b|organiz.{0,30}docs
+pattern: subagent|delegat|spawn.{0,30}agent|review.{0,30}\bpr\b|organiz.{0,30}docs
 scope: agent
 refire: 0.15
 ---

--- a/hooks/ways/softwaredev/environment/ssh/ssh.md
+++ b/hooks/ways/softwaredev/environment/ssh/ssh.md
@@ -1,7 +1,7 @@
 ---
 description: SSH remote access, key management, secure file transfer, non-interactive authentication
 vocabulary: ssh remote key scp rsync bastion jumphost tunnel forwarding batchmode noninteractive
-pattern: (?i)\bssh\b|remote.?server|remote.?host|sshpass
+pattern: \bssh\b|remote.?server|remote.?host|sshpass
 commands: ^ssh\ |^scp\ |^rsync.*:|\bsshpass\b
 scope: agent, subagent
 refire: 0.15

--- a/hooks/ways/workstation/pkghistory/pkghistory.md
+++ b/hooks/ways/workstation/pkghistory/pkghistory.md
@@ -1,7 +1,7 @@
 ---
 description: going over the stuff you have added to a machine over time and deciding what you no longer need — auditing a workstation for forgotten, unused, or leftover software you installed and stopped using, reviewing what accumulated, grouping it by subject, and trimming the cruft. The retrospective audit-and-cull side of installing software, distinct from project dependency management.
 vocabulary: stuff I added installation machine workstation unneeded dont need anymore no longer use forgotten unused leftover smelly leftovers cruft accumulated go over review audit clean up trim prune get rid of remove uninstall what did I add what have I installed group by subject still need AUR yay go over the stuff I added go over what I installed
-pattern: (?i)stuff i.?ve added|what (did|have) i install|(unneeded|leftover|forgotten|unused) (things|stuff|packages|software)|(don.?t|do not) (need|want) (it|them|this|that|th[eo]se|any ?more)|no longer (use|need)|(clean up|get rid of|trim|prune|cull).{0,30}(cruft|leftover|smelly|packages)|smelly .{0,20}leftover
+pattern: stuff i.?ve added|what (did|have) i install|(unneeded|leftover|forgotten|unused) (things|stuff|packages|software)|(don.?t|do not) (need|want) (it|them|this|that|th[eo]se|any ?more)|no longer (use|need)|(clean up|get rid of|trim|prune|cull).{0,30}(cruft|leftover|smelly|packages)|smelly .{0,20}leftover
 scope: agent
 refire: 0.12
 ---

--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -351,7 +351,9 @@ pub fn command(
             .as_deref()
             .and_then(|p| regex_span(p, cmd))
             .or_else(|| match (description, way.pattern.as_deref()) {
-                (Some(desc), Some(pat)) => regex_span(pat, &desc.to_lowercase()),
+                // Pattern compiles case-insensitively (ADR-157), so match the
+                // description in its original case for a truer captured span.
+                (Some(desc), Some(pat)) => regex_span(pat, desc),
                 _ => None,
             });
 
@@ -816,8 +818,21 @@ fn mask_nonlinguistic(text: &str) -> String {
     url.replace_all(&no_fences, " ").into_owned()
 }
 
+/// Compile a trigger pattern case-insensitively (ADR-157). The keyword lane
+/// means the *concept*, not a casing — `\bssh\b` must match `SSH`, `\bpr\b`
+/// must match `PR`. The flag lives on the compiled pattern rather than on the
+/// text so deliberately-uppercase patterns (`SKILL\.md`) still match and the
+/// captured span keeps its original case. A pattern may override with an inline
+/// `(?-i)` scope if it ever needs case-sensitivity.
+fn compile_trigger(pattern: &str) -> Option<Regex> {
+    regex::RegexBuilder::new(pattern)
+        .case_insensitive(true)
+        .build()
+        .ok()
+}
+
 fn regex_matches(pattern: &str, text: &str) -> bool {
-    Regex::new(pattern)
+    compile_trigger(pattern)
         .map(|re| re.is_match(text))
         .unwrap_or(false)
 }
@@ -829,7 +844,7 @@ fn regex_matches(pattern: &str, text: &str) -> bool {
 /// itself is author-controlled, so a match is normally a bounded keyword.
 fn regex_span(pattern: &str, text: &str) -> Option<String> {
     const MAX_SPAN: usize = 120;
-    let m = Regex::new(pattern).ok()?.find(text)?;
+    let m = compile_trigger(pattern)?.find(text)?;
     let s = m.as_str();
     Some(match s.char_indices().nth(MAX_SPAN) {
         Some((byte, _)) => format!("{}…", &s[..byte]),
@@ -947,6 +962,23 @@ mod near_miss_tests {
             }
             _ => panic!("expected keyword Fired"),
         }
+    }
+
+    #[test]
+    fn trigger_regex_is_case_insensitive() {
+        // ADR-157: lowercase patterns match the uppercase acronyms users type,
+        // corpus-wide, without per-way (?i). Both helpers share compile_trigger.
+        assert!(regex_matches(r"\bssh\b", "connect over SSH"));
+        assert!(regex_matches(r"\bpr\b", "open a PR for this"));
+        assert_eq!(
+            regex_span(r"\berd\b", "draw an ERD diagram").as_deref(),
+            Some("ERD"),
+            "captured span keeps the input's original case"
+        );
+        // Deliberately-uppercase pattern still matches its lowercase form.
+        assert!(regex_matches(r"SKILL\.md", "editing skill.md"));
+        // An inline (?-i) scope can still opt back into case-sensitivity.
+        assert!(!regex_matches(r"(?-i)SSH", "lowercase ssh only"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Compile trigger patterns case-insensitively (`RegexBuilder::case_insensitive(true)`) in the shared `regex_matches` / `regex_span` helpers, so a lowercase author pattern matches the uppercase acronyms users type (`\bssh\b` → `SSH`, `\bpr\b` → `PR`) — corpus-wide, across the keyword / `cmds:` / `files:` lanes.

## Why

The keyword lane matched the **original-case** prompt, so lowercase patterns silently missed `SSH`, `ERD`, `PR`, `ADR`, `DBML`, `MTTR`… PR #301 patched five patterns with inline `(?i)` — per-way cruft that fixes only what someone noticed and re-arms the trap for the next author. Case-sensitivity is the wrong default for a trigger channel: an author means the *concept*, not a casing.

Blast-radius survey (see ADR-157): `cmds:` has no cased patterns (no-op); `files:` benefits (`README\.md`, `Makefile` variants); the one deliberately-cased `SKILL\.md` still matches `skill.md`.

## Design

- ADR-157 (Accepted) records the decision + alternatives (text-lowercasing and keyword-lane-only both rejected, with rationale).
- Flag on the **pattern**, not the text → deliberately-uppercase patterns still match, captured span keeps original case, and a pattern can opt back with inline `(?-i)`.
- New `compile_trigger()`; both helpers route through it.
- Description path drops the now-redundant `.to_lowercase()` → truer `matched_span`.
- Retired the 5 inline `(?i)` flags.
- Docs reconciled to source (source-grounding): `engine-reference.md`, `hooks-and-ways.md`, `matching.md` (its pre-existing "case-insensitively" claim is now actually true), `architecture.md` diagram (`lowercased` → `masked` — it was never lowercased), authoring way.

## Verify

- `cargo test -p ways --bin ways --all-features` — 275 pass (+`trigger_regex_is_case_insensitive`)
- `cargo test -p ways-core --lib` — 109 pass
- clippy clean; `ways lint hooks/ways` — 0 errors, 0 warnings; `adr lint` clean

Closes #309.

https://claude.ai/code/session_017bpbXScJHd91buptnw7piy