### PR TITLE
fix(introspect): re-detect ctx window in live view (200K launch-race)

### DIFF
--- a/tools/ways-cli/src/cmd/rethink/run.rs
+++ b/tools/ways-cli/src/cmd/rethink/run.rs
@@ -234,6 +234,18 @@ fn refresh_live(player: &mut Player) {
     }
     player.events_sig = sig;
 
+    // Re-detect the context window. At launch the transcript may hold no assistant
+    // message yet (the monitor can start seconds into a session, before the first
+    // model turn is written), so startup detection returns the 200K fallback and,
+    // uncorrected, every re-disclosure threshold — scaled off the window — reads far
+    // too tight (a 1M session mislabeled 200K marks nearly everything "re-disclose
+    // now"). Re-detecting here self-heals once a model turn lands. Adopt only an
+    // upgrade: the fallback is a floor a real detection replaces, and a real window
+    // never shrinks mid-session, so `max` also ignores a transient read error or a
+    // stray sub-agent (e.g. haiku) message being the newest one detection sees.
+    let detected_k = session::detect_context_window_for(&player.project_name, &player.session_id) / 1000;
+    player.context_window_k = player.context_window_k.max(detected_k);
+
     let content = ways_core::firing::load_events_text();
     let events = load_session_events(&content, &player.session_id);
     if events.is_empty() {

--- a/tools/ways-cli/src/session.rs
+++ b/tools/ways-cli/src/session.rs
@@ -320,6 +320,44 @@ fn context_window_from_transcript(transcript: &std::path::Path) -> u64 {
     fallback()
 }
 
+#[cfg(test)]
+mod context_window_tests {
+    use super::*;
+
+    #[test]
+    fn detects_opus_1m_but_falls_back_before_first_model_turn() {
+        let dir = std::env::temp_dir();
+        let opus = dir.join(format!("ways-ctx-opus-{}.jsonl", std::process::id()));
+        let early = dir.join(format!("ways-ctx-early-{}.jsonl", std::process::id()));
+
+        // A transcript with an opus-4 assistant turn resolves to the 1M window.
+        std::fs::write(
+            &opus,
+            "{\"type\":\"user\"}\n{\"type\":\"assistant\",\"message\":{\"model\":\"claude-opus-4-8\"}}\n",
+        )
+        .unwrap();
+        assert_eq!(context_window_from_transcript(&opus), 1_000_000);
+
+        // The launch race: the monitor can start seconds into a session, before the
+        // first assistant turn is written. With no model to read, detection returns
+        // the fallback — NOT 1M — which is why the live view must re-detect on refresh
+        // rather than cache this startup value for the whole session.
+        std::fs::write(&early, "{\"type\":\"user\"}\n").unwrap();
+        assert_ne!(
+            context_window_from_transcript(&early),
+            1_000_000,
+            "no assistant turn yet → cannot detect the 1M window"
+        );
+        // Absent a CLAUDE_CONTEXT_WINDOW override, the fallback is the 200K default.
+        if std::env::var("CLAUDE_CONTEXT_WINDOW").is_err() {
+            assert_eq!(context_window_from_transcript(&early), 200_000);
+        }
+
+        let _ = std::fs::remove_file(&opus);
+        let _ = std::fs::remove_file(&early);
+    }
+}
+
 // ── Check fire count ────────────────────────────────────────────
 
 /// Get and increment fire count for a check.


### PR DESCRIPTION
## Problem

`ways introspect live` showed **200K ctx** for a 1M session (see header `epoch 12 · 200K ctx`), and as a direct consequence marked **19 ways as "re-disclose now"** that shouldn't be — re-disclosure thresholds scale off the context window (`fallback_refire_k = context_window_k * 25 / 100`), so a 5×-too-small window makes nearly everything read as past-threshold.

## Root cause

The live view computes the context window **once** at `run_live` startup and caches it (`refresh_live` reused `player.context_window_k`). A monitor can launch seconds into a session — before the first assistant/model turn is written to the transcript — so `context_window_from_transcript` finds no model and returns the **200K fallback**, which then sticks for the whole session even as opus-4 turns fill the transcript.

The `dump` path was unaffected (it detects at invocation time, after model turns exist) — which is why `introspect dump` correctly reported `window_k: 1000` for the same session.

## Fix

`refresh_live` re-detects the window on refresh and adopts it **monotonically** (`max`):
- the fallback is a floor a real detection replaces;
- a real window never shrinks mid-session;
- `max` also ignores a transient read error or a stray sub-agent (e.g. haiku) turn being the newest one detection sees.

Self-heals on the first refresh after a model turn lands.

## Test

Adds a `session.rs` unit test pinning both the `opus-4 → 1M` detection and the before-first-turn fallback (the race the live view must re-detect past). Full lib suite: 275 passed. (Pre-existing `session_sim` scenario failures reproduce on clean `main` — an `XDG_RUNTIME_DIR` marker-path issue in the sandbox, unrelated.)

## Note

Currently-running monitors run the old binary and won't self-heal until relaunched on the rebuilt binary (`ways update`).