### PR TITLE
release(ways): 1.2.2 — remove broken tune-curves command

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "ways"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "agent-fmt",
  "anyhow",

--- a/tools/ways-cli/Cargo.toml
+++ b/tools/ways-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ways"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 description = "Unified CLI for ways — knowledge guidance for Claude Code"
 license = "MIT"


### PR DESCRIPTION
Patch release bumping `tools/ways-cli` 1.2.1 → 1.2.2.

Ships the ADR-159 removal of `ways tune-curves` (#307, merged to main). The command wrote a legacy ADR-123 `curve:`/`half_life` block that the schema and `ways lint` reject. On current refire-only way files `--apply` errors ("no curve: block found"); the dry run emits misleading `half_life` suggestions against a retired field. Removing a broken command is a fix, so a patch bump — and it keeps the deferred migrator removal on its own 1.3.0 milestone.

After merge: annotated tag `ways-v1.2.2` → CI publishes → `ways update`.

https://claude.ai/code/session_017bpbXScJHd91buptnw7piy