### PR TITLE
feat(introspect): read-side precision instrument (fire surface + `introspect fires`)

### DIFF
--- a/tools/ways-cli/src/cmd/introspect.rs
+++ b/tools/ways-cli/src/cmd/introspect.rs
@@ -140,3 +140,106 @@ pub fn dump(session: Option<&str>, project: Option<&str>, all: bool) -> Result<(
     println!("{}", serde_json::to_string_pretty(&model)?);
     Ok(())
 }
+
+/// `ways introspect fires` — the read-side precision instrument (task #2 of the
+/// ADR-160 calibration work). Reads `way_fired`/`way_redisclosed` events straight
+/// from events.jsonl — no `SessionIntrospection` reconstruction, no re-embedding —
+/// and prints each *semantic* fire as `score · surface · way`, borderline (lowest
+/// score) first, so a human can judge whether the matcher fired on text that
+/// actually warranted the way. Pair with `--max-score` to isolate the suspect tail
+/// that gate calibration (task #5) has to defend.
+pub fn fires(
+    session: Option<&str>,
+    project: Option<&str>,
+    all: bool,
+    max_score: Option<f64>,
+    limit: Option<usize>,
+) -> Result<()> {
+    let content = ways_core::firing::load_events_text();
+    if content.trim().is_empty() {
+        println!("No events recorded yet.");
+        return Ok(());
+    }
+
+    let scope = rethink::resolve_project_scope(project, all)?;
+    let session_id = match session {
+        Some(s) => s.to_string(),
+        None => match rethink_dump::most_recent_session(&content, scope.as_deref()) {
+            Some(s) => s,
+            None => {
+                println!("No sessions found in scope.");
+                return Ok(());
+            }
+        }
+    };
+
+    // Pull semantic fires for this session. A fire is semantic when its trigger
+    // begins `semantic:` (`semantic:embedding:en|multi`); keyword/state fires have
+    // no score or surface to eyeball, so they are out of scope for this view.
+    let mut rows: Vec<(f64, String, String, bool)> = Vec::new();
+    for line in content.lines() {
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else { continue };
+        if v.get("session").and_then(|s| s.as_str()) != Some(session_id.as_str()) {
+            continue;
+        }
+        let event = v.get("event").and_then(|e| e.as_str()).unwrap_or("");
+        let redisclosed = match event {
+            "way_fired" => false,
+            "way_redisclosed" => true,
+            _ => continue,
+        };
+        let trigger = v.get("trigger").and_then(|t| t.as_str()).unwrap_or("");
+        if !trigger.starts_with("semantic:") {
+            continue;
+        }
+        // `fire_score` is written as a formatted string field (see show::way_scored).
+        let Some(score) = v.get("fire_score").and_then(|s| s.as_str()).and_then(|s| s.parse::<f64>().ok())
+        else {
+            continue;
+        };
+        if let Some(cap) = max_score {
+            if score > cap {
+                continue;
+            }
+        }
+        let way = v.get("way").and_then(|w| w.as_str()).unwrap_or("?").to_string();
+        // `surface` only rides fires logged after the read-side instrument shipped;
+        // older events legitimately lack it — show a placeholder rather than drop them.
+        let surface = v
+            .get("surface")
+            .and_then(|s| s.as_str())
+            .unwrap_or("—")
+            .to_string();
+        rows.push((score, way, surface, redisclosed));
+    }
+
+    if rows.is_empty() {
+        println!(
+            "No semantic fires for session {} (keyword/state fires carry no score/surface).",
+            &session_id[..session_id.len().min(12)]
+        );
+        return Ok(());
+    }
+
+    // Borderline first: the lowest-scoring fires are the ones whose relevance is
+    // most in question, so they lead the readout.
+    rows.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    let total = rows.len();
+    let shown = limit.unwrap_or(total).min(total);
+
+    println!(
+        "{} semantic fire{} · session {} · lowest score first{}",
+        total,
+        if total == 1 { "" } else { "s" },
+        &session_id[..session_id.len().min(12)],
+        max_score.map(|c| format!(" · ≤ {c:.2}")).unwrap_or_default(),
+    );
+    for (score, way, surface, redisclosed) in rows.into_iter().take(shown) {
+        let mark = if redisclosed { "↻" } else { " " };
+        println!("  {score:.3} {mark} {way:<44}  {surface}");
+    }
+    if shown < total {
+        println!("  … {} more (raise --limit)", total - shown);
+    }
+    Ok(())
+}

