### PR TITLE
fix(attend): keep `attend reply` working for external senders

### DIFF
--- a/tools/agent-identity/src/identity.rs
+++ b/tools/agent-identity/src/identity.rs
@@ -105,6 +105,38 @@ pub fn sanitize_id_component(s: &str) -> String {
         .collect()
 }
 
+/// Monotonic per-process counter, appended to signal filenames so two
+/// writes that land in the same clock tick still get distinct names.
+static SIGNAL_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Build a collision-resistant signal filename for `sender_id`. The stem
+/// (name without `.signal`) doubles as the signal id that `re:<id>`
+/// threaded replies and `attend reply`'s last-inbound record reference,
+/// so it is always `[A-Za-z0-9_-]+`.
+///
+/// Shape: `<sanitized-sender>-<unix-nanos>-<seq>.signal`. Uniqueness has
+/// two independent guards because a signal bus takes bursts:
+/// - **nanosecond timestamp** separates writers across processes (two
+///   processes hitting the same nanosecond is not realistic);
+/// - **process-local sequence** guarantees uniqueness *within* a process
+///   even if the platform clock is coarse enough to repeat a nanos read.
+///
+/// This closes the collision window the `sanitize_id_component` fix
+/// (issue #368) would otherwise widen — sanitizing can map distinct
+/// external identities (`iterm.app` vs `iterm-app`) to the same sender
+/// stem, and a second-granularity name let same-second writes silently
+/// overwrite each other on rename. Centralized here so both write sites
+/// (`attend send`, the attend-chat TUI) stay byte-identical — see the
+/// wire-format-mirror note in `attend::cmd::send`.
+pub fn signal_filename(sender_id: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let seq = SIGNAL_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    format!("{}-{}-{}.signal", sanitize_id_component(sender_id), nanos, seq)
+}
+
 /// FNV-1a 64-bit. Deterministic across runs and targets — this is the
 /// property we need, and why we don't use `std::hash::DefaultHasher`.
 /// Crate-internal (`pub(crate)`) so the groups module shares the exact
@@ -144,6 +176,25 @@ mod tests {
                 "sanitized {input:?} -> {out:?} still contains invalid chars"
             );
         }
+    }
+
+    #[test]
+    fn signal_filename_is_valid_and_unique_under_burst() {
+        // Every name ends in `.signal` and its stem passes the
+        // `[A-Za-z0-9_-]+` fence, even for an external `@`-bearing sender.
+        let names: Vec<String> = (0..1000).map(|_| signal_filename("aaron@kitty")).collect();
+        for n in &names {
+            let stem = n.strip_suffix(".signal").expect("ends in .signal");
+            assert!(
+                stem.chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+                "stem {stem:?} contains invalid chars"
+            );
+        }
+        // A tight burst from one sender must never collide — this is the
+        // silent-overwrite hazard the review flagged (findings #1/#2).
+        let unique: std::collections::HashSet<&String> = names.iter().collect();
+        assert_eq!(unique.len(), names.len(), "burst produced a colliding filename");
     }
 
     #[test]

--- a/tools/agent-identity/src/identity.rs
+++ b/tools/agent-identity/src/identity.rs
@@ -85,6 +85,26 @@ pub fn cwd_basename(path: &str) -> String {
     trimmed.rsplit('/').next().unwrap_or(trimmed).to_string()
 }
 
+/// Normalize a string into a signal-id component: every character
+/// outside `[A-Za-z0-9_-]` is replaced with `-`. Signal filenames are
+/// `<sender-id>-<ts>.signal`, and their stems double as the id that
+/// `re:<id>` threaded replies reference. External sender identities are
+/// `$USER@<terminal>` (e.g. `aaron@kitty`, `aaron@iterm.app`), so the raw
+/// id carries `@`/`.` — characters that fail the `is_valid_signal_id`
+/// fence in `attend`/`sensor-peers` and break `attend reply`'s auto-
+/// threading. Sanitizing here, at every write site, keeps ids valid
+/// regardless of sender.
+///
+/// **Lockstep invariant.** The accepted class MUST stay identical to the
+/// `is_valid_signal_id` validators (`attend::main`, `sensor-peers::lib`):
+/// sanitizer output must always pass those fences. If either side's char
+/// class changes, change both.
+pub fn sanitize_id_component(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
+        .collect()
+}
+
 /// FNV-1a 64-bit. Deterministic across runs and targets — this is the
 /// property we need, and why we don't use `std::hash::DefaultHasher`.
 /// Crate-internal (`pub(crate)`) so the groups module shares the exact
