### PR TITLE
ADR-162: mechanical session-link suppression + deny hook

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -81,7 +81,8 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-158](./system/ADR-158-calibration-boundary-quality-hard-negatives-and-fire-breadth-ship-gate.md) | Calibration boundary quality — hard negatives and a fire-breadth ship gate | Accepted |
 | [ADR-159](./system/ADR-159-remove-ways-tune-curves-and-the-legacy-curve-cadence-field.md) | Remove ways tune-curves and the legacy curve: cadence field | Accepted |
 | [ADR-160](./system/ADR-160-chunked-late-interaction-matching-with-softmax-share-gating-for-way-selection.md) | Chunked late-interaction matching with softmax-share gating for way selection | Accepted |
-| [ADR-161](./system/ADR-161-queued-mid-turn-operator-messages-as-an-aggregated-scan-surface.md) | Queued mid-turn operator messages as an aggregated scan surface | Draft |
+| [ADR-161](./system/ADR-161-queued-mid-turn-operator-messages-as-an-aggregated-scan-surface.md) | Queued mid-turn operator messages as an aggregated scan surface | Proposed |
+| [ADR-162](./system/ADR-162-mechanical-session-link-suppression-as-defense-against-transcript-disclosure.md) | Mechanical session-link suppression as defense against transcript disclosure | Draft |
 
 ## Governance
 _Provenance, traceability, controls, compliance mapping_

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -82,7 +82,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-159](./system/ADR-159-remove-ways-tune-curves-and-the-legacy-curve-cadence-field.md) | Remove ways tune-curves and the legacy curve: cadence field | Accepted |
 | [ADR-160](./system/ADR-160-chunked-late-interaction-matching-with-softmax-share-gating-for-way-selection.md) | Chunked late-interaction matching with softmax-share gating for way selection | Accepted |
 | [ADR-161](./system/ADR-161-queued-mid-turn-operator-messages-as-an-aggregated-scan-surface.md) | Queued mid-turn operator messages as an aggregated scan surface | Proposed |
-| [ADR-162](./system/ADR-162-mechanical-session-link-suppression-as-defense-against-transcript-disclosure.md) | Mechanical session-link suppression as defense against transcript disclosure | Draft |
+| [ADR-162](./system/ADR-162-mechanical-session-link-suppression-as-defense-against-transcript-disclosure.md) | Mechanical session-link suppression as defense against transcript disclosure | Accepted |
 
 ## Governance
 _Provenance, traceability, controls, compliance mapping_

