### PR TITLE
docs(adr): ADR-164 — distribute file artifacts by value, not host-absolute reference

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -84,6 +84,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-161](./system/ADR-161-queued-mid-turn-operator-messages-as-an-aggregated-scan-surface.md) | Queued mid-turn operator messages as an aggregated scan surface | Proposed |
 | [ADR-162](./system/ADR-162-mechanical-session-link-suppression-as-defense-against-transcript-disclosure.md) | Mechanical session-link suppression as defense against transcript disclosure | Accepted |
 | [ADR-163](./system/ADR-163-config-separation-dotfiles-source-of-truth.md) | Config separation — dotfiles as source-of-truth feeding the settings fragment store | Accepted |
+| [ADR-164](./system/ADR-164-file-artifacts-distributed-across-hosts-must-be-carried-by-value-not-host-absolute-reference.md) | File artifacts distributed across hosts must be carried by value not host-absolute reference | Accepted |
 
 ## Governance
 _Provenance, traceability, controls, compliance mapping_

--- a/docs/architecture/system/ADR-164-file-artifacts-distributed-across-hosts-must-be-carried-by-value-not-host-absolute-reference.md
+++ b/docs/architecture/system/ADR-164-file-artifacts-distributed-across-hosts-must-be-carried-by-value-not-host-absolute-reference.md
@@ -1,0 +1,87 @@
+---
+status: Accepted
+date: 2026-07-07
+deciders:
+  - aaronsb
+  - claude
+related:
+  - "[[ADR-163]]"
+  - "[[ADR-147]]"
+  - "[[ADR-142]]"
+---
+
+# ADR-164: File artifacts distributed across hosts must be carried by value not host-absolute reference
+
+## Context
+
+ADR-163 split config artifact ownership: the settings fragment store owns
+settings.json **keys**, and dotfiles owns **file artifacts** and deploys them to
+`~/.claude`. Its validating pilot claimed the `statusline.sh` file artifact was
+"distributed" across hosts.
+
+It was not. The dotfiles-tracked artifact was itself a **symlink whose target was an
+absolute path into a per-host directory** — `/home/<authoring-user>/.local/share/
+agent-ways/statusline.sh`. That link resolved only on the host that authored it. On
+a second host with a different `$HOME` (a different username) the target did not
+exist, so the deployed `~/.claude/statusline.sh` dangled and the status line was
+broken — the very cross-host drift ADR-163 set out to end, reintroduced one layer
+down. The keys half of the pipeline never had this problem: the fragment store holds
+real YAML, so it already travelled by value.
+
+The failure mode generalizes beyond statusline: any artifact distributed **by
+reference**, where the reference encodes a host-local absolute path (a `$HOME`, an
+app dir, a cache dir, a username), silently fails to reproduce on a host whose layout
+differs.
+
+## Decision
+
+**A file artifact carried through the config pipeline is distributed by value — its
+content — never by a reference that encodes a host-local absolute path.**
+
+Concretely, the dotfiles-tracked artifact is the **real file**. `dotfiles deploy`
+then symlinks `~/.claude/<artifact>` to that dotfiles copy — a link whose target is
+host-relative under `$HOME`, so it resolves identically regardless of username or
+where the application happens to be installed. No artifact anywhere in the pipeline
+may be a symlink whose target is an absolute path into a per-host application, cache,
+or home directory.
+
+Corollary: dotfiles is the source of truth for a managed artifact's content
+(consistent with ADR-163) — which also lets the operator customize it. Managing an
+app-shipped default in dotfiles means dotfiles wins; the artifact is no longer an
+alias of the app's copy.
+
+## Consequences
+
+### Positive
+
+- Distributed artifacts reproduce on any host regardless of username or install
+  layout; ADR-163's cross-host distribution claim actually holds.
+- Operators can customize a managed artifact, because dotfiles owns its content
+  rather than pointing at an app-shipped file.
+
+### Negative
+
+- App updates to a shipped default (e.g. a new `statusline.sh`) no longer flow
+  automatically to a host that manages it via dotfiles — the operator re-syncs the
+  content when they want the newer default. A by-value file is opaque to which app
+  version produced it.
+
+### Neutral
+
+- This brings file artifacts to parity with the keys half of the pipeline, which was
+  already by-value (the fragment store holds real YAML).
+- A future "file-artifact projection built into agent-ways" (ADR-163 Alternatives,
+  deferred) would supersede the dotfiles-owns-files mechanism, but must honour this
+  same by-value principle — it too cannot distribute a host-absolute reference.
+
+## Alternatives Considered
+
+- **Relative symlink into the app dir** (e.g. `../../.local/share/agent-ways/
+  statusline.sh`). Rejected: still by-reference. It aliases the app's copy rather
+  than owning content, so the application stays the true owner (contra ADR-163); it
+  breaks if the dotfiles store or the app dir moves relative to `$HOME`; and it
+  cannot carry operator customization.
+- **A symlink target with `$HOME`/env expansion.** Rejected: a symlink stores literal
+  bytes; the OS does not expand environment variables in a link target.
+- **Leave the artifact host-absolute and re-author it per host.** Rejected: that is
+  exactly the silent cross-host drift ADR-163 set out to end.


### PR DESCRIPTION
## Summary

ADR-163 split config-artifact ownership (fragment store owns settings **keys**;
dotfiles owns **file artifacts**) and claimed its `statusline.sh` pilot was
distributed across hosts. Auditing the pipeline across three hosts (north/aaron,
slab/bockeliea, cube/aaron) showed it wasn't: the dotfiles-tracked `statusline.sh`
was a **symlink whose target baked the authoring host's absolute `$HOME`** —
`/home/aaron/.local/share/agent-ways/statusline.sh` — so it dangled on any host
with a different username, and the status line was broken there. That's the exact
cross-host drift ADR-163 set out to end, reintroduced one layer down.

ADR-164 records the durable principle: **a file artifact in the config pipeline is
carried by value (its real content), never by a reference that encodes a host-local
absolute path.** dotfiles owns the content; `dotfiles deploy` symlinks
`~/.claude/<artifact>` to that host-relative copy.

## Validation

The fix is already live and proven:
- north's dotfiles `claude/statusline.sh` converted symlink → real file (pushed).
- slab and cube pulled the portable version, deployed, and projected the `statusLine`
  key; the status line now runs on all three hosts.

## Status

Accepted — documents an already-implemented, validated decision.