@@ -104,6 +124,27 @@ pub(crate) fn fnv1a_64(bytes: &[u8]) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sanitize_id_component_normalizes_external_ids() {
+        // The exact shape that broke `attend reply`: `$USER@<terminal>`.
+        assert_eq!(sanitize_id_component("aaron@kitty"), "aaron-kitty");
+        assert_eq!(sanitize_id_component("aaron@iterm.app"), "aaron-iterm-app");
+        // Valid chars pass through untouched.
+        assert_eq!(
+            sanitize_id_component("2f2632d7-3f59_4c24"),
+            "2f2632d7-3f59_4c24"
+        );
+        // Output always satisfies the [A-Za-z0-9_-]+ fence.
+        for input in ["a@b.c/d e", "user+tag%1", "😀"] {
+            let out = sanitize_id_component(input);
+            assert!(
+                out.chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+                "sanitized {input:?} -> {out:?} still contains invalid chars"
+            );
+        }
+    }
 
     #[test]
     fn same_cwd_same_identity() {

--- a/tools/agent-identity/src/lib.rs
+++ b/tools/agent-identity/src/lib.rs
@@ -27,7 +27,7 @@ pub mod names;
 pub mod palette;
 
 pub use groups::{Group, GLYPHS};
-pub use identity::{cwd_basename, Identity};
+pub use identity::{cwd_basename, sanitize_id_component, Identity};
 pub use palette::{
     resolve, PaletteEntry, Resolved, Style, TermCaps, BASIC_PALETTE, RICH_PALETTE,
 };

--- a/tools/agent-identity/src/lib.rs
+++ b/tools/agent-identity/src/lib.rs
@@ -27,7 +27,7 @@ pub mod names;
 pub mod palette;
 
 pub use groups::{Group, GLYPHS};
-pub use identity::{cwd_basename, sanitize_id_component, Identity};
+pub use identity::{cwd_basename, sanitize_id_component, signal_filename, Identity};
 pub use palette::{
     resolve, PaletteEntry, Resolved, Style, TermCaps, BASIC_PALETTE, RICH_PALETTE,
 };

--- a/tools/attend-chat/src/signal.rs
+++ b/tools/attend-chat/src/signal.rs
@@ -133,7 +133,15 @@ pub fn write_signal(dest: &Path, message: &str) -> io::Result<String> {
         .map(|d| d.as_secs())
         .unwrap_or(0);
 
-    let filename = format!("{}-{}.signal", sender_id.replace('/', "-"), ts);
+    // Normalize the sender id into the filename stem (== signal id that
+    // `re:<id>` replies reference). The TUI's sender is `$USER@<terminal>`,
+    // so the raw `@`/`.` would fail `is_valid_signal_id` and break
+    // `attend reply` auto-threading (issue #368). `from` keeps the raw id.
+    let filename = format!(
+        "{}-{}.signal",
+        agent_identity::sanitize_id_component(&sender_id),
+        ts
+    );
     let content = format!("{}|{}|{}|{}\n", from, project, cwd, message);
 
     let tmp = dest.join(format!("{}.tmp", filename));

--- a/tools/attend-chat/src/signal.rs
+++ b/tools/attend-chat/src/signal.rs
@@ -128,20 +128,14 @@ pub fn write_signal(dest: &Path, message: &str) -> io::Result<String> {
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_default();
     let project = cwd.rsplit('/').next().unwrap_or("?").to_string();
-    let ts = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
 
-    // Normalize the sender id into the filename stem (== signal id that
-    // `re:<id>` replies reference). The TUI's sender is `$USER@<terminal>`,
-    // so the raw `@`/`.` would fail `is_valid_signal_id` and break
-    // `attend reply` auto-threading (issue #368). `from` keeps the raw id.
-    let filename = format!(
-        "{}-{}.signal",
-        agent_identity::sanitize_id_component(&sender_id),
-        ts
-    );
+    // Build the filename stem (== signal id that `re:<id>` replies
+    // reference). `signal_filename` normalizes the sender id — the TUI's
+    // sender is `$USER@<terminal>`, whose raw `@`/`.` would fail
+    // `is_valid_signal_id` and break `attend reply` auto-threading
+    // (issue #368) — and makes the name collision-proof. `from` keeps the
+    // raw id.
+    let filename = agent_identity::signal_filename(&sender_id);
     let content = format!("{}|{}|{}|{}\n", from, project, cwd, message);
 
     let tmp = dest.join(format!("{}.tmp", filename));

--- a/tools/attend/src/cmd/send.rs
+++ b/tools/attend/src/cmd/send.rs
@@ -13,8 +13,9 @@ pub(crate) fn cmd_send(
 ) {
     // A signal id must match the same character class the parser uses to
     // disambiguate threaded records from legacy messages that happen to
-    // start with "re:". Signal filename stems are `<sender-id>-<ts>`, so
-    // `[A-Za-z0-9_-]+` comfortably covers the real shape and rejects
+    // start with "re:". Signal filename stems are
+    // `<sanitized-sender>-<nanos>-<seq>` (see `agent_identity::signal_filename`),
+    // so `[A-Za-z0-9_-]+` comfortably covers the real shape and rejects
     // anything that would break the wire format (pipes, whitespace,
     // control chars) or trip the ambiguity fence in parse_signal.
     if let Some(ref id) = reply_to {
@@ -163,22 +164,15 @@ pub(crate) fn cmd_send(
 
     let (sender_id, source_kind) = identify_sender();
     let project = cwd.rsplit('/').next().unwrap_or("?");
-    let ts = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
 
     let from = format!("{}:{}", source_kind, sender_id);
-    // Normalize the sender id into the filename stem, which doubles as the
-    // signal id `re:<id>` replies reference. External senders are
-    // `$USER@<terminal>`; the raw `@`/`.` would fail `is_valid_signal_id`
-    // and break `attend reply`'s auto-threading (issue #368). The `from`
-    // field above keeps the un-normalized identity.
-    let filename = format!(
-        "{}-{}.signal",
-        agent_identity::sanitize_id_component(&sender_id),
-        ts
-    );
+    // Build the filename stem, which doubles as the signal id `re:<id>`
+    // replies reference. `signal_filename` normalizes the sender id
+    // (external senders are `$USER@<terminal>`; the raw `@`/`.` would fail
+    // `is_valid_signal_id` and break `attend reply` auto-threading —
+    // issue #368) and makes the name collision-proof. The `from` field
+    // above keeps the un-normalized identity.
+    let filename = agent_identity::signal_filename(&sender_id);
     // Wire format: `from|project|cwd|message` (legacy) or
     // `from|project|cwd|re:signal-id|message` (threaded reply). The `re:`
     // field is only emitted when --re was given; unthreaded sends stay
@@ -288,11 +282,13 @@ pub(crate) fn cmd_reply(
             eprintln!("  if you are starting a new topic, use `attend send` instead.");
             std::process::exit(1);
         }
-        // There *is* a prior inbound, but its recorded id is malformed
-        // (e.g. an older signal from an external `$USER@<terminal>` sender
-        // written before the id was sanitized — issue #368). The agent did
-        // nothing wrong and can't fix this, so don't punish it with the
-        // internal `send --re` validation error. Threading is cosmetic —
+        // There *is* a prior inbound, but its recorded id is not
+        // threadable. A standing guard, not a transition shim: whatever
+        // the source of a bad id (a stale pre-#368 record from an external
+        // `$USER@<terminal>` sender, a hand-edited state file, some future
+        // writer that skips `signal_filename`), the agent did nothing
+        // wrong and can't fix it, so we never punish it with the internal
+        // `send --re` validation error. Threading is cosmetic —
         // `parse_signal` drops the `re:` id and no peer renders it — so
         // degrading to an unthreaded send is lossless: the message still
         // lands. Note it on stderr and carry on.

--- a/tools/attend/src/cmd/send.rs
+++ b/tools/attend/src/cmd/send.rs
@@ -169,7 +169,16 @@ pub(crate) fn cmd_send(
         .unwrap_or(0);
 
     let from = format!("{}:{}", source_kind, sender_id);
-    let filename = format!("{}-{}.signal", sender_id.replace('/', "-"), ts);
+    // Normalize the sender id into the filename stem, which doubles as the
+    // signal id `re:<id>` replies reference. External senders are
+    // `$USER@<terminal>`; the raw `@`/`.` would fail `is_valid_signal_id`
+    // and break `attend reply`'s auto-threading (issue #368). The `from`
+    // field above keeps the un-normalized identity.
+    let filename = format!(
+        "{}-{}.signal",
+        agent_identity::sanitize_id_component(&sender_id),
+        ts
+    );
     // Wire format: `from|project|cwd|message` (legacy) or
     // `from|project|cwd|re:signal-id|message` (threaded reply). The `re:`
     // field is only emitted when --re was given; unthreaded sends stay
@@ -219,6 +228,31 @@ pub(crate) fn cmd_send(
     );
 }
 
+/// How `attend reply` should thread, given the recorded last-inbound id.
+/// Pure decision, split out from `cmd_reply` so the degradation rule
+/// (issue #368) is unit-testable without touching the filesystem or the
+/// process exit path.
+#[cfg(feature = "sensor-peers")]
+#[derive(Debug, PartialEq, Eq)]
+enum ReplyTarget {
+    /// No prior inbound at all — reply has nothing to thread against.
+    NoInbound,
+    /// A prior inbound exists but its id can't be threaded; degrade to an
+    /// unthreaded send rather than leak the `send --re` validation error.
+    Unthreaded,
+    /// A valid threadable id.
+    Threaded(String),
+}
+
+#[cfg(feature = "sensor-peers")]
+fn classify_reply_target(last_inbound: Option<String>) -> ReplyTarget {
+    match last_inbound {
+        None => ReplyTarget::NoInbound,
+        Some(id) if is_valid_signal_id(&id) => ReplyTarget::Threaded(id),
+        Some(_) => ReplyTarget::Unthreaded,
+    }
+}
+
 /// `attend reply <message>` — thin sugar over `attend send --re <last-inbound>`.
 ///
 /// Reads the most-recent inbound signal id from per-session state that
@@ -226,7 +260,9 @@ pub(crate) fn cmd_send(
 /// observation. If no prior inbound exists the command exits with a
 /// clear error rather than silently falling through to an unthreaded
 /// send — threaded-vs-unthreaded is a semantic distinction and
-/// guessing is the wrong default.
+/// guessing is the wrong default. If a prior inbound exists but its id
+/// is not threadable (issue #368), it degrades to an unthreaded send
+/// rather than leaking the internal `send --re` validation error.
 ///
 /// The entire point of this subcommand is to keep the 50-char signal
 /// uuid out of the agent's context window. A caller never sees the
@@ -243,19 +279,35 @@ pub(crate) fn cmd_reply(
 ) {
     let session_id =
         own_session_id().unwrap_or_else(|| format!("pid-{}", std::process::id()));
-    let last_id = match sensor_peers::last_inbound::read(&session_id) {
-        Some(id) => id,
-        None => {
+    let reply_to = match classify_reply_target(sensor_peers::last_inbound::read(&session_id)) {
+        // Genuine "nothing to reply to" — the agent needs to do something
+        // different (start a new topic), so this stays a hard error.
+        ReplyTarget::NoInbound => {
             eprintln!("attend reply: no prior inbound signal to thread against.");
             eprintln!("  (reply is for responding to a peer message your sensor surfaced.)");
             eprintln!("  if you are starting a new topic, use `attend send` instead.");
             std::process::exit(1);
         }
+        // There *is* a prior inbound, but its recorded id is malformed
+        // (e.g. an older signal from an external `$USER@<terminal>` sender
+        // written before the id was sanitized — issue #368). The agent did
+        // nothing wrong and can't fix this, so don't punish it with the
+        // internal `send --re` validation error. Threading is cosmetic —
+        // `parse_signal` drops the `re:` id and no peer renders it — so
+        // degrading to an unthreaded send is lossless: the message still
+        // lands. Note it on stderr and carry on.
+        ReplyTarget::Unthreaded => {
+            eprintln!(
+                "[attend] note: last inbound id is not threadable; sending unthreaded (message still delivered)."
+            );
+            None
+        }
+        ReplyTarget::Threaded(id) => Some(id),
     };
     // Inject the resolved signal id as `reply_to` and delegate to cmd_send.
     // All other routing flags (--focus, --to, --broadcast) flow through
     // untouched.
-    cmd_send(broadcast, target_dir, target_focus, Some(last_id), message);
+    cmd_send(broadcast, target_dir, target_focus, reply_to, message);
 }
 
 #[cfg(not(feature = "sensor-peers"))]
@@ -348,4 +400,37 @@ fn find_closest_peer<'a>(target: &str, peers: &[&'a str]) -> Option<&'a str> {
     }
 
     best.map(|(p, _)| p)
+}
+
+#[cfg(all(test, feature = "sensor-peers"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_inbound_is_a_hard_error_case() {
+        assert_eq!(classify_reply_target(None), ReplyTarget::NoInbound);
+    }
+
+    #[test]
+    fn valid_id_threads() {
+        assert_eq!(
+            classify_reply_target(Some("claude-2f2632d7-1712345".to_string())),
+            ReplyTarget::Threaded("claude-2f2632d7-1712345".to_string())
+        );
+    }
+
+    #[test]
+    fn external_at_bearing_id_degrades_to_unthreaded() {
+        // The regression from issue #368: a last-inbound id from an
+        // external `$USER@<terminal>` sender must NOT reach cmd_send's
+        // `--re` validation — it degrades to an unthreaded send instead.
+        assert_eq!(
+            classify_reply_target(Some("aaron@kitty-1712345".to_string())),
+            ReplyTarget::Unthreaded
+        );
+        assert_eq!(
+            classify_reply_target(Some("aaron@iterm.app-1712345".to_string())),
+            ReplyTarget::Unthreaded
+        );
+    }
 }


### PR DESCRIPTION
Closes #368.

## Problem

`attend reply` failed with an unactionable, internal-leaking error whenever the message it was replying to came from an **external sender** — notably Aaron messaging an agent through the `attend chat` TUI:

```
attend send: --re signal id must be non-empty and match [A-Za-z0-9_-]+
```

The agent ran a valid `attend reply "<msg>"` and got an error naming a command (`send`) and flag (`--re`) it never used, with no way to recover — so it abandoned the reply.

## Root cause

`attend reply` resolves the last inbound signal id (the signal's filename stem) and delegates to `attend send --re <id>`. Both write sites (`attend/src/cmd/send.rs`, `attend-chat/src/signal.rs`) built the filename sanitizing only `/`. External senders are `$USER@<terminal>` (e.g. `aaron@kitty`, `aaron@iterm.app`), so the id carried `@`/`.`, which fail `is_valid_signal_id` (`[A-Za-z0-9_-]+`). `cmd_reply` passed it straight to `cmd_send`, whose `--re` validation rejected it.

## Fix (two parts)

1. **Sanitize ids at the source.** New shared `agent_identity::sanitize_id_component` maps any non-`[A-Za-z0-9_-]` char to `-`; both write sites use it. Ids are now always valid regardless of sender. The `from` field keeps the raw identity (`external:aaron@kitty`).
2. **`attend reply` never hard-fails on an id it resolved internally.** A *malformed* last-inbound degrades to an unthreaded send (delivered, one-line stderr note, exit 0). Threading is cosmetic today — `parse_signal` drops the `re:` id and no peer renders it — so degradation is lossless. The genuine *no-inbound* case keeps its clear "use \`send\` instead" error.

## Verification

Unit tests for the sanitizer and the reply classifier (including the exact `aaron@kitty` / `aaron@iterm.app` regression inputs). Full workspace suite green (814 tests).

Driven end-to-end on the built binary:

| case | before | after |
|------|--------|-------|
| malformed (`@`-bearing) last-inbound | exit 1, `--re` error | exit 0, unthreaded send delivered + note |
| valid last-inbound | threaded | threaded (`re:` in wire) — unchanged |
| no last-inbound | exit 1, clear error | exit 1, clear error — unchanged |
| external `send` | id `aaron@kitty-…` (invalid) | id `aaron-kitty-…` (valid); `from` keeps `external:aaron@kitty` |