### PR TITLE
fix(way-embed): reject downloaded binary lacking `match --batch` (ADR-160 was silently off)

### DIFF
--- a/tools/way-embed/download-binary.sh
+++ b/tools/way-embed/download-binary.sh
@@ -139,5 +139,19 @@ else
   exit 1
 fi
 
+# Capability gate: the late-interaction matcher (ADR-160) requires `match --batch`,
+# added in #319. A release binary cut before that runs fine (`--version` passes) but
+# lacks --batch — and the matcher then silently degrades to the single-vector
+# fail-safe on every scan, so ADR-160 is effectively off. The version string does not
+# distinguish them (both report 0.1.0), so probe the contract directly: the supporting
+# binary names `--batch` in its `match` usage. Reject a binary that does not, so
+# `setup-binary` falls through to a source build until a new release is cut.
+if ! "$OUTPUT_FILE" match --batch </dev/null 2>&1 | grep -q -- "--batch"; then
+  echo "Downloaded way-embed predates the required 'match --batch' primitive (ADR-160, #319)." >&2
+  echo "Building from source instead." >&2
+  rm -f "$OUTPUT_FILE" "$PLATFORM_FILE"
+  exit 1
+fi
+
 # Output path for scripts to capture
 echo "$OUTPUT_FILE"


### PR DESCRIPTION
## The bug (high impact)

`ways update` → `make update-binaries` → `way-embed-rebuild` → `download-binary.sh` installs way-embed by **downloading the latest GitHub release**, building from source **only if the download fails**.

The latest way-embed release predates **#319** (`feat(way-embed): add match --batch`), the primitive ADR-160's late-interaction matcher is built on. But the download *succeeds* (a platform binary exists — just an old one), so the source-build fallback never triggers and a **pre-`--batch` binary gets deployed** to `~/.cache/agent-ways/user/way-embed`.

The failure is silent and total: `late_interaction::run` calls `way-embed match --batch`, which the old binary rejects; `batch_match` returns `None`; **every scan falls back to the single-vector gate.** The late-interaction matcher (ADR-160) never actually runs, and nothing surfaces the degradation.

This was found while building the late-interaction authoring diagnostic: it returned "surface too sparse to chunk" on a clearly-chunkable 3-sentence query, which traced to `batch_match` failing against the deployed binary.

## Fix

`--version` can't distinguish the two (both report `way-embed 0.1.0`), so probe the contract directly — a `--batch`-capable binary names `--batch` in its `match` usage string:

```sh
if ! "$OUTPUT_FILE" match --batch </dev/null 2>&1 | grep -q -- "--batch"; then
  # predates #319 → remove and fall through to source build
```

Verified: rejects the stale released binary, accepts the source build. `setup-binary` then builds from source until a way-embed release carrying #319 is cut.

## Follow-up

The durable fix is to **cut a way-embed release** that includes #319 (tracked separately). Until then this gate makes `ways update` self-heal by building from source.