### PR TITLE
feat(match): late-interaction `ways match` — the ADR-160 authoring diagnostic

### DIFF
--- a/tools/ways-cli/src/cmd/match_cmd.rs
+++ b/tools/ways-cli/src/cmd/match_cmd.rs
@@ -84,6 +84,79 @@ pub fn run(query: String, _corpus: Option<String>) -> Result<()> {
     Ok(())
 }
 
+/// Late-interaction diagnostic (ADR-160) — the authoring view that reflects the
+/// live fire path, replacing the single-vector cosine table for way authoring.
+///
+/// For each top candidate it shows the matcher's actual decision quantities: the
+/// **peak** per-chunk cosine (specificity), the summed-**share** (what the share
+/// gate reads), the **body-confirm** (winning chunk vs the way's own body prose),
+/// and whether the way **fired** — plus the surface chunk it won on, so an author
+/// can see the exact evidence a fire hinges on. Falls back to the single-vector
+/// view when late-interaction cannot run (sparse surface / no engine), mirroring
+/// production's fail-safe.
+pub fn run_late(query: String, project: Option<&str>) -> Result<()> {
+    const TOP_N: usize = 20;
+    let Some((reduced, rows)) = crate::cmd::scan::diagnose(&query, project, TOP_N) else {
+        eprintln!(
+            "late-interaction unavailable for this query (surface too sparse to chunk, \
+             or the embedding engine is not set up) — showing the single-vector view.\n"
+        );
+        return run(query, None);
+    };
+
+    // Hand-format: `agent_fmt::Table` shrinks columns to the terminal width when
+    // piped, ellipsizing the scores to `0.5…` — useless for a diagnostic. Fixed
+    // columns keep full precision; only the won-chunk (last) column is bounded.
+    let share_gate = crate::cmd::scan::DIAG_SHARE_GATE;
+    let confirm_gate = crate::cmd::scan::DIAG_CONFIRM_GATE;
+    let fired_n = rows.iter().filter(|r| r.fired).count();
+
+    println!();
+    println!(
+        "late-interaction (ADR-160) · share gate ≥ {share_gate:.2} · confirm gate ≥ {confirm_gate:.2} · {fired_n} would fire"
+    );
+    println!("reduced surface: {reduced}");
+    println!();
+    println!("  {:<34}  {:>5}  {:>5}  {:>7}  {:<8}  won chunk", "way", "peak", "share", "confirm", "outcome");
+    println!("  {}", "─".repeat(96));
+
+    for r in rows {
+        let confirm = match r.confirm {
+            Some(c) => format!("{c:.3}"),
+            None => "  —  ".to_string(), // below share gate → confirmation not run
+        };
+        // Annotate why a candidate did not fire, so authoring is actionable.
+        let outcome = if r.fired {
+            "fired ✓"
+        } else if r.share < share_gate {
+            "< share"
+        } else {
+            "< confirm"
+        };
+        let id = truncate_col(&r.id, 34);
+        let chunk = truncate_col(&r.won_chunk, 46);
+        println!(
+            "  {id:<34}  {:>5.3}  {:>5.3}  {confirm:>7}  {outcome:<8}  {chunk}",
+            r.peak, r.share
+        );
+    }
+
+    println!();
+    println!("fired ✓ = cleared both gates · '< share'/'< confirm' = fell short of that gate");
+    println!("(ranked by share, the share-gate quantity; peak is the way's strongest single-chunk cosine)");
+    println!();
+    Ok(())
+}
+
+/// Truncate a display column on a char boundary, appending `…` when cut.
+fn truncate_col(s: &str, width: usize) -> String {
+    if s.chars().count() <= width {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(width.saturating_sub(1)).collect();
+    format!("{head}…")
+}
+
 fn load_descriptions(corpus_path: &str) -> HashMap<String, String> {
     let mut map = HashMap::new();
     if let Ok(content) = std::fs::read_to_string(corpus_path) {

--- a/tools/ways-cli/src/cmd/scan/late_interaction.rs
+++ b/tools/ways-cli/src/cmd/scan/late_interaction.rs
@@ -84,6 +84,85 @@ impl Verdicts {
     }
 }
 
+// ── Authoring diagnostic (task #5 — the late-interaction `ways match`) ──
+// The gates a way must clear to fire, exposed so the diagnostic can annotate
+// each candidate's outcome the way an author needs to read it.
+pub(crate) const DIAG_SHARE_GATE: f64 = SHARE_GATE;
+pub(crate) const DIAG_CONFIRM_GATE: f64 = CONFIRM_GATE;
+
+/// One candidate's full late-interaction evidence, for the authoring view. Unlike
+/// [`Verdicts`] (fired-only, share-only), this carries the peak, the winning chunk,
+/// and the body-confirm — everything an author needs to see *why* a way fired or
+/// fell short of a gate.
+pub(crate) struct DiagRow {
+    pub id: String,
+    /// Max per-chunk cosine (specificity — the way's strongest single match).
+    pub peak: f64,
+    /// Summed softmax-share / n_chunks (the ranking + share-gate quantity).
+    pub share: f64,
+    /// The surface chunk the way peaked on — the evidence that would fire it.
+    pub won_chunk: String,
+    /// Body cross-similarity of the won chunk against the way's body. `None` when
+    /// the way fell below the share gate (confirmation is not run for it).
+    pub confirm: Option<f64>,
+    /// Cleared both gates — would fire in production.
+    pub fired: bool,
+}
+
+/// Run the matcher in diagnostic mode: the same chunk → share → body-confirm
+/// pipeline as [`run`], but returning the top `top_n` candidates by share with
+/// their full evidence (including those that failed a gate, so an author can see
+/// how close a way came). Returns `None` on the same fail-safe conditions as
+/// [`run`] — the caller then reports that late-interaction could not run and falls
+/// back to the single-vector view, mirroring production.
+pub(crate) fn run_diagnostic(
+    surface: &str,
+    bodies: &HashMap<String, PathBuf>,
+    top_n: usize,
+) -> Option<Vec<DiagRow>> {
+    let dbg = std::env::var("WAYS_LI_DEBUG").is_ok();
+    let Some(bin) = find_way_embed() else {
+        if dbg { eprintln!("DIAG: find_way_embed → None"); }
+        return None;
+    };
+    let xdg = crate::paths::corpus_dir();
+    let corpus = xdg.join("ways-corpus-en.jsonl");
+    let model = xdg.join("minilm-l6-v2.gguf");
+    if !corpus.is_file() || !model.is_file() {
+        if dbg { eprintln!("DIAG: corpus={} exists={} model={} exists={}", corpus.display(), corpus.is_file(), model.display(), model.is_file()); }
+        return None;
+    }
+
+    if dbg { eprintln!("DIAG: bin={} corpus={} model={}", bin.display(), corpus.display(), model.display()); }
+    let chunks = chunk_surface(surface);
+    if dbg { eprintln!("DIAG: {} chunks", chunks.len()); }
+    if chunks.len() < 2 {
+        return None;
+    }
+    let Some(per_chunk) = batch_match(&bin, &corpus, &model, &chunks) else {
+        if dbg { eprintln!("DIAG: batch_match → None"); }
+        return None;
+    };
+    let ranked = aggregate(&per_chunk, chunks.len());
+
+    let mut rows = Vec::new();
+    for r in ranked.into_iter().take(top_n) {
+        let won_chunk = chunks.get(r.peak_chunk).cloned().unwrap_or_default();
+        // Confirmation is only defined for share-gate survivors — the same set the
+        // live matcher would confirm — so a below-share row reports `confirm: None`.
+        let confirm = if r.share >= SHARE_GATE {
+            bodies
+                .get(&r.id)
+                .and_then(|path| body_confirm(&bin, &model, &chunks[r.peak_chunk..=r.peak_chunk], path))
+        } else {
+            None
+        };
+        let fired = confirm.is_some_and(|c| c >= CONFIRM_GATE);
+        rows.push(DiagRow { id: r.id, peak: r.peak, share: r.share, won_chunk, confirm, fired });
+    }
+    Some(rows)
+}
+
 /// Run the matcher over `surface`. `bodies` maps a way's corpus id to its `.md`
 /// path (for body-confirm). Returns `None` when the matcher cannot run — the
 /// caller then falls back to the single-vector semantic gate.

--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -215,6 +215,25 @@ pub fn prompt(
     Ok(())
 }
 
+// ── Authoring diagnostic (task #5) ─────────────────────────────
+
+pub(crate) use late_interaction::{DiagRow, DIAG_CONFIRM_GATE, DIAG_SHARE_GATE};
+
+/// Run the late-interaction matcher over `query` for way authoring — the modern
+/// equivalent of the single-vector `ways match`. Reduces the query exactly as the
+/// prompt scan does (so the diagnostic sees the surface production sees), then
+/// returns the top candidates' evidence (peak / share / body-confirm / fired) with
+/// the reduced surface for context. `None` means late-interaction could not run
+/// (engine unavailable, or the surface is too sparse to chunk) — the caller then
+/// falls back to the single-vector view, mirroring production's fail-safe.
+pub fn diagnose(query: &str, project: Option<&str>, top_n: usize) -> Option<(String, Vec<DiagRow>)> {
+    let project_dir = project.map(|s| s.to_string()).unwrap_or_else(default_project);
+    let candidates = collect_candidates(&project_dir);
+    let reduced = reduce::reduce_for_embed(query, BUDGET_PROMPT);
+    let rows = late_interaction::run_diagnostic(&reduced, &body_map(&candidates), top_n)?;
+    Some((reduced, rows))
+}
+
 // ── Task scan (subagent/teammate stash) ────────────────────────
 
 pub fn task(

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -73,13 +73,22 @@ enum Commands {
         #[arg(long)]
         if_stale: bool,
     },
-    /// Score a query against ways (embedding cosine similarity, ADR-125)
+    /// Diagnose how a query matches ways under the live late-interaction matcher
+    /// (ADR-160): peak · share · body-confirm · fired, per candidate — the tool for
+    /// authoring a way against how it actually fires. `--cosine` shows the legacy
+    /// single-vector view (which no longer reflects the fire path).
     Match {
         /// The query string to match
         query: String,
-        /// Path to corpus JSONL
+        /// Path to corpus JSONL (single-vector `--cosine` view only)
         #[arg(long)]
         corpus: Option<String>,
+        /// Show the legacy single-vector cosine view instead of late-interaction
+        #[arg(long)]
+        cosine: bool,
+        /// Project directory (for project-local ways; default: current)
+        #[arg(long)]
+        project: Option<String>,
     },
     /// Score a query against ways using embedding similarity
     Embed {
@@ -758,7 +767,13 @@ fn run() -> Result<()> {
         Commands::Context { project, json } => cmd::context::run(project.as_deref(), json),
         Commands::Lint { path, schema, check, fix, global } => cmd::lint::run(path, schema, check, fix, global),
         Commands::Corpus { ways_dir, output, quiet, if_stale } => cmd::corpus::run(ways_dir, output, quiet, if_stale),
-        Commands::Match { query, corpus } => cmd::match_cmd::run(query, corpus),
+        Commands::Match { query, corpus, cosine, project } => {
+            if cosine {
+                cmd::match_cmd::run(query, corpus)
+            } else {
+                cmd::match_cmd::run_late(query, project.as_deref())
+            }
+        }
         Commands::Embed { query, corpus, model } => cmd::embed::run(query, corpus, model),
         Commands::Siblings { id, threshold, corpus, model } => {
             cmd::siblings::run(id, threshold, corpus, model)


### PR DESCRIPTION
## Why

`ways match` scored a query with single-vector cosine (`batch_embed_score`) — but that is no longer the fire path. The live matcher is chunked **late-interaction** (peak → softmax-share → body-confirm, ADR-160). Every way was interactively tuned against the cosine view, so authoring feedback no longer predicts whether — or how strongly — a way actually fires. This is the successor tool.

## What

`ways match <query>` now runs the **real late-interaction pipeline** and shows, per candidate, the matcher's own decision quantities:

```
late-interaction (ADR-160) · share gate ≥ 0.15 · confirm gate ≥ 0.40 · 0 would fire
reduced surface: I need to write an architecture decision record for our new database. We should also design the schema migration carefully. Then open a pull request so the team can review it.

  way                                  peak  share  confirm  outcome   won chunk
  ────────────────────────────────────────────────────────────────────────────────────────────
  documentation/adr                   0.536  0.132     —     < share   I need to write an architecture decision reco…
  data/migrations                     0.525  0.088     —     < share   We should also design the schema migration ca…
  softwaredev/delivery/github         0.450  0.089     —     < share   Then open a pull request so the team can revi…
```

- **peak** — strongest single-chunk cosine (specificity)
- **share** — the share-gate quantity (summed softmax mass / n_chunks)
- **confirm** — body cross-similarity of the won chunk (only run for share-gate survivors; `—` otherwise)
- **outcome** — `fired ✓`, or *why* it fell short: `< share` / `< confirm`
- **won chunk** — the surface sentence the way's fire hinges on

`--cosine` keeps the legacy single-vector view; `--project` scopes project-local ways. A sparse surface (<2 chunks) falls back to the single-vector view, mirroring production's fail-safe.

## Immediate payoff — it exposes a calibration crisis

On a clear 3-topic prompt, **nothing fires**: the best match (`documentation/adr`) has a strong peak (0.536) but share **0.132 < 0.15**, so body-confirm is never reached. The provisional operating points were never exercised against real late-interaction surfaces (see #328 — the matcher was silently on single-vector). This diagnostic is what the gate-calibration task will tune against.

## Internals

`late_interaction::run_diagnostic` mirrors `run` but returns the top-N candidates' full evidence (including gate-failers), reusing the same chunk/match/aggregate/confirm helpers. `scan::diagnose` reduces the query as the prompt scan does. Output is hand-formatted because `agent_fmt::Table` truncates numeric cells to terminal width when piped (ellipsizing scores to `0.5…`).

## Depends on

Requires a `--batch`-capable way-embed to run late-interaction (else it falls back to the cosine view). See #328 — without it the matcher is off entirely.