### PR TITLE
release(ways): 1.2.1 — semantic over-firing fix

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "ways"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "agent-fmt",
  "anyhow",

--- a/tools/ways-cli/Cargo.toml
+++ b/tools/ways-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ways"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 description = "Unified CLI for ways — knowledge guidance for Claude Code"
 license = "MIT"


### PR DESCRIPTION
Patch release bumping `tools/ways-cli` 1.2.0 → 1.2.1.

Delivers to installs (via `ways update` regenerating the corpus from the new baked-in probes + tightened aliases):
- **ADR-158 / #314** — semantic over-firing fix: refit with hard negatives (de-saturates the calibration slope) + per-way alias tightening. Session chatter / adjacent-domain over-firing drops materially (live case 6→2 core ways; session_meta panel 2.0→0.8) with recall preserved and off-topic still 0.
- **ADR-157 / #313** — case-insensitive trigger regex.

After merge: annotated tag `ways-v1.2.1` → CI publishes binaries → `ways update`.

https://claude.ai/code/session_017bpbXScJHd91buptnw7piy