### PR TITLE
Stable session identity: attend-session crate + attend whoami (ADR-171)

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -91,6 +91,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-168](./system/ADR-168-instance-addressable-directed-messaging-for-same-cwd-attend-siblings.md) | Instance-addressable directed messaging for same-cwd attend siblings | Draft |
 | [ADR-169](./system/ADR-169-agent-ways-relinquishes-user-scoped-settings-json-retains-only-its-operational-baseline.md) | agent-ways relinquishes user-scoped settings.json; retains only its operational baseline | Proposed |
 | [ADR-170](./system/ADR-170-human-focus-group-membership-via-username-identity-and-a-shared-attend-groups-crate.md) | Human focus-group membership via username identity and a shared attend-groups crate | Accepted |
+| [ADR-171](./system/ADR-171-stable-session-identity-the-roster-enumerates-addressable-coordinating-units.md) | Stable session identity — the roster enumerates addressable coordinating units | Accepted |
 
 ## Governance
 _Provenance, traceability, controls, compliance mapping_

--- a/docs/architecture/system/ADR-171-stable-session-identity-the-roster-enumerates-addressable-coordinating-units.md
+++ b/docs/architecture/system/ADR-171-stable-session-identity-the-roster-enumerates-addressable-coordinating-units.md
@@ -1,0 +1,115 @@
+---
+status: Accepted
+date: 2026-07-21
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-129
+  - ADR-136
+  - ADR-168
+  - ADR-170
+---
+
+# ADR-171: Stable session identity — the roster enumerates addressable coordinating units
+
+## Context
+
+A live multi-session test (issue #378) surfaced the "multiple personalities"
+failure: one human and two claude sessions rendered as four-plus identities
+(`hana`, `Hana-beta`, the ghost `Hana-alpha`, a `tools/`-keyed persona from
+the same session). Three root causes were reproduced from one session's own
+history:
+
+1. **Identity keyed off process cwd at launch.** attend derived its working
+   dir from `current_dir()`, so a stray shell `cd` leaking into an
+   `attend run` launch (a Monitor inheriting a build directory) put the
+   session on the bus as a different persona than its project.
+2. **Registration happened once, at startup.** The periodic instance-registry
+   maintenance used `touch`, which is a no-op for a missing entry — a session
+   whose registration was GC'd or never written rendered as the bare
+   nickname forever.
+3. **Historical wire data kept superseded personas alive** in the chat
+   legend for as long as their signals sat in the buffer.
+
+The debate (operator + two peer sessions, recorded on #378) also settled what
+identity *is* on this bus, which the fix must encode.
+
+## Decision
+
+**Identity is the coordinating unit, not the process.** A claude's canonical
+identity is the tuple `(sessionId ∩ origin_path)` — the session UID paired
+with the *session record's* cwd, never the process cwd. Concretely:
+
+- **A new `attend-session` crate owns the one derivation** of "who am I on
+  the bus": pid-ancestry walk over `~/.claude/sessions/*.json` for the
+  session UID, the session record's `cwd` as the origin path, with explicit
+  flagged fallbacks (`pid-<pid>` + process cwd, `resolved: false`) for
+  processes no Claude session owns. attend (run, send, status, peers, inbox,
+  config), sensor-peers, the instance registry, the heartbeat id, and
+  focus-group member ids all resolve through it. Downstream durable state —
+  the planned per-session consumption checkpoint (drain research) — keys on
+  the same tuple by calling the same derivation.
+- **`attend whoami` is the CLI accessor** for the tuple (`--machine` emits
+  `key=value` of only the stable fields), so hooks and scripts obtain
+  identity without touching attend-owned state. The rendered display name is
+  deliberately absent from machine output: **ordinals are presentation,
+  never keys.**
+- **The roster enumerates addressable coordinating units** — top-level
+  sessions, by session UID per origin dir. A second top-level instance in
+  the same origin dir takes the next Greek letter (the existing ADR-129
+  allocator, which was already idempotent per `(cwd, sessionId)`; this ADR
+  fixes its *inputs*). Subagents are the supervisor's efferent limbs, not
+  afferent participants: they get no roster identity and no letter. Their
+  activity may render as decoration on the parent's chip (deferred,
+  presentation-only).
+- **The periodic registry maintenance upserts** (`register`, idempotent)
+  instead of touching, so a session with a missing entry self-heals within
+  one interval instead of rendering bare forever.
+
+## Consequences
+
+### Positive
+
+- A session's bus persona is immune to shell cwd drift — the launch
+  environment can no longer mint accidental identities.
+- The "bare nickname" degradation self-heals; ghosts stop accumulating at
+  their source.
+- One identity derivation shared by four consumers replaces three partial
+  ones; the drain checkpoint research can key on it without re-implementing
+  resolution.
+- A minimal attend build (without sensor-peers) now resolves real session
+  identity instead of degrading to `pid-<pid>` member ids.
+
+### Negative
+
+- Session-record resolution costs a sessions-dir walk plus a `ps`-based
+  ancestry climb per subcommand invocation — negligible at CLI cadence, but
+  no longer a bare `getcwd`.
+- Historical signals written under superseded personas still render as
+  distinct chips until they age out of buffers — display residue this ADR
+  accepts rather than rewriting history.
+
+### Neutral
+
+- Humans are unaffected: their username identity (ADR-170) was stable by
+  construction.
+- `Focus::default_focus()` keeps its process-cwd default for the generic
+  sensor API; attend overrides the working dir at the one place identity is
+  authoritative.
+
+## Alternatives Considered
+
+- **Per-process registry identity (PID lineage) so subagents get letters** —
+  rejected in the #378 debate: subagents have no independent voice in the
+  channel, letters would flicker with worker lifecycles, and consumption is
+  session-level regardless. Identity follows addressability.
+- **Keying anything on the rendered ordinal** — rejected: slot reuse would
+  alias different sessions over time; monotonic slots grow unboundedly.
+  Ordinal is presentation; the tuple is the key.
+- **Fixing cwd drift by documenting "don't `cd` before launching attend"** —
+  rejected: the failure was produced by an agent following normal build
+  workflows; discipline that one stray `cd` defeats is not an invariant.
+- **Synthesizing session records for non-session processes** — rejected:
+  pollutes Claude Code-owned state (same reasoning as ADR-170's rejection of
+  synthetic session files).

--- a/docs/cli/attend.md
+++ b/docs/cli/attend.md
@@ -1,0 +1,412 @@
+# Command-Line Help for `attend`
+
+This document contains the help content for the `attend` command-line program.
+
+**Command Overview:**
+
+* [`attend`↴](#attend)
+* [`attend run`↴](#attend-run)
+* [`attend peers`↴](#attend-peers)
+* [`attend inbox`↴](#attend-inbox)
+* [`attend status`↴](#attend-status)
+* [`attend whoami`↴](#attend-whoami)
+* [`attend sensors`↴](#attend-sensors)
+* [`attend send`↴](#attend-send)
+* [`attend reply`↴](#attend-reply)
+* [`attend chat`↴](#attend-chat)
+* [`attend focus`↴](#attend-focus)
+* [`attend focus on`↴](#attend-focus-on)
+* [`attend focus off`↴](#attend-focus-off)
+* [`attend focus clear`↴](#attend-focus-clear)
+* [`attend focus pin`↴](#attend-focus-pin)
+* [`attend focus unpin`↴](#attend-focus-unpin)
+* [`attend focus dissolve`↴](#attend-focus-dissolve)
+* [`attend focus all`↴](#attend-focus-all)
+* [`attend focus list`↴](#attend-focus-list)
+* [`attend scene`↴](#attend-scene)
+* [`attend scenes`↴](#attend-scenes)
+* [`attend tune`↴](#attend-tune)
+* [`attend permissions`↴](#attend-permissions)
+* [`attend permissions audit`↴](#attend-permissions-audit)
+* [`attend cleanup`↴](#attend-cleanup)
+* [`attend config`↴](#attend-config)
+* [`attend config init`↴](#attend-config-init)
+* [`attend config show`↴](#attend-config-show)
+* [`attend config path`↴](#attend-config-path)
+* [`attend config lint`↴](#attend-config-lint)
+
+## `attend`
+
+Active awareness for Claude Code sessions
+
+**Usage:** `attend [COMMAND]`
+
+###### **Subcommands:**
+
+* `run` — Start the sensor loop (use with Monitor for async delivery)
+* `peers` — List active Claude Code sessions and focus groups
+* `inbox` — Read pending messages from peers
+* `status` — Show running instances, signals, and focus state
+* `whoami` — Print this session's canonical bus identity (issue #378)
+* `sensors` — List all sensors — built-in and config-defined script sensors
+* `send` — Send a signal to peer sessions (defaults to #open base channel)
+* `reply` — Reply to the most recent peer message (auto-threaded)
+* `chat` — Launch the interactive chat TUI (ADR-120)
+* `focus` — Manage attention groups (default: list joined groups)
+* `scene` — Activate a named scene (reconfigure focus groups)
+* `scenes` — List available scenes
+* `tune` — Survey session history and derive engagement config
+* `permissions` — Audit sensor permissions against settings.json (default: audit)
+* `cleanup` — Reap signal files whose owning project is gone, and prune empty project dirs. Messages are never removed by age — lifetime is bound to project liveness (ADR-136)
+* `config` — Manage configuration (default: show)
+
+
+
+## `attend run`
+
+Start the sensor loop (use with Monitor for async delivery)
+
+**Usage:** `attend run [OPTIONS]`
+
+###### **Options:**
+
+* `--catchup` — Replay backlog signals on startup before normal cadence
+
+
+
+## `attend peers`
+
+List active Claude Code sessions and focus groups
+
+**Usage:** `attend peers`
+
+
+
+## `attend inbox`
+
+Read pending messages from peers
+
+**Usage:** `attend inbox [OPTIONS] [MSG_ID]`
+
+###### **Arguments:**
+
+* `<MSG_ID>` — Specific message id to read in detail (omit to list inbox)
+
+###### **Options:**
+
+* `--limit <LIMIT>` — Max messages per page, newest first
+
+  Default value: `25`
+* `--page <PAGE>` — Page number; 1 = newest. Higher numbers walk back into history
+
+  Default value: `1`
+* `--before <TS>` — Cursor: only show messages older than this unix timestamp
+
+
+
+## `attend status`
+
+Show running instances, signals, and focus state
+
+**Usage:** `attend status`
+
+
+
+## `attend whoami`
+
+Print this session's canonical bus identity (issue #378)
+
+**Usage:** `attend whoami [OPTIONS]`
+
+###### **Options:**
+
+* `--machine` — Emit the stable key as `key=value` lines for scripts/hooks (session_id, origin_path, resolved) instead of the human-readable table. Downstream state must key on these fields — the display name is presentation, never a key
+
+
+
+## `attend sensors`
+
+List all sensors — built-in and config-defined script sensors
+
+**Usage:** `attend sensors`
+
+
+
+## `attend send`
+
+Send a signal to peer sessions (defaults to #open base channel)
+
+**Usage:** `attend send [OPTIONS] [MESSAGE]...`
+
+###### **Arguments:**
+
+* `<MESSAGE>` — Message body (must follow all flags)
+
+###### **Options:**
+
+* `--broadcast` — Force broadcast (every peer + every Aaron session)
+* `--to <PATH>` — Scope send to a specific project path
+* `--focus <NAME>` — Scope send to a named focus group
+
+
+
+## `attend reply`
+
+Reply to the most recent peer message (auto-threaded)
+
+**Usage:** `attend reply [OPTIONS] [MESSAGE]...`
+
+###### **Arguments:**
+
+* `<MESSAGE>` — Message body (must follow all flags)
+
+###### **Options:**
+
+* `--broadcast` — Force broadcast
+* `--to <PATH>` — Scope send to a specific project path
+* `--focus <NAME>` — Scope send to a named focus group
+
+
+
+## `attend chat`
+
+Launch the interactive chat TUI (ADR-120)
+
+**Usage:** `attend chat [PASSTHROUGH]...`
+
+###### **Arguments:**
+
+* `<PASSTHROUGH>` — Arguments passed through to the `attend-chat` binary
+
+
+
+## `attend focus`
+
+Manage attention groups (default: list joined groups)
+
+**Usage:** `attend focus [COMMAND]`
+
+###### **Subcommands:**
+
+* `on` — Join a focus group
+* `off` — Leave a focus group
+* `clear` — Leave every joined group
+* `pin` — Pin a group so it persists across scene changes
+* `unpin` — Unpin a group
+* `dissolve` — Dissolve a group (remove for every peer)
+* `all` — Show every available group
+* `list` — List joined groups (default action)
+
+
+
+## `attend focus on`
+
+Join a focus group
+
+**Usage:** `attend focus on [OPTIONS] <NAME>`
+
+###### **Arguments:**
+
+* `<NAME>` — Group name
+
+###### **Options:**
+
+* `--pin` — Pin so it persists across scene changes
+
+
+
+## `attend focus off`
+
+Leave a focus group
+
+**Usage:** `attend focus off <NAME>`
+
+###### **Arguments:**
+
+* `<NAME>` — Group name
+
+
+
+## `attend focus clear`
+
+Leave every joined group
+
+**Usage:** `attend focus clear`
+
+
+
+## `attend focus pin`
+
+Pin a group so it persists across scene changes
+
+**Usage:** `attend focus pin <NAME>`
+
+###### **Arguments:**
+
+* `<NAME>`
+
+
+
+## `attend focus unpin`
+
+Unpin a group
+
+**Usage:** `attend focus unpin <NAME>`
+
+###### **Arguments:**
+
+* `<NAME>`
+
+
+
+## `attend focus dissolve`
+
+Dissolve a group (remove for every peer)
+
+**Usage:** `attend focus dissolve <NAME>`
+
+###### **Arguments:**
+
+* `<NAME>`
+
+
+
+## `attend focus all`
+
+Show every available group
+
+**Usage:** `attend focus all`
+
+
+
+## `attend focus list`
+
+List joined groups (default action)
+
+**Usage:** `attend focus list`
+
+
+
+## `attend scene`
+
+Activate a named scene (reconfigure focus groups)
+
+**Usage:** `attend scene <NAME>`
+
+###### **Arguments:**
+
+* `<NAME>` — Scene name (try `attend scenes` to list)
+
+
+
+## `attend scenes`
+
+List available scenes
+
+**Usage:** `attend scenes`
+
+
+
+## `attend tune`
+
+Survey session history and derive engagement config
+
+**Usage:** `attend tune [OPTIONS]`
+
+###### **Options:**
+
+* `--apply` — Write derived values to the user config
+
+
+
+## `attend permissions`
+
+Audit sensor permissions against settings.json (default: audit)
+
+**Usage:** `attend permissions [COMMAND]`
+
+###### **Subcommands:**
+
+* `audit` — Compare each sensor's `requires:` against settings.json
+
+
+
+## `attend permissions audit`
+
+Compare each sensor's `requires:` against settings.json
+
+**Usage:** `attend permissions audit`
+
+
+
+## `attend cleanup`
+
+Reap signal files whose owning project is gone, and prune empty project dirs. Messages are never removed by age — lifetime is bound to project liveness (ADR-136)
+
+**Usage:** `attend cleanup [OPTIONS]`
+
+###### **Options:**
+
+* `-n`, `--dry-run` — List what would be removed without deleting
+* `--all` — Remove every signal file regardless of project liveness
+
+
+
+## `attend config`
+
+Manage configuration (default: show)
+
+**Usage:** `attend config [COMMAND]`
+
+###### **Subcommands:**
+
+* `init` — Write a default config file to the user scope
+* `show` — Display the current effective configuration (default)
+* `path` — Print the user/project config file paths
+* `lint` — Validate the config file
+
+
+
+## `attend config init`
+
+Write a default config file to the user scope
+
+**Usage:** `attend config init`
+
+
+
+## `attend config show`
+
+Display the current effective configuration (default)
+
+**Usage:** `attend config show`
+
+
+
+## `attend config path`
+
+Print the user/project config file paths
+
+**Usage:** `attend config path`
+
+
+
+## `attend config lint`
+
+Validate the config file
+
+**Usage:** `attend config lint [OPTIONS]`
+
+###### **Options:**
+
+* `--fix` — Auto-fix what can be fixed
+* `--check` — Exit non-zero on errors (for CI)
+
+
+
+<hr/>
+
+<small><i>
+    This document was generated automatically by
+    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
+</i></small>

--- a/statusline.sh
+++ b/statusline.sh
@@ -9,6 +9,20 @@ DIR=$(basename "$(pwd)")
 # Get current time
 TIME=$(date +%H:%M)
 
+# Get attend agent name if this session is enrolled (attend running).
+# CLI is the contract: read the sanctioned `attend peers` surface rather than
+# attend-owned state. The (self) row's Agent column holds our nickname.
+AGENT_INFO=""
+if command -v attend > /dev/null 2>&1; then
+    ESC=$(printf '\033')
+    AGENT_NAME=$(timeout $TIMEOUT attend peers 2>/dev/null \
+        | sed "s/${ESC}\[[0-9;]*m//g" \
+        | awk '/\(self\)/{print $2; exit}')
+    if [[ -n "$AGENT_NAME" ]]; then
+        AGENT_INFO="🤖 $AGENT_NAME "
+    fi
+fi
+
 # Get git branch and remote if in a git repo
 GIT_INFO=""
 REMOTE_INFO=""
@@ -31,4 +45,4 @@ if timeout $TIMEOUT git rev-parse --git-dir > /dev/null 2>&1; then
 fi
 
 # Combine all elements
-echo "📁 $DIR$GIT_INFO$REMOTE_INFO | 🕐 $TIME"
+echo "${AGENT_INFO}📁 $DIR$GIT_INFO$REMOTE_INFO | 🕐 $TIME"

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -226,6 +226,7 @@ dependencies = [
  "attend-groups",
  "attend-heartbeat",
  "attend-instances",
+ "attend-session",
  "clap",
  "clap-markdown",
  "sensor-context",
@@ -270,6 +271,10 @@ version = "0.1.0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "attend-session"
+version = "0.1.0"
 
 [[package]]
 name = "autocfg"
@@ -1212,6 +1217,7 @@ dependencies = [
 name = "sensor-peers"
 version = "0.6.0"
 dependencies = [
+ "attend-session",
  "sensor-trait",
  "serde_json",
  "ways-core",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "attend-groups",
     "attend-heartbeat",
     "attend-instances",
+    "attend-session",
 ]
 resolver = "2"
 

--- a/tools/attend-session/Cargo.toml
+++ b/tools/attend-session/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "attend-session"
+version = "0.1.0"
+edition = "2021"
+description = "Canonical session self-identity for the attend mesh: (sessionId ∩ origin_path) — issue #378"
+license = "MIT OR Apache-2.0"
+
+[lib]
+name = "attend_session"
+path = "src/lib.rs"

--- a/tools/attend-session/src/lib.rs
+++ b/tools/attend-session/src/lib.rs
@@ -1,0 +1,290 @@
+//! Canonical session self-identity for the attend mesh (issue #378).
+//!
+//! One derivation of "who am I on the bus", consumed by everything
+//! that needs a stable key: the instance registry, the heartbeat,
+//! focus-group member ids, signal wire identity, and (planned) the
+//! per-session consumption checkpoint. The invariant this crate
+//! guards:
+//!
+//! > A claude's identity is `(sessionId ∩ origin_path)` — the session
+//! > UID from Claude Code's session record, paired with the *session
+//! > record's* cwd, never the process cwd.
+//!
+//! Why not process cwd: a shell `cd` that leaks into an `attend run`
+//! launch (or any subcommand) would otherwise put the session on the
+//! bus as a different persona than its project — the "multiple
+//! personalities" failure #378 documents. The session record is the
+//! stable half of the tuple; process cwd is only ever a fallback for
+//! processes that genuinely have no Claude session (a human's shell).
+//!
+//! ## Resolution
+//!
+//! 1. Walk `~/.claude/sessions/*.json` into a pid → sessionId map.
+//! 2. Climb our own pid's ancestry (≤15 hops) until a mapped pid is
+//!    found — that session is ours.
+//! 3. Read that session record's `cwd` as the origin path.
+//!
+//! Fallbacks are explicit and flagged (`resolved: false`): no session
+//! record → `pid-<pid>` + process cwd. Callers that require a real
+//! session (registry, groups) can branch on `resolved`.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// The canonical identity tuple. `session_id` and `origin_path` are
+/// the stable key downstream state must use; display naming (nickname
+/// + Greek ordinal) is presentation layered on top and never a key.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SessionIdentity {
+    /// Claude Code session UID, or `pid-<pid>` when unresolved.
+    pub session_id: String,
+    /// The session record's cwd, or the process cwd when unresolved.
+    pub origin_path: String,
+    /// True iff both halves came from a real session record.
+    pub resolved: bool,
+}
+
+/// Resolve the identity of the current process.
+pub fn identity() -> SessionIdentity {
+    identity_for_pid(std::process::id())
+}
+
+/// Resolve the identity of an arbitrary pid (test seam + tooling).
+pub fn identity_for_pid(pid: u32) -> SessionIdentity {
+    identity_in(&sessions_dir(), pid)
+}
+
+/// Core resolution against an arbitrary sessions directory, so tests
+/// can drive it without touching `$HOME`. The ancestry walk still
+/// uses the real process table — tests pass their own pid with a
+/// session record naming it directly.
+pub fn identity_in(dir: &Path, pid: u32) -> SessionIdentity {
+    let process_cwd = || {
+        std::env::current_dir()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default()
+    };
+    match find_session_id_in(dir, pid) {
+        Some(sid) => {
+            let origin = origin_path_in(dir, &sid);
+            let resolved = origin.is_some();
+            SessionIdentity {
+                origin_path: origin.unwrap_or_else(process_cwd),
+                session_id: sid,
+                resolved,
+            }
+        }
+        None => SessionIdentity {
+            session_id: format!("pid-{pid}"),
+            origin_path: process_cwd(),
+            resolved: false,
+        },
+    }
+}
+
+/// Find the Claude Code session owning `own_pid` by climbing its
+/// process ancestry against the session records' pids.
+pub fn find_own_session_id(own_pid: u32) -> Option<String> {
+    find_session_id_in(&sessions_dir(), own_pid)
+}
+
+/// Test-seam counterpart to [`find_own_session_id`].
+pub fn find_session_id_in(dir: &Path, own_pid: u32) -> Option<String> {
+    let mut pid_to_session: HashMap<u32, String> = HashMap::new();
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            if let Ok(content) = fs::read_to_string(entry.path()) {
+                if let (Some(pid), Some(sid)) = (
+                    extract_json_u64(&content, "pid"),
+                    extract_json_string(&content, "sessionId"),
+                ) {
+                    pid_to_session.insert(pid as u32, sid);
+                }
+            }
+        }
+    }
+    if pid_to_session.is_empty() {
+        return None;
+    }
+
+    let mut pid = own_pid;
+    for _ in 0..15 {
+        if let Some(sid) = pid_to_session.get(&pid) {
+            return Some(sid.clone());
+        }
+        if pid <= 1 {
+            break;
+        }
+        match get_parent_pid(pid) {
+            Some(ppid) if ppid != pid => pid = ppid,
+            _ => break,
+        }
+    }
+    None
+}
+
+/// The origin path recorded for `session_id`, from its session record.
+pub fn origin_path(session_id: &str) -> Option<String> {
+    origin_path_in(&sessions_dir(), session_id)
+}
+
+/// Test-seam counterpart to [`origin_path`].
+pub fn origin_path_in(dir: &Path, session_id: &str) -> Option<String> {
+    let entries = fs::read_dir(dir).ok()?;
+    for entry in entries.flatten() {
+        let Ok(content) = fs::read_to_string(entry.path()) else {
+            continue;
+        };
+        if extract_json_string(&content, "sessionId").as_deref() == Some(session_id) {
+            return extract_json_string(&content, "cwd");
+        }
+    }
+    None
+}
+
+fn sessions_dir() -> PathBuf {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(home).join(".claude").join("sessions")
+}
+
+/// Return the parent PID of `pid`, or `None` if it cannot be
+/// determined. Byte-compatible with the sensor-peers implementation
+/// this crate canonicalizes.
+#[cfg(not(windows))]
+fn get_parent_pid(pid: u32) -> Option<u32> {
+    let output = Command::new("ps")
+        .args(["--no-headers", "-p", &pid.to_string(), "-o", "ppid"])
+        .output()
+        .ok()?;
+    if output.status.success() {
+        let s = String::from_utf8_lossy(&output.stdout);
+        s.trim().parse::<u32>().ok().filter(|&p| p > 0)
+    } else {
+        None
+    }
+}
+
+#[cfg(windows)]
+fn get_parent_pid(pid: u32) -> Option<u32> {
+    let script = format!(
+        "(Get-CimInstance Win32_Process -Filter 'ProcessId={}').ParentProcessId",
+        pid
+    );
+    let output = Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+        .output()
+        .ok()?;
+    if output.status.success() {
+        let s = String::from_utf8_lossy(&output.stdout);
+        s.trim().parse::<u32>().ok().filter(|&p| p > 0)
+    } else {
+        None
+    }
+}
+
+/// Quick-and-dirty JSON string extractor — the session file schema is
+/// flat and stable, so a parser dependency would be pure ceremony.
+fn extract_json_string(json: &str, key: &str) -> Option<String> {
+    let pattern = format!("\"{}\":\"", key);
+    let start = json.find(&pattern)? + pattern.len();
+    let rest = &json[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+fn extract_json_u64(json: &str, key: &str) -> Option<u64> {
+    let pattern = format!("\"{}\":", key);
+    let start = json.find(&pattern)? + pattern.len();
+    let rest = json[start..].trim_start();
+    let end = rest
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(rest.len());
+    rest[..end].parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn tempdir_like() -> PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "attend-session-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    fn write_session(dir: &Path, sid: &str, pid: u32, cwd: &str) {
+        let body = format!(r#"{{"sessionId":"{sid}","cwd":"{cwd}","pid":{pid},"model":"x"}}"#);
+        let mut f = fs::File::create(dir.join(format!("{sid}.json"))).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn identity_resolves_own_pid_via_direct_record() {
+        // Our own test process pid mapped directly — no ancestry hops
+        // needed, so the walk terminates on the first lookup.
+        let dir = tempdir_like();
+        let pid = std::process::id();
+        write_session(&dir, "sess-me", pid, "/home/me/proj");
+        let id = identity_in(&dir, pid);
+        assert!(id.resolved);
+        assert_eq!(id.session_id, "sess-me");
+        assert_eq!(id.origin_path, "/home/me/proj");
+    }
+
+    #[test]
+    fn origin_path_comes_from_record_not_process_cwd() {
+        // The #378 invariant: even though this test process's cwd is
+        // wherever cargo put it, the identity's origin_path is the
+        // session record's cwd.
+        let dir = tempdir_like();
+        let pid = std::process::id();
+        write_session(&dir, "sess-me", pid, "/canonical/origin");
+        let id = identity_in(&dir, pid);
+        let actual_cwd = std::env::current_dir().unwrap().to_string_lossy().to_string();
+        assert_eq!(id.origin_path, "/canonical/origin");
+        assert_ne!(id.origin_path, actual_cwd);
+    }
+
+    #[test]
+    fn unresolved_identity_falls_back_flagged() {
+        let dir = tempdir_like(); // empty sessions dir
+        let id = identity_in(&dir, std::process::id());
+        assert!(!id.resolved);
+        assert_eq!(id.session_id, format!("pid-{}", std::process::id()));
+        assert!(!id.origin_path.is_empty());
+    }
+
+    #[test]
+    fn find_session_id_none_when_dir_missing() {
+        let dir = tempdir_like().join("nope");
+        assert_eq!(find_session_id_in(&dir, std::process::id()), None);
+    }
+
+    #[test]
+    fn origin_path_matches_by_session_id() {
+        let dir = tempdir_like();
+        write_session(&dir, "sess-a", 1111, "/proj/a");
+        write_session(&dir, "sess-b", 2222, "/proj/b");
+        assert_eq!(origin_path_in(&dir, "sess-b").as_deref(), Some("/proj/b"));
+        assert_eq!(origin_path_in(&dir, "sess-zz"), None);
+    }
+
+    #[test]
+    fn extract_json_u64_parses_pid() {
+        assert_eq!(extract_json_u64(r#"{"pid":12345,"x":"y"}"#, "pid"), Some(12345));
+        assert_eq!(extract_json_u64(r#"{"pid": 99}"#, "pid"), Some(99));
+        assert_eq!(extract_json_u64(r#"{"nope":1}"#, "pid"), None);
+    }
+}

--- a/tools/attend-session/src/lib.rs
+++ b/tools/attend-session/src/lib.rs
@@ -42,13 +42,34 @@ pub struct SessionIdentity {
     pub session_id: String,
     /// The session record's cwd, or the process cwd when unresolved.
     pub origin_path: String,
-    /// True iff both halves came from a real session record.
-    pub resolved: bool,
+    /// True iff `session_id` came from a real session record.
+    pub session_resolved: bool,
+    /// True iff `origin_path` came from that record's `cwd` field.
+    /// Distinct from `session_resolved` so "no session at all" and
+    /// "session record without a cwd" stay distinguishable.
+    pub origin_resolved: bool,
 }
 
-/// Resolve the identity of the current process.
+impl SessionIdentity {
+    /// Fully resolved: both halves of the tuple came from a session
+    /// record. Callers that gate behavior (instance registration,
+    /// whoami's fallback warning) branch on this.
+    pub fn resolved(&self) -> bool {
+        self.session_resolved && self.origin_resolved
+    }
+}
+
+/// Resolve the identity of the current process. Memoized for the
+/// process lifetime — the tuple is stable by definition (a process
+/// cannot change its owning session), and one-shot commands like
+/// `attend send` would otherwise repeat the sessions-dir walk and
+/// `ps` ancestry climb several times per invocation.
 pub fn identity() -> SessionIdentity {
-    identity_for_pid(std::process::id())
+    use std::sync::OnceLock;
+    static IDENT: OnceLock<SessionIdentity> = OnceLock::new();
+    IDENT
+        .get_or_init(|| identity_for_pid(std::process::id()))
+        .clone()
 }
 
 /// Resolve the identity of an arbitrary pid (test seam + tooling).
@@ -69,19 +90,42 @@ pub fn identity_in(dir: &Path, pid: u32) -> SessionIdentity {
     match find_session_id_in(dir, pid) {
         Some(sid) => {
             let origin = origin_path_in(dir, &sid);
-            let resolved = origin.is_some();
+            let origin_resolved = origin.is_some();
             SessionIdentity {
                 origin_path: origin.unwrap_or_else(process_cwd),
                 session_id: sid,
-                resolved,
+                session_resolved: true,
+                origin_resolved,
             }
         }
         None => SessionIdentity {
             session_id: format!("pid-{pid}"),
             origin_path: process_cwd(),
-            resolved: false,
+            session_resolved: false,
+            origin_resolved: false,
         },
     }
+}
+
+/// Is `ancestor` in `pid`'s process ancestry (inclusive)? The
+/// canonical home for ancestry checks — sensor-peers' own-session
+/// detection delegates here so hop limits and parent-pid resolution
+/// cannot drift between crates.
+pub fn pid_has_ancestor(pid: u32, ancestor: u32) -> bool {
+    let mut cur = pid;
+    for _ in 0..15 {
+        if cur == ancestor {
+            return true;
+        }
+        if cur <= 1 {
+            break;
+        }
+        match get_parent_pid(cur) {
+            Some(ppid) if ppid != cur => cur = ppid,
+            _ => break,
+        }
+    }
+    false
 }
 
 /// Find the Claude Code session owning `own_pid` by climbing its
@@ -186,12 +230,16 @@ fn get_parent_pid(pid: u32) -> Option<u32> {
     }
 }
 
-/// Quick-and-dirty JSON string extractor — the session file schema is
-/// flat and stable, so a parser dependency would be pure ceremony.
+/// Minimal JSON field extractor — the session file schema is flat and
+/// stable, so a parser dependency would be pure ceremony. Unlike the
+/// historical copies this canonicalizes, it tolerates whitespace after
+/// the colon (`"key": "value"`): as the now-single point of failure
+/// for identity, it must not silently break if Claude Code ever
+/// pretty-prints the record.
 fn extract_json_string(json: &str, key: &str) -> Option<String> {
-    let pattern = format!("\"{}\":\"", key);
+    let pattern = format!("\"{}\":", key);
     let start = json.find(&pattern)? + pattern.len();
-    let rest = &json[start..];
+    let rest = json[start..].trim_start().strip_prefix('"')?;
     let end = rest.find('"')?;
     Some(rest[..end].to_string())
 }
@@ -238,9 +286,59 @@ mod tests {
         let pid = std::process::id();
         write_session(&dir, "sess-me", pid, "/home/me/proj");
         let id = identity_in(&dir, pid);
-        assert!(id.resolved);
+        assert!(id.resolved());
+        assert!(id.session_resolved && id.origin_resolved);
         assert_eq!(id.session_id, "sess-me");
         assert_eq!(id.origin_path, "/home/me/proj");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn identity_resolves_via_ancestry_hop() {
+        // The record names our *parent* pid — resolution must climb
+        // one ancestry hop to find it, exercising the walk rather
+        // than the direct-map shortcut.
+        let dir = tempdir_like();
+        let parent = std::os::unix::process::parent_id();
+        write_session(&dir, "sess-parent", parent, "/via/hop");
+        let id = identity_in(&dir, std::process::id());
+        assert!(id.resolved());
+        assert_eq!(id.session_id, "sess-parent");
+        assert_eq!(id.origin_path, "/via/hop");
+    }
+
+    #[test]
+    fn session_without_cwd_is_partially_resolved() {
+        // A record that names us but carries no cwd: the session half
+        // resolves, the origin half falls back — and the two flags
+        // keep the cases distinguishable.
+        let dir = tempdir_like();
+        let pid = std::process::id();
+        let body = format!(r#"{{"sessionId":"sess-nocwd","pid":{pid}}}"#);
+        std::fs::write(dir.join("sess-nocwd.json"), body).unwrap();
+        let id = identity_in(&dir, pid);
+        assert!(id.session_resolved);
+        assert!(!id.origin_resolved);
+        assert!(!id.resolved());
+        assert_eq!(id.session_id, "sess-nocwd");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pid_has_ancestor_finds_parent_and_self() {
+        let me = std::process::id();
+        assert!(pid_has_ancestor(me, me));
+        assert!(pid_has_ancestor(me, std::os::unix::process::parent_id()));
+        // A pid that cannot be in our ancestry (pid 0 never is).
+        assert!(!pid_has_ancestor(me, 0));
+    }
+
+    #[test]
+    fn extractors_tolerate_whitespace_after_colon() {
+        let json = r#"{ "sessionId": "sess-x", "pid": 42, "cwd": "/p" }"#;
+        assert_eq!(extract_json_string(json, "sessionId").as_deref(), Some("sess-x"));
+        assert_eq!(extract_json_string(json, "cwd").as_deref(), Some("/p"));
+        assert_eq!(extract_json_u64(json, "pid"), Some(42));
     }
 
     #[test]
@@ -261,7 +359,8 @@ mod tests {
     fn unresolved_identity_falls_back_flagged() {
         let dir = tempdir_like(); // empty sessions dir
         let id = identity_in(&dir, std::process::id());
-        assert!(!id.resolved);
+        assert!(!id.resolved());
+        assert!(!id.session_resolved && !id.origin_resolved);
         assert_eq!(id.session_id, format!("pid-{}", std::process::id()));
         assert!(!id.origin_path.is_empty());
     }

--- a/tools/attend/Cargo.toml
+++ b/tools/attend/Cargo.toml
@@ -23,6 +23,7 @@ agent-identity = { path = "../agent-identity" }
 attend-groups = { path = "../attend-groups" }
 attend-heartbeat = { path = "../attend-heartbeat" }
 attend-instances = { path = "../attend-instances" }
+attend-session = { path = "../attend-session" }
 sensor-trait = { path = "../sensor-trait" }
 # CLI parsing — matches ADR-111's choice for `ways-cli`. Doc comments on
 # the `Cli`/`Commands` types in `cli.rs` are the single source of truth

--- a/tools/attend/src/cli.rs
+++ b/tools/attend/src/cli.rs
@@ -57,6 +57,16 @@ pub(crate) enum Commands {
     /// Show running instances, signals, and focus state
     Status,
 
+    /// Print this session's canonical bus identity (issue #378)
+    Whoami {
+        /// Emit the stable key as `key=value` lines for scripts/hooks
+        /// (session_id, origin_path, resolved) instead of the
+        /// human-readable table. Downstream state must key on these
+        /// fields — the display name is presentation, never a key.
+        #[arg(long)]
+        machine: bool,
+    },
+
     /// List all sensors — built-in and config-defined script sensors
     Sensors,
 

--- a/tools/attend/src/cmd.rs
+++ b/tools/attend/src/cmd.rs
@@ -18,3 +18,4 @@ pub(crate) mod send;
 pub(crate) mod sensors;
 pub(crate) mod status;
 pub(crate) mod tune;
+pub(crate) mod whoami;

--- a/tools/attend/src/cmd/inbox.rs
+++ b/tools/attend/src/cmd/inbox.rs
@@ -68,9 +68,7 @@ pub(crate) fn parse_signal(content: &str) -> Option<ParsedSignal<'_>> {
 
 pub(crate) fn cmd_inbox_read(msg_id: &str) {
     let base = signals_base();
-    let cwd = std::env::current_dir()
-        .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_default();
+    let cwd = crate::util::own_origin_cwd();
     let own_encoded = encode_project(&cwd);
     let r = get_groups();
     let mut scan_dirs = vec![
@@ -124,9 +122,7 @@ pub(crate) fn cmd_inbox_read(msg_id: &str) {
 
 pub(crate) fn cmd_inbox(limit: usize, page: usize, before: Option<u64>) {
     let base = signals_base();
-    let cwd = std::env::current_dir()
-        .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_default();
+    let cwd = crate::util::own_origin_cwd();
     let own_session_id = own_session_id().unwrap_or_default();
 
     // Scan same dirs as the peer sensor: own project + broadcast + focus group

--- a/tools/attend/src/cmd/peers.rs
+++ b/tools/attend/src/cmd/peers.rs
@@ -21,11 +21,10 @@ pub(crate) fn cmd_peers() {
     let mut t = agent_fmt::Table::new(&["Focus", "Agent", "Status", "Context"]);
     t.max_width(1, 28);
 
-    // Self row: derive identity from our cwd so the nickname matches
-    // what peers see when they render a signal from us.
-    let cwd = std::env::current_dir()
-        .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_default();
+    // Self row: derive identity from our origin path (issue #378) so
+    // the nickname matches what peers see when they render a signal
+    // from us — including when the shell's cwd has drifted.
+    let cwd = crate::util::own_origin_cwd();
     let self_id = Identity::for_cwd(&cwd, caps);
     // Look up our own instance suffix (ADR-129). Falls back to the
     // bare nickname when the registry is unreadable or our session

--- a/tools/attend/src/cmd/permissions.rs
+++ b/tools/attend/src/cmd/permissions.rs
@@ -7,7 +7,11 @@ use crate::sensors::Focus;
 pub(crate) fn cmd_permissions_audit() {
     use agent_fmt::permissions;
 
-    let focus = Focus::default_focus();
+    // Same config scope as the running loop (issue #378 / PR #380
+    // review finding 4): resolve the project from the session record
+    // so this report describes the config `attend run` actually uses.
+    let mut focus = Focus::default_focus();
+    focus.working_dir = crate::util::own_origin_cwd();
     let cfg = config::Config::load(&focus.working_dir);
 
     // Load settings.json grants

--- a/tools/attend/src/cmd/run/mod.rs
+++ b/tools/attend/src/cmd/run/mod.rs
@@ -30,14 +30,25 @@ const RELOAD_CHECK_INTERVAL: Duration = Duration::from_secs(10);
 pub(crate) fn cmd_run_with_catchup(catchup: bool) {
     emit::log("starting attend");
 
-    let focus = Focus::default_focus();
+    // Canonical identity (issue #378): session id + the session
+    // record's origin path, resolved once and used for everything —
+    // config scope, sensor scoping, tray naming, instance
+    // registration, group membership. Overriding the Focus default's
+    // process cwd here is what keeps a stray shell `cd` at launch
+    // (e.g. a Monitor inheriting a build directory) from putting this
+    // session on the bus as a different persona.
+    let ident = attend_session::identity();
+    let mut focus = Focus::default_focus();
+    if ident.resolved {
+        focus.working_dir = ident.origin_path.clone();
+    }
     emit::log(&format!("focus: {} ({})", focus.description, focus.working_dir));
 
     // Load config: user scope → project scope overlay
     let cfg = config::Config::load(&focus.working_dir);
 
     // Initialize rooms for signal routing (ADR-118)
-    let session_id = own_session_id().unwrap_or_else(|| format!("pid-{}", std::process::id()));
+    let session_id = ident.session_id.clone();
 
     // Duplicate-attend guard (ADR-129). Acquire an exclusive flock on
     // our heartbeat file so a second attend process cannot start for

--- a/tools/attend/src/cmd/run/mod.rs
+++ b/tools/attend/src/cmd/run/mod.rs
@@ -22,7 +22,7 @@ use governor::{DisclosureGovernor, ScheduledSensor};
 use tick::{build_engagement, maybe_self_reload, tick_iteration, TickState};
 
 use crate::sensors::Focus;
-use crate::util::{own_session_id, signals_base};
+use crate::util::signals_base;
 use crate::{config, emit, groups, sensors, state};
 
 const RELOAD_CHECK_INTERVAL: Duration = Duration::from_secs(10);
@@ -39,7 +39,7 @@ pub(crate) fn cmd_run_with_catchup(catchup: bool) {
     // session on the bus as a different persona.
     let ident = attend_session::identity();
     let mut focus = Focus::default_focus();
-    if ident.resolved {
+    if ident.resolved() {
         focus.working_dir = ident.origin_path.clone();
     }
     emit::log(&format!("focus: {} ({})", focus.description, focus.working_dir));
@@ -110,17 +110,26 @@ pub(crate) fn cmd_run_with_catchup(catchup: bool) {
     // attend will fail similarly. Log and continue with no
     // discriminator so renders fall back to the bare nickname.
     let instance_registry = attend_instances::Registry::new();
-    let my_instance = match instance_registry.register(&focus.working_dir, &session_id) {
-        Ok(s) => {
-            emit::log(&format!("instance: {s} (cwd: {})", focus.working_dir));
-            Some(s)
+    // Roster gate (ADR-171): only a fully resolved session registers.
+    // The roster enumerates addressable coordinating units; a
+    // `pid-<pid>` fallback runner is not one, and registering it
+    // would allocate a Greek slot to a persona nobody can address.
+    let my_instance = if ident.resolved() {
+        match instance_registry.register(&focus.working_dir, &session_id) {
+            Ok(s) => {
+                emit::log(&format!("instance: {s} (cwd: {})", focus.working_dir));
+                Some(s)
+            }
+            Err(e) => {
+                emit::log(&format!(
+                    "instance registry unavailable ({e}); rendering without suffix"
+                ));
+                None
+            }
         }
-        Err(e) => {
-            emit::log(&format!(
-                "instance registry unavailable ({e}); rendering without suffix"
-            ));
-            None
-        }
+    } else {
+        emit::log("identity unresolved (no session record); skipping roster registration");
+        None
     };
     let _ = &my_instance; // consumed by render layer once the suffix is wired in
 
@@ -153,9 +162,15 @@ pub(crate) fn cmd_run_with_catchup(catchup: bool) {
         slot.engagement = sensor_trait::EngagementState::new(engagement_curve.clone());
     }
 
-    // State persistence
-    let session_id = own_session_id();
-    let state_store = state::StateStore::new(session_id);
+    // State persistence — same canonical identity, Option-shaped for
+    // the store's "no session, no persistence" behavior. Deriving from
+    // `ident` (not a fresh resolution) is load-bearing: a re-derivation
+    // that raced claude startup could disagree with the identity the
+    // registry and heartbeat use, freezing a mixed persona (PR #380
+    // review, finding 1).
+    let state_store = state::StateStore::new(
+        ident.session_resolved.then(|| ident.session_id.clone()),
+    );
 
     // Try to restore state from previous run
     if let Some(snapshot) = state_store.restore() {
@@ -240,13 +255,12 @@ pub(crate) fn cmd_run_with_catchup(catchup: bool) {
     let initial_hash = tick::initial_self_hash(self_exe.as_deref());
     let mut last_reload_check = Instant::now();
 
-    // Heartbeat identifier (ADR-129). Real session id when resolvable,
-    // otherwise a pid-based fallback so a heartbeat exists even when
-    // session resolution is racing claude's startup. Re-derived here
-    // because the canonical `session_id` was shadowed by `state_store`'s
-    // Option<String> form.
-    let heartbeat_id =
-        own_session_id().unwrap_or_else(|| format!("pid-{}", std::process::id()));
+    // Heartbeat identifier (ADR-129) — the same canonical identity as
+    // everything else in this run. `session_id` already carries the
+    // `pid-<pid>` fallback when unresolved, so a heartbeat always
+    // exists; what matters is that it can never *disagree* with the
+    // id the registry and groups saw (PR #380 review, finding 1).
+    let heartbeat_id = session_id.clone();
 
     loop {
         // Heartbeat — touched at the top of every tick so a single
@@ -284,6 +298,7 @@ pub(crate) fn cmd_run_with_catchup(catchup: bool) {
             msg_governor: &mut msg_governor,
             last_checkpoint: &mut last_checkpoint,
             last_instance_touch: &mut last_instance_touch,
+            register_instances: ident.resolved(),
             last_cleanup: &mut last_cleanup,
             state_store: &state_store,
             instance_registry: &instance_registry,

--- a/tools/attend/src/cmd/run/tick.rs
+++ b/tools/attend/src/cmd/run/tick.rs
@@ -36,6 +36,10 @@ pub(super) struct TickState<'a> {
     pub(super) msg_governor: &'a mut DisclosureGovernor,
     pub(super) last_checkpoint: &'a mut Instant,
     pub(super) last_instance_touch: &'a mut Instant,
+    /// Roster gate (ADR-171): false for fallback identities, which
+    /// must never allocate registry slots — see the startup gate in
+    /// `cmd_run_with_catchup`.
+    pub(super) register_instances: bool,
     pub(super) last_cleanup: &'a mut Option<Instant>,
     pub(super) state_store: &'a state::StateStore,
     pub(super) instance_registry: &'a attend_instances::Registry,
@@ -286,7 +290,7 @@ pub(super) fn tick_iteration(s: &mut TickState) {
     // ("bare @Hana"). `register` is idempotent — an existing entry is
     // refreshed and keeps its slot; a missing one is re-allocated —
     // so the roster self-heals within one interval.
-    if s.last_instance_touch.elapsed() >= INSTANCE_TOUCH_INTERVAL {
+    if s.register_instances && s.last_instance_touch.elapsed() >= INSTANCE_TOUCH_INTERVAL {
         s.instance_registry
             .register(&s.focus.working_dir, s.heartbeat_id)
             .ok();

--- a/tools/attend/src/cmd/run/tick.rs
+++ b/tools/attend/src/cmd/run/tick.rs
@@ -278,12 +278,17 @@ pub(super) fn tick_iteration(s: &mut TickState) {
         *s.last_checkpoint = Instant::now();
     }
 
-    // Periodic instance-registry touch — refresh `last_seen` so the
-    // GC clock cannot expire an active session. Cheap when we already
-    // know we have an entry; no-op when registration failed at startup.
+    // Periodic instance-registry upsert — refresh `last_seen` so the
+    // GC clock cannot expire an active session, and *re-register* if
+    // our entry is missing (issue #378). `touch` was a silent no-op
+    // for unregistered sessions, which left a session whose entry was
+    // GC'd or never written rendering as the bare nickname forever
+    // ("bare @Hana"). `register` is idempotent — an existing entry is
+    // refreshed and keeps its slot; a missing one is re-allocated —
+    // so the roster self-heals within one interval.
     if s.last_instance_touch.elapsed() >= INSTANCE_TOUCH_INTERVAL {
         s.instance_registry
-            .touch(&s.focus.working_dir, s.heartbeat_id)
+            .register(&s.focus.working_dir, s.heartbeat_id)
             .ok();
         *s.last_instance_touch = Instant::now();
     }

--- a/tools/attend/src/cmd/send.rs
+++ b/tools/attend/src/cmd/send.rs
@@ -46,9 +46,9 @@ pub(crate) fn cmd_send(
     }
 
     let base = signals_base();
-    let cwd = std::env::current_dir()
-        .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_default();
+    // Wire identity rides this cwd (issue #378): the session record's
+    // origin path, so a stray shell `cd` can't relabel our sends.
+    let cwd = crate::util::own_origin_cwd();
 
     // Validate --to path against active peers
     if let Some(ref path) = target_dir {

--- a/tools/attend/src/cmd/sensors.rs
+++ b/tools/attend/src/cmd/sensors.rs
@@ -10,7 +10,11 @@ use crate::sensors::{enumerate_sensors, Focus, SensorEntry, SensorState};
 use std::time::Duration;
 
 pub(crate) fn cmd_sensors() {
-    let focus = Focus::default_focus();
+    // Same config scope as the running loop (issue #378 / PR #380
+    // review finding 4): a sensors listing must describe the sensor
+    // set `attend run` would actually start.
+    let mut focus = Focus::default_focus();
+    focus.working_dir = crate::util::own_origin_cwd();
     let cfg = Config::load(&focus.working_dir);
     let entries = enumerate_sensors(&cfg, &focus);
 

--- a/tools/attend/src/cmd/status.rs
+++ b/tools/attend/src/cmd/status.rs
@@ -33,9 +33,7 @@ pub(crate) fn cmd_status() {
 
     // Gather all data before building a single unified table
     let base = signals_base();
-    let cwd = std::env::current_dir()
-        .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_default();
+    let cwd = crate::util::own_origin_cwd();
     let own_dir = base.join(encode_project(&cwd));
     let broadcast_dir = base.join("_broadcast");
     let own_count = count_signals(&own_dir);

--- a/tools/attend/src/cmd/whoami.rs
+++ b/tools/attend/src/cmd/whoami.rs
@@ -1,0 +1,55 @@
+//! `attend whoami` — print this session's canonical bus identity.
+//!
+//! The CLI accessor for the `(sessionId ∩ origin_path)` derivation
+//! (issue #378), so external consumers — hooks, scripts, the planned
+//! drain checkpoint (ADR-171 research) — obtain the stable key by
+//! shelling out to attend instead of re-implementing resolution or
+//! reading attend-owned state. CLI is the contract.
+//!
+//! `--machine` emits `key=value` lines of ONLY the stable fields.
+//! The display name (nickname + instance suffix) appears in the
+//! human table as context, but is deliberately absent from machine
+//! output: ordinals are presentation and must never become keys.
+
+use agent_identity::{Identity, TermCaps};
+
+pub(crate) fn cmd_whoami(machine: bool) {
+    let ident = attend_session::identity();
+
+    if machine {
+        println!("session_id={}", ident.session_id);
+        println!("origin_path={}", ident.origin_path);
+        println!("resolved={}", ident.resolved);
+        return;
+    }
+
+    let caps = TermCaps::detect();
+    let display = Identity::for_cwd(&ident.origin_path, caps);
+    let instance = attend_instances::Registry::new()
+        .lookup(&ident.origin_path, &ident.session_id);
+    let rendered = match &instance {
+        Some(suffix) => format!("{}-{}", display.nickname, suffix),
+        None => display.nickname.to_string(),
+    };
+
+    let mut t = agent_fmt::Table::new(&["", "Value"]);
+    t.add(vec!["session", ident.session_id.as_str()]);
+    t.add(vec!["origin", ident.origin_path.as_str()]);
+    t.add(vec![
+        "resolved",
+        if ident.resolved {
+            "yes (session record)"
+        } else {
+            "no (pid/cwd fallback)"
+        },
+    ]);
+    t.add(vec!["display", rendered.as_str()]);
+    t.print();
+
+    if !ident.resolved {
+        eprintln!(
+            "\n[attend] no Claude session owns this process — identity is a fallback; \
+             registry and groups will not treat it as a session"
+        );
+    }
+}

--- a/tools/attend/src/cmd/whoami.rs
+++ b/tools/attend/src/cmd/whoami.rs
@@ -17,9 +17,9 @@ pub(crate) fn cmd_whoami(machine: bool) {
     let ident = attend_session::identity();
 
     if machine {
-        println!("session_id={}", ident.session_id);
-        println!("origin_path={}", ident.origin_path);
-        println!("resolved={}", ident.resolved);
+        for line in machine_lines(&ident) {
+            println!("{line}");
+        }
         return;
     }
 
@@ -37,8 +37,10 @@ pub(crate) fn cmd_whoami(machine: bool) {
     t.add(vec!["origin", ident.origin_path.as_str()]);
     t.add(vec![
         "resolved",
-        if ident.resolved {
+        if ident.resolved() {
             "yes (session record)"
+        } else if ident.session_resolved {
+            "partial (session record has no cwd; origin is process cwd)"
         } else {
             "no (pid/cwd fallback)"
         },
@@ -46,10 +48,48 @@ pub(crate) fn cmd_whoami(machine: bool) {
     t.add(vec!["display", rendered.as_str()]);
     t.print();
 
-    if !ident.resolved {
+    if !ident.resolved() {
         eprintln!(
-            "\n[attend] no Claude session owns this process — identity is a fallback; \
-             registry and groups will not treat it as a session"
+            "\n[attend] identity is not fully resolved — the instance roster will \
+             exclude this process; sends and group membership use the fallback id"
         );
+    }
+}
+
+/// The `--machine` output contract: `key=value` lines of the stable
+/// identity fields, nothing else. Downstream consumers (hooks, the
+/// drain checkpoint) key on these; the display name is deliberately
+/// absent — ordinals are presentation, never keys.
+fn machine_lines(ident: &attend_session::SessionIdentity) -> Vec<String> {
+    vec![
+        format!("session_id={}", ident.session_id),
+        format!("origin_path={}", ident.origin_path),
+        format!("resolved={}", ident.resolved()),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn machine_output_is_stable_fields_only() {
+        let ident = attend_session::SessionIdentity {
+            session_id: "sess-x".into(),
+            origin_path: "/proj".into(),
+            session_resolved: true,
+            origin_resolved: true,
+        };
+        let lines = machine_lines(&ident);
+        assert_eq!(
+            lines,
+            vec![
+                "session_id=sess-x".to_string(),
+                "origin_path=/proj".to_string(),
+                "resolved=true".to_string(),
+            ]
+        );
+        // Contract guard: no display/ordinal fields may creep in.
+        assert!(lines.iter().all(|l| !l.contains("display") && !l.contains("instance")));
     }
 }

--- a/tools/attend/src/config_lint.rs
+++ b/tools/attend/src/config_lint.rs
@@ -114,7 +114,7 @@ fn user_config_path() -> PathBuf {
 }
 
 fn project_config_path() -> PathBuf {
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let cwd = PathBuf::from(crate::util::own_origin_cwd());
     cwd.join(".claude").join("attend.yaml")
 }
 

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -60,6 +60,7 @@ fn main() {
             None => cmd::inbox::cmd_inbox(limit, page, before),
         },
         Commands::Status => cmd::status::cmd_status(),
+        Commands::Whoami { machine } => cmd::whoami::cmd_whoami(machine),
         Commands::Sensors => cmd::sensors::cmd_sensors(),
         Commands::Send { broadcast, to, focus, re, message } => {
             cmd::send::cmd_send(broadcast, to, focus, re, message);
@@ -151,9 +152,7 @@ fn dispatch_config(sub: ConfigCmd) {
                 format!("{}/.config", std::env::var("HOME").unwrap_or_default())
             });
             println!("user:    {}/attend/config.yaml", home);
-            let cwd = std::env::current_dir()
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or_default();
+            let cwd = util::own_origin_cwd();
             println!("project: {}/.claude/attend.yaml", cwd);
         }
         ConfigCmd::Lint { fix, check } => {

--- a/tools/attend/src/sensors/mod.rs
+++ b/tools/attend/src/sensors/mod.rs
@@ -17,7 +17,7 @@ pub use sensor_git::GitSensor;
 pub use sensor_context::ContextSensor;
 
 #[cfg(feature = "sensor-peers")]
-pub use sensor_peers::{PeerSensor, find_own_session_id};
+pub use sensor_peers::PeerSensor;
 
 #[cfg(feature = "sensor-processes")]
 pub use sensor_processes::ProcessSensor;

--- a/tools/attend/src/util.rs
+++ b/tools/attend/src/util.rs
@@ -8,8 +8,6 @@
 //! reaching into `main`.
 
 use crate::groups;
-#[cfg(feature = "sensor-peers")]
-use crate::sensors;
 
 pub(crate) fn signals_base() -> std::path::PathBuf {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
@@ -41,16 +39,22 @@ pub(crate) fn encode_project(path: &str) -> String {
         .collect()
 }
 
-/// Delegate to the shared implementation in the peer sensor module.
+/// Delegate to the canonical identity derivation (issue #378). No
+/// longer gated on the sensor-peers feature — a minimal attend build
+/// used to degrade own-identity to `pid-<pid>`, which polluted
+/// `_groups.yaml` member ids.
 pub(crate) fn own_session_id() -> Option<String> {
-    #[cfg(feature = "sensor-peers")]
-    {
-        sensors::find_own_session_id(std::process::id())
-    }
-    #[cfg(not(feature = "sensor-peers"))]
-    {
-        None
-    }
+    attend_session::find_own_session_id(std::process::id())
+}
+
+/// The cwd this session is *about* — the session record's origin path
+/// (issue #378), falling back to the process cwd only when no Claude
+/// session owns this process. Every subcommand that means "my
+/// project" (send identity, tray scan, status, registration) resolves
+/// through here, so a stray shell `cd` can no longer put the session
+/// on the bus as a different persona.
+pub(crate) fn own_origin_cwd() -> String {
+    attend_session::identity().origin_path
 }
 
 pub(crate) fn count_signals(dir: &std::path::Path) -> usize {

--- a/tools/sensor-peers/Cargo.toml
+++ b/tools/sensor-peers/Cargo.toml
@@ -6,6 +6,7 @@ description = "discovers Claude Code sessions and reads peer signals"
 license = "MIT"
 
 [dependencies]
+attend-session = { path = "../attend-session" }
 sensor-trait = { path = "../sensor-trait" }
 ways-core = { path = "../ways-core" }
 serde_json = "1"

--- a/tools/sensor-peers/src/lib.rs
+++ b/tools/sensor-peers/src/lib.rs
@@ -839,55 +839,13 @@ fn pid_is_claude(pid: u32) -> bool {
     }
 }
 
-/// Return the parent PID of `pid`, or `None` if it cannot be determined.
-#[cfg(not(windows))]
-fn get_parent_pid(pid: u32) -> Option<u32> {
-    let output = Command::new("ps")
-        .args(["--no-headers", "-p", &pid.to_string(), "-o", "ppid"])
-        .output()
-        .ok()?;
-    if output.status.success() {
-        let s = String::from_utf8_lossy(&output.stdout);
-        s.trim().parse::<u32>().ok().filter(|&p| p > 0)
-    } else {
-        None
-    }
-}
-
-#[cfg(windows)]
-fn get_parent_pid(pid: u32) -> Option<u32> {
-    let script = format!(
-        "(Get-CimInstance Win32_Process -Filter 'ProcessId={}').ParentProcessId",
-        pid
-    );
-    let output = Command::new("powershell")
-        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
-        .output()
-        .ok()?;
-    if output.status.success() {
-        let s = String::from_utf8_lossy(&output.stdout);
-        s.trim().parse::<u32>().ok().filter(|&p| p > 0)
-    } else {
-        None
-    }
-}
-
-/// Check if a session PID is an ancestor of our own PID (i.e., our session).
+/// Check if a session PID is an ancestor of our own PID (i.e., our
+/// session). Delegates to the canonical ancestry walk in
+/// attend-session (issue #378) so hop limits and parent-pid
+/// resolution cannot drift between the identity derivation and this
+/// sensor's own-session filter.
 fn is_own_session(session_pid: u32, own_pid: u32) -> bool {
-    let mut pid = own_pid;
-    for _ in 0..10 {
-        if pid == session_pid {
-            return true;
-        }
-        if pid <= 1 {
-            break;
-        }
-        match get_parent_pid(pid) {
-            Some(ppid) if ppid != pid => pid = ppid,
-            _ => break,
-        }
-    }
-    false
+    attend_session::pid_has_ancestor(own_pid, session_pid)
 }
 
 /// Quick-and-dirty JSON string extraction without serde.

--- a/tools/sensor-peers/src/lib.rs
+++ b/tools/sensor-peers/src/lib.rs
@@ -916,39 +916,11 @@ fn extract_json_string(json: &str, key: &str) -> Option<String> {
 /// every subcommand invocation. Probing the pid index directly avoids that
 /// trap and works for both kinds of session.
 pub fn find_own_session_id(own_pid: u32) -> Option<String> {
-    let sessions_dir = home_dir().join(".claude").join("sessions");
-    let mut pid_to_session: std::collections::HashMap<u32, String> =
-        std::collections::HashMap::new();
-    if let Ok(entries) = fs::read_dir(&sessions_dir) {
-        for entry in entries.flatten() {
-            if let Ok(content) = fs::read_to_string(entry.path()) {
-                if let (Some(pid), Some(sid)) = (
-                    extract_json_u64(&content, "pid"),
-                    extract_json_string(&content, "sessionId"),
-                ) {
-                    pid_to_session.insert(pid as u32, sid);
-                }
-            }
-        }
-    }
-    if pid_to_session.is_empty() {
-        return None;
-    }
-
-    let mut pid = own_pid;
-    for _ in 0..15 {
-        if let Some(sid) = pid_to_session.get(&pid) {
-            return Some(sid.clone());
-        }
-        if pid <= 1 {
-            break;
-        }
-        match get_parent_pid(pid) {
-            Some(ppid) if ppid != pid => pid = ppid,
-            _ => break,
-        }
-    }
-    None
+    // Canonicalized in the attend-session crate (issue #378) — one
+    // resolution shared by attend, this sensor, and any future
+    // consumer, so "who am I" can never drift between them. This
+    // wrapper survives for API stability.
+    attend_session::find_own_session_id(own_pid)
 }
 
 // ── Message chunking ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **ADR-171 (Accepted)**: a claude's bus identity is `(sessionId ∩ origin_path)` — the session UID plus the *session record's* cwd, never the process cwd. The roster enumerates addressable coordinating units (top-level sessions); subagents are efferent limbs with no roster identity; ordinals are presentation, never keys. Encodes the three-party design debate and operator sign-off on #378.
- **New `attend-session` crate** owns the single identity derivation, consumed by attend (run/send/status/peers/inbox/config), sensor-peers (now a delegating wrapper), the instance registry key, heartbeat id, and group member ids. Fixes the latent minimal-build degradation to `pid-<pid>` member ids.
- **Ghost-class fixes**: `attend run` takes its working dir from the session record (shell-`cd` drift can't mint personas); periodic instance maintenance upserts instead of touching (bare-nickname entries self-heal within one interval).
- **`attend whoami`** (`--machine` for `key=value` stable fields) — the CLI seam the drain-checkpoint research asked for, honoring CLI-is-the-contract. `docs/cli/attend.md` regenerated and now tracked.

Closes #378.

## Test plan

- 264 tests across the affected crates, clippy clean, release build green.
- Live verification on the real bus: `attend whoami` from a deliberately drifted shell cwd (`tools/`) resolves the session's true origin path and suffixed display name — the exact failure case that motivated #378.

Deferred (recorded in ADR-171): subagent activity decoration on parent chips (presentation-only); historical-signal persona residue ages out naturally.