### PR TITLE
fix(install): ask for darwin-arm64, not darwin-aarch64, on Apple Silicon

### DIFF
--- a/tools/attend-chat/download-attend-chat.sh
+++ b/tools/attend-chat/download-attend-chat.sh
@@ -15,10 +15,8 @@ set -euo pipefail
 # degrade `ways update` to a from-source build.
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" && pwd)/prebuilt-lib.sh"
 
-# Platform detection
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-ARCH=$(uname -m | sed 's/arm64/aarch64/')
-PLATFORM="${OS}-${ARCH}"
+# Platform detection — see detect_platform() in ../scripts/prebuilt-lib.sh
+PLATFORM="$(detect_platform)"
 
 GH_REPO="aaronsb/agent-ways"
 RELEASE_TAG="${ATTEND_CHAT_RELEASE:-latest}"

--- a/tools/attend/download-attend.sh
+++ b/tools/attend/download-attend.sh
@@ -15,10 +15,8 @@ set -euo pipefail
 # degrade `ways update` to a from-source build.
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" && pwd)/prebuilt-lib.sh"
 
-# Platform detection
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-ARCH=$(uname -m | sed 's/arm64/aarch64/')
-PLATFORM="${OS}-${ARCH}"
+# Platform detection — see detect_platform() in ../scripts/prebuilt-lib.sh
+PLATFORM="$(detect_platform)"
 
 GH_REPO="aaronsb/agent-ways"
 RELEASE_TAG="${ATTEND_RELEASE:-latest}"

--- a/tools/scripts/prebuilt-lib.sh
+++ b/tools/scripts/prebuilt-lib.sh
@@ -14,6 +14,31 @@
 # Run a command, retrying on failure with exponential backoff. Returns the
 # command's own exit status once it succeeds, or non-zero after the last try.
 # Progress notes go to stderr so callers can capture stdout cleanly.
+# Echo the platform slug used in release asset names (`<component>-<platform>`),
+# e.g. `ways-darwin-arm64`.
+#
+# ARM64 has two spellings for one architecture, and `uname -m` reports whichever
+# the kernel prefers: `arm64` on Darwin, `aarch64` on Linux. The release assets
+# follow the same split — `darwin-arm64` but `linux-aarch64`. So the mapping is
+# per-OS, not global: a blanket `arm64`→`aarch64` rewrite asks for
+# `darwin-aarch64`, an asset that has never been published, and every Apple
+# Silicon download 404s into a silent from-source build.
+detect_platform() {
+  local os arch
+  os=$(uname -s | tr '[:upper:]' '[:lower:]')
+  arch=$(uname -m)
+  case "$arch" in
+    x86_64 | amd64) arch=x86_64 ;;
+    arm64 | aarch64)
+      case "$os" in
+        darwin) arch=arm64 ;;
+        *) arch=aarch64 ;;
+      esac
+      ;;
+  esac
+  printf '%s-%s\n' "$os" "$arch"
+}
+
 retry() {
   local n=1 max="${RETRY_MAX:-3}" delay="${RETRY_DELAY:-2}"
   while true; do

--- a/tools/ways-audit/download-ways-audit.sh
+++ b/tools/ways-audit/download-ways-audit.sh
@@ -15,10 +15,8 @@ set -euo pipefail
 # degrade `ways update` to a from-source build.
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" && pwd)/prebuilt-lib.sh"
 
-# Platform detection
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-ARCH=$(uname -m | sed 's/arm64/aarch64/')
-PLATFORM="${OS}-${ARCH}"
+# Platform detection — see detect_platform() in ../scripts/prebuilt-lib.sh
+PLATFORM="$(detect_platform)"
 
 GH_REPO="aaronsb/agent-ways"
 RELEASE_TAG="${WAYS_AUDIT_RELEASE:-latest}"

--- a/tools/ways-cli/download-ways.sh
+++ b/tools/ways-cli/download-ways.sh
@@ -15,10 +15,8 @@ set -euo pipefail
 # degrade `ways update` to a from-source build.
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" && pwd)/prebuilt-lib.sh"
 
-# Platform detection
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-ARCH=$(uname -m | sed 's/arm64/aarch64/')
-PLATFORM="${OS}-${ARCH}"
+# Platform detection — see detect_platform() in ../scripts/prebuilt-lib.sh
+PLATFORM="$(detect_platform)"
 
 GH_REPO="aaronsb/agent-ways"
 RELEASE_TAG="${WAYS_RELEASE:-latest}"


### PR DESCRIPTION
## Summary

Every Apple Silicon install has been silently building from source instead of using our published binaries.

`uname -m` reports `arm64` on Darwin and `aarch64` on Linux — two spellings, one architecture. Our release assets follow the same split: we publish **`darwin-arm64`** but **`linux-aarch64`**.

Four downloaders normalized with a blanket rewrite:

```sh
ARCH=$(uname -m | sed 's/arm64/aarch64/')
```

On Linux that's a no-op (`uname -m` already says `aarch64`). The **only** platform it changes is macOS, and there it produces `darwin-aarch64` — an asset that has never been published. Each script then prints `Available: ... darwin-arm64` in its own `--help`, one screen below the line that mangled it.

Affected: `download-ways.sh`, `download-attend.sh`, `download-attend-chat.sh`, `download-ways-audit.sh`.
Not affected: `way-embed/download-binary.sh`, which never applied the sed — which is precisely why `way-embed` is the one component that successfully fetches a prebuilt on macOS.

## Why it stayed hidden

The 404 isn't loud. `make setup` treats a failed prebuilt download as "no binary available" and falls back to a from-source build. That's the same silent degradation `prebuilt-lib.sh` was created to eliminate — its header says so:

> a transient GitHub API / network blip ... was swallowed, so an empty result read as "no release" and `ways update` silently degraded to a from-source build

It was hardened against the *transient* cause. This one fails 100% of the time on Apple Silicon, and produced a working install anyway, so nobody chased it.

## Change

Platform detection moves into `prebuilt-lib.sh` — already sourced by all four scripts — as `detect_platform()`, mapping per-OS to the spelling each release actually publishes.

## Test plan

- `detect_platform()` unit-checked against a shadowed `uname` for all six host combinations:
  `Darwin/arm64 → darwin-arm64`, `Darwin/x86_64 → darwin-x86_64`, `Linux/aarch64 → linux-aarch64`, `Linux/x86_64 → linux-x86_64`, plus the inverted spellings `Linux/arm64 → linux-aarch64` and `Darwin/aarch64 → darwin-arm64`. All pass.
- Cross-checked all **16** component x platform slugs against the assets GitHub actually publishes (`ways`, `attend`, `attend-chat`, `ways-audit` x 4 platforms) — every one resolves to a real asset.
- `bash -n` on all five scripts; each downloader's `--help` still reports a platform.
- `scripts/check-portability.sh` passes.

## Safety

If a downloaded binary won't execute, `download-ways.sh` runs `--version`, deletes it, and exits 1 — so `make setup` falls back to the source build. Fixing the slug cannot strand anyone with a binary that doesn't run on their machine.

## Not in scope

Surfaced while debugging a macOS report where `way-embed` is killed with `signal: 9 (SIGKILL)` on a CrowdStrike-managed laptop — killed even when built from source, so it is not a provenance/signature issue. Tracked separately. This PR only fixes the slug.