### PR TITLE
release(ways-audit): v1.0.1

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "ways-audit"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/tools/ways-audit/Cargo.toml
+++ b/tools/ways-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ways-audit"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 description = "Compliance claim/finding operator surface for the ways toolchain (ADR-151, ADR-200)"
 license = "MIT"


### PR DESCRIPTION
Version bump for the ways-audit 1.0.1 release (ADR-150). After merge, tag it: `make publish-release COMPONENT=ways-audit` — that pushes `ways-audit-v1.0.1` and CI builds all platforms + creates the GitHub Release.