### PR TITLE
feat(attend-chat): echo directed @mention sends in the sender's own transcript

### DIFF
--- a/tools/attend-chat/src/app/keys.rs
+++ b/tools/attend-chat/src/app/keys.rs
@@ -15,7 +15,10 @@ use crate::legend::{
     parse_addressed, Addressed, Sigil,
 };
 use crate::sessions::discover as discover_sessions;
-use crate::signal::{compose_self_echo, cwd_dir, write_broadcast, write_signal, Signal};
+use crate::signal::{
+    compose_self_echo, cwd_dir, encode_cwd, signals_base, write_broadcast, write_signal, Signal,
+};
+use crate::watcher::accept_path;
 use crate::slash;
 use crate::text_layout::split_at_char;
 
@@ -97,24 +100,50 @@ pub fn handle_enter(input_value: &str, signals: &[Signal]) -> EnterAction {
             Err(e) => EnterAction::StatusOnly(format!("send failed: {e}")),
         }
     } else {
-        // Directed sends go to each recipient's cwd inbox, which the
-        // sender does not watch — so echo the message once (regardless of
-        // recipient count) into the sender's own transcript. The "sent →
-        // @a @b" status line already reports where it went.
         let sent = resolve_recipients(&recipients, &agents).and_then(|dests| {
             for dir in &dests {
                 write_signal(dir, &msg)?;
             }
-            Ok(())
+            Ok(dests)
         });
         match sent {
-            Ok(()) => EnterAction::ClearWithStatusAndEcho {
-                status: format!("sent → {}", recipient_labels(&recipients).join(" ")),
-                echo: compose_self_echo(&msg),
-            },
+            Ok(dests) => {
+                let status = format!("sent → {}", recipient_labels(&recipients).join(" "));
+                // Echo only when the message reaches NO inbox the sender's
+                // own watcher already surfaces — otherwise it round-trips
+                // and a synthetic echo would double-render it. `#open`
+                // lands in `_broadcast/` and `#group` in `@group/` (both
+                // watched); an `@agent` in our *own* cwd lands in
+                // `own_encoded` (watched). Only `@agent` sends to *other*
+                // cwds are invisible without an echo.
+                if dests.iter().any(|d| sender_watches(d)) {
+                    EnterAction::ClearWithStatus(status)
+                } else {
+                    EnterAction::ClearWithStatusAndEcho {
+                        status,
+                        echo: compose_self_echo(&msg),
+                    }
+                }
+            }
             Err(e) => EnterAction::StatusOnly(format!("send failed: {e}")),
         }
     }
+}
+
+/// Does the sender's own chat watcher already surface signals written to
+/// `dest`? Reuses [`accept_path`] — the single source of truth for what
+/// the transcript shows — so a directed send that round-trips (a
+/// `#group` / `#open` landing in a watched dir, or an `@agent` in our own
+/// cwd) is not *also* echoed synthetically and rendered twice.
+fn sender_watches(dest: &std::path::Path) -> bool {
+    let base = signals_base();
+    let own_cwd = std::env::current_dir()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let own_encoded = encode_cwd(&own_cwd);
+    // `accept_path` classifies by the first path component (the inbox dir
+    // name); hand it a probe file inside `dest` so it judges that dir.
+    accept_path(&base, &own_encoded, &dest.join("probe.signal"))
 }
 
 /// Render the addressed recipients back as their `@name` / `#group`
@@ -347,6 +376,27 @@ mod tests {
             EnterAction::None => {}
             _ => panic!("empty input should produce EnterAction::None"),
         }
