### PR TITLE
fix(migrate): compare owned files, not raw counts, in what_if_mutates_nothing

### DIFF
--- a/tools/ways-cli/src/cmd/migrate_exec.rs
+++ b/tools/ways-cli/src/cmd/migrate_exec.rs
@@ -612,17 +612,32 @@ mod tests {
         c
     }
 
+    /// The set of files under `root` that the user's tree actually owns —
+    /// Spotlight's `.DS_Store` and friends excluded. `phase_backup` already
+    /// compares by this set rather than a raw count; the reason is the same here.
+    fn owned_files(root: &Path) -> std::collections::BTreeSet<String> {
+        relative_files(root)
+            .into_iter()
+            .filter(|p| !is_os_transient(p))
+            .collect()
+    }
+
     #[test]
     fn what_if_mutates_nothing() {
         let base = sandbox("whatif");
         let dest = base.join(".claude");
         fake_clone(&dest);
-        let before = count_files(&dest);
+        // Compare by set, not by count: on macOS, Spotlight can drop a `.DS_Store`
+        // into the tree between the two observations, which fails a raw count
+        // equality with a useless `43 != 44` and says nothing about what moved.
+        // A set diff names the offending path instead. Same `is_os_transient`
+        // exemption `phase_backup` carries, for the same reason.
+        let before = owned_files(&dest);
         let ctx = ctx_for(&dest, true, &base);
         for f in [phase_backup, phase_relocate, phase_lift_state, phase_lift_user, phase_projection, phase_cache, phase_bootstrap] {
             f(&ctx).unwrap();
         }
-        assert_eq!(count_files(&dest), before, "what-if must not change the tree");
+        assert_eq!(owned_files(&dest), before, "what-if must not change the tree");
         assert!(!ctx.data.exists(), "what-if must not create $XDG_DATA");
         let _ = std::fs::remove_dir_all(&base);
     }


### PR DESCRIPTION
## Summary

`cmd::migrate_exec::tests::what_if_mutates_nothing` fails intermittently on macOS with `assertion left == right failed: what-if must not change the tree / left: 43 / right: 44`.

This is a **known, already-diagnosed flake** — just never fixed in this one place. `phase_backup` carries the diagnosis in a comment:

> Compare by set, not raw count: macOS Spotlight can drop a `.DS_Store` into a directory between the pre-count and the copy, and such OS-transients aren't part of the user's tree — counting them made the backup fail spuriously on macOS only (**the `43/44` flake**). If a real file is ever missing, it's named.

`phase_backup` was hardened with a set diff plus an `is_os_transient` exemption. `what_if_mutates_nothing` still does `assert_eq!(count_files(&dest), before)`, so the identical Spotlight write still fails it — with the identical `43/44`, and with no indication of *which* path appeared.

This applies the same treatment: compare the set of **owned** files (transients filtered out) before and after. A genuine `what-if` mutation now names the offending path rather than printing two integers.

## Why now

Surfaced while landing #354 (`ways corpus --verbose`), whose macOS CI leg went red on this test. #354 touches only `corpus.rs`, `main.rs`, and a docs page — nothing that could reach `migrate_exec`. Confirmed it's not that PR:

- `main` @ portability, dispatched fresh: macOS **passes**
- #354 commit 1: macOS **passes**
- #354 commit 2 (a 6-line stderr change in `corpus.rs`): macOS **fails**, twice

Nondeterministic, macOS-only, and independent of the diff — consistent with Spotlight timing on the runner. Fixing it here, on `main`, rather than smuggling it into the diagnostics PR.

## Test plan

- `cargo test -p ways -- --test-threads=1` — 346 pass, 0 fail
- `cargo clippy -p ways --all-targets` — no new warnings (`count_files` still used by `phase_backup`, so no dead-code)
- Cross-platform CI on this branch is the real check: the macOS leg is the one that matters