### PR TITLE
ADR-167: sessionUrl governs the session-link trailer (supersedes ADR-162)

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -82,10 +82,11 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-159](./system/ADR-159-remove-ways-tune-curves-and-the-legacy-curve-cadence-field.md) | Remove ways tune-curves and the legacy curve: cadence field | Accepted |
 | [ADR-160](./system/ADR-160-chunked-late-interaction-matching-with-softmax-share-gating-for-way-selection.md) | Chunked late-interaction matching with softmax-share gating for way selection | Accepted |
 | [ADR-161](./system/ADR-161-queued-mid-turn-operator-messages-as-an-aggregated-scan-surface.md) | Queued mid-turn operator messages as an aggregated scan surface | Proposed |
-| [ADR-162](./system/ADR-162-mechanical-session-link-suppression-as-defense-against-transcript-disclosure.md) | Mechanical session-link suppression as defense against transcript disclosure | Accepted |
+| [ADR-162](./system/ADR-162-mechanical-session-link-suppression-as-defense-against-transcript-disclosure.md) | Mechanical session-link suppression as defense against transcript disclosure | Superseded |
 | [ADR-163](./system/ADR-163-config-separation-dotfiles-source-of-truth.md) | Config separation — dotfiles as source-of-truth feeding the settings fragment store | Accepted |
 | [ADR-164](./system/ADR-164-file-artifacts-distributed-across-hosts-must-be-carried-by-value-not-host-absolute-reference.md) | File artifacts distributed across hosts must be carried by value not host-absolute reference | Accepted |
 | [ADR-165](./system/ADR-165-loop-control-bookends-start-develop-merge-release-wrap.md) | Loop-control bookends: start, develop, merge, release, wrap | Accepted |
+| [ADR-167](./system/ADR-167-session-link-suppression-attribution-sessionurl-as-primary-control-deny-hook-as-backstop.md) | Session-link suppression: attribution.sessionUrl as primary control, deny hook as backstop | Accepted |
 
 ## Governance
 _Provenance, traceability, controls, compliance mapping_

--- a/docs/architecture/system/ADR-162-mechanical-session-link-suppression-as-defense-against-transcript-disclosure.md
+++ b/docs/architecture/system/ADR-162-mechanical-session-link-suppression-as-defense-against-transcript-disclosure.md
@@ -1,15 +1,39 @@
 ---
-status: Accepted
+status: Superseded
 date: 2026-07-06
+revised: 2026-07-16
 deciders:
   - aaronsb
   - claude
 related:
   - 152
   - 163
+  - 167
+superseded_by: ADR-167
 ---
 
 # ADR-162: Mechanical session-link suppression as defense against transcript disclosure
+
+## Status: Superseded by ADR-167
+
+**Superseded 2026-07-16.** The threat model below is correct and load-bearing: the
+session link resolves to the full transcript, and publishing it on a public repo is an
+accidental-disclosure surface. The **hook** this ADR designed also survives unchanged —
+deny rather than rewrite, at user scope, trailer/footer position only. Its *rationale*
+does not.
+
+This ADR's central claim — that no setting can govern the link, so suppression must be
+mechanical — was **false when written**. It rests on a mis-citation: `#18253` is the
+Co-Authored-By/footer bug ([CLOSED/COMPLETED]), not the session link; the issue meant
+was `#41873` ([CLOSED/NOT_PLANNED]). And `#41873` had already been superseded by
+`attribution.sessionUrl`, shipped in **v2.1.183 (2026-06-19)** — seventeen days before
+this ADR was dated. A controlled experiment on 2026-07-16 (same repo, same v2.1.212,
+only the key differing) confirms the setting governs the trailer.
+
+[[ADR-167]] carries the corrected decision: `attribution.sessionUrl: false` is the
+primary control, and the hook below is retained as a **backstop** rather than the sole
+defense. Read this ADR for the threat model and the hook's design; read ADR-167 for
+what actually defends against it.
 
 ## Context
 

