### PR TITLE
feat(attend-chat): inline slash help in the status slot (#398)

### DIFF
--- a/tools/attend-chat/src/app/mod.rs
+++ b/tools/attend-chat/src/app/mod.rs
@@ -367,6 +367,17 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
     // is past its name, the registry's `ArgKind` routes the helper
     // (`/whois ` → agents, `/join ` → channels).
     let helper_mode = helper::derive(&input_snapshot);
+    // #398: while the typed slash command is unambiguous, the status
+    // slot shows that command's inline help — documentation at the
+    // point of intent. The swap is display-time only: the stored
+    // result string is never overwritten, so backspacing to an empty
+    // prompt restores it for free.
+    let status_line = match &helper_mode {
+        helper::HelperMode::Slash(Some(p)) => {
+            slash::single_match_help(p).unwrap_or_else(|| status.to_string())
+        }
+        _ => status.to_string(),
+    };
     let rows: Vec<_> = signals
         .read()
         .iter()
@@ -579,7 +590,7 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                 HelperMode::Slash(p) => slash::slash_legend_row(p.as_deref()),
             })
             View(height: 1, padding_left: 1) {
-                Text(color: Color::DarkGrey, content: status.to_string(), wrap: TextWrap::NoWrap)
+                Text(color: Color::DarkGrey, content: status_line, wrap: TextWrap::NoWrap)
             }
         }
     }

--- a/tools/attend-chat/src/slash.rs
+++ b/tools/attend-chat/src/slash.rs
@@ -180,6 +180,31 @@ pub struct SlashPartial<'a> {
     pub partial: &'a str,
 }
 
+/// Inline help for the status slot while composing (#398): when
+/// exactly one registry command has `partial` as a prefix, return its
+/// one-line help; otherwise `None` and the caller keeps showing the
+/// last executed result. An empty partial matches everything, so the
+/// bare `/` menu keeps the result visible beneath the full list.
+pub fn single_match_help(partial: &str) -> Option<String> {
+    let mut matches = REGISTRY.iter().filter(|c| c.name.starts_with(partial));
+    match (matches.next(), matches.next()) {
+        (Some(cmd), None) => {
+            let arg = match cmd.arg_kind {
+                ArgKind::None => "",
+                ArgKind::Agent => " <@name>",
+                ArgKind::Group => " <#channel>",
+            };
+            let planned = if cmd.status == Status::Planned {
+                " (planned)"
+            } else {
+                ""
+            };
+            Some(format!("/{}{} — {}{}", cmd.name, arg, cmd.description, planned))
+        }
+        _ => None,
+    }
+}
+
 pub fn find_slash_partial(input: &str) -> Option<SlashPartial<'_>> {
     // Mirror [`parse`]'s leading-whitespace tolerance so every caller
     // (Enter interceptor, Tab completion, helper-row state machine)
@@ -746,5 +771,32 @@ mod tests {
         // now dispatches; a new Planned entry should be a deliberate
         // roadmap choice, not a leftover.
         assert!(REGISTRY.iter().all(|c| c.status == Status::Implemented));
+    }
+}
+
+#[cfg(test)]
+mod single_match_tests {
+    use super::*;
+
+    #[test]
+    fn unique_prefix_yields_help_with_arg_hint() {
+        // "/w" → only whois. Help carries the @name hint.
+        let h = single_match_help("w").expect("whois is the only w-command");
+        assert!(h.starts_with("/whois <@name> — "), "got: {h}");
+    }
+
+    #[test]
+    fn ambiguous_and_empty_prefixes_yield_none() {
+        // Empty matches everything → the bare / menu keeps the last
+        // result visible (#398 step 2).
+        assert!(single_match_help("").is_none());
+        // "p" is ambiguous (peers, purge).
+        assert!(single_match_help("p").is_none());
+    }
+
+    #[test]
+    fn full_name_and_unknown_behave() {
+        assert!(single_match_help("peers").is_some());
+        assert!(single_match_help("zzz").is_none());
     }
 }


### PR DESCRIPTION
Implements #398 exactly as specced by the operator: status slot shows the last executed result until the typed slash prefix matches exactly one command, at which point it shows that command's inline help (`/whois <@name> — …`, planned commands marked); backspace-to-empty restores the result — for free, because the swap is display-time only and the stored string is never touched.

Small, display-only change (one pure fn + render seam), 3 new unit tests covering unique/ambiguous/empty/unknown prefixes; 210 attend-chat tests green, clippy clean. Given the size, gate is CI + self-review rather than the full reviewer pass.