+    }
+
+    #[test]
+    fn sender_watches_matches_the_watchers_accept_set() {
+        // Regression guard for the double-render bug: a directed send is
+        // echoed synthetically ONLY when it reaches no inbox the sender's
+        // own watcher surfaces. `sender_watches` must agree with
+        // `accept_path` about which destination dirs those are.
+        use crate::signal::{broadcast_dir, cwd_dir, signals_base};
+
+        // `#open` → _broadcast/ : watched (would round-trip, so NO echo).
+        assert!(sender_watches(&broadcast_dir()));
+        // `#group` → @group/ : watched.
+        assert!(sender_watches(&signals_base().join("@deploy")));
+        // `@agent` in our own cwd → own_encoded : watched.
+        let own = std::env::current_dir()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default();
+        assert!(sender_watches(&cwd_dir(&own)));
+        // `@agent` in some other cwd : NOT watched (invisible → echo).
+        assert!(!sender_watches(&signals_base().join("some-other-cwd-abc123")));
     }
 
     #[test]

--- a/tools/attend-chat/src/app/keys.rs
+++ b/tools/attend-chat/src/app/keys.rs
@@ -15,7 +15,7 @@ use crate::legend::{
     parse_addressed, Addressed, Sigil,
 };
 use crate::sessions::discover as discover_sessions;
-use crate::signal::{cwd_dir, write_broadcast, write_signal, Signal};
+use crate::signal::{compose_self_echo, cwd_dir, write_broadcast, write_signal, Signal};
 use crate::slash;
 use crate::text_layout::split_at_char;
 
