### PR TITLE
fix(scan): remove dead strip_frontmatter (broke lint gate on main)

### DIFF
--- a/tools/ways-cli/src/cmd/scan/state.rs
+++ b/tools/ways-cli/src/cmd/scan/state.rs
@@ -162,21 +162,6 @@ fn evaluate_file_exists(pattern: &str, project_dir: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn strip_frontmatter(content: &str) -> String {
-    let mut fm_count = 0;
-    let mut body = Vec::new();
-    for line in content.lines() {
-        if line == "---" {
-            fm_count += 1;
-            continue;
-        }
-        if fm_count >= 2 {
-            body.push(line);
-        }
-    }
-    body.join("\n")
-}
-
 fn capture_show_core(session_id: &str) -> String {
     crate::cmd::show::core(session_id).unwrap_or_default()
 }


### PR DESCRIPTION
The #323 repeat-branch removal left scan/state.rs's strip_frontmatter uncalled, so `clippy -D warnings` (what `make lint` runs) failed on main. Remove it; tree.rs's same-named helper is separate and still used. clippy clean.