--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -192,7 +192,7 @@ pub fn prompt(
 
         match outcome {
             PromptMatch::Fired { channel, score, matched_span } => {
-                let out = capture_show_way(&way.id, session_id, &channel, score, matched_span.as_deref());
+                let out = capture_show_way(&way.id, session_id, &channel, score, matched_span.as_deref(), Some(reduced.as_str()));
                 if !out.is_empty() {
                     context.push_str(&out);
                     context.push_str("\n\n");
@@ -381,7 +381,7 @@ pub fn command(
             });
 
         if let Some(span) = matched_span {
-            let out = capture_show_way(&way.id, session_id, "bash", None, Some(span.as_str()));
+            let out = capture_show_way(&way.id, session_id, "bash", None, Some(span.as_str()), None);
             if !out.is_empty() {
                 context.push_str(&out);
             }
@@ -413,7 +413,7 @@ pub fn command(
             None
         };
         if let Some((channel, score)) = fired {
-            let out = capture_show_way(&way.id, session_id, channel, score, None);
+            let out = capture_show_way(&way.id, session_id, channel, score, None, Some(reduced_for_embed.as_str()));
             if !out.is_empty() {
                 context.push_str(&out);
             }
@@ -488,7 +488,7 @@ pub fn file(filepath: &str, session_id: &str, project: Option<&str>) -> Result<(
 
         if let Some(ref files_pattern) = way.files {
             if let Some(span) = regex_span(files_pattern, filepath) {
-                let out = capture_show_way(&way.id, session_id, "file", None, Some(span.as_str()));
+                let out = capture_show_way(&way.id, session_id, "file", None, Some(span.as_str()), None);
                 if !out.is_empty() {
                     context.push_str(&out);
                 }

--- a/tools/ways-cli/src/cmd/scan/scoring.rs
+++ b/tools/ways-cli/src/cmd/scan/scoring.rs
@@ -219,8 +219,9 @@ pub(crate) fn capture_show_way(
     trigger: &str,
     fire_score: Option<f64>,
     matched_span: Option<&str>,
+    surface: Option<&str>,
 ) -> String {
-    crate::cmd::show::way_scored(id, session_id, trigger, fire_score, matched_span)
+    crate::cmd::show::way_scored(id, session_id, trigger, fire_score, matched_span, surface)
         .unwrap_or_default()
 }
 

--- a/tools/ways-cli/src/cmd/scan/state.rs
+++ b/tools/ways-cli/src/cmd/scan/state.rs
@@ -92,7 +92,7 @@ pub fn state(
         // the branch was dead. (The mark-tasks-active hook still writes the marker;
         // it is dormant, kept as the hook-point should per-way tasks-active
         // suppression be wanted again.)
-        let out = capture_show_way(&way.id, session_id, "state", None, None);
+        let out = capture_show_way(&way.id, session_id, "state", None, None, None);
         if !out.is_empty() {
             context.push_str(&out);
             context.push_str("\n\n");

--- a/tools/ways-cli/src/cmd/show/mod.rs
+++ b/tools/ways-cli/src/cmd/show/mod.rs
@@ -16,7 +16,22 @@ use metrics::{compute_tree_metrics, count_siblings, git_version, dirty_status_te
 // ── ways show way ───────────────────────────────────────────────
 
 pub fn way(id: &str, session_id: &str, trigger: &str) -> Result<String> {
-    way_scored(id, session_id, trigger, None, None)
+    way_scored(id, session_id, trigger, None, None, None)
+}
+
+/// Bound a matched surface to a single readable line for the `surface` telemetry
+/// field: collapse all whitespace to single spaces and truncate to ~200 chars on
+/// a char boundary (appending `…`). The snippet is a human read-side aid — a
+/// judgeable record of *what* the semantic channel matched on — so it favours
+/// legibility over fidelity.
+const SURFACE_SNIPPET_CHARS: usize = 200;
+fn surface_snippet(surface: &str) -> String {
+    let collapsed = surface.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() <= SURFACE_SNIPPET_CHARS {
+        return collapsed;
+    }
+    let head: String = collapsed.chars().take(SURFACE_SNIPPET_CHARS).collect();
+    format!("{head}…")
 }
 
 /// Like [`way`], but records the embedding score that caused a semantic fire
@@ -24,12 +39,19 @@ pub fn way(id: &str, session_id: &str, trigger: &str) -> Result<String> {
 /// `Some` only for embedding-channel fires from the in-process scan path;
 /// keyword/state/CLI fires pass `None` and log no score (they have none). The
 /// firing model is already implicit in `trigger` (`semantic:embedding:en|multi`).
+///
+/// `surface` is the noise-stripped surface the matcher scored (the `reduce_for_embed`
+/// output common to both the late-interaction and single-vector paths). It is logged
+/// — bounded by [`surface_snippet`] — only alongside a `fire_score`, i.e. on semantic
+/// fires, giving the read-side precision instrument a judgeable record of what fired
+/// each way without re-embedding history. Keyword fires already carry `matched_span`.
 pub fn way_scored(
     id: &str,
     session_id: &str,
     trigger: &str,
     fire_score: Option<f64>,
     matched_span: Option<&str>,
+    surface: Option<&str>,
 ) -> Result<String> {
     let project_dir = std::env::var("CLAUDE_PROJECT_DIR")
         .unwrap_or_else(|_| std::env::var("PWD").unwrap_or_else(|_| ".".to_string()));
@@ -174,6 +196,13 @@ pub fn way_scored(
     // no score (they have none).
     if let Some(score) = fire_score {
         log_fields.push(("fire_score", format!("{score:.4}")));
+        // The surface rides with the score (semantic fires only): together they make
+        // a fire judgeable on the read side — "this score, on this text" — without
+        // re-embedding the historical surface. A redisclosure carries its own surface,
+        // so this is not gated on first-fire (unlike `matched_span`).
+        if let Some(s) = surface.filter(|s| !s.is_empty()) {
+            log_fields.push(("surface", surface_snippet(s)));
+        }
     }
     // ADR-153 §3: the deterministic-channel match text, so introspection can show
     // *what* fired the way without transcript replay. First-fire only (a
@@ -425,6 +454,28 @@ fn normalize_way_id(id: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn surface_snippet_collapses_whitespace() {
+        assert_eq!(
+            surface_snippet("write   an\nADR\tand   open a PR"),
+            "write an ADR and open a PR"
+        );
+    }
+
+    #[test]
+    fn surface_snippet_bounds_long_input_on_char_boundary() {
+        let long = "é".repeat(500); // multi-byte; truncation must not split a char
+        let out = surface_snippet(&long);
+        assert_eq!(out.chars().count(), SURFACE_SNIPPET_CHARS + 1, "200 chars + ellipsis");
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn surface_snippet_leaves_short_input_untruncated() {
+        let s = "short surface";
+        assert_eq!(surface_snippet(s), s);
+    }
 
     #[test]
     fn normalize_collapses_duplicate_leaf() {

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -466,6 +466,27 @@ enum IntrospectCommand {
         #[arg(long)]
         project: Option<String>,
     },
+    /// List semantic way fires as `score · surface · way`, read straight from
+    /// events.jsonl (no introspection model) — the read-side precision instrument:
+    /// eyeball whether each fire matched the surface it fired on. Defaults to the
+    /// most recent session in the current project, borderline (lowest-score) first.
+    Fires {
+        /// Session ID to read (default: most recent in scope)
+        #[arg(long)]
+        session: Option<String>,
+        /// Scope to this project path (default: current project)
+        #[arg(long)]
+        project: Option<String>,
+        /// Pick the session across every project, not just the current one
+        #[arg(long)]
+        all: bool,
+        /// Only show fires at or below this score (surface the suspect tail)
+        #[arg(long)]
+        max_score: Option<f64>,
+        /// Cap the number of rows shown (default: all)
+        #[arg(long)]
+        limit: Option<usize>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -786,6 +807,9 @@ fn run() -> Result<()> {
             }
             IntrospectCommand::Live { session, project } => {
                 cmd::introspect::live(session.as_deref(), project.as_deref())
+            }
+            IntrospectCommand::Fires { session, project, all, max_score, limit } => {
+                cmd::introspect::fires(session.as_deref(), project.as_deref(), all, max_score, limit)
             }
         },
         Commands::Status { json } => cmd::status::run(json),


### PR DESCRIPTION
## Why

ADR-160 gate calibration needs to judge **whether each semantic fire matched the surface it fired on** — precision was only observable as a bare score, never as "this score, *on this text*."

## Write-side

`way_scored` logs a bounded (~200-char, whitespace-collapsed) `surface` snippet on every semantic fire — the `reduce_for_embed` surface the matcher actually scored, common to both the late-interaction and single-vector paths. It:
- rides alongside `fire_score` (semantic fires only — keyword fires already carry `matched_span`);
- threads through `capture_show_way`, exactly like `fire_score`/`matched_span`;
- is judgeable where a hash was not, and isn't cheaply recoverable later (that would mean re-embedding history).

## Read-side

`ways introspect fires` reads `way_fired`/`way_redisclosed` events **straight from events.jsonl** — no `SessionIntrospection` reconstruction, no re-embedding — and prints each semantic fire as `score · surface · way`, **lowest-score first** so the borderline tail leads:

```
8 semantic fires · session test-surface · lowest score first
  0.512   meta/deployment                     write an architecture decision record and open a pull request for the migration
  0.659   softwaredev/architecture            write an architecture decision record and open a pull request for the migration
  ...
  0.891   softwaredev/freshness/groundtruth   write an architecture decision record and open a pull request for the migration
```

`--max-score` isolates the suspect band calibration must defend; `--session`/`--project`/`--all` scope like `dump`. Older events without a `surface` render `—`.

## Verification

End-to-end: ran a fresh scan on the new binary, confirmed the `surface` field lands on each semantic fire event and the reader renders it. `surface_snippet` unit tests (whitespace collapse, char-boundary bounding on multi-byte input, short-input passthrough). Full suite: 278 passed, clippy clean.

## Note

Enables the gate-calibration task. The scores this surfaces also expose a separate finding I'll raise separately: per-way `threshold` frontmatter (hand-tuned against the single-vector `ways match` diagnostic) is largely vestigial under the late-interaction matcher.