### PR TITLE
feat(lint): reconcile way schema to code + functional-activeness rule

### DIFF
--- a/hooks/ways/frontmatter-schema.yaml
+++ b/hooks/ways/frontmatter-schema.yaml
@@ -7,6 +7,33 @@
 #   default. Linter flags absence as a warning (with --strict).
 # "optional" means absence is correct and never flagged.
 # "conditional" means required only when a paired field is present.
+#
+# ── Functional firing contract (ground truth from the fire-time code) ──
+# A way is *functionally active* only if it has at least one live firing path.
+# The fire-time parser (scan/candidates.rs → WayCandidate, via get_fm_field) is
+# a FLAT top-level `key: value` reader plus one bespoke `when:` block handler —
+# nested YAML is invisible to it. The live paths and who consumes them:
+#
+#   semantic  description AND vocabulary (both non-empty)  → corpus embed → late-interaction
+#   keyword   pattern (+ pattern_strict)                   → scan regex lane
+#   bash      commands                                     → scan bash surface
+#   file      files                                        → scan Edit/Write surface
+#   state     trigger: session-start|context-threshold|file-exists (flat)  → scan/state.rs
+#             (context-threshold also needs threshold; file-exists needs path)
+#   attend    trigger: { type: attend, signals: [...] } (NESTED)           → attend binary
+#             (read by extract_attend_signals, NOT by scan — flat parser sees trigger: as empty)
+#
+# Note the top-level `trigger:` key is dual-shaped: a flat string routes to the
+# state lane; a nested `type/signals` map routes to the attend lane. They are
+# documented below under `state:` and `attend:` respectively.
+#
+# Fields that are NOT firing paths — modifiers consumed by other subsystems:
+#   scope, when.*   preconditions/gates (scan)
+#   refire          re-fire cadence (ADR-126 marker subsystem, not candidate parsing)
+#   macro           runs macro.sh (shell hook), not read by the Rust fire path
+#   requires        ADR-116 permission audit only (ways lint / permissions), not fire-time
+#   pattern_keep    pattern-hygiene lint directive only (ADR-155 §5), not fire-time
+#   scan_exclude    macro.sh scan filter only, not read by the Rust fire path
 
 way:
   trigger:
@@ -86,12 +113,19 @@ way:
           required: optional
           role: Only fire in this project directory
 
+  # The attend lane is the NESTED shape of the top-level `trigger:` key:
+  #   trigger:
+  #     type: attend
+  #     signals: [context-pressure, build-complete]
+  # Read by extract_attend_signals (show/helpers.rs) and dispatched by the
+  # attend binary — invisible to the scan fire path (its flat parser reads
+  # `trigger:` as empty here). Not a scan/state trigger.
   attend:
     type:
       type: enum
       values: [attend]
       required: optional
-      role: Marks this way as a handler for attend signal types (ADR-114)
+      role: Under `trigger:`, marks this way as an attend signal handler (ADR-114)
     signals:
       type: array
       required: conditional  # required when type is attend
@@ -102,15 +136,14 @@ way:
       type: enum
       values: [context-threshold, file-exists, session-start]
       required: optional
-      role: State-based trigger type (instead of pattern/semantic)
+      role: >
+        Flat state-trigger value (the top-level `trigger:` key as a string,
+        instead of pattern/semantic). Routes to scan/state.rs. The nested
+        `trigger: { type: attend, … }` form is the *attend* lane, not this.
     threshold:
       type: number
       required: conditional  # required when trigger is context-threshold
       role: Percentage (0-100) of context-window fill that fires the way. Only read for trigger, context-threshold.
-    repeat:
-      type: boolean
-      required: optional
-      role: Keep firing until condition met
     path:
       type: glob
       required: optional

--- a/tools/ways-cli/src/cmd/lint/per_file.rs
+++ b/tools/ways-cli/src/cmd/lint/per_file.rs
@@ -19,6 +19,19 @@ use super::schema::{is_reserved_field, Schema};
 
 use crate::util::home_dir;
 
