### PR TITLE
release(ways): v1.3.0

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "ways"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "agent-fmt",
  "anyhow",

--- a/tools/ways-cli/Cargo.toml
+++ b/tools/ways-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ways"
-version = "1.2.2"
+version = "1.3.0"
 edition = "2021"
 description = "Unified CLI for ways — knowledge guidance for Claude Code"
 license = "MIT"


### PR DESCRIPTION
Version bump for the ways 1.3.0 release (ADR-150). After merge, tag it: `make publish-release COMPONENT=ways` — that pushes `ways-v1.3.0` and CI builds all platforms + creates the GitHub Release.