### PR TITLE
fix: drop dead Write(~/.claude/**) permission rule

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -10,7 +10,6 @@
     "allow": [
       "Edit(~/.claude/**)",
       "Read",
-      "Write(~/.claude/**)",
       "Bash(~/.claude/hooks/ways/list-triggered.sh:*)",
       "Bash(cat:*)",
       "Bash(head:*)",


### PR DESCRIPTION
## Summary
- `Write(~/.claude/**)` in the allow list is dead — Claude Code's permission engine only checks `Edit(path)` rules for file-writing tools, and `Edit(~/.claude/**)` on the line above already covers Write/Edit/NotebookEdit.
- The stray rule surfaced as a startup warning on every `claude` launch. Removing it silences the warning with no change in effective permissions.

## Test plan
- `python3 -m json.tool settings.json` passes (valid JSON).
- Next `claude` start no longer prints the `Write(~/.claude/**) is not matched by file permission checks` warning.