### PR TITLE
docs(adr-160): record first calibration findings (multi-topic share dilution)

### DIFF
--- a/docs/architecture/system/ADR-160-chunked-late-interaction-matching-with-softmax-share-gating-for-way-selection.md
+++ b/docs/architecture/system/ADR-160-chunked-late-interaction-matching-with-softmax-share-gating-for-way-selection.md
@@ -39,6 +39,15 @@ The pipeline is lenient where it ranks (peak + softmax-share admit a way on its 
 
 **Status: Accepted — shipped with provisional operating points.** The operating points (softmax temperature, share gate, confirm gate) are hand-set. The one over-pruning failure a live trial surfaced — a mean-of-max confirm over every surface chunk diluting a way that matched only part of a multi-topic surface — is resolved by scoping confirmation to the winning chunk (stage 5), and the matcher ships as *the* semantic matcher on `main`. The points remain **provisional, not finally calibrated**: the follow-up is (a) a **precision instrument** — replaying each fire's surface from the transcript at its logged token position so relevance is judgeable — and (b) tuning the points against it and against live observation of whether ways are better-behaved. That is refinement of a shipped matcher, not a gate on adoption; a regression is handled by tuning or, in the limit, superseding this ADR.
 
+### Calibration findings (in progress)
+
+First observations from the read-side precision instrument and the late-interaction authoring diagnostic (`ways match`), on `main` once a `--batch`-capable embedder was actually deployed — a deployment defect had been silently routing every scan to the single-vector fail-safe, so the operating points had never been exercised against real late-interaction surfaces at all:
+
+- **Single-topic surfaces fire cleanly.** A focused multi-sentence prompt lands its owning way well above gate (e.g. a testing prompt → `softwaredev/code/testing` share 0.36, confirm 0.45; a commit prompt → `softwaredev/delivery/commits` share 0.42, confirm 0.54). The confirm stage behaves as designed.
+- **Topic-diverse surfaces under-fire.** On a three-topic prompt (ADR + migration + PR) *nothing* fires: the best-matched way (`documentation/adr`) has a strong peak (0.54) but a share of only 0.13, below the 0.15 share gate, so confirmation is never reached. The cause is structural: `share = Σ(per-chunk softmax mass) / n_chunks` caps a way that legitimately owns *one* of N topics at ≈ 1/N, so a genuinely-specific match on a diverse surface is diluted below any fixed share gate. Real session prompts are highly multi-topic, so this is the common case, not an edge one.
+- **Hypothesis to evaluate:** admit a way on a strong *peak* even when its share is diluted — fire on `share ≥ SHARE_GATE` **or** (`peak ≥ PEAK_GATE` **and** confirm clears) — letting the body-confirm (already strict) carry precision for the high-peak/low-share case. This is an algorithm change to stage 4, not just a number, and wants evaluation against a judged set before adoption.
+- **ADR-vs-implementation gap:** stage 4 above specifies routing the summed mass through *the existing calibrated fire gate* (ADR-156, `g(s) ≥ τ_s`); the implementation instead divides by `n_chunks` and thresholds a **hand-set** `SHARE_GATE = 0.15`, bypassing ADR-156's calibration. Calibration must reconcile the two — either the share is a calibrated quantity or the ADR text is updated to match a deliberately hand-set gate.
+
 ## Consequences
 
 ### Positive


### PR DESCRIPTION
Records the first real calibration evidence for ADR-160's provisional operating points, now that the matcher actually runs (#328 fixed a deployment defect that had silently routed every scan to the single-vector fail-safe — the points had never been exercised against real late-interaction surfaces).

**Findings** (via the read-side instrument #327 and the `ways match` diagnostic #329):
- **Single-topic surfaces fire cleanly** — a focused prompt lands its owning way well above gate (testing → share 0.36/confirm 0.45; commits → 0.42/0.54).
- **Topic-diverse surfaces under-fire** — a 3-topic prompt (ADR+migration+PR) fires *nothing*: best match `documentation/adr` has peak 0.54 but share 0.13 < 0.15 gate. Cause is structural: `share = Σ(softmax mass)/n_chunks` caps a way owning one of N topics at ≈1/N. Real prompts are multi-topic, so this is the common case.

**Recorded, not decided:**
- Hypothesis: admit on a strong *peak* even when share is diluted (`share ≥ gate` OR `peak ≥ gate AND confirm clears`), letting the strict body-confirm carry precision.
- ADR-vs-code gap: stage 4 specifies routing summed mass through ADR-156's *calibrated* gate; the code thresholds a *hand-set* `SHARE_GATE=0.15`. Calibration must reconcile these.

Docs-only; feeds the provisional-points follow-up (#2). ADR lint clean.