### PR TITLE
feat(update): ways update --ref <branch|tag|sha> — source-pinned local deploys

### DIFF
--- a/docs/architecture/system/ADR-142-agent-ways-1-0-xdg-application-distribution.md
+++ b/docs/architecture/system/ADR-142-agent-ways-1-0-xdg-application-distribution.md
@@ -329,3 +329,30 @@ Accepted:
 - **Whether the two children stay separate ADRs or fold into this spine** — see ADR-143 / ADR-144;
   current recommendation is to keep them separate (below).
 - Bootstrap-exemption mechanism and Windows materialization specifics are parked in **child ADR-144**.
+
+## Amendment (2026-07-05): source-pinned deploys — `ways update --ref`
+
+§4's **out-of-date → update** from-state advances `$XDG_DATA` to the *latest
+release* on the tracked branch and refreshes binaries download-first (§7). A
+development need sits alongside it: deploying an **unpublished ref** — a feature
+branch, a tag, or a bare commit — onto a live install to dogfood it, without
+publishing to `main` and cutting a release.
+
+`ways update --ref <branch|tag|sha>` serves that need as a variant of the update
+from-state, with three deliberate differences from the release-channel path:
+
+- **Fetch + detached checkout of the ref**, not a pull of the tracking branch.
+  The checkout lands on a detached HEAD at the ref; `ways update --ref main`
+  returns to the release channel.
+- **Build the whole suite from source** (`ways-rebuild` and the sibling
+  `*-rebuild` targets, plus way-embed's source target) — an unpublished ref has
+  no pre-built release binary to download, so download-first (§7) does not apply.
+- **The ADR-150 downgrade guard is bypassed** (see that ADR's amendment): pinning
+  an explicit ref is a deliberate choice, not a channel update, so "never move
+  backward" is not the right invariant.
+
+The reconciler tail is unchanged: after the source build it runs the same relink
++ corpus regen + `ways reconcile` projection as any other update, so the trust
+posture (§5: app-scope plus the one `settings.json` merge) is identical. This
+stays a developer/dogfooding affordance layered on the update from-state, not a
+fifth reconciler mode.

--- a/docs/architecture/system/ADR-150-version-truth-and-downgrade-safe-self-update.md
+++ b/docs/architecture/system/ADR-150-version-truth-and-downgrade-safe-self-update.md
@@ -158,3 +158,25 @@ existing tag scheme and independent CI workflows.
 - **Embed a monotonic build number instead of `git describe`.** Rejected: it
   needs external state (a counter), where `git describe` derives ordering from
   the repo itself for free and is human-legible.
+
+## Amendment (2026-07-05): the downgrade guard does not apply to `--ref`
+
+The guard above governs the **release channel**: `ways update` pulls the tracked
+branch and must never replace a binary with an older published one. `ways update
+--ref <branch|tag|sha>` (ADR-142's amendment) is a different lifecycle — an
+explicit pin to a chosen ref, built from source — and the guard is
+**intentionally bypassed** there, for two reasons:
+
+- **Download-first cannot apply.** An unpublished ref has no GitHub Release
+  binary, so `--ref` always builds from source. There is no downloaded candidate
+  to compare — which is the only thing the guard gates.
+- **"Never move backward" is the wrong invariant for an explicit pin.** The guard
+  exists because a *channel* update should be monotonic. Choosing to deploy a
+  specific commit — including one behind the current build, to reproduce or
+  bisect — is a deliberate act, not an accidental downgrade. The guard's job is to
+  stop *silent* regressions; a named `--ref` is neither silent nor accidental.
+
+The safety that remains is structural, not guard-based: `--ref` still touches only
+app-scope (`$XDG_DATA` plus the regenerable projection) per ADR-142 §5, and
+returning to the release channel is one command (`ways update --ref main`), after
+which the guard governs again as normal.

--- a/tools/ways-cli/src/cmd/update.rs
+++ b/tools/ways-cli/src/cmd/update.rs
@@ -239,11 +239,27 @@ fn run_ref_upgrade(app: &Path, git_ref: &str, dry_run: bool, has_toolchain: bool
     //    own matcher is what gets installed. Optional: semantic matching degrades
     //    to regex without it.
     eprintln!("==> build way-embed from source");
-    if let Err(e) = run_step(
+    match run_step(
         Command::new("make").args(["-C", "tools/way-embed"]).current_dir(app),
         "way-embed source build",
     ) {
-        eprintln!("  ⚠ way-embed not rebuilt ({e}); semantic matching degrades to regex.");
+        Ok(()) => {
+            // The engine's find_way_embed() resolves the cache copy
+            // ($XDG_CACHE/agent-ways/user/way-embed) BEFORE the projected
+            // ~/.claude/bin symlink. A prior release install leaves a cache copy
+            // that would shadow this fresh source build — which lands in bin/ and
+            // is relinked into ~/.claude/bin, not the cache — so the ref's
+            // way-embed would build but never actually run. Remove the shadowing
+            // copy; it is regenerable cache (a later `ways update` re-downloads it).
+            let cached = crate::paths::corpus_dir().join(exe("way-embed"));
+            if cached.exists() {
+                match std::fs::remove_file(&cached) {
+                    Ok(()) => eprintln!("     cleared shadowing cache binary {}", cached.display()),
+                    Err(e) => eprintln!("  ⚠ could not clear cache binary {} ({e})", cached.display()),
+                }
+            }
+        }
+        Err(e) => eprintln!("  ⚠ way-embed not rebuilt ({e}); semantic matching degrades to regex."),
     }
 
     // 5. Ensure every suite binary is linked onto PATH.

--- a/tools/ways-cli/src/cmd/update.rs
+++ b/tools/ways-cli/src/cmd/update.rs
@@ -33,7 +33,7 @@ use anyhow::{bail, Context, Result};
 use std::path::Path;
 use std::process::Command;
 
-pub fn run(dry_run: bool) -> Result<()> {
+pub fn run(dry_run: bool, git_ref: Option<String>) -> Result<()> {
     let app = paths::data_root();
 
     // Guard 1: a pre-1.0 in-place clone (~/.claude is itself the repo) must
@@ -56,6 +56,16 @@ pub fn run(dry_run: bool) -> Result<()> {
     }
 
     let has_toolchain = tool_present("cargo");
+
+    // `--ref` is a different lifecycle from "pull the latest release": it pins
+    // the app checkout to an arbitrary branch/tag/sha and builds the whole suite
+    // from source. An unpublished ref has no pre-built binary to download, and
+    // the ADR-150 downgrade guard is intentionally bypassed — you are pinning a
+    // ref, not chasing newest. Handled entirely by run_ref_upgrade.
+    if let Some(git_ref) = git_ref {
+        return run_ref_upgrade(&app, &git_ref, dry_run, has_toolchain);
+    }
+
     let ways_bin = app.join("bin").join(exe("ways"));
 
     if dry_run {
@@ -150,6 +160,116 @@ pub fn run(dry_run: bool) -> Result<()> {
         println!("available and no build toolchain?). Your install still runs the previous binary —");
         println!("retry `ways update`, or `make update` with a toolchain, then restart Claude Code.");
     }
+    Ok(())
+}
+
+/// `ways update --ref <ref>` — pin the install to a branch, tag, or commit and
+/// build the whole suite from source, then relink + reconcile. Distinct from the
+/// release-channel update: fetch-and-checkout instead of pull, force source
+/// builds instead of download-first (an unpublished ref has no pre-built
+/// binary), and no downgrade guard (an explicit pin is not a downgrade). Lands on
+/// a detached HEAD at the ref; `ways update --ref main` returns to the channel.
+fn run_ref_upgrade(app: &Path, git_ref: &str, dry_run: bool, has_toolchain: bool) -> Result<()> {
+    let ways_bin = app.join("bin").join(exe("ways"));
+
+    if dry_run {
+        println!("ways update --ref {git_ref} would, in {}:", app.display());
+        println!("  1. git fetch origin {git_ref}");
+        println!("  2. git checkout --detach       — pin the checkout to the ref");
+        println!("  3. make ways-rebuild ways-audit-rebuild attend-rebuild attend-chat-rebuild  (source, needs cargo)");
+        println!("  4. make -C tools/way-embed     — build way-embed from source (needs cmake; optional)");
+        println!("  5. make relink                 — symlink every suite binary onto PATH");
+        println!("  6. {} corpus + reconcile       — regenerate corpus, reproject ~/.claude", ways_bin.display());
+        println!("(dry-run — nothing executed)");
+        return Ok(());
+    }
+
+    if !has_toolchain {
+        bail!(
+            "`ways update --ref` builds the suite from source, which needs a Rust toolchain \
+             (cargo not found). Install it (https://rustup.rs/), then retry."
+        );
+    }
+
+    // 1. Fetch the ref. A targeted fetch puts exactly <ref> into FETCH_HEAD,
+    //    which then detaches uniformly whether it is a branch, tag, or sha. If
+    //    the server won't serve the ref directly (rare — e.g. a bare sha), fall
+    //    back to a full fetch and resolve the name in the working checkout.
+    eprintln!("==> fetch {git_ref} ({})", app.display());
+    let direct = Command::new("git")
+        .args(["fetch", "origin", git_ref])
+        .current_dir(app)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    let checkout_target = if direct {
+        "FETCH_HEAD".to_string()
+    } else {
+        eprintln!("  (couldn't fetch {git_ref} directly; fetching all refs + tags)");
+        run_step(
+            Command::new("git").args(["fetch", "--tags", "origin"]).current_dir(app),
+            "git fetch",
+        )?;
+        git_ref.to_string()
+    };
+
+    // 2. Pin to the ref (detached). Fails loudly on a dirty tree rather than
+    //    discarding local changes — the app checkout is normally clean (build
+    //    artifacts are gitignored; corpus/settings land outside it).
+    eprintln!("==> checkout {git_ref} (detached)");
+    run_step(
+        Command::new("git")
+            .args(["-c", "advice.detachedHead=false", "checkout", "--detach", &checkout_target])
+            .current_dir(app),
+        "git checkout",
+    )?;
+
+    // 3. Build the Rust suite from source — force (no download for an
+    //    unpublished ref). The *-rebuild targets each cargo-build and relink.
+    eprintln!("==> build ways/ways-audit/attend/attend-chat from source");
+    run_step(
+        Command::new("make")
+            .args(["ways-rebuild", "ways-audit-rebuild", "attend-rebuild", "attend-chat-rebuild"])
+            .current_dir(app),
+        "suite source build",
+    )?;
+
+    // 4. Build way-embed from source. Its default make target is a source build
+    //    (cmake), unlike `rebuild-binary` which is download-first — so the ref's
+    //    own matcher is what gets installed. Optional: semantic matching degrades
+    //    to regex without it.
+    eprintln!("==> build way-embed from source");
+    if let Err(e) = run_step(
+        Command::new("make").args(["-C", "tools/way-embed"]).current_dir(app),
+        "way-embed source build",
+    ) {
+        eprintln!("  ⚠ way-embed not rebuilt ({e}); semantic matching degrades to regex.");
+    }
+
+    // 5. Ensure every suite binary is linked onto PATH.
+    eprintln!("==> relink suite binaries onto PATH");
+    if let Err(e) = run_step(Command::new("make").arg("relink").current_dir(app), "relink") {
+        eprintln!(
+            "  ⚠ could not relink binaries ({e}); run `make install` in {} to fix PATH links.",
+            app.display()
+        );
+    }
+
+    // 6. Regenerate the corpus (best-effort) and reproject with the newly-built
+    //    ways binary. Reconcile always runs so the checked-out source is projected.
+    if !ways_bin.exists() {
+        bail!("no ways binary at {} after the source build — cannot reconcile.", ways_bin.display());
+    }
+    eprintln!("==> regenerate corpus");
+    if let Err(e) = run_step(Command::new(&ways_bin).args(["corpus", "--quiet"]).current_dir(app), "ways corpus") {
+        eprintln!("  ⚠ corpus not regenerated now ({e}); it self-heals on the next session.");
+    }
+    eprintln!("==> reconcile projection");
+    run_step(Command::new(&ways_bin).arg("reconcile").current_dir(app), "ways reconcile")?;
+
+    println!("\nUpgraded to {git_ref} (built from source; the checkout is on a detached HEAD).");
+    println!("Return to the release channel with:  ways update --ref main");
+    println!("Restart Claude Code to pick up the new version.");
     Ok(())
 }
 

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -399,6 +399,11 @@ enum Commands {
         /// Show what would run without executing it
         #[arg(long)]
         dry_run: bool,
+        /// Pin the install to a specific branch, tag, or commit and build the
+        /// whole suite from source, instead of pulling the latest release.
+        /// Leaves the release channel until `ways update --ref main`.
+        #[arg(long = "ref", value_name = "REF")]
+        git_ref: Option<String>,
     },
     /// settings.json fragment store — author settings as composable YAML fragments (ADR-147)
     Settings {
@@ -887,7 +892,7 @@ fn run() -> Result<()> {
                 PermissionsCommand::Audit => cmd::permissions::audit(global),
             }
         }
-        Commands::Update { dry_run } => cmd::update::run(dry_run),
+        Commands::Update { dry_run, git_ref } => cmd::update::run(dry_run, git_ref),
         Commands::Settings { command } => match command {
             SettingsCommand::Lint { path, json } => {
                 let dir = path.unwrap_or_else(|| paths::config_root().join("settings"));


### PR DESCRIPTION
## What

`ways update` gains a `--ref` flag that pins the install to an arbitrary git ref (branch, tag, or commit) and builds the whole suite **from source**, instead of pulling the latest release. This is the local-deploy path for **dogfooding a fork build** — deploy a feature branch onto a live install without publishing to `main` or cutting a release.

```
ways update                              # latest release (unchanged)
ways update --ref feat/some-branch       # pin + build from source
ways update --ref v1.2.2
ways update --ref a1b2c3d
ways update --ref main                   # return to the release channel
```

Bare `ways update` (no `--ref`) is **byte-for-byte unchanged**.

## Why it's a distinct lifecycle

An unpublished ref has no pre-built release binary, and pinning a ref is a deliberate choice — not a channel update. So `--ref` departs from the release path in three deliberate ways:

- **fetch + detached checkout** of the ref, not a pull of the tracking branch (lands on a detached HEAD; `--ref main` returns to the channel);
- **force source builds** — `ways-rebuild` + the sibling `*-rebuild` targets, plus way-embed's source target — because download-first has nothing to download;
- **the ADR-150 downgrade guard is bypassed** — "never move backward" is the wrong invariant for an explicit, named pin.

The reconciler tail (relink + corpus regen + `ways reconcile`) and trust posture are identical to a normal update.

## ADRs

Amends the two ADRs it touches rather than adding a new one:
- **ADR-142** — `--ref` as a source-pinned variant of the update from-state (not a fifth reconciler mode).
- **ADR-150** — the downgrade guard is intentionally bypassed under `--ref`, with the rationale.

## Verification

- `--dry-run` for both `ways update` and `ways update --ref <ref>` prints the correct plan; bare-update plan unchanged.
- The fetch + detached-checkout sequence validated against a throwaway clone: resolves a branch ref to the exact commit, checked-out source contains the branch's changes.
- **Dogfooded end-to-end**: used a dev-built `ways` to `--ref`-deploy a combined branch onto this machine — full suite rebuilt from source (incl. way-embed with the submodule clone), reconciled, and the deployed way-embed ran the branch's new `match --batch`. The loop works: fork build → live install, no publish.
- ADR lint clean (the one warning is pre-existing on ADR-127).