--- a/docs/architecture/system/ADR-163-config-separation-dotfiles-source-of-truth.md
+++ b/docs/architecture/system/ADR-163-config-separation-dotfiles-source-of-truth.md
@@ -33,10 +33,12 @@ surfaced silent drift that no CI catches:
   credentials was present on north, **absent on slab** — a security drift.
 - Session-link (`Claude-Session:`) suppression worked on north **only because a per-host
   `~/.claude` memory told the agent to disobey the harness prompt** — slab lacked the
-  memory and leaked the URL into commits/PRs. (ADR-162 establishes why: the
-  `attribution.sessionUrl` config key is broken upstream, so a mechanical hook that
-  denies the publishing command is the real fix. *Distributing* that fix is this ADR's
-  concern.)
+  memory and leaked the URL into commits/PRs. (This ADR originally recorded ADR-162's
+  reason: that `attribution.sessionUrl` was *broken upstream*, leaving a mechanical deny
+  hook as the real fix. That premise was false — [[ADR-167]] proves the key governs the
+  link and supersedes ADR-162. The observation above is unaffected: the control, whatever
+  it is, only defends the hosts it reaches. *Distributing* it is this ADR's concern, and
+  the drift is the point.)
 
 Separately, the framework repo was **force-claiming a user-scoped key**: `statusLine` sat
 inert in the repo-tracked `settings.json` (reconcile co-owns only `hooks` +

--- a/docs/architecture/system/ADR-167-session-link-suppression-attribution-sessionurl-as-primary-control-deny-hook-as-backstop.md
+++ b/docs/architecture/system/ADR-167-session-link-suppression-attribution-sessionurl-as-primary-control-deny-hook-as-backstop.md
@@ -5,6 +5,7 @@ deciders:
   - aaronsb
   - claude
 related:
+  - "[[ADR-104]]"
   - "[[ADR-147]]"
   - "[[ADR-162]]"
   - "[[ADR-163]]"
@@ -35,7 +36,7 @@ That conclusion was false when written, and it rested on two errors.
 — Co-Authored-By and PR footer added despite empty attribution config"
 ([CLOSED/COMPLETED]) — and concerns the **footers**, never the session link. The issue
 it meant is `#41873`, "attribution setting does not control session URL in commit
-messages" ([CLOSED/NOT_PLANNED], April 2026).
+messages" (filed April 2026, [CLOSED/NOT_PLANNED] 2026-05-22).
 
 **A superseded fact.** `#41873` was closed not-planned, and then upstream shipped the
 control anyway. Claude Code **v2.1.183** (2026-06-19) added `attribution.sessionUrl`:
@@ -69,7 +70,7 @@ no repository, therefore no commit instructions). Only the controlled pair is ev
 
 ### How the error persisted
 
-The mis-citation propagated into four artifacts, each of which made the next look
+The mis-citation propagated into five artifacts, each of which made the next look
 corroborated:
 
 1. **ADR-162** — the original wrong citation.
