### PR TITLE
fix(way): meta/workflows YAML + gate frontmatter lint in CI

### DIFF
--- a/.github/workflows/build-ways.yml
+++ b/.github/workflows/build-ways.yml
@@ -92,6 +92,14 @@ jobs:
         run: cargo test --manifest-path tools/Cargo.toml -p ways
       - name: Run simulation tests
         run: cargo test --manifest-path tools/Cargo.toml -p ways --test session_sim -- --test-threads=1
+      - name: Lint way frontmatter
+        # Invokes the ways binary directly against the repo corpus. `ways lint`
+        # resolves its schema from hooks/ways/frontmatter-schema.yaml, so this
+        # needs no ~/.claude projection and no make target — a frontmatter error
+        # that would silently drop a way from matching fails the build here.
+        run: |
+          cargo build --manifest-path tools/Cargo.toml -p ways
+          tools/target/debug/ways lint --check hooks/ways
 
   collect:
     needs: [build, test]

--- a/hooks/ways/meta/workflows/workflows.md
+++ b/hooks/ways/meta/workflows/workflows.md
@@ -1,5 +1,5 @@
 ---
-description: When to reach for the Workflow tool — deterministic multi-agent orchestration: fan-out, staged pipelines, verification and synthesis across many items, and how far up the substrate ladder a task warrants climbing
+description: When to reach for the Workflow tool — deterministic multi-agent orchestration (fan-out, staged pipelines, verification and synthesis across many items) and how far up the substrate ladder a task warrants climbing
 vocabulary: workflow orchestrate orchestration fan out pipeline multi-agent parallel stage deterministic deliver decompose verify synthesize substrate gate remediate adversarially scale
 pattern: orchestrat|fan.?out|pipeline|multi.?agent
 scope: agent

--- a/tools/ways-cli/src/cmd/lint/mod.rs
+++ b/tools/ways-cli/src/cmd/lint/mod.rs
@@ -42,8 +42,40 @@ use std::path::PathBuf;
 use crate::util::{detect_project_dir, home_dir};
 
 pub fn run(path: Option<String>, schema: bool, check: bool, fix: bool, global: bool) -> Result<()> {
-    let ways_dir = home_dir().join(".claude/hooks/ways");
-    let schema_path = ways_dir.join("frontmatter-schema.yaml");
+    let home_ways_dir = home_dir().join(".claude/hooks/ways");
+
+    // Determine the corpus to lint:
+    // 1. Explicit path arg wins
+    // 2. CLAUDE_PROJECT_DIR .claude/ways/ if it exists (unless --global)
+    // 3. Global ways dir (the ~/.claude projection)
+    let (scan_dir, is_targeted, project_label) = if let Some(ref p) = path {
+        (PathBuf::from(p), true, None)
+    } else if !global {
+        let project_dir = std::env::var("CLAUDE_PROJECT_DIR")
+            .ok()
+            .or_else(detect_project_dir);
+        match project_dir {
+            Some(pd) if PathBuf::from(&pd).join(".claude/ways").is_dir() => {
+                let pw = PathBuf::from(&pd).join(".claude/ways");
+                (pw, true, Some(pd))
+            }
+            _ => (home_ways_dir.clone(), false, None),
+        }
+    } else {
+        (home_ways_dir.clone(), false, None)
+    };
+
+    // Schema resolution — `ways lint` stays self-sufficient, with no coupling to
+    // make/install. Prefer the schema that ships alongside the corpus being
+    // linted, so `ways lint <repo>/hooks/ways` validates against that repo's own
+    // schema with no ~/.claude projection required (make absent ≠ lint broken);
+    // fall back to the installed global schema for the projected / --global case.
+    let local_schema = scan_dir.join("frontmatter-schema.yaml");
+    let schema_path = if local_schema.is_file() {
+        local_schema
+    } else {
+        home_ways_dir.join("frontmatter-schema.yaml")
+    };
 
     if schema {
         let content = std::fs::read_to_string(&schema_path)
@@ -57,37 +89,19 @@ pub fn run(path: Option<String>, schema: bool, check: bool, fix: bool, global: b
     eprintln!();
     eprintln!("Way Frontmatter Lint");
     eprintln!("Schema: {}", schema_path.display());
+    if let Some(pd) = &project_label {
+        eprintln!("Project: {pd}");
+    }
     eprintln!();
 
     let mut errors = 0u32;
     let mut warnings = 0u32;
     let mut fixes = 0u32;
 
-    // Determine scan directory:
-    // 1. Explicit path arg wins
-    // 2. CLAUDE_PROJECT_DIR .claude/ways/ if it exists (unless --global)
-    // 3. Global ways dir
-    let (scan_dir, is_targeted) = if let Some(ref p) = path {
-        (PathBuf::from(p), true)
-    } else if !global {
-        let project_dir = std::env::var("CLAUDE_PROJECT_DIR")
-            .ok()
-            .or_else(detect_project_dir);
-        if let Some(ref pd) = project_dir {
-            let project_ways = PathBuf::from(pd).join(".claude/ways");
-            if project_ways.is_dir() {
-                eprintln!("Project: {pd}");
-                eprintln!();
-                (project_ways, true)
-            } else {
-                (ways_dir.clone(), false)
-            }
-        } else {
-            (ways_dir.clone(), false)
-        }
-    } else {
-        (ways_dir.clone(), false)
-    };
+    // Canonical ways root for relpath display and the sub-linters: the corpus
+    // actually being scanned (which exists in CI with no projection), not a
+    // hard-coded home path that may be absent.
+    let ways_dir = scan_dir.clone();
 
     let file_count = scanning::scan_and_lint(
         &scan_dir,


### PR DESCRIPTION
## Hotfix — a live regression I introduced in #332

My positive-prose rewrite of `meta/workflows` wrote:
> …deterministic multi-agent orchestration**: **fan-out, staged pipelines…

The unquoted **colon-space** parses as a YAML mapping value, so `serde_yaml` fails to load the frontmatter and the matcher **silently drops `meta/workflows` from the corpus entirely**. The way is currently absent from matching on `main`.

## Fix

Colon → parentheses. `ways lint` goes from **1 error → 0**, the frontmatter parses, and the way returns to the corpus on the next regeneration.

`description: …orchestration (fan-out, staged pipelines, verification and synthesis across many items) and how far up the substrate ladder a task warrants climbing`

## Why it slipped through (two process holes)

1. **My check was wrong.** In #332 I "verified lint clean" by grepping the output for positive-prose warnings — I never saw the ERROR line. Reading the summary would have caught it.
2. **`ways lint` is not a CI gate.** No `.github/workflows/` step runs it, so #332's green checks (build-only) never exercised the strict-YAML rule that exists precisely to catch a silently-dropped way.

## Follow-up (not in this PR)

Wire `ways lint --check` into CI so this class of bug — a frontmatter error that drops a way from matching with no other symptom — fails the build instead of merging.

https://claude.ai/code/session_01DNV2WVBmE5ALxjnQCCNGEP