--- a/docs/architecture/system/ADR-162-mechanical-session-link-suppression-as-defense-against-transcript-disclosure.md
+++ b/docs/architecture/system/ADR-162-mechanical-session-link-suppression-as-defense-against-transcript-disclosure.md
@@ -1,0 +1,129 @@
+---
+status: Draft
+date: 2026-07-06
+deciders:
+  - aaronsb
+  - claude
+related:
+  - 152
+  - 163
+---
+
+# ADR-162: Mechanical session-link suppression as defense against transcript disclosure
+
+## Context
+
+Claude Code appends a session link to git commit messages (`Claude-Session:
+https://claude.ai/code/session_…`) and to PR bodies. That link resolves to the
+**full session transcript**. A transcript routinely contains material that
+scrolled through the conversation — file contents, environment values, tokens,
+internal paths. Publishing the link therefore places a single click between a
+public commit and whatever secret happened to pass through the session. On a
+public repository this is an accidental-disclosure surface, not a convenience.
+
+A prior attempt to close this (commit `3b7f04c`, "give the session-link trailer a
+control surface") set `attribution.commit` and `attribution.pr` to `""` and added
+a *report-only* block to the GitHub delivery macro. Subsequent investigation shows
+that attempt did not govern the session link at all:
+
+- `attribution.commit` / `attribution.pr` only suppress the **Co-Authored-By /
+  "Generated with Claude Code"** footers. They never controlled the session link.
+- The key that does govern it, `attribution.sessionUrl`, is **undocumented**
+  (added in v2.1.183) and is **not reliably injected into the model's context**
+  (upstream issue [#18253](https://github.com/anthropics/claude-code/issues/18253),
+  marked *not planned*). The system-prompt instruction to append the link survives
+  the setting, and the model follows it.
+- Claude Code has **no mechanism that strips** such a link after it is written. The
+  entire design is preventive ("do not instruct the model"), and the injection bug
+  defeats prevention.
+
+The failure is observable: a PR was authored in an unrelated repository that had
+**no local `.claude/settings.json`** — it inherited the global
+`attribution: {commit:"", pr:""}` — and the session link still landed in the PR
+body. The setting layer neither reached the model nor covered a repo without local
+config.
+
+The conclusion is that any control depending on the harness honoring a setting, or
+on the model choosing to obey it, is not load-bearing. Suppression must be
+mechanical and must live in a layer we own.
+
+## Decision
+
+Add a **PreToolUse hook on `Bash`** that inspects command invocations which author
+commits or pull requests — `git commit`, `gh pr create`, `gh pr edit` (and the
+`git commit -m` / heredoc / `--body` forms) — and prevents any `Claude-Session:`
+trailer or `claude.ai/code/session_…` URL from landing. Where the harness supports
+rewriting tool input, the hook strips the offending lines in place; otherwise it
+denies the call with a remediation message instructing removal. Either path
+guarantees the link does not reach git or GitHub.
+
+The hook must operate at **user scope** — covering **every** repository the
+operator works in, independent of whether a repo carries local config — rather
+than as a per-project hook. That is the property this decision requires; *how*
+the hook is distributed to achieve it (dotfile source-of-truth, the settings
+projection, cross-host travel, key-vs-file ownership) is the province of ADR-163,
+which carries this hook as the primitive it distributes. What matters here is the
+guarantee, not the delivery: suppression does not depend on the harness injecting
+the `attribution` setting, on the model obeying it, or on a per-project note.
+
+As belt-and-suspenders — cheap and correct in intent even while #18253 stands — we
+also set `attribution.sessionUrl: false` in the settings store. The existing
+report-only macro block is retained; it now reports the true effective state
+alongside a hook that actually enforces it.
+
+Scope boundary: this ADR governs suppression of the **session link** specifically.
+It does not remove the Co-Authored-By footer (an independent operator preference
+already handled by `attribution.commit`/`.pr`).
+
+## Consequences
+
+### Positive
+
+- Every repository is protected regardless of local config, the harness injection
+  bug, or model obedience. The unrelated-repo leak that motivated this ADR is
+  closed at the layer we control.
+- Enforcement is auditable and testable — a hook script with explicit patterns,
+  not a soft instruction competing with the system prompt.
+- Defense-in-depth composes with ADR-152's secret-path deny baseline: 152 keeps
+  secret *files* out of the model's reach; 162 keeps a *pointer to the whole
+  transcript* out of published history.
+
+### Negative
+
+- A PreToolUse hook adds a small latency and a failure surface to every `git`/`gh`
+  Bash call; it must fail open on parse it cannot understand rather than block
+  legitimate commits.
+- Interception is bounded by what the hook can see. Inline `-m` and heredoc bodies
+  are greppable in the command string; a body passed via `--body-file`/`-F <path>`
+  requires the hook to read and rewrite that file, which is a second code path to
+  maintain.
+- If Claude Code changes the link format, the hook's patterns need updating — a
+  maintenance coupling to an undocumented upstream string.
+
+### Neutral
+
+- The change belongs in the GitHub delivery way alongside the existing attribution
+  report block. The hook entry lives in the **reconcile-owned `settings.json` hooks
+  block** (beside the existing `check-bash-pre.sh` gate), not the settings-fragment
+  store — `ways settings project` deliberately skips the hooks/permissions slices,
+  so a fragment-authored hook would silently never fire. Its cross-host distribution
+  is owned by ADR-163.
+- The hook rewrites the command in place via PreToolUse `updatedInput`
+  (`permissionDecision: allow`), a confirmed Claude Code capability, so the commit
+  flow is never interrupted. The alternative — block-with-remediation (exit 2) — was
+  available but rejected as needless friction once silent rewrite was confirmed.
+
+## Alternatives Considered
+
+- **Rely on `attribution.sessionUrl: false` alone.** Rejected: undocumented and
+  defeated by injection bug #18253, with no coverage for repos where the setting
+  never reaches the model. Kept only as a secondary layer.
+- **A way / memory instruction telling the model to omit the link.** Rejected:
+  soft, competes with the system-prompt instruction, and scoped per project. This
+  is precisely what already failed — the leaking repo had no such note.
+- **Post-hoc history rewrite / secret rotation.** Rejected as the primary control:
+  reactive, triggered only after the link (and any secret) is already pushed.
+  Remains the incident response if a link ever slips past the hook.
+- **Do nothing / accept the setting layer as sufficient.** Rejected: the motivating
+  leak proves the setting layer is not load-bearing, and the exposure is a security
+  posture, not a preference.

--- a/docs/architecture/system/ADR-162-mechanical-session-link-suppression-as-defense-against-transcript-disclosure.md
+++ b/docs/architecture/system/ADR-162-mechanical-session-link-suppression-as-defense-against-transcript-disclosure.md
@@ -50,11 +50,16 @@ mechanical and must live in a layer we own.
 ## Decision
 
 Add a **PreToolUse hook on `Bash`** that inspects command invocations which author
-commits, PRs, or issues — `git commit`, `gh pr create|edit|comment`,
-`gh issue create|edit|comment` — and **denies** any that carry a `Claude-Session:`
-trailer or `claude.ai/code/session_…` URL, returning a remediation message that
-instructs the model to remove the link and re-issue. The clean re-issue passes
-through the normal permission flow. The link never reaches git or GitHub.
+commits, PRs, or issues — `git … commit`, `gh … pr create|edit|comment`,
+`gh … issue create|edit|comment`, matched on token presence (newline-collapsed) so
+intervening flags such as `git -C <path> commit` or `gh <global-flags> pr create`
+cannot evade the gate — and **denies** any that carry a `Claude-Session:` trailer or
+a bare `claude.ai/code/session_…` URL **in trailer/footer position** (line-leading),
+returning a remediation message that instructs the model to remove the link and
+re-issue. A session URL mentioned *inline in prose* is not a leak and passes, so a
+repo can still discuss `Claude-Session` as subject matter without a deny-loop. The
+clean re-issue passes through the normal permission flow. The link is blocked on the
+covered command forms (coverage gaps are listed in Consequences).
 
 The hook **denies rather than rewrites**. Rewriting a command in place (PreToolUse
 `updatedInput`) is honored *only* when the hook also sets `permissionDecision:
@@ -74,10 +79,13 @@ which carries this hook as the primitive it distributes. What matters here is th
 guarantee, not the delivery: suppression does not depend on the harness injecting
 the `attribution` setting, on the model obeying it, or on a per-project note.
 
-As belt-and-suspenders — cheap and correct in intent even while #18253 stands — we
-also set `attribution.sessionUrl: false` in the settings store. The existing
-report-only macro block is retained; it now reports the true effective state
-alongside a hook that actually enforces it.
+The `attribution.sessionUrl: false` key (undocumented, v2.1.183+) is the harness's
+own would-be control; **this change does not set it** — it is defeated by #18253
+today, and coupling to an undocumented key risks tripping settings validation for
+no working benefit. The hook is the load-bearing control. The existing report-only
+macro block is retained; it reports the effective `attribution` state alongside a
+hook that actually enforces suppression. An operator may set `sessionUrl: false`
+additionally once upstream honors it.
 
 Scope boundary: this ADR governs suppression of the **session link** specifically.
 It does not remove the Co-Authored-By footer (an independent operator preference
@@ -88,8 +96,9 @@ already handled by `attribution.commit`/`.pr`).
 ### Positive
 
 - Every repository is protected regardless of local config, the harness injection
-  bug, or model obedience. The unrelated-repo leak that motivated this ADR is
-  closed at the layer we control.
+  bug, or model obedience. The unrelated-repo leak that motivated this ADR — a
+  trailer/footer link on a commit or PR — is closed on the covered command forms at
+  the layer we control.
 - Enforcement is auditable and testable — a hook script with explicit patterns,
   not a soft instruction competing with the system prompt.
 - Defense-in-depth composes with ADR-152's secret-path deny baseline: 152 keeps
@@ -104,11 +113,17 @@ already handled by `attribution.commit`/`.pr`).
   than leaks.
 - Deny costs one extra round-trip each time the model appends a link — until it
   adapts within the session. Benign but visible friction on the first commit/PR.
-- Detection is bounded by what the hook can see. Inline `-m` and heredoc bodies are
-  greppable in the command string; a link in a body passed via `--body-file`/`-F
-  <path>` lives in a file the hook cannot inspect from the command string, so it is
-  a coverage gap that would slip through. Inline/heredoc is how the model formats
-  these by default, so the common case is covered.
+- Detection is bounded by what the hook can see in the command string, so the
+  control is **best-effort, not a guarantee**. Inline `-m` and heredoc bodies are
+  covered (this is how the model formats commits/PRs by default). Uncovered vectors,
+  each of which would slip a link through:
+  - a body/message passed via `--body-file`/`-F <path>` — the text lives in a file
+    the hook can't read from the command string;
+  - a bare `git commit` that opens `$EDITOR` — the message isn't in the command at
+    all;
+  - message-carrying siblings not in scope — `git tag -m`, `gh release create`,
+    `gh gist create`.
+  These are documented residual gaps, not silent ones.
 - If Claude Code changes the link format, the hook's patterns need updating — a
   maintenance coupling to an undocumented upstream string.
 
@@ -125,6 +140,10 @@ already handled by `attribution.commit`/`.pr`).
   *not* rewrite the command in place: see the Decision and the rejected silent-strip
   alternative for why forcing `permissionDecision: allow` — the only way to make
   `updatedInput` take effect — is unacceptable here.
+- The hook shares the `Bash` PreToolUse matcher with the disclosure gate
+  `check-bash-pre.sh`. Multiple matching hooks all run and the most-restrictive
+  result wins (`deny > defer > ask > allow`), independent of array order, so the
+  deny takes effect regardless of position — no ordering dependency.
 
 ## Alternatives Considered
 

--- a/docs/architecture/system/ADR-162-mechanical-session-link-suppression-as-defense-against-transcript-disclosure.md
+++ b/docs/architecture/system/ADR-162-mechanical-session-link-suppression-as-defense-against-transcript-disclosure.md
@@ -50,12 +50,20 @@ mechanical and must live in a layer we own.
 ## Decision
 
 Add a **PreToolUse hook on `Bash`** that inspects command invocations which author
-commits or pull requests — `git commit`, `gh pr create`, `gh pr edit` (and the
-`git commit -m` / heredoc / `--body` forms) — and prevents any `Claude-Session:`
-trailer or `claude.ai/code/session_…` URL from landing. Where the harness supports
-rewriting tool input, the hook strips the offending lines in place; otherwise it
-denies the call with a remediation message instructing removal. Either path
-guarantees the link does not reach git or GitHub.
+commits, PRs, or issues — `git commit`, `gh pr create|edit|comment`,
+`gh issue create|edit|comment` — and **denies** any that carry a `Claude-Session:`
+trailer or `claude.ai/code/session_…` URL, returning a remediation message that
+instructs the model to remove the link and re-issue. The clean re-issue passes
+through the normal permission flow. The link never reaches git or GitHub.
+
+The hook **denies rather than rewrites**. Rewriting a command in place (PreToolUse
+`updatedInput`) is honored *only* when the hook also sets `permissionDecision:
+allow` — `updatedInput` alone is ignored, and no pass-through value exists
+(upstream FR #381). Forcing `allow` would bypass the operator's own
+Deny/Allow/Ask rules for that call, including on outward-facing `gh pr create` /
+`gh issue create` — silently defeating a review gate the operator may rely on.
+Deny bypasses nothing: it costs one extra round-trip, after which the model
+re-issues cleanly (and adapts within the session to stop appending the link).
 
 The hook must operate at **user scope** — covering **every** repository the
 operator works in, independent of whether a repo carries local config — rather
@@ -90,13 +98,17 @@ already handled by `attribution.commit`/`.pr`).
 
 ### Negative
 
-- A PreToolUse hook adds a small latency and a failure surface to every `git`/`gh`
-  Bash call; it must fail open on parse it cannot understand rather than block
-  legitimate commits.
-- Interception is bounded by what the hook can see. Inline `-m` and heredoc bodies
-  are greppable in the command string; a body passed via `--body-file`/`-F <path>`
-  requires the hook to read and rewrite that file, which is a second code path to
-  maintain.
+- A PreToolUse hook adds a small latency to every `git`/`gh` Bash call. On its
+  no-op paths (no command, out of scope, no link) it fails **open**; once a link is
+  actually detected it fails **closed** (deny), so a hook error there blocks rather
+  than leaks.
+- Deny costs one extra round-trip each time the model appends a link — until it
+  adapts within the session. Benign but visible friction on the first commit/PR.
+- Detection is bounded by what the hook can see. Inline `-m` and heredoc bodies are
+  greppable in the command string; a link in a body passed via `--body-file`/`-F
+  <path>` lives in a file the hook cannot inspect from the command string, so it is
+  a coverage gap that would slip through. Inline/heredoc is how the model formats
+  these by default, so the common case is covered.
 - If Claude Code changes the link format, the hook's patterns need updating — a
   maintenance coupling to an undocumented upstream string.
 
@@ -108,16 +120,26 @@ already handled by `attribution.commit`/`.pr`).
   store — `ways settings project` deliberately skips the hooks/permissions slices,
   so a fragment-authored hook would silently never fire. Its cross-host distribution
   is owned by ADR-163.
-- The hook rewrites the command in place via PreToolUse `updatedInput`
-  (`permissionDecision: allow`), a confirmed Claude Code capability, so the commit
-  flow is never interrupted. The alternative — block-with-remediation (exit 2) — was
-  available but rejected as needless friction once silent rewrite was confirmed.
+- The hook enforces by **deny** (`permissionDecision: deny` with a
+  `permissionDecisionReason`, falling back to exit 2 + stderr). It deliberately does
+  *not* rewrite the command in place: see the Decision and the rejected silent-strip
+  alternative for why forcing `permissionDecision: allow` — the only way to make
+  `updatedInput` take effect — is unacceptable here.
 
 ## Alternatives Considered
 
 - **Rely on `attribution.sessionUrl: false` alone.** Rejected: undocumented and
   defeated by injection bug #18253, with no coverage for repos where the setting
   never reaches the model. Kept only as a secondary layer.
+- **Silently rewrite the command in place (PreToolUse `updatedInput`).** Rejected:
+  `updatedInput` is honored only alongside `permissionDecision: allow` — it is
+  ignored on its own, and no pass-through value exists (upstream FR #381). The
+  rewrite would therefore force-approve the command and bypass the operator's
+  Deny/Allow/Ask gates, including on outward-facing `gh pr create` / `gh issue
+  create`. Cleaner UX, but a real permission regression on exactly the commands
+  worth gating; deny preserves the gate for the price of one retry. (This was the
+  initially-ratified choice, reversed once the `updatedInput`→`allow` coupling was
+  confirmed.)
 - **A way / memory instruction telling the model to omit the link.** Rejected:
   soft, competes with the system-prompt instruction, and scoped per project. This
   is precisely what already failed — the leaking repo had no such note.

--- a/docs/architecture/system/ADR-162-mechanical-session-link-suppression-as-defense-against-transcript-disclosure.md
+++ b/docs/architecture/system/ADR-162-mechanical-session-link-suppression-as-defense-against-transcript-disclosure.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-07-06
 deciders:
   - aaronsb

--- a/hooks/ways/strip-session-link-pre.sh
+++ b/hooks/ways/strip-session-link-pre.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# PreToolUse (Bash): strip the Claude-Session transcript link from commit / PR /
-# issue authoring commands before they run. See ADR-162.
+# PreToolUse (Bash): deny commit / PR / issue authoring commands that carry the
+# Claude-Session transcript link, instructing a clean re-issue. See ADR-162.
 #
 # The session link resolves to the FULL session transcript; publishing it in a
 # commit trailer or PR/issue body is a thin wall in front of accidental secret
@@ -8,15 +8,21 @@
 # does not reliably reach the model (upstream #18253) and the system prompt keeps
 # instructing the link — so enforcement lives here, at user scope, for every repo.
 #
-# Mechanism: rewrite the command in place via PreToolUse `updatedInput` and allow
-# the cleaned command to proceed. The commit flow is never blocked; the link just
-# never lands. Posture is FAIL-OPEN — on any internal error the original command
-# proceeds unchanged, so a broken hook can never block a legitimate commit.
+# Mechanism: DENY, not rewrite. Rewriting in place (PreToolUse `updatedInput`) is
+# honored only when the hook also forces `permissionDecision: allow`, which would
+# bypass the operator's own Deny/Allow/Ask rules on outward-facing gh create/edit
+# commands (no pass-through option — upstream FR #381). Deny bypasses nothing: the
+# model re-issues the command WITHOUT the link, and that clean command goes through
+# normal permission evaluation. Cost is one retry, not a lost commit.
+#
+# Fail posture: the no-op paths (no command / out of scope / no link) allow. Once a
+# link IS detected the hook fails CLOSED — on any internal error it still blocks
+# (exit 2) rather than let the link through.
 
 INPUT=$(cat)
 CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
-# No command, or not a command that publishes to git/GitHub → nothing to do.
+# No command, or not a command that publishes to git/GitHub → nothing to enforce.
 [[ -z "$CMD" ]] && exit 0
 case "$CMD" in
   *"git commit"*|*"gh pr create"*|*"gh pr edit"*|*"gh pr comment"* \
@@ -24,30 +30,17 @@ case "$CMD" in
   *) exit 0 ;;
 esac
 
-# Fast path: no session link present.
+# No session link present → allow, normal permission flow applies.
 printf '%s' "$CMD" | grep -qiE 'claude\.ai/code/session_|Claude-Session:' || exit 0
 
-# Strip, line-wise where possible, then any residual inline token.
-CLEANED=$(printf '%s' "$CMD" | perl -0pe '
-  # A Claude-Session: trailer line (drop the leading newline with it).
-  s/\n[ \t]*Claude-Session:[ \t]*https?:\/\/claude\.ai\/code\/session_\S*[ \t]*(?=\n|$)//gi;
-  # A line that is only a bare session URL.
-  s/\n[ \t]*https?:\/\/claude\.ai\/code\/session_\S*[ \t]*(?=\n|$)//gi;
-  # Any residual inline session URL token.
-  s/https?:\/\/claude\.ai\/code\/session_\S+//gi;
-' 2>/dev/null)
+REASON='Blocked (ADR-162): this command publishes a Claude-Session transcript link — a "Claude-Session:" trailer or a claude.ai/code/session_ URL — to git or GitHub. That link resolves to the full session transcript and must not be published. Re-run the command with the trailer/URL removed from the commit message or PR/issue body.'
 
-# Transform failed or was a no-op → allow the original command unchanged.
-[[ -z "$CLEANED" || "$CLEANED" == "$CMD" ]] && exit 0
-
-# Rewrite the command, preserving the rest of tool_input (e.g. description).
-ORIG_INPUT=$(printf '%s' "$INPUT" | jq -c '.tool_input // {}' 2>/dev/null)
-[[ -z "$ORIG_INPUT" ]] && exit 0
-
-jq -cn --argjson orig "$ORIG_INPUT" --arg cmd "$CLEANED" '{
+# Deny via structured output; if jq fails, fall back to exit 2 + stderr (also a
+# block). Either way the link does not land.
+jq -cn --arg reason "$REASON" '{
   hookSpecificOutput: {
     hookEventName: "PreToolUse",
-    permissionDecision: "allow",
-    updatedInput: ($orig + { command: $cmd })
+    permissionDecision: "deny",
+    permissionDecisionReason: $reason
   }
-}' 2>/dev/null || exit 0
+}' 2>/dev/null || { printf '%s\n' "$REASON" >&2; exit 2; }

--- a/hooks/ways/strip-session-link-pre.sh
+++ b/hooks/ways/strip-session-link-pre.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# PreToolUse (Bash): strip the Claude-Session transcript link from commit / PR /
+# issue authoring commands before they run. See ADR-162.
+#
+# The session link resolves to the FULL session transcript; publishing it in a
+# commit trailer or PR/issue body is a thin wall in front of accidental secret
+# disclosure. Claude Code ships no mechanical strip — the `attribution` setting
+# does not reliably reach the model (upstream #18253) and the system prompt keeps
+# instructing the link — so enforcement lives here, at user scope, for every repo.
+#
+# Mechanism: rewrite the command in place via PreToolUse `updatedInput` and allow
+# the cleaned command to proceed. The commit flow is never blocked; the link just
+# never lands. Posture is FAIL-OPEN — on any internal error the original command
+# proceeds unchanged, so a broken hook can never block a legitimate commit.
+
+INPUT=$(cat)
+CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# No command, or not a command that publishes to git/GitHub → nothing to do.
+[[ -z "$CMD" ]] && exit 0
+case "$CMD" in
+  *"git commit"*|*"gh pr create"*|*"gh pr edit"*|*"gh pr comment"* \
+  |*"gh issue create"*|*"gh issue edit"*|*"gh issue comment"*) ;;
+  *) exit 0 ;;
+esac
+
+# Fast path: no session link present.
+printf '%s' "$CMD" | grep -qiE 'claude\.ai/code/session_|Claude-Session:' || exit 0
+
+# Strip, line-wise where possible, then any residual inline token.
+CLEANED=$(printf '%s' "$CMD" | perl -0pe '
+  # A Claude-Session: trailer line (drop the leading newline with it).
+  s/\n[ \t]*Claude-Session:[ \t]*https?:\/\/claude\.ai\/code\/session_\S*[ \t]*(?=\n|$)//gi;
+  # A line that is only a bare session URL.
+  s/\n[ \t]*https?:\/\/claude\.ai\/code\/session_\S*[ \t]*(?=\n|$)//gi;
+  # Any residual inline session URL token.
+  s/https?:\/\/claude\.ai\/code\/session_\S+//gi;
+' 2>/dev/null)
+
+# Transform failed or was a no-op → allow the original command unchanged.
+[[ -z "$CLEANED" || "$CLEANED" == "$CMD" ]] && exit 0
+
+# Rewrite the command, preserving the rest of tool_input (e.g. description).
+ORIG_INPUT=$(printf '%s' "$INPUT" | jq -c '.tool_input // {}' 2>/dev/null)
+[[ -z "$ORIG_INPUT" ]] && exit 0
+
+jq -cn --argjson orig "$ORIG_INPUT" --arg cmd "$CLEANED" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "allow",
+    updatedInput: ($orig + { command: $cmd })
+  }
+}' 2>/dev/null || exit 0

--- a/hooks/ways/strip-session-link-pre.sh
+++ b/hooks/ways/strip-session-link-pre.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# PreToolUse (Bash): deny commit / PR / issue authoring commands that carry the
-# Claude-Session transcript link, instructing a clean re-issue. See ADR-162.
+# PreToolUse (Bash): deny commit / PR / issue authoring commands that carry a
+# Claude-Session transcript link in trailer/footer position. See ADR-162.
 #
 # The session link resolves to the FULL session transcript; publishing it in a
 # commit trailer or PR/issue body is a thin wall in front of accidental secret
@@ -11,32 +11,44 @@
 # Mechanism: DENY, not rewrite. Rewriting in place (PreToolUse `updatedInput`) is
 # honored only when the hook also forces `permissionDecision: allow`, which would
 # bypass the operator's own Deny/Allow/Ask rules on outward-facing gh create/edit
-# commands (no pass-through option — upstream FR #381). Deny bypasses nothing: the
-# model re-issues the command WITHOUT the link, and that clean command goes through
-# normal permission evaluation. Cost is one retry, not a lost commit.
+# commands (no pass-through — upstream FR #381). Deny bypasses nothing: the model
+# re-issues WITHOUT the link and that clean command goes through normal permission
+# evaluation. Cost is one retry, not a lost commit.
 #
-# Fail posture: the no-op paths (no command / out of scope / no link) allow. Once a
-# link IS detected the hook fails CLOSED — on any internal error it still blocks
-# (exit 2) rather than let the link through.
+# Two-part gate, both must hold to deny:
+#   (1) the command PUBLISHES to git/GitHub — matched on token presence, newline-
+#       collapsed, so intervening flags (git -C <path> commit, gh <flags> pr
+#       create) cannot evade the gate; and
+#   (2) a session link sits in TRAILER/FOOTER position — a `Claude-Session:` line
+#       or a bare session URL alone on its line. A URL mentioned INLINE in prose is
+#       not a leak and passes, so this repo can discuss Claude-Session as subject
+#       matter without a deny-loop.
+#
+# Fail posture: no-op paths (no command / not publishing / no trailer) allow. Once
+# a trailer/footer link IS detected the hook fails CLOSED — on jq failure it still
+# blocks (exit 2) rather than let the link through.
 
 INPUT=$(cat)
 CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-
-# No command, or not a command that publishes to git/GitHub → nothing to enforce.
 [[ -z "$CMD" ]] && exit 0
-case "$CMD" in
-  *"git commit"*|*"gh pr create"*|*"gh pr edit"*|*"gh pr comment"* \
-  |*"gh issue create"*|*"gh issue edit"*|*"gh issue comment"*) ;;
-  *) exit 0 ;;
-esac
 
-# No session link present → allow, normal permission flow applies.
-printf '%s' "$CMD" | grep -qiE 'claude\.ai/code/session_|Claude-Session:' || exit 0
+# (1) Publishing command? (flag- and continuation-tolerant)
+printf '%s' "$CMD" | tr '\n' ' ' \
+  | grep -qiE '(\bgit\b.*\bcommit\b|\bgh\b.*\b(pr|issue)\b)' || exit 0
 
-REASON='Blocked (ADR-162): this command publishes a Claude-Session transcript link — a "Claude-Session:" trailer or a claude.ai/code/session_ URL — to git or GitHub. That link resolves to the full session transcript and must not be published. Re-run the command with the trailer/URL removed from the commit message or PR/issue body.'
+# (2) Session link in trailer/footer position? (anchored per line; inline mentions
+#     fall through and are allowed)
+# The URL must be line-LEADING (optionally behind the `Claude-Session:` key) — that
+# is what makes it a footer/trailer rather than an inline mention. After the id we
+# allow only non-alphanumeric terminators to end-of-line (closing "/'/)/} from the
+# `-m "…"` and `--body "…"` forms), so `Claude-Session: <url>"` matches but
+# `see <url> for context` does not.
+printf '%s' "$CMD" \
+  | grep -qiE '^[[:space:]]*(Claude-Session:[[:space:]]*)?https?://claude\.ai/code/session_[A-Za-z0-9_-]+[^A-Za-z0-9]*$' \
+  || exit 0
 
-# Deny via structured output; if jq fails, fall back to exit 2 + stderr (also a
-# block). Either way the link does not land.
+REASON='Blocked (ADR-162): this command publishes a Claude-Session transcript link (a "Claude-Session:" trailer or a bare claude.ai/code/session_ URL on its own line) to git or GitHub. That link resolves to the full session transcript and must not be published. Remove the trailer/footer line from the commit message or PR/issue body and re-run. (A session URL mentioned inline in prose is allowed; only trailer/footer lines are blocked.)'
+
 jq -cn --arg reason "$REASON" '{
   hookSpecificOutput: {
     hookEventName: "PreToolUse",

--- a/settings.json
+++ b/settings.json
@@ -216,6 +216,10 @@
           {
             "type": "command",
             "command": "${HOME}/.claude/hooks/ways/check-bash-pre.sh"
+          },
+          {
+            "type": "command",
+            "command": "${HOME}/.claude/hooks/ways/strip-session-link-pre.sh"
           }
         ]
       },


### PR DESCRIPTION
## Summary

ADR + working hook that stops the `Claude-Session` transcript link from landing in
commits and PR/issue bodies. Motivated by the concern that the link resolves to the
**full session transcript** — a thin wall in front of accidental secret disclosure,
especially on public repos. **Status: ADR-162 Accepted (ratified).**

## Why the old control didn't hold

A prior fix set `attribution.commit/pr=""` and added a report-only macro block.
That never governed the session link:

- `attribution.commit/pr` only suppress the Co-Authored-By / "Generated with"
  footers — never the session link.
- The real key, `attribution.sessionUrl`, is **undocumented** and defeated by
  upstream bug #18253 (attribution settings not reliably injected into model
  context; marked *not planned*). The system-prompt instruction survives and the
  model follows it.
