### PR TITLE
Repair way-embed SIGKILL (Code Signature Invalid) after in-place upgrade

### DIFF
--- a/docs/explanation/troubleshooting-embedding-engine.md
+++ b/docs/explanation/troubleshooting-embedding-engine.md
@@ -1,0 +1,83 @@
+# Troubleshooting: embedding engine "NOT functional" (way-embed SIGKILL)
+
+## Symptom
+
+SessionStart prints:
+
+```
+⚠  Embedding engine is NOT functional — semantic way matching is OFF.
+WARNING: EN embedding generation failed (signal: 9 (SIGKILL))
+```
+
+Ways still fire on explicit `pattern:` / `commands:` / `files:` triggers, but
+meaning-based (semantic) matching is off, so ways over- and under-fire.
+
+Running the embedder directly confirms it: **any** invocation of `way-embed` —
+even `--version` — exits `137` with no output.
+
+```console
+$ bin/way-embed --version
+$ echo $?
+137            # 128 + 9 = killed by SIGKILL
+```
+
+## Root cause
+
+This is **not** a broken binary and **not** an out-of-memory kill. The
+authoritative reason is in the crash report:
+
+```console
+$ ls -t ~/Library/Logs/DiagnosticReports/way-embed-*.ips | head -1 | xargs grep -o '"signal":"[^"]*"'
+"signal":"SIGKILL (Code Signature Invalid)"
+```
+
+macOS kills the process at `exec`, *before* dyld loads a single library
+(`usedImages` in the report lists only `dyld`), so linked libraries such as
+Homebrew's OpenSSL are a red herring.
+
+The binary is validly ad-hoc (linker-)signed — `codesign --verify` passes
+"valid on disk". The mismatch is in the kernel: macOS 26's Code Signing Monitor
+(`codeSigningMonitor: 2` in the report) holds a **cached cdhash for the file's
+inode**, and after an in-place replace — a version upgrade that `cp`s a new
+`way-embed` over the existing path — that cache no longer matches the file
+content. Userspace `codesign` recomputes from disk and passes; the kernel
+compares against the stale cache and kills the launch.
+
+A quick way to confirm it is a cache issue and not the file: copy the binary to
+a fresh inode and it launches fine.
+
+```console
+$ cp bin/way-embed /tmp/we && /tmp/we --version
+way-embed 0.1.0
+```
+
+## Fix
+
+Re-sign the binary in place. That rewrites the signature (and the file), which
+invalidates the stale cache so the next `exec` re-evaluates cleanly. **No
+rebuild is needed** — `make setup` would work but is unnecessary and slow, and
+requires the C++ toolchain.
+
+```console
+$ scripts/fix-way-embed-signature.sh
+```
+
+The script re-signs every `way-embed` binary in `bin/`, verifies the invoked
+one now launches, and regenerates the corpus so semantic matching is live. Then
+start a new Claude Code session to pick up the repaired engine.
+
+Manual equivalent:
+
+```console
+$ codesign --force --sign - bin/way-embed
+$ codesign --force --sign - bin/way-embed-darwin-arm64
+$ bin/ways corpus
+```
+
+## Why the build doesn't hit this
+
+`make setup` builds `way-embed` and `cp`s it into place while it is *not* mapped
+by a running process, so the kernel caches the fresh cdhash on first launch. The
+stale-cache case only arises when a new binary replaces one whose old cdhash the
+kernel already cached for that path — i.e. an update over a previously-run
+install.

