### PR TITLE
release(attend-chat): v0.5.0

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "attend-chat"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "agent-fmt",
  "agent-identity",

--- a/tools/attend-chat/Cargo.toml
+++ b/tools/attend-chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "attend-chat"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Interactive chat TUI for attend — human seat at the signal bus (ADR-120)"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Version bump for the attend-chat 0.5.0 release (ADR-150). After merge, tag it: `make publish-release COMPONENT=attend-chat` — that pushes `attend-chat-v0.5.0` and CI builds all platforms + creates the GitHub Release.