+/// Whether a way has at least one live firing path — the predicate behind the
+/// functional-activeness lint. A way fires via a frontmatter channel
+/// (`fires_on_something`: semantic, pattern, commands, files, trigger) or via an
+/// ADR-135 `postcheck.sh` sidecar in its directory (reactive PostToolUse
+/// dispatch, keyed off the file's existence rather than frontmatter). `way_dir`
+/// is the directory holding the way's `.md`; `None` skips the sidecar check.
+pub(super) fn has_firing_path(fm_str: &str, way_dir: Option<&Path>) -> bool {
+    crate::frontmatter::fires_on_something(fm_str)
+        || way_dir
+            .map(|d| d.join("postcheck.sh").is_file())
+            .unwrap_or(false)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn lint_file(
     path: &Path,
@@ -148,6 +161,31 @@ pub(super) fn lint_file(
         } else {
             eprintln!("  INFO: {rel} — attend signal handler (matched by signal name, not semantic)");
         }
+    }
+
+    // Functional activeness (ground truth: scan/candidates.rs + check-post.sh).
+    // A way must have at least one live firing path, or it can never fire and is
+    // dead weight in the corpus (the localize case that motivated this rule).
+    // `fires_on_something` covers the frontmatter channels — semantic, pattern,
+    // commands, files, and `trigger:` (which is present for both the flat state
+    // trigger and the nested attend block). The one channel it can't see is the
+    // ADR-135 `postcheck.sh` sidecar: reactive PostToolUse dispatch keyed off the
+    // file's existence, not frontmatter, so check for it explicitly.
+    //
+    // Deliberately NOT checked: "fires but injects nothing" (empty body). It
+    // isn't mechanically decidable — a macro.sh or postcheck.sh emits its
+    // disclosure conditionally at runtime, so an empty .md body is legitimate.
+    // Top-level files (core.md) are base guidance injected unconditionally via
+    // `macro: prepend`, not matchable ways — the scanner skips them (their
+    // way-id is empty). Mirror that exclusion so the rule targets real ways only.
+    let is_top_level = relpath.parent().map(|p| p.as_os_str().is_empty()).unwrap_or(true);
+    if !is_check && !is_top_level && !has_firing_path(&fm_str, path.parent()) {
+        eprintln!(
+            "  WARNING: {rel} — no firing path: none of description+vocabulary, \
+             pattern, commands, files, trigger, or a postcheck.sh sidecar. \
+             This way can never fire (dead in the corpus)."
+        );
+        *warnings += 1;
     }
 
     // ADR-126: fire-bearing ways should carry a `refire:` field. Fire
@@ -369,4 +407,55 @@ pub(super) fn lint_file(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_firing_path;
+    use std::path::Path;
+
+    #[test]
+    fn firing_path_via_frontmatter_channels() {
+        // Semantic needs both fields; each keyword/bash/file/state channel fires alone.
+        assert!(has_firing_path("description: x\nvocabulary: y\n", None));
+        assert!(has_firing_path("pattern: '^foo'\n", None));
+        assert!(has_firing_path("commands: 'git .*'\n", None));
+        assert!(has_firing_path("files: '\\.rs$'\n", None));
+        assert!(has_firing_path("trigger: session-start\n", None));
+        // The nested attend block still presents a top-level `trigger:` line.
+        assert!(has_firing_path("trigger:\n  type: attend\n  signals:\n    - x\n", None));
+    }
+
+    #[test]
+    fn no_firing_path_on_modifier_only_frontmatter() {
+        // scope/refire are modifiers, not channels — a way with only these is dead
+        // unless a postcheck.sh sidecar rescues it (next test).
+        assert!(!has_firing_path("scope: agent\nrefire: 0.2\n", None));
+        assert!(!has_firing_path("description: x\n", None)); // half a semantic pair
+    }
+
+    #[test]
+    fn postcheck_sidecar_is_a_firing_path() {
+        let dir = std::env::temp_dir().join(format!("ways-fp-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // Modifier-only frontmatter is dead...
+        assert!(!has_firing_path("scope: agent\nrefire: 0.2\n", Some(&dir)));
+        // ...until a postcheck.sh sits alongside it (ADR-135, the overbuild case).
+        std::fs::write(dir.join("postcheck.sh"), "#!/usr/bin/env bash\nexit 0\n").unwrap();
+        assert!(has_firing_path("scope: agent\nrefire: 0.2\n", Some(&dir)));
+        // A different sidecar name does not count.
+        let dir2 = dir.join("other");
+        std::fs::create_dir_all(&dir2).unwrap();
+        std::fs::write(dir2.join("macro.sh"), "#!/usr/bin/env bash\n").unwrap();
+        assert!(!has_firing_path("scope: agent\n", Some(&dir2)));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_way_dir_skips_the_sidecar_check() {
+        // `None` (no directory) must not panic and must not conjure a firing path.
+        assert!(!has_firing_path("scope: agent\n", Some(Path::new("/nonexistent/xyz"))));
+        assert!(!has_firing_path("scope: agent\n", None));
+    }
 }


### PR DESCRIPTION
Phase 1 of the ways scaffolding cleanup: **make the linter accurate.** We've been reshaping the trigger classifier fast, so the schema + linter had drifted from what the fire-time code actually reads. This ground-truths the functional frontmatter contract from the executable (`scan/candidates.rs`, `scan/mod.rs`, `state.rs`, `corpus.rs`, `check-post.sh`) and brings the scaffolding back in line.

## Ground truth: what makes a way functionally active

The fire-time parser (`WayCandidate` via `get_fm_field`) is a **flat top-level `key: value` reader** — nested YAML is invisible to it. A way fires iff it has ≥1 live path:

| Lane | Fields | Runtime |
|---|---|---|
| semantic | `description` + `vocabulary` | corpus → late-interaction |
| keyword | `pattern` | scan regex |
| bash | `commands` | scan bash surface |
| file | `files` | scan Edit/Write surface |
| state | flat `trigger: session-start\|context-threshold\|file-exists` | `state.rs` |
| attend | nested `trigger: { type: attend, signals }` | attend binary |
| **postcheck** | `postcheck.sh` sidecar | `check-post.sh` (ADR-135) |

## Schema (`frontmatter-schema.yaml`)

- Document the firing contract in the header (the seven paths + who consumes each; and the modifier fields that are *not* firing paths: `scope`, `when`, `refire`, `macro`, `requires`, `pattern_keep`, `scan_exclude`).
- **Drop dead `state.repeat`** — `state.rs` stopped honoring it; no way uses it.
- Clarify the dual-shaped `trigger:` key (flat = state lane; nested `type: attend` = attend lane, not scan).

## Linter (`per_file.rs`)

- **New functional-activeness rule**: warns on any way with no live firing path. This is the mechanical check that catches a dead way — the `localize` case (#338) that had to be spotted in the inspector — instead of it passing 0/0.
- Reuses ways-core's `fires_on_something` for frontmatter channels; adds the ADR-135 `postcheck.sh` sidecar path it can't see (so `overbuild`, which fires only via postcheck, is correctly *not* flagged); excludes top-level base files (`core.md`, injected unconditionally) mirroring the scanner's empty-id skip.
- Extracts `has_firing_path` helper + 4 unit tests.

## Verification

- `ways lint --check hooks/ways` → **0 errors, 0 warnings** across all 128 ways (every current way has a firing path — validated first with a standalone classifier over the corpus).
- Synthetic modifier-only way → flagged; `postcheck.sh` sidecar → not flagged; `core.md` → not flagged.
- 4 new unit tests pass; clippy clean; `--check` gates on errors only, so the new warning won't break CI while still catching future dead ways.

## Not in scope

The ADR-baseline consolidation (ADRs unduly steering Claude's context) is the maintainer's, deferred. Phase 2 (sonnet fan-out audit of all ways against this now-validated contract) is next.