@@ -44,6 +44,13 @@ pub enum EnterAction {
     None,
     /// Success path: set status, clear input + cursor.
     ClearWithStatus(String),
+    /// Directed-send success: like [`EnterAction::ClearWithStatus`], but
+    /// also append `echo` to the transcript. Directed (`@name`) sends
+    /// land in the recipient's cwd inbox, which the sender does not
+    /// watch, so — unlike broadcasts — they never round-trip back into
+    /// the sender's own view. The closure appends `echo` so the sender
+    /// sees their own message land.
+    ClearWithStatusAndEcho { status: String, echo: Signal },
     /// Failure path: set status, leave input + cursor intact so the
     /// user can edit and retry.
     StatusOnly(String),
@@ -81,19 +88,32 @@ pub fn handle_enter(input_value: &str, signals: &[Signal]) -> EnterAction {
     // entire send if any address is bad, so one typo doesn't
     // half-deliver and the user can edit + retry the original line.
     let recipients = parse_addressed(&msg);
-    let result = if recipients.is_empty() {
-        write_broadcast(&msg).map(|n| format!("sent: {n}"))
+    if recipients.is_empty() {
+        // Broadcast rides `_broadcast/`, which the sender's own watcher
+        // surfaces — so it self-echoes through the normal signal path and
+        // needs no synthetic echo here.
+        match write_broadcast(&msg) {
+            Ok(n) => EnterAction::ClearWithStatus(format!("sent: {n}")),
+            Err(e) => EnterAction::StatusOnly(format!("send failed: {e}")),
+        }
     } else {
-        resolve_recipients(&recipients, &agents).and_then(|dests| {
+        // Directed sends go to each recipient's cwd inbox, which the
+        // sender does not watch — so echo the message once (regardless of
+        // recipient count) into the sender's own transcript. The "sent →
+        // @a @b" status line already reports where it went.
+        let sent = resolve_recipients(&recipients, &agents).and_then(|dests| {
             for dir in &dests {
                 write_signal(dir, &msg)?;
             }
-            Ok(format!("sent → {}", recipient_labels(&recipients).join(" ")))
-        })
-    };
-    match result {
-        Ok(s) => EnterAction::ClearWithStatus(s),
-        Err(e) => EnterAction::StatusOnly(format!("send failed: {}", e)),
+            Ok(())
+        });
+        match sent {
+            Ok(()) => EnterAction::ClearWithStatusAndEcho {
+                status: format!("sent → {}", recipient_labels(&recipients).join(" ")),
+                echo: compose_self_echo(&msg),
+            },
+            Err(e) => EnterAction::StatusOnly(format!("send failed: {e}")),
+        }
     }
 }
 

--- a/tools/attend-chat/src/app/mod.rs
+++ b/tools/attend-chat/src/app/mod.rs
@@ -48,6 +48,20 @@ pub struct AppProps {
 /// per-append stays O(cap).
 const MAX_SIGNALS: usize = 5000;
 
+/// Append `sig` to the message buffer, dropping from the head if it would
+/// exceed [`MAX_SIGNALS`]. Both writers into `signals` — the async
+/// watcher drain and the directed-send echo — go through here so the
+/// cap/overflow policy has a single home and the two paths cannot desync.
+fn push_capped(signals: &mut State<Vec<Signal>>, sig: Signal) {
+    let mut v = signals.read().clone();
+    v.push(sig);
+    if v.len() > MAX_SIGNALS {
+        let drop_n = v.len() - MAX_SIGNALS;
+        v.drain(0..drop_n);
+    }
+    signals.set(v);
+}
+
 #[component]
 pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let mut system = hooks.use_context_mut::<SystemContext>();
@@ -85,13 +99,7 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
     if let Some(rx) = props.receiver.clone() {
         hooks.use_future(async move {
             while let Ok(sig) = rx.recv().await {
-                let mut v = signals.read().clone();
-                v.push(sig);
-                if v.len() > MAX_SIGNALS {
-                    let drop_n = v.len() - MAX_SIGNALS;
-                    v.drain(0..drop_n);
-                }
-                signals.set(v);
+                push_capped(&mut signals, sig);
             }
         });
     }
@@ -142,17 +150,11 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                             status.set(s);
                             input.set(String::new());
                             cursor.set(0);
-                            // Append the display-only echo, mirroring the
-                            // watcher drain (read/clone/push/cap/set) so a
+                            // Append the display-only echo through the same
+                            // capped path the watcher drain uses, so a
                             // directed send appears in the sender's own
                             // transcript just as a broadcast would.
-                            let mut v = signals.read().clone();
-                            v.push(echo);
-                            if v.len() > MAX_SIGNALS {
-                                let drop_n = v.len() - MAX_SIGNALS;
-                                v.drain(0..drop_n);
-                            }
-                            signals.set(v);
+                            push_capped(&mut signals, echo);
                         }
                         EnterAction::StatusOnly(s) => status.set(s),
                     }

--- a/tools/attend-chat/src/app/mod.rs
+++ b/tools/attend-chat/src/app/mod.rs
@@ -120,18 +120,39 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                 }
                 KeyCode::Enter => {
                     let v = input.read().clone();
-                    // Hold the read guard rather than clone — Rust
-                    // deref-coerces `&Ref<Vec<Signal>>` to `&[Signal]`,
-                    // so the handler sees a borrowed slice without
-                    // copying the (capped, but potentially 5000-entry)
-                    // signal buffer on every keypress.
-                    let sigs_guard = signals.read();
-                    match handle_enter(&v, &sigs_guard) {
+                    // Scope the read guard to the handler call only: the
+                    // echo arm below needs to `signals.set(...)`, which
+                    // cannot run while a read guard is live. Hold the guard
+                    // rather than clone for the call — Rust deref-coerces
+                    // `&Ref<Vec<Signal>>` to `&[Signal]`, so the handler
+                    // sees a borrowed slice without copying the (capped,
+                    // but potentially 5000-entry) buffer on every keypress.
+                    let action = {
+                        let sigs_guard = signals.read();
+                        handle_enter(&v, &sigs_guard)
+                    };
+                    match action {
                         EnterAction::None => {}
                         EnterAction::ClearWithStatus(s) => {
                             status.set(s);
                             input.set(String::new());
                             cursor.set(0);
+                        }
+                        EnterAction::ClearWithStatusAndEcho { status: s, echo } => {
+                            status.set(s);
+                            input.set(String::new());
+                            cursor.set(0);
+                            // Append the display-only echo, mirroring the
+                            // watcher drain (read/clone/push/cap/set) so a
+                            // directed send appears in the sender's own
+                            // transcript just as a broadcast would.
+                            let mut v = signals.read().clone();
+                            v.push(echo);
+                            if v.len() > MAX_SIGNALS {
+                                let drop_n = v.len() - MAX_SIGNALS;
+                                v.drain(0..drop_n);
+                            }
+                            signals.set(v);
                         }
                         EnterAction::StatusOnly(s) => status.set(s),
                     }

--- a/tools/attend-chat/src/signal.rs
+++ b/tools/attend-chat/src/signal.rs
@@ -122,12 +122,7 @@ pub fn write_broadcast(message: &str) -> io::Result<String> {
 pub fn write_signal(dest: &Path, message: &str) -> io::Result<String> {
     fs::create_dir_all(dest)?;
 
-    let (sender_id, kind) = identify_sender();
-    let from = format!("{}:{}", kind, sender_id);
-    let cwd = std::env::current_dir()
-        .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_default();
-    let project = cwd.rsplit('/').next().unwrap_or("?").to_string();
+    let (sender_id, from, project, cwd) = sender_identity();
 
     // Build the filename stem (== signal id that `re:<id>` replies
     // reference). `signal_filename` normalizes the sender id — the TUI's
@@ -158,12 +153,7 @@ pub fn write_signal(dest: &Path, message: &str) -> io::Result<String> {
 /// identical to how their own broadcast already appears. It writes
 /// nothing — echo is a display concern, not a bus event.
 pub fn compose_self_echo(message: &str) -> Signal {
-    let (sender_id, kind) = identify_sender();
-    let from = format!("{}:{}", kind, sender_id);
-    let cwd = std::env::current_dir()
-        .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_default();
-    let project = cwd.rsplit('/').next().unwrap_or("?").to_string();
+    let (_sender_id, from, project, cwd) = sender_identity();
     let ts = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map(|d| d.as_secs())
@@ -179,6 +169,30 @@ pub fn compose_self_echo(message: &str) -> Signal {
         message: message.to_string(),
         ts,
     }
+}
+
+/// Derive this session's wire identity fields once: `(sender_id, from,
+/// project, cwd)`. Shared by `write_signal` (the delivered signal) and
+/// `compose_self_echo` (the local echo) so the echoed row's chip is
+/// always derived identically to the delivered signal's — if this logic
+/// changes, both move together instead of drifting.
+///
+/// `project` is the last non-empty cwd segment, or `"?"` when the cwd is
+/// empty (e.g. `current_dir()` failed). Note `"".rsplit('/').next()`
+/// yields `Some("")`, not `None`, so a naive `.next().unwrap_or("?")`
+/// would render a blank chip — `find(non-empty)` is deliberate.
+fn sender_identity() -> (String, String, String, String) {
+    let (sender_id, kind) = identify_sender();
+    let from = format!("{}:{}", kind, sender_id);
+    let cwd = std::env::current_dir()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let project = cwd
+        .rsplit('/')
+        .find(|seg| !seg.is_empty())
+        .unwrap_or("?")
+        .to_string();
+    (sender_id, from, project, cwd)
 }
 
 /// Identify the human at the keyboard. attend-chat is almost always

--- a/tools/attend-chat/src/signal.rs
+++ b/tools/attend-chat/src/signal.rs
@@ -145,6 +145,42 @@ pub fn write_signal(dest: &Path, message: &str) -> io::Result<String> {
     Ok(filename)
 }
 
+/// Compose the in-memory `Signal` for a message THIS session just sent,
+/// so the sender's own transcript can echo it.
+///
+/// Why this exists: a broadcast rides `_broadcast/`, which the sender's
+/// own watcher surfaces (`watcher::accept_path`), so it self-echoes for
+/// free. A directed (`@name`) send is written to the *recipient's* cwd
+/// inbox, which the sender does not watch — so without this it would
+/// vanish from the sender's view even though it was delivered. This
+/// builds the same identity fields the wire signal carries (`from`,
+/// `project`, `cwd`) so the echoed row renders with the sender's chip,
+/// identical to how their own broadcast already appears. It writes
+/// nothing — echo is a display concern, not a bus event.
+pub fn compose_self_echo(message: &str) -> Signal {
+    let (sender_id, kind) = identify_sender();
+    let from = format!("{}:{}", kind, sender_id);
+    let cwd = std::env::current_dir()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let project = cwd.rsplit('/').next().unwrap_or("?").to_string();
+    let ts = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    Signal {
+        // Not a bus id — this row never came off disk. Marked so it is
+        // never mistaken for a real signal stem should that ever matter.
+        id: format!("local-echo-{ts}"),
+        from,
+        project,
+        cwd,
+        reply_to: None,
+        message: message.to_string(),
+        ts,
+    }
+}
+
 /// Identify the human at the keyboard. attend-chat is almost always
 /// running outside a Claude session (it's the human's coordination
 /// surface), so we skip the Claude-session detection the CLI does and
@@ -246,6 +282,22 @@ mod tests {
         assert_eq!(sig.message, "round-trip body");
         assert!(sig.from.starts_with("external:"));
         assert!(sig.reply_to.is_none());
+    }
+
+    #[test]
+    fn compose_self_echo_carries_message_and_self_identity() {
+        // The echo must render as coming from THIS session (so it shows
+        // the sender's own chip) and carry the message verbatim. It is a
+        // display object, never written to disk.
+        let echo = compose_self_echo("hello @peer");
+        assert_eq!(echo.message, "hello @peer");
+        assert!(
+            echo.from.starts_with("claude:") || echo.from.starts_with("external:"),
+            "echo.from should be a real sender identity, got {:?}",
+            echo.from
+        );
+        assert!(echo.reply_to.is_none());
+        assert!(echo.id.starts_with("local-echo-"), "echo id marks it non-bus");
     }
 
     #[test]


### PR DESCRIPTION
Closes #370.

## Problem

`@mention` an agent in the `attend chat` TUI and the message is delivered but **never shows up in your own transcript** — it reads as vanished. Broadcasts (`#open`) *do* appear in your own view, so the asymmetry looks like "single mention works, directed is broken." This is the genuinely-present half of the multi-@mention report; the routing half (wrong-agent / only-one) was already fixed in `c7c938f` and ships in the installed binary.

## Root cause

Directed sends are written to the **recipient's** cwd inbox. The sender's own watcher only surfaces `_broadcast/`, `@<group>/`, and the sender's own cwd (`watcher::accept_path`). A broadcast self-echoes because it rides `_broadcast/`; a directed send goes to a dir the sender doesn't watch, and there was no local echo.

## Fix

Echo directed sends as a **display-only** concern:
- `signal::compose_self_echo` builds the in-memory `Signal` for the just-sent message from this session's own identity, so it renders with the sender's chip exactly as their own broadcast already does. It writes nothing.
- `handle_enter` returns it via a new `EnterAction::ClearWithStatusAndEcho`; the Enter handler appends it to the transcript, mirroring the watcher-drain (read/clone/push/cap/set).
- Echoed once regardless of recipient count. The `sent → @a @b` status line reports routing — and surfaces the *resolved* target, so a fuzzy-match recovery is now visible.
- Broadcasts untouched (no double-render).

## Scope decisions (documented in #370)

- **Fuzzy nickname match** (`resolve_nickname`, Levenshtein ≤2): working as designed — exact-first, refuses on ambiguity/ties, capped, live regression test. Left unchanged; the echo makes its resolution visible, which addresses the "did it go where I meant?" concern without regressing a tested feature.
- **Same-cwd sibling instances** (ADR-129 `-alpha`/`-beta`): can't be addressed separately under cwd-keyed routing. Architectural (ADR-129 ↔ ADR-136); routed to an ADR, not this fix.

## Verification

- Unit: `compose_self_echo` (message + self-identity + non-bus id); full suite green (816).
- Clean build + clippy; the new `EnterAction` variant and the guard-scoping in the Enter handler are borrow-checked (the echo arm must `signals.set` after dropping the read guard — mirrors the existing watcher drain).
- **Not driven live:** the TUI echo *row* isn't exercised end-to-end — iocraft needs a real TTY and directed resolution needs a live peer with a fresh heartbeat, neither scriptable here. The echo logic is a minimal branch over already-tested primitives (`parse_addressed`, `resolve_recipients`, `compose_self_echo`). Happy to walk through a manual two-session check.