### PR TITLE
chore(scan): remove the dead repeat-branch and unused repeat field

### DIFF
--- a/tools/ways-cli/src/cmd/scan/candidates.rs
+++ b/tools/ways-cli/src/cmd/scan/candidates.rs
@@ -233,7 +233,6 @@ fn parse_candidate(id: &str, corpus_prefix: &str, path: &Path, content: &str) ->
         when_project: get_when_field(&fm, "project"),
         when_file_exists: get_when_field(&fm, "file_exists"),
         trigger: get_fm_field(&fm, "trigger"),
-        repeat: get_fm_field(&fm, "repeat").as_deref() == Some("true"),
         trigger_path: get_fm_field(&fm, "path"),
     })
 }

--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -55,7 +55,6 @@ pub(crate) struct WayCandidate {
     pub when_project: Option<String>,
     pub when_file_exists: Option<String>,
     pub trigger: Option<String>,
-    pub repeat: bool,
     pub trigger_path: Option<String>,
 }
 

--- a/tools/ways-cli/src/cmd/scan/state.rs
+++ b/tools/ways-cli/src/cmd/scan/state.rs
@@ -85,35 +85,17 @@ pub fn state(
             continue;
         }
 
-        // Handle repeating context-threshold ways
-        if trigger_type == "context-threshold" && way.repeat {
-            let tasks_marker = format!("{}/{session_id}/tasks-active", crate::session::sessions_root());
-            if std::path::Path::new(&tasks_marker).exists() {
-                continue; // tasks active, suppress repeat
-            }
-            // Repeating: output body directly (no marker gating)
-            let content = std::fs::read_to_string(&way.path).unwrap_or_default();
-            let body = strip_frontmatter(&content);
-            if !body.is_empty() {
-                context.push_str(&body);
-                context.push_str("\n\n");
-                session::log_event(&[
-                    ("event", "way_fired"),
-                    ("way", &way.id),
-                    ("domain", way.id.split('/').next().unwrap_or(&way.id)),
-                    ("trigger", "state"),
-                    ("scope", &scope),
-                    ("project", &project_dir),
-                    ("session", session_id),
-                ]);
-            }
-        } else {
-            // Standard one-shot: marker-gated via show
-            let out = capture_show_way(&way.id, session_id, "state", None, None);
-            if !out.is_empty() {
-                context.push_str(&out);
-                context.push_str("\n\n");
-            }
+        // Marker-gated via show; refire cadence follows the way's own `refire:`
+        // curve (ADR-126). The former `repeat: true` bypass — which dumped the
+        // body every threshold crossing and consulted a `tasks-active` marker —
+        // is gone: no way uses `repeat` since todos moved to its refire curve, so
+        // the branch was dead. (The mark-tasks-active hook still writes the marker;
+        // it is dormant, kept as the hook-point should per-way tasks-active
+        // suppression be wanted again.)
+        let out = capture_show_way(&way.id, session_id, "state", None, None);
+        if !out.is_empty() {
+            context.push_str(&out);
+            context.push_str("\n\n");
         }
     }
 


### PR DESCRIPTION
Removes the unreachable `context-threshold && way.repeat` bypass in the state scan (no way uses `repeat` since todos moved to its refire curve), plus the now-unused `WayCandidate.repeat` field and its parse. State ways uniformly take the marker-gated show path. The dormant mark-tasks-active hook/marker are left as the repurpose hook-point. Task #6. 271 tests pass.