- Claude Code has **no mechanical strip** — prevention is purely "don't instruct,"
  which the bug defeats.

Observed leak: a PR in an unrelated repo with **no local config** still got the
link, inheriting global `attribution=""`.

## What this does

- **ADR-162** (Accepted) — records the decision + rejected alternatives. Scoped to
  the **hook mechanism**; distribution across hosts is ADR-163's concern (paired
  work).
- **`hooks/ways/strip-session-link-pre.sh`** — PreToolUse Bash hook that **denies**
  `git commit` / `gh pr|issue create|edit|comment` when the command carries a
  `Claude-Session:` trailer or bare `session_` URL, instructing a clean re-issue
  that then passes through normal permission evaluation.
- **settings.json** — wires the hook into the reconcile-owned Bash PreToolUse block
  (beside `check-bash-pre.sh`), not the fragment store (which skips hooks slices).

## Key decision: deny, not silent-rewrite

Silent-rewrite via PreToolUse `updatedInput` was the initial choice, but review
found `updatedInput` is honored **only** with `permissionDecision: allow` (no
pass-through — upstream FR #381), which would **bypass the operator's own
Deny/Allow/Ask gates** on outward-facing `gh pr/issue create`. Deny bypasses
nothing; cost is one retry, not a lost commit. Re-ratified to deny by @aaronsb;
review lead concurred.

## Known gap

`--body-file`/`-F <path>` bodies live in a file the hook can't inspect from the
command string — a documented coverage gap (inline/heredoc, the model's default
format, is covered).

## Not done here

- Not merged; `reconcile` not run — no change to live `~/.claude`.

Paired with ADR-163 (config distribution / dotfiles layering), which references this
hook as the distributed primitive.