### PR TITLE
release(attend): v0.11.0

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attend"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "agent-fmt",
  "agent-identity",

--- a/tools/attend/Cargo.toml
+++ b/tools/attend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "attend"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Active awareness module — adaptive sensing and disclosure for Claude Code sessions"
 license = "MIT"


### PR DESCRIPTION
Version bump for the attend 0.11.0 release (ADR-150). After merge, tag it: `make publish-release COMPONENT=attend` — that pushes `attend-v0.11.0` and CI builds all platforms + creates the GitHub Release.