### PR TITLE
docs(core): reframe base config as ways-driven, add Method to core.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,14 @@
-# ADR-Driven Development Config
+# Ways-Driven Development Config
 
-ADR-driven workflow with GitHub-first collaboration.
+Contextual ways of working, disclosed by hooks, with GitHub-first collaboration.
+Architecture decisions are recorded as ADRs — one thread among several, not the
+whole method.
 
-**Instructions are injected via hooks, not this file.**
+**Guidance is injected via hooks, not this file.** It loads on **SessionStart**
+(including after compaction), so the relevant ways stay live in the conversation
+window instead of sitting as a distant, always-on system prompt.
 
-Instructions are loaded at critical moments to maintain relevance:
-- **SessionStart** - Fresh context when sessions begin
-- **PreCompact** - Fresh context after compaction events
-
-This approach ensures guidance stays active in the conversation window rather than being buried as distant system prompts.
-
-See `hooks/ways/core.md` for the base guidance and `hooks/ways/*.md` for contextual instructions.
+The live guidance is installed under `~/.claude/`, not this repo's working tree.
+See `~/.claude/hooks/ways/core.md` for the base posture, and the other
+`~/.claude/hooks/ways/**` files for the contextual ways that disclose themselves
+when triggered.

--- a/hooks/ways/core.md
+++ b/hooks/ways/core.md
@@ -44,6 +44,12 @@ Just work naturally. No need to request guidance upfront.
 
 **No apology reflex.** When corrected, absorb and move. Don't ritualize the correction into an Event that needs memory capture. "Got it, moving on" beats "noted, saving this, will be more careful." Memory is for what's load-bearing across sessions, not prostration gestures.
 
+## Method
+
+Work here is driven by recorded decisions and held to evidence. Architecture decisions become ADRs (`docs/architecture/`, via `docs/scripts/adr`) so the *why* outlives the moment, and collaboration is GitHub-first — changes move through PRs, even solo.
+
+The ledger is not the whole method, and recording a decision does not make it true. Prose — ADRs, design notes, specs, use cases, READMEs — states *claims*, and claims are held to the evidence the running system produces: a passing test, an exercised flow, a verified contract. (Glue code around a remote endpoint can assert anything; what's checkable is the contract, not the prose.) When a decision turns on how something outside the code actually behaves, find the shape empirically first, then record it. And because a ledger accrues and drifts, newer decisions supersede older ones rather than silently contradicting them.
+
 ## Language
 
 All file output (commit messages, comments, documentation, PR descriptions) must be in English regardless of interface language setting.


### PR DESCRIPTION
## What

- **CLAUDE.md**: retitle `ADR-Driven` → `Ways-Driven`; demote ADRs to "one thread among several, not the whole method"; point at the installed `~/.claude/hooks/ways/core.md` instead of a repo-relative path; drop the stale `PreCompact` line (no such hook — compaction rides the SessionStart `compact` matcher).
- **core.md**: add a `## Method` section. core.md was posture + invariants only and never carried the old CLAUDE.md's method intent. The new section records it and widens past ADRs.

## Why

The base config over-indexed on "ADR-driven." The framework is ways-driven; ADRs are one instrument. The Method section states, at posture altitude:
- decisions are recorded (ADRs, GitHub-first) **but held to evidence** — prose is *claims*, verified by a test / exercised flow / contract (glue code can assert anything; the contract is what's checkable);
- when a decision turns on external behavior, find the shape empirically **first**, then record it;
- the ledger drifts — newer decisions **supersede** older ones rather than silently contradicting them.

The detailed procedures already live in the `prototype`, `groundtruth`, and `freshness` ways; this is the base they specialize.

## Notes

- Frontmatter untouched — core.md still injects at SessionStart as before.
- Reaches installs via `ways reconcile` / update.