--- a/scripts/fix-way-embed-signature.sh
+++ b/scripts/fix-way-embed-signature.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Repair a way-embed binary that macOS kills at launch with
+# "SIGKILL (Code Signature Invalid)".
+#
+# Symptom: SessionStart reports "Embedding engine is NOT functional" and
+# `ways corpus` prints `... failed (signal: 9 (SIGKILL))`. Any invocation of
+# way-embed — even `--version` — exits 137 with no output, because the kernel
+# rejects the binary at exec before dyld loads a single library.
+#
+# Root cause: the checked-in binary is validly ad-hoc (linker-)signed, and
+# `codesign --verify` passes on disk. But after an in-place replace (a version
+# upgrade `cp`-ing a new binary over the old path), macOS's Code Signing Monitor
+# can hold a stale cached cdhash for that inode that no longer matches the file
+# content, and kills the process at launch. See
+#   docs/explanation/troubleshooting-embedding-engine.md
+#
+# Fix: re-sign the binary in place. That rewrites the signature (and the file),
+# which invalidates the stale cache and lets the next exec re-evaluate cleanly.
+# No rebuild is needed — the binary content was never the problem. Then
+# regenerate the corpus so semantic matching comes back on.
+#
+# macOS only — codesign and this failure mode do not exist elsewhere. On other
+# platforms the script is a no-op and exits 0.
+#
+# Exit code: 0 = repaired (or not applicable), 1 = re-signed but still failing.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || exit 2
+
+if [ "$(uname -s)" != "Darwin" ]; then
+    echo "Not macOS — the code-signing SIGKILL does not apply here. Nothing to do."
+    exit 0
+fi
+
+if ! command -v codesign >/dev/null 2>&1; then
+    echo "ERROR: codesign not found (expected on macOS)." >&2
+    exit 2
+fi
+
+# Re-sign every way-embed binary present in bin/ (the invoked `way-embed` plus
+# the platform-tagged copy `make setup` produces). Globbing keeps this correct
+# if the platform tag ever changes (e.g. darwin-x86_64).
+shopt -s nullglob
+signed=0
+for bin in bin/way-embed bin/way-embed-*; do
+    [ -f "$bin" ] || continue
+    echo "Re-signing $bin ..."
+    codesign --force --sign - "$bin"
+    signed=$((signed + 1))
+done
+
+if [ "$signed" -eq 0 ]; then
+    echo "No way-embed binary found in bin/ — run 'make setup' first." >&2
+    exit 2
+fi
+
+# Verify the invoked binary now launches (the exec that was being SIGKILL'd).
+echo "Verifying bin/way-embed launches ..."
+if ! bin/way-embed --version >/dev/null 2>&1; then
+    echo "ERROR: bin/way-embed still fails to launch after re-signing." >&2
+    echo "  Inspect the crash report for the real reason:" >&2
+    echo "    ls -t ~/Library/Logs/DiagnosticReports/way-embed-*.ips | head -1" >&2
+    exit 1
+fi
+echo "  ok: $(bin/way-embed --version)"
+
+# Regenerate the corpus with embeddings so semantic matching is live again.
+echo "Regenerating corpus ..."
+bin/ways corpus
+
+echo ""
+echo "Done. Start a new Claude Code session to pick up the repaired engine."


### PR DESCRIPTION
## Problem

On macOS, `way-embed` is killed at launch with **SIGKILL (Code Signature Invalid)** — every invocation (even `--version`) exits 137 with no output, and SessionStart reports the embedding engine as *NOT functional* (semantic way matching off, only coarse pattern/file triggers fire).

It presents as a mysterious signal-9 because:
- `codesign --verify` **passes** on disk ("valid on disk").
- The kill happens at `exec`, before dyld loads any dylib (the crash report's `usedImages` lists only `dyld`), so linked libraries like Homebrew OpenSSL are a red herring.

## Root cause

The binary is validly ad-hoc (linker-)signed, but after an **in-place upgrade** `cp`s a new `way-embed` over the existing path, macOS 26's Code Signing Monitor holds a **stale cached cdhash for that inode** that no longer matches the file content. Userspace `codesign` recomputes from disk (passes); the kernel compares against the stale cache and kills the launch.

Authoritative evidence from `~/Library/Logs/DiagnosticReports/way-embed-*.ips`:
```
"signal":"SIGKILL (Code Signature Invalid)"
"codeSigningMonitor": 2
```
Confirmed a cache (not content) issue: copying the binary to a fresh inode launches fine.

## Fix

Re-sign the binary in place — that rewrites the file and clears the stale cache. **No rebuild needed.**

- `scripts/fix-way-embed-signature.sh` — macOS-guarded repair script: re-signs every `bin/way-embed*`, verifies the invoked binary launches, and regenerates the corpus so semantic matching returns. No-op with exit 0 off macOS.
- `docs/explanation/troubleshooting-embedding-engine.md` — symptom → root-cause evidence → fix, pointing at the script; also explains why a clean `make setup` build doesn't hit this.

## Verification

Ran the script end-to-end: both binaries re-signed, `way-embed --version` → exit 0, corpus regenerated (141 ways, 384-dim, calibration AUC 0.94), no SIGKILL. A live match query (`"create a pull request and merge it"`) correctly ranks `softwaredev/delivery/github` top.

## Notes

- No git-tracked binaries change (`bin/` is gitignored); this adds a script + doc only.
- Optional follow-up worth considering: fold an auto-re-sign step into `make setup`/`ways update` so upgrades self-heal.