@@ -77,13 +78,23 @@ corroborated:
    setting does not reliably reach the model (upstream #18253)".
 3. **The operator's memory entry** — repeats "attribution setting doesn't govern it
    (#18253)".
-4. **The `softwaredev/delivery/github` macro** — reports `Session-link trailer: OFF`
+4. **[[ADR-163]]** — records the premise second-hand: "the `attribution.sessionUrl`
+   config key is broken upstream, so a mechanical hook that denies the publishing
+   command is the real fix". Its own decision does not rest on this, but an Accepted
+   ADR restating the claim lends it the weight of a second source.
+5. **The `softwaredev/delivery/github` macro** — reports `Session-link trailer: OFF`
    from `attribution.commit`/`.pr` alone, having never read `sessionUrl`.
 
 The macro is the sharp end. It rendered the wrong fact as a reassuring green light in
 every session, including sessions whose system prompt carried the trailer. In the
 control run above, the session had to reason around its own status line contradicting
 its system prompt.
+
+The count itself makes the point. This ADR's first draft listed **four** carriers and
+missed ADR-163 — a document it cites approvingly in its own Decision and lists in
+`related:`. A reviewer found it. An argument about how unchecked claims propagate is
+exactly the argument whose own citations go unchecked, and being the one making it
+confers no immunity.
 
 The lesson generalizes past this key: ADR-162 froze a **contingent upstream fact** as
 though it were a durable architectural truth. Upstream behavior is evidence with a
@@ -105,20 +116,32 @@ outward-facing `gh` commands), user scope rather than per-project, trailer/foote
 position only so inline prose mentions pass. What changes is its standing: it is no
 longer the sole defense.
 
-It is retained because the primary control is weaker than it looks:
+It is retained for two reasons, and two only:
 
 - **Undocumented** — absent from the official settings docs (`#69614`), so it cannot be
-  rediscovered from primary sources and may change without notice.
-- **Default-on** — a host that never receives the fragment leaks by default.
-- **Scope-qualified upstream** — the changelog scopes it to "web and Remote Control
-  sessions". This operator runs `remoteControlAtStartup: true`, which is the likely
-  reason the link reached commits at all; the boundary for other session types is not
-  characterized.
+  rediscovered from primary sources and may change without notice. A key we found by
+  reading a changelog is a key upstream never promised us.
+- **Default-on, and delivered by an independent path** — a host that never receives the
+  fragment leaks by default. This bites only because hook and fragment travel
+  *separately*: the hook rides reconcile-owned `hooks`, the fragment rides dotfiles →
+  fragment store → project. Were they one pipeline, the backstop would be absent exactly
+  when it was needed and would cover nothing. [[ADR-163]] records a real instance —
+  suppression held on one host and leaked on another.
+
+A third reason was considered and **rejected as circular**: that the changelog
+scope-qualifies the key to "web and Remote Control sessions". The qualifier cuts both
+ways. If Remote Control is the likely reason the link reached commits at all — and this
+operator runs `remoteControlAtStartup: true` — then the qualifier may describe *complete
+coverage*, not a gap. Reasoning "the boundary is uncharacterized, therefore keep the
+backstop" while also holding "the backstop stands, therefore the boundary needn't be
+characterized" is ADR-162's error inverted: an unexamined boundary dressed as a known
+risk. The boundary is genuinely uncharacterized. That is an open question, not evidence.
+The two reasons above carry the decision without it.
 
 The backstop costs nothing when the primary control works: the model never emits the
-link, so the hook never fires. It is insurance against the fragment not being
-projected, the key being renamed upstream, or a session type the setting does not
-cover.
+link, so the hook never fires. It is insurance against the fragment not being projected
+and against the key changing upstream — not against a session-type gap we have never
+observed.
 
 **Status surfaces must read the key that governs.** The `github` macro reports the
 session link off `attribution.sessionUrl` (absent means ON), and reports the
@@ -157,7 +180,10 @@ catches, macro reports. Each is independently insufficient.
 - ADR-162's hook code is untouched by this decision; only its header comment needs its
   rationale corrected.
 - The scope boundary of `sessionUrl` ("web and Remote Control sessions") is uncharted
-  for other session types. It is not worth characterizing while the backstop stands.
+  for other session types — it is not known whether such sessions receive the link at
+  all. Characterizing it is cheap (one controlled run with `remoteControlAtStartup`
+  off) and would either close the question or reveal a real gap. Left open
+  deliberately, and named here so the omission is visible rather than assumed away.
 
 ## Alternatives Considered
 

--- a/docs/architecture/system/ADR-167-session-link-suppression-attribution-sessionurl-as-primary-control-deny-hook-as-backstop.md
+++ b/docs/architecture/system/ADR-167-session-link-suppression-attribution-sessionurl-as-primary-control-deny-hook-as-backstop.md
@@ -1,0 +1,179 @@
+---
+status: Accepted
+date: 2026-07-16
+deciders:
+  - aaronsb
+  - claude
+related:
+  - "[[ADR-147]]"
+  - "[[ADR-162]]"
+  - "[[ADR-163]]"
+supersedes: ADR-162
+---
+
+# ADR-167: Session-link suppression: attribution.sessionUrl as primary control, deny hook as backstop
+
+## Context
+
+The disclosure surface [[ADR-162]] identified is real and unchanged: Claude Code
+appends a session link to commit messages and PR bodies, that link resolves to the
+**full session transcript**, and a transcript routinely carries material that merely
+scrolled through the conversation — file contents, environment values, tokens,
+internal paths. On a public repository, publishing it puts one click between a commit
+and whatever secret happened to pass through the session.
+
+What has changed is the claim that nothing but a hook can stop it. ADR-162 concluded:
+
+> The conclusion is that any control depending on the harness honoring a setting, or
+> on the model choosing to obey it, is not load-bearing. Suppression must be
+> mechanical and must live in a layer we own.
+
+That conclusion was false when written, and it rested on two errors.
+
+**A mis-citation.** ADR-162 attributed the failure to upstream `#18253`, described as
+*marked not planned*. `#18253` is a different bug — "Attribution settings not honored
+— Co-Authored-By and PR footer added despite empty attribution config"
+([CLOSED/COMPLETED]) — and concerns the **footers**, never the session link. The issue
+it meant is `#41873`, "attribution setting does not control session URL in commit
+messages" ([CLOSED/NOT_PLANNED], April 2026).
+
+**A superseded fact.** `#41873` was closed not-planned, and then upstream shipped the
+control anyway. Claude Code **v2.1.183** (2026-06-19) added `attribution.sessionUrl`:
+
+> Added `attribution.sessionUrl` setting to omit the claude.ai session link from
+> commits and PRs in web and Remote Control sessions
+
+ADR-162 is dated 2026-07-06 — seventeen days after the key shipped. It named
+`attribution.sessionUrl` as "the key that does govern it" and then dismissed it as
+unreliable on the strength of an issue about a different bug. The key is absent from
+the official settings documentation (upstream `#69614`, open), which is why it stayed
+unset here long after it was available; `#66504` (open) separately argues the link
+should be opt-in rather than default-on.
+
+### The evidence
+
+A single-variable experiment on 2026-07-16 settles it. Same repository, same binary
+(**v2.1.212**), same account; only `attribution.sessionUrl` differs. The question put
+to each session: *does your system prompt instruct you to end git commit messages with
+a Claude-Session trailer?*
+
+| Run | `attribution.sessionUrl` | Trailer instruction in system prompt |
+|-----|--------------------------|--------------------------------------|
+| control | `true` | **present** — a `Claude-Session:` trailer naming a session URL |
+| treatment | `false` | **absent** |
+
+The setting governs the trailer. Two earlier attempts did **not** establish this and
+were discarded: a headless `claude -p` pair (void — `-p` never injects the trailer, so
+the control could not reproduce the baseline) and a run in a non-git directory (void —
+no repository, therefore no commit instructions). Only the controlled pair is evidence.
+
+### How the error persisted
+
+The mis-citation propagated into four artifacts, each of which made the next look
+corroborated:
+
+1. **ADR-162** — the original wrong citation.
+2. **`strip-session-link-pre.sh`** — its header comment repeats "the `attribution`
+   setting does not reliably reach the model (upstream #18253)".
+3. **The operator's memory entry** — repeats "attribution setting doesn't govern it
+   (#18253)".
+4. **The `softwaredev/delivery/github` macro** — reports `Session-link trailer: OFF`
+   from `attribution.commit`/`.pr` alone, having never read `sessionUrl`.
+
+The macro is the sharp end. It rendered the wrong fact as a reassuring green light in
+every session, including sessions whose system prompt carried the trailer. In the
+control run above, the session had to reason around its own status line contradicting
+its system prompt.
+
+The lesson generalizes past this key: ADR-162 froze a **contingent upstream fact** as
+though it were a durable architectural truth. Upstream behavior is evidence with a
+shelf life. A decision that depends on it should say so, and should name the
+observation that would overturn it.
+
+## Decision
+
+**`attribution.sessionUrl: false` is the primary control.** It is authored as a
+fragment in the settings store ([[ADR-147]]) and reaches `~/.claude/settings.json`
+through the dotfiles source-of-truth ([[ADR-163]]) — `20-attribution.md`, carrying
+`commit: ""`, `pr: ""`, and `sessionUrl: false`. Suppression happens at the source: the
+model is never instructed to emit the link, so there is nothing to catch.
+
+**The ADR-162 hook is retained, demoted to backstop.** Its mechanism is unchanged and
+its design rationale still holds — deny rather than rewrite (rewriting requires forcing
+`permissionDecision: allow`, which would bypass the operator's own permission rules on
+outward-facing `gh` commands), user scope rather than per-project, trailer/footer
+position only so inline prose mentions pass. What changes is its standing: it is no
+longer the sole defense.
+
+It is retained because the primary control is weaker than it looks:
+
+- **Undocumented** — absent from the official settings docs (`#69614`), so it cannot be
+  rediscovered from primary sources and may change without notice.
+- **Default-on** — a host that never receives the fragment leaks by default.
+- **Scope-qualified upstream** — the changelog scopes it to "web and Remote Control
+  sessions". This operator runs `remoteControlAtStartup: true`, which is the likely
+  reason the link reached commits at all; the boundary for other session types is not
+  characterized.
+
+The backstop costs nothing when the primary control works: the model never emits the
+link, so the hook never fires. It is insurance against the fragment not being
+projected, the key being renamed upstream, or a session type the setting does not
+cover.
+
+**Status surfaces must read the key that governs.** The `github` macro reports the
+session link off `attribution.sessionUrl` (absent means ON), and reports the
+Co-Authored-By / "Generated with Claude Code" footers separately off `commit`/`pr`.
+Conflating two independent controls under one label is the error this ADR corrects; a
+surface that asserts a fact it never read is worse than no surface.
+
+**Defense in depth is the posture, not a single mechanism.** Setting suppresses, hook
+catches, macro reports. Each is independently insufficient.
+
+## Consequences
+
+### Positive
+
+- The link is suppressed **before** the model is instructed to emit it, rather than
+  denied after it is written. No retry round-trip, no reliance on the model adapting
+  within a session.
+- The hook stops being load-bearing, so a gap in its command coverage (ADR-162 lists
+  them) is no longer a leak on its own.
+- The operator's config carries the reason: the fragment body records why the key is
+  set, what governs what, and why the hook remains.
+
+### Negative
+
+- The primary control is undocumented upstream. If Anthropic renames or removes
+  `sessionUrl`, the fragment silently stops working — and the failure is invisible
+  (a link appears where none did before). The backstop exists for exactly this.
+- The key is not in the vendored SchemaStore schema, which declares `attribution` with
+  `additionalProperties: false` and only `commit`/`pr`. `ways settings new
+  attribution.sessionUrl` therefore refuses it, and the fragment is hand-authored.
+  Tracked separately, with an upstream PR as the durable fix.
+- Two mechanisms to maintain where ADR-162 had one.
+
+### Neutral
+
+- ADR-162's hook code is untouched by this decision; only its header comment needs its
+  rationale corrected.
+- The scope boundary of `sessionUrl` ("web and Remote Control sessions") is uncharted
+  for other session types. It is not worth characterizing while the backstop stands.
+
+## Alternatives Considered
+
+- **Keep the hook as sole defense; ignore the setting.** Rejected: preserves the
+  false premise, and pays a deny/retry round-trip on every commit for a leak the
+  harness will suppress for free. Being wrong for a good reason is still wrong.
+- **Adopt the setting; retire the hook.** Rejected. The setting is undocumented,
+  default-on, and scope-qualified — three properties that individually argue for a
+  backstop. ADR-162's instinct was half right: the harness honors the setting fine;
+  the failure was in our reading of it. That is a reason to verify the setting, not to
+  trust it alone.
+- **Amend ADR-162 in place.** Rejected: the *decision* changes, not merely its
+  context. The hook's role moves from sole defense to backstop, and a new control is
+  introduced. Precedent ([[ADR-104]] → ADR-123) supersedes when the decision moves and
+  preserves what remains correct — which is what this does.
+- **Set `sessionUrl` directly in `~/.claude/settings.json`.** Rejected: unmanaged,
+  host-local, and undocumented — the same shape of failure ADR-162 recorded, where a
+  repository without local config leaked because the control never traveled. The
+  fragment store carries it to every host by construction.

--- a/hooks/ways/strip-session-link-pre.sh
+++ b/hooks/ways/strip-session-link-pre.sh
@@ -1,12 +1,24 @@
 #!/usr/bin/env bash
 # PreToolUse (Bash): deny commit / PR / issue authoring commands that carry a
-# Claude-Session transcript link in trailer/footer position. See ADR-162.
+# Claude-Session transcript link in trailer/footer position. See ADR-167
+# (supersedes ADR-162).
 #
 # The session link resolves to the FULL session transcript; publishing it in a
 # commit trailer or PR/issue body is a thin wall in front of accidental secret
-# disclosure. Claude Code ships no mechanical strip — the `attribution` setting
-# does not reliably reach the model (upstream #18253) and the system prompt keeps
-# instructing the link — so enforcement lives here, at user scope, for every repo.
+# disclosure.
+#
+# This hook is a BACKSTOP, not the primary control. `attribution.sessionUrl: false`
+# suppresses the link at the source — the model is never instructed to emit it, so
+# when that works this hook never fires. The key shipped in v2.1.183 and is
+# projected to ~/.claude/settings.json from the settings fragment store (ADR-147 /
+# ADR-163). A controlled experiment on 2026-07-16 (same repo, same v2.1.212, only
+# the key differing) confirms it governs the trailer.
+#
+# It is retained because that setting is undocumented (upstream #69614), defaults
+# to ON, and is scope-qualified upstream ("web and Remote Control sessions") — a
+# host that never receives the fragment leaks by default. ADR-162 previously
+# claimed no setting could govern the link at all, citing #18253; that was the
+# Co-Authored-By/footer bug, not the session link. See ADR-167 for the correction.
 #
 # Mechanism: DENY, not rewrite. Rewriting in place (PreToolUse `updatedInput`) is
 # honored only when the hook also forces `permissionDecision: allow`, which would


### PR DESCRIPTION
## Summary

- **ADR-162's central claim was false when written.** It concluded no setting could govern the `Claude-Session` trailer, so a PreToolUse deny hook had to be the sole mechanical defense. It cited `#18253` as "marked not planned" — but that's the Co-Authored-By/footer bug [CLOSED/COMPLETED], not the session link. The issue it meant is `#41873` [CLOSED/NOT_PLANNED], which upstream then superseded by shipping `attribution.sessionUrl` in **v2.1.183 (2026-06-19)** — seventeen days *before* ADR-162 was dated.
- **ADR-167** records the corrected decision: `attribution.sessionUrl: false` is the primary control; the ADR-162 hook is **retained as a backstop** (the key is undocumented upstream `#69614`, defaults to ON, and is scope-qualified to "web and Remote Control sessions"). Hook code is untouched — only its header comment, which repeated the same mis-citation.
- **ADR-162** marked `Superseded`, keeping its threat model and hook design intact per the ADR-104 precedent.

## Evidence

Single-variable experiment — same repo, same binary (v2.1.212), same account:

| `attribution.sessionUrl` | Trailer instruction in system prompt |
|---|---|
| `true` (control) | **present** |
| `false` (treatment) | **absent** |

Two earlier attempts were discarded as void and are documented as such in the ADR: a headless `claude -p` pair (`-p` never injects the trailer, so the control couldn't reproduce the baseline) and a run in a non-git directory (no repo, no commit instructions). Only the controlled pair is evidence.

## Why this persisted

One mis-citation propagated into four artifacts, each making the next look corroborated: ADR-162 → the hook's header comment → the operator's memory entry → the `delivery/github` macro, which rendered the wrong fact as a reassuring `Session-link trailer: OFF` in every session — including sessions whose system prompt carried the trailer.

The generalizable lesson, recorded in ADR-167: ADR-162 froze a **contingent upstream fact** as though it were a durable architectural truth. Upstream behavior is evidence with a shelf life.

## Follow-ups (tracked, not in this PR)

- Fix the `delivery/github` macro to read `sessionUrl` (it reports on `commit`/`pr` alone)
- `ways settings lint` doesn't validate nested sub-keys — `permissions.alow` lints clean and silently drops your rules
- Upstream PR to SchemaStore adding `attribution.sessionUrl` (declares `additionalProperties: false` today, so it marks a real key invalid)

## Test plan

- `docs/scripts/adr lint` — 0 errors (1 pre-existing warning on ADR-127, unrelated)
- `docs/scripts/adr index -y` — INDEX.md regenerated; ADR-162 shows `Superseded`
- Hook change is comment-only; no behavior change