### PR TITLE
fix(corpus): calibration silently no-ops on projection installs

### DIFF
--- a/tools/ways-cli/src/cmd/corpus.rs
+++ b/tools/ways-cli/src/cmd/corpus.rs
@@ -458,6 +458,20 @@ fn scan_ways_dir(
     Ok(count)
 }
 
+/// Resolve the `way-embed` binary: prefer the engine dir, then the projected
+/// `~/.claude/bin`. `auto_embed` and `fit_calibration` both need it and must
+/// resolve it identically — on a projection install the binary lives in
+/// `~/.claude/bin`, not the engine/cache dir, so a resolver that only checks the
+/// engine dir silently no-ops (this is how per-model calibration went missing).
+fn resolve_embed_bin(engine_dir: &Path) -> Option<PathBuf> {
+    [
+        engine_dir.join("way-embed"),
+        home_dir().join(".claude/bin/way-embed"),
+    ]
+    .into_iter()
+    .find(|p| p.is_file())
+}
+
 /// Shell out to way-embed generate for embedding vectors.
 /// Generates two corpus files: one with EN model embeddings, one with multilingual.
 ///
@@ -465,14 +479,7 @@ fn scan_ways_dir(
 /// cache) supplies the way-embed binary and GGUF models. The two differ only
 /// when `ways corpus --output <dir>` redirects an isolated build.
 fn auto_embed(out_dir: &Path, engine_dir: &Path, corpus: &Path, log: &dyn Fn(&str)) -> Result<()> {
-    let embed_bin = [
-        engine_dir.join("way-embed"),
-        home_dir().join(".claude/bin/way-embed"),
-    ]
-    .into_iter()
-    .find(|p| p.is_file());
-
-    let bin = match embed_bin {
+    let bin = match resolve_embed_bin(engine_dir) {
         Some(b) => b,
         None => {
             log(&format!(
@@ -765,10 +772,10 @@ fn fit_calibration(
     const PROBES: &str = include_str!("calibration_probes.jsonl");
     const AUC_FLOOR: f64 = 0.70;
 
-    let bin = engine_dir.join("way-embed");
-    if !bin.is_file() {
-        return Calibration::default();
-    }
+    let bin = match resolve_embed_bin(engine_dir) {
+        Some(b) => b,
+        None => return Calibration::default(),
+    };
 
     let aliases = match load_aliases(&out_dir.join("ways-corpus-en.jsonl")) {
         Some(m) if !m.is_empty() => m,


### PR DESCRIPTION
## Problem

`ways corpus` never generated ADR-156 per-model calibration on any projection install — `ways status` showed **Calibration: MISSING — semantic lane disabled (keyword-only)** on every host, silently, with no log line explaining why. Semantic *firing* was degraded to the keyword lane everywhere.

## Root cause

Two functions in `corpus.rs` resolve the `way-embed` binary, and they drifted:

- `auto_embed` tries `engine_dir/way-embed` **then falls back** to `~/.claude/bin/way-embed`.
- `fit_calibration` checked **only** `engine_dir/way-embed`, then `return Calibration::default()` on miss — no log.

On a projection install (ADR-142) `way-embed` lives in `~/.claude/bin/` (symlinked into `$XDG_DATA`), **not** in the engine/cache dir where the `.gguf` models sit. So `auto_embed` succeeded (embeddings generated) but `fit_calibration` bailed silently → empty `"calibration": {}` in the manifest → keyword-only firing.

## Fix

Extract the resolution into one `resolve_embed_bin()` helper used by both call sites, so they can't diverge again (the divergence *was* the bug).

## Verification

Before: `ways corpus` emits no calibration line; `"calibration": {}`.
After (rebuilt binary): 

```
calibration[en]:   a=19.02 b=-6.05 AUC=0.941 (n=134)
calibration[multi]: a=17.39 b=-6.30 AUC=0.943 (n=134)
Calibration: EN AUC 0.941, multi AUC 0.943
```

Both lanes well above the 0.70 AUC floor. `cargo clippy` clean, `cargo test -p ways` 15/15 pass.