### PR TITLE
refactor(settings): stop shipping statusLine from repo settings.json

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -299,10 +299,6 @@
       }
     ]
   },
-  "statusLine": {
-    "type": "command",
-    "command": "${HOME}/.claude/statusline.sh"
-  },
   "enabledPlugins": {
     "clangd-lsp@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true,


### PR DESCRIPTION
## What
Removes the inert `statusLine` block from the repo-tracked `settings.json`.

## Why
`ways reconcile` co-owns only the `hooks` + `permissions` slices and never projected `statusLine`. The pointer that appears in `~/.claude/settings.json` on existing hosts is residue from the pre-1.0 in-place-clone topology, not an active projection.

`statusLine` is a user-scoped key. Per **ADR-147**, the framework stops force-claiming user-scoped keys. It now lives in the user-scope fragment store (`~/.config/agent-ways/settings/`), projected via `ways settings project`; the `statusline.sh` script itself is owned by dotfiles.

## Impact
Zero runtime change — the key was never projected by reconcile. Verified: no test or installer consumes it; the installer merges only hooks + permissions.

Refs: ADR-147. Part of the config-separation / dotfiles thread (coordinated with the session-link-suppression ADR, system-162).