### PR TITLE
feat: channel lifecycle, hierarchical command grammar, kick guard (#404 #405 #406)

### DIFF
--- a/docs/cli/attend.md
+++ b/docs/cli/attend.md
@@ -17,6 +17,9 @@ This document contains the help content for the `attend` command-line program.
 * [`attend join`↴](#attend-join)
 * [`attend leave`↴](#attend-leave)
 * [`attend channels`↴](#attend-channels)
+* [`attend channels list`↴](#attend-channels-list)
+* [`attend channels create`↴](#attend-channels-create)
+* [`attend channels describe`↴](#attend-channels-describe)
 * [`attend dissolve`↴](#attend-dissolve)
 * [`attend focus`↴](#attend-focus)
 * [`attend focus on`↴](#attend-focus-on)
@@ -58,7 +61,7 @@ Active awareness for Claude Code sessions
 * `chat` — Launch the interactive chat TUI (ADR-120)
 * `join` — Join a channel (creates it if absent)
 * `leave` — Leave a channel
-* `channels` — List channels — all available, with joined ones marked
+* `channels` — Channel lifecycle (default: list all, joined ones marked)
 * `dissolve` — Dissolve a channel (removes it for every member)
 * `focus` — Deprecated alias for the channel verbs (join/leave/channels/dissolve; ADR-173)
 * `scene` — Activate a named scene (reconfigure channel membership; `scene private` leaves all channels)
@@ -222,9 +225,49 @@ Leave a channel
 
 ## `attend channels`
 
-List channels — all available, with joined ones marked
+Channel lifecycle (default: list all, joined ones marked)
 
-**Usage:** `attend channels`
+**Usage:** `attend channels [COMMAND]`
+
+###### **Subcommands:**
+
+* `list` — List all channels with joined marks (default)
+* `create` — Create a channel without joining it (pinned so it persists empty)
+* `describe` — Set or replace a channel's single-line description
+
+
+
+## `attend channels list`
+
+List all channels with joined marks (default)
+
+**Usage:** `attend channels list`
+
+
+
+## `attend channels create`
+
+Create a channel without joining it (pinned so it persists empty)
+
+**Usage:** `attend channels create <NAME> [DESCRIPTION]...`
+
+###### **Arguments:**
+
+* `<NAME>` — Channel name (with or without the # prefix)
+* `<DESCRIPTION>` — Optional single-line description (all trailing words)
+
+
+
+## `attend channels describe`
+
+Set or replace a channel's single-line description
+
+**Usage:** `attend channels describe <NAME> [DESCRIPTION]...`
+
+###### **Arguments:**
+
+* `<NAME>` — Channel name (with or without the # prefix)
+* `<DESCRIPTION>` — The description text (all trailing words; empty clears)
 
 
 

--- a/tools/attend-chat/src/app/keys.rs
+++ b/tools/attend-chat/src/app/keys.rs
@@ -757,6 +757,15 @@ pub fn handle_tab(
         return unchanged;
     }
 
+    // Subcommand completion (#405): past the name, at a grammar
+    // subcommand choice, Tab completes the level's partial exactly
+    // like the top level completes the name. Silent fall-through
+    // otherwise — deeper levels (`@`/`#` tokens) keep the mention
+    // completion below.
+    if let Some((next, new_cursor)) = slash::complete_subcommand(buf) {
+        return TabResult { new_buf: next, new_cursor, new_cycle: None };
+    }
+
     // Cycling: if we have a stored cycle and the buffer still ends
     // with the candidate we just inserted (sigil + name + trailing
     // space, the exact form `apply_completion` produces), advance

--- a/tools/attend-chat/src/app/keys.rs
+++ b/tools/attend-chat/src/app/keys.rs
@@ -1234,6 +1234,35 @@ mod tests {
         assert_eq!(members, vec!["someone-else"]);
     }
 
+    /// #406: the agent→human kick guard lives in the shared crate
+    /// (`Groups::kick` refuses when the ACTING id is agent-shaped and
+    /// the target is human). The TUI acts with an empty member id,
+    /// which classifies as human — so the guard can never fire here
+    /// and operator kicks of human members keep working. If the
+    /// acting identity ever changes to an agent shape, this test
+    /// fails before the regression ships; and if the guard did fire,
+    /// `kick_member_in`'s Err arm surfaces its message through the
+    /// #400 status path rather than swallowing it.
+    #[test]
+    fn tui_kick_acts_as_operator_and_can_remove_human_members() {
+        let base = tempdir_like();
+        assert!(
+            !attend_groups::is_agent_member(""),
+            "TUI acting id must classify as human (operator power)"
+        );
+        // A human member (username shape, ADR-170) is kickable from
+        // the TUI — the one-way power the guard preserves.
+        attend_groups::Groups::new(&base, "somebody")
+            .join("ops", false)
+            .unwrap();
+        match kick_member_in(&base, "ops", "somebody", "somebody") {
+            EnterAction::ClearWithStatus(s) => {
+                assert!(s.contains("kicked @somebody from #ops"), "got: {s}")
+            }
+            _ => panic!("operator kick of a human member must succeed"),
+        }
+    }
+
     #[test]
     fn channels_status_lists_base_and_counts() {
         let base = tempdir_like();

--- a/tools/attend-chat/src/app/keys.rs
+++ b/tools/attend-chat/src/app/keys.rs
@@ -92,6 +92,12 @@ pub fn handle_enter(input_value: &str, signals: &[Signal], foreground: &Tab) -> 
             slash::SlashOutcome::ListChannels => {
                 channels_status_in(&signals_base(), attend_groups::member_alive)
             }
+            slash::SlashOutcome::CreateChannel { name, description } => {
+                create_channel_in(&signals_base(), &name, description.as_deref())
+            }
+            slash::SlashOutcome::DescribeChannel { name, description } => {
+                describe_channel_in(&signals_base(), &name, &description)
+            }
             slash::SlashOutcome::Purge(chan) => run_purge(chan, foreground),
             slash::SlashOutcome::Peers => run_peers(),
             slash::SlashOutcome::Whois(name) => run_whois(&name),
@@ -300,6 +306,39 @@ fn dissolve_group_in<F: Fn(&str) -> bool>(
     EnterAction::ClearWithStatus(format!("dissolved #{name}"))
 }
 
+/// Filesystem-effect core of `/channels create` (#404), parameterized
+/// on the base dir so tests can drive it against a tempdir. The
+/// acting member id is irrelevant — create is a lifecycle verb, not a
+/// membership change; `Groups::create` pins the channel so it
+/// survives empty until joined or dissolved. Duplicate/reserved
+/// errors pass through to the status row (#400).
+fn create_channel_in(
+    base: &std::path::Path,
+    name: &str,
+    description: Option<&str>,
+) -> EnterAction {
+    match attend_groups::Groups::new(base, "").create(name, description) {
+        Ok(()) => EnterAction::ClearWithStatus(match description {
+            Some(d) => format!("created #{name} — {d}"),
+            None => format!("created #{name}"),
+        }),
+        Err(e) => EnterAction::StatusOnly(format!("/channels create: {e}")),
+    }
+}
+
+/// Filesystem-effect core of `/channels describe` (#404). Empty text
+/// clears the description — same contract as the CLI's `describe`.
+/// `set_description` owns existence checking and its error strings.
+fn describe_channel_in(base: &std::path::Path, name: &str, text: &str) -> EnterAction {
+    match attend_groups::Groups::new(base, "").set_description(name, text) {
+        Ok(()) if text.trim().is_empty() => {
+            EnterAction::ClearWithStatus(format!("cleared #{name} description"))
+        }
+        Ok(()) => EnterAction::ClearWithStatus(format!("#{name} — {}", text.trim())),
+        Err(e) => EnterAction::StatusOnly(format!("/channels describe: {e}")),
+    }
+}
+
 /// `/channels` — one status line listing every channel with
 /// live/total member counts, IRC `/list` shaped. Rides the same
 /// discovery the channel bar uses (`channels_in`), so orphan dirs
@@ -322,7 +361,16 @@ fn channels_status_in<F: Fn(&str) -> bool>(
             let total = kg.membership.members.len();
             let live = kg.membership.members.iter().filter(|m| is_live(m)).count();
             let pin = if kg.membership.pinned { " pinned" } else { "" };
-            format!("#{} {live}/{total} live{pin}", kg.group.name)
+            // Description rides the same line (#404) — the listing is
+            // the discovery surface, so "what is this channel for"
+            // belongs next to "who's in it".
+            let desc = kg
+                .membership
+                .description
+                .as_deref()
+                .map(|d| format!(" — {d}"))
+                .unwrap_or_default();
+            format!("#{} {live}/{total} live{pin}{desc}", kg.group.name)
         })
         .collect();
     EnterAction::ClearWithStatus(format!("channels: {}", parts.join(" · ")))
@@ -1192,6 +1240,73 @@ mod tests {
                 assert!(s.contains("#bg-test 0/0 live"), "got: {s}");
             }
             _ => panic!("/channels should clear input with status"),
+        }
+    }
+
+    #[test]
+    fn channels_status_shows_descriptions() {
+        let base = tempdir_like();
+        create_channel_in(&base, "plans", Some("roadmap talk"));
+        match channels_status_in(&base, |_| false) {
+            EnterAction::ClearWithStatus(s) => {
+                assert!(s.contains("#plans 0/0 live pinned — roadmap talk"), "got: {s}");
+            }
+            _ => panic!("/channels should clear input with status"),
+        }
+    }
+
+    #[test]
+    fn create_channel_pins_and_reports_duplicates() {
+        let base = tempdir_like();
+        match create_channel_in(&base, "plans", Some("roadmap talk")) {
+            EnterAction::ClearWithStatus(s) => {
+                assert!(s.contains("created #plans — roadmap talk"), "got: {s}")
+            }
+            _ => panic!("successful create should clear input with status"),
+        }
+        // Pinned, empty, dir present — the explicit-lifecycle contract.
+        let entry = &attend_groups::load_groups(&base)["plans"];
+        assert!(entry.pinned, "explicit create must survive empty");
+        assert!(entry.members.is_empty());
+        assert!(base.join("@plans").is_dir());
+        // Duplicate: Groups::create's error passes through the #400
+        // error path (input kept for retry).
+        match create_channel_in(&base, "plans", None) {
+            EnterAction::StatusOnly(s) => {
+                assert!(s.contains("already exists"), "got: {s}")
+            }
+            _ => panic!("duplicate create should keep input with status"),
+        }
+    }
+
+    #[test]
+    fn describe_channel_sets_clears_and_rejects_unknown() {
+        let base = tempdir_like();
+        create_channel_in(&base, "plans", None);
+        match describe_channel_in(&base, "plans", "roadmap talk") {
+            EnterAction::ClearWithStatus(s) => {
+                assert!(s.contains("#plans — roadmap talk"), "got: {s}")
+            }
+            _ => panic!("successful describe should clear input with status"),
+        }
+        assert_eq!(
+            attend_groups::load_groups(&base)["plans"].description.as_deref(),
+            Some("roadmap talk")
+        );
+        // Empty text clears — CLI parity.
+        match describe_channel_in(&base, "plans", "") {
+            EnterAction::ClearWithStatus(s) => {
+                assert!(s.contains("cleared #plans description"), "got: {s}")
+            }
+            _ => panic!("clearing describe should clear input with status"),
+        }
+        assert_eq!(attend_groups::load_groups(&base)["plans"].description, None);
+        // Unknown channel: set_description's error passes through.
+        match describe_channel_in(&base, "ghost", "d") {
+            EnterAction::StatusOnly(s) => {
+                assert!(s.contains("unknown group"), "got: {s}")
+            }
+            _ => panic!("unknown channel should keep input with status"),
         }
     }
 

--- a/tools/attend-chat/src/app/mod.rs
+++ b/tools/attend-chat/src/app/mod.rs
@@ -391,21 +391,20 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
         .map(|m| m.partial.to_string());
     // Helper-row mode is a pure function of the input buffer. The
     // state machine lives in `helper::derive` — see that module's
-    // docs + tests for the full rule table. Once a slash command
-    // is past its name, the registry's `ArgKind` routes the helper
-    // (`/whois ` → agents, `/join ` → channels).
+    // docs + tests for the full rule table. Once a slash command is
+    // past its name, the registry grammar walk routes the helper
+    // level by level (#405): `/whois ` → agents, `/channels ` → the
+    // subcommand choices, `/channels create ` → the name hint.
     let helper_mode = helper::derive(&input_snapshot);
     // #398 + #400 priority rule: a fresh result (inside the assert
     // window) beats the help; the help beats the stored result while a
-    // command uniquely matches; the stored result is never mutated, so
-    // backspacing to empty restores it for free.
+    // grammar node is unambiguous; the stored result is never mutated,
+    // so backspacing to empty restores it for free. The help follows
+    // the grammar recursion — deepest unambiguous node wins (#405).
     let fresh = status_set_at
         .get()
         .is_some_and(|t| t.elapsed() < STATUS_ASSERT);
-    let help = match &helper_mode {
-        helper::HelperMode::Slash(Some(p)) => slash::single_match_help(p),
-        _ => None,
-    };
+    let help = slash::contextual_help(&input_snapshot);
     let (status_line, status_color) =
         status_slot(fresh, status_is_error.get(), help, &status.to_string());
     let rows: Vec<_> = signals
@@ -618,6 +617,9 @@ pub fn App(props: &AppProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>>
                 HelperMode::Agents(p) => legend_row(&known, p.as_deref()),
                 HelperMode::Groups(p) => group_legend_row(&groups_known, p.as_deref()),
                 HelperMode::Slash(p) => slash::slash_legend_row(p.as_deref()),
+                HelperMode::SubCommands { choices, partial } =>
+                    slash::subcommand_legend_row(choices, partial.as_deref()),
+                HelperMode::FreeText(hint) => slash::hint_row(hint),
             })
             View(height: 1, padding_left: 1) {
                 Text(color: status_color, content: status_line, wrap: TextWrap::NoWrap)

--- a/tools/attend-chat/src/grammar.rs
+++ b/tools/attend-chat/src/grammar.rs
@@ -1,0 +1,298 @@
+//! Command grammars and the hierarchical narrowing walk (#405).
+//!
+//! Every slash command carries a grammar — a sequence of [`Token`]s,
+//! optionally opening with a subcommand choice — instead of the old
+//! single-valued `ArgKind`. The helper row narrows through it the way
+//! Rhino 3D / AutoCAD command lines do: while a token is being typed,
+//! the current level's candidates render with prefix highlight; a
+//! completed token + space descends one level; backspacing ascends
+//! naturally because [`walk`] re-derives the position from the input
+//! string on every render — there is no hidden mode state.
+//!
+//! The walk is pure string work over `&'static` grammar data, so the
+//! whole state space is unit-testable without a terminal. Structural
+//! tokens split on whitespace (the same rule `slash::dispatch` uses
+//! to parse arguments, so the helper can never disagree with what
+//! Enter will do); a [`Token::Rest`] swallows everything after it,
+//! which is where free-text descriptions live.
+
+/// One token position in a slash command's grammar.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Token {
+    /// An `@agent` argument — the helper shows the agent legend.
+    Agent { required: bool },
+    /// A `#channel` argument — the helper shows the channel legend.
+    Group { required: bool },
+    /// A single free-word token (e.g. a NEW channel name that no
+    /// legend can offer). The hint carries its own `<>`/`[]`
+    /// brackets and renders verbatim in the helper and in help.
+    Word(&'static str),
+    /// Free text to end of line. Hint carries its own brackets.
+    /// Nothing can follow a `Rest` — it swallows the tail.
+    Rest(&'static str),
+    /// A subcommand choice steering into per-branch grammars. By
+    /// convention this is a command's sole top-level token (slash
+    /// commands stay top-level; subcommands steer into them), and
+    /// it is optional — a bare command falls back to its default
+    /// behavior, so the signature renders in `[]`.
+    Subcommands(&'static [SubCommand]),
+}
+
+/// One branch of a [`Token::Subcommands`] choice.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SubCommand {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub grammar: &'static [Token],
+}
+
+/// Where in a grammar the caret currently sits. Derived fresh from
+/// the args string each render — see module docs.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Pos {
+    /// At a subcommand choice; `partial` is the token being typed
+    /// (`None` right after a descent, before any narrowing).
+    Sub {
+        choices: &'static [SubCommand],
+        partial: Option<String>,
+    },
+    /// At an `@agent` token. Partial is sigil-normalized: `@` is
+    /// stripped, a bare word passes through, the wrong sigil yields
+    /// `None` (no hijacking the other legend's narrowing).
+    Agent(Option<String>),
+    /// At a `#channel` token; same normalization, `#` expected.
+    Group(Option<String>),
+    /// At a free token — the hint to render dimmed in the helper.
+    Free(&'static str),
+    /// Grammar satisfied; nothing more is expected.
+    Done,
+}
+
+/// Walk `grammar` against the args string (everything after the
+/// command name, leading whitespace already trimmed by
+/// `slash::parse`). Trailing whitespace is significant: it is the
+/// descend gesture — a token followed by a space is completed, a
+/// token without one is still being typed at its level.
+pub fn walk(grammar: &'static [Token], args: &str) -> Pos {
+    let mut toks: Vec<&str> = args.split_whitespace().collect();
+    let current: Option<&str> = if !args.is_empty() && !args.ends_with(char::is_whitespace) {
+        toks.pop()
+    } else {
+        None
+    };
+    walk_tokens(grammar, &toks, current)
+}
+
+fn walk_tokens(grammar: &'static [Token], completed: &[&str], current: Option<&str>) -> Pos {
+    let mut specs = grammar.iter();
+    let mut spec = specs.next();
+    let mut i = 0;
+    // Consume completed tokens against the grammar sequence.
+    while i < completed.len() {
+        match spec {
+            // More typed than the grammar knows — past the end.
+            None => return Pos::Done,
+            Some(Token::Subcommands(subs)) => {
+                return match subs.iter().find(|s| s.name == completed[i]) {
+                    // A completed subcommand descends: its branch
+                    // grammar takes over for everything after it.
+                    Some(sub) => walk_tokens(sub.grammar, &completed[i + 1..], current),
+                    // Unknown completed token: stay at this level with
+                    // no narrowing so the user can see valid options —
+                    // same posture as an unknown top-level command.
+                    None => Pos::Sub {
+                        choices: subs,
+                        partial: None,
+                    },
+                };
+            }
+            // Rest swallows the tail — the position never advances.
+            Some(Token::Rest(h)) => return Pos::Free(h),
+            Some(Token::Agent { .. } | Token::Group { .. } | Token::Word(_)) => {
+                i += 1;
+                spec = specs.next();
+            }
+        }
+    }
+    // Completed tokens all consumed — `current` sits at `spec`.
+    match spec {
+        None => Pos::Done,
+        Some(Token::Subcommands(subs)) => Pos::Sub {
+            choices: subs,
+            partial: current.map(str::to_string),
+        },
+        Some(Token::Agent { .. }) => Pos::Agent(sigil_partial(current, '@', '#')),
+        Some(Token::Group { .. }) => Pos::Group(sigil_partial(current, '#', '@')),
+        Some(Token::Word(h)) | Some(Token::Rest(h)) => Pos::Free(h),
+    }
+}
+
+/// Normalize the token being typed at a sigil position: the expected
+/// sigil strips off; a bare word narrows as-is (the Rhino model —
+/// candidates match without ceremony); the *other* sigil yields no
+/// partial rather than narrowing the wrong legend.
+fn sigil_partial(current: Option<&str>, expect: char, other: char) -> Option<String> {
+    let t = current?;
+    if let Some(stripped) = t.strip_prefix(expect) {
+        return Some(stripped.to_string());
+    }
+    if t.starts_with(other) {
+        return None;
+    }
+    Some(t.to_string())
+}
+
+/// Render a grammar as the usage tail for help lines — `" <@name>
+/// [#channel]"` — leading space per token so it concatenates directly
+/// after a command name. Word/Rest hints carry their own brackets.
+pub fn signature(grammar: &[Token]) -> String {
+    let mut out = String::new();
+    for t in grammar {
+        out.push(' ');
+        match t {
+            Token::Agent { required: true } => out.push_str("<@name>"),
+            Token::Agent { required: false } => out.push_str("[@name]"),
+            Token::Group { required: true } => out.push_str("<#channel>"),
+            Token::Group { required: false } => out.push_str("[#channel]"),
+            Token::Word(h) | Token::Rest(h) => out.push_str(h),
+            Token::Subcommands(subs) => {
+                let names: Vec<&str> = subs.iter().map(|s| s.name).collect();
+                out.push('[');
+                out.push_str(&names.join("|"));
+                out.push(']');
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    //! The grammar walk's visible specification — the same
+    //! table-of-states idiom as `helper`'s tests. Fixtures mirror
+    //! the real registry shapes (channels / invite) without
+    //! depending on the registry itself.
+
+    use super::*;
+
+    const CREATE: &[Token] = &[Token::Word("<name>"), Token::Rest("[description…]")];
+    const DESCRIBE: &[Token] = &[
+        Token::Group { required: true },
+        Token::Rest("[description…]"),
+    ];
+    const SUBS: &[SubCommand] = &[
+        SubCommand { name: "list", description: "list them", grammar: &[] },
+        SubCommand { name: "create", description: "create one", grammar: CREATE },
+        SubCommand { name: "describe", description: "describe one", grammar: DESCRIBE },
+    ];
+    const FAMILY: &[Token] = &[Token::Subcommands(SUBS)];
+    const MEMBERSHIP: &[Token] = &[
+        Token::Agent { required: true },
+        Token::Group { required: false },
+    ];
+
+    // ── Top of a grammar ───────────────────────────────────────
+
+    #[test]
+    fn empty_grammar_is_done_immediately() {
+        assert_eq!(walk(&[], ""), Pos::Done);
+        // Stray args past the grammar are past-the-end, not an error.
+        assert_eq!(walk(&[], "extra"), Pos::Done);
+        assert_eq!(walk(&[], "extra tokens "), Pos::Done);
+    }
+
+    #[test]
+    fn subcommand_level_narrows_by_prefix() {
+        // Right after the command name + space: full choice list.
+        assert_eq!(walk(FAMILY, ""), Pos::Sub { choices: SUBS, partial: None });
+        // Typing narrows at this level, exactly like the top level.
+        assert_eq!(
+            walk(FAMILY, "cre"),
+            Pos::Sub { choices: SUBS, partial: Some("cre".into()) }
+        );
+        // A full name without the space is still a partial — descent
+        // is the space, not the spelling.
+        assert_eq!(
+            walk(FAMILY, "create"),
+            Pos::Sub { choices: SUBS, partial: Some("create".into()) }
+        );
+    }
+
+    #[test]
+    fn completed_subcommand_descends_into_its_branch() {
+        assert_eq!(walk(FAMILY, "create "), Pos::Free("<name>"));
+        assert_eq!(walk(FAMILY, "describe "), Pos::Group(None));
+        // A branch with an empty grammar is immediately done.
+        assert_eq!(walk(FAMILY, "list "), Pos::Done);
+    }
+
+    #[test]
+    fn unknown_completed_subcommand_stays_at_level_unnarrowed() {
+        assert_eq!(walk(FAMILY, "bogus "), Pos::Sub { choices: SUBS, partial: None });
+        assert_eq!(walk(FAMILY, "bogus more "), Pos::Sub { choices: SUBS, partial: None });
+    }
+
+    // ── Per-level narrowing below a descent ────────────────────
+
+    #[test]
+    fn word_token_hints_while_typing_then_advances() {
+        assert_eq!(walk(FAMILY, "create pla"), Pos::Free("<name>"));
+        assert_eq!(walk(FAMILY, "create plans "), Pos::Free("[description…]"));
+    }
+
+    #[test]
+    fn rest_token_swallows_the_tail() {
+        assert_eq!(walk(FAMILY, "create plans roadmap"), Pos::Free("[description…]"));
+        assert_eq!(
+            walk(FAMILY, "create plans roadmap talk for q3 "),
+            Pos::Free("[description…]")
+        );
+    }
+
+    #[test]
+    fn group_token_narrows_with_and_without_sigil() {
+        assert_eq!(walk(DESCRIBE, "#pla"), Pos::Group(Some("pla".into())));
+        // Bare word narrows too — the Rhino model, no ceremony.
+        assert_eq!(walk(DESCRIBE, "pla"), Pos::Group(Some("pla".into())));
+        // Wrong sigil doesn't hijack the channel legend's narrowing.
+        assert_eq!(walk(DESCRIBE, "@who"), Pos::Group(None));
+        // Bare sigil: committed, nothing typed — empty partial.
+        assert_eq!(walk(DESCRIBE, "#"), Pos::Group(Some("".into())));
+    }
+
+    #[test]
+    fn sequence_walks_agent_then_optional_group() {
+        assert_eq!(walk(MEMBERSHIP, ""), Pos::Agent(None));
+        assert_eq!(walk(MEMBERSHIP, "@Cl"), Pos::Agent(Some("Cl".into())));
+        // Completed agent + space descends to the channel level.
+        assert_eq!(walk(MEMBERSHIP, "@Cleo "), Pos::Group(None));
+        assert_eq!(walk(MEMBERSHIP, "@Cleo #dep"), Pos::Group(Some("dep".into())));
+        // Both consumed: grammar satisfied.
+        assert_eq!(walk(MEMBERSHIP, "@Cleo #deploy "), Pos::Done);
+        assert_eq!(walk(MEMBERSHIP, "@Cleo #deploy extra"), Pos::Done);
+    }
+
+    #[test]
+    fn ascent_is_free_because_state_derives_from_the_string() {
+        // The backspace path retraces the descend path in reverse —
+        // no mode to unwind, just shorter strings.
+        assert_eq!(walk(FAMILY, "create plans "), Pos::Free("[description…]"));
+        assert_eq!(walk(FAMILY, "create plans"), Pos::Free("<name>"));
+        assert_eq!(
+            walk(FAMILY, "create"),
+            Pos::Sub { choices: SUBS, partial: Some("create".into()) }
+        );
+        assert_eq!(walk(FAMILY, ""), Pos::Sub { choices: SUBS, partial: None });
+    }
+
+    // ── Signatures ─────────────────────────────────────────────
+
+    #[test]
+    fn signatures_render_grammar_shapes() {
+        assert_eq!(signature(MEMBERSHIP), " <@name> [#channel]");
+        assert_eq!(signature(FAMILY), " [list|create|describe]");
+        assert_eq!(signature(CREATE), " <name> [description…]");
+        assert_eq!(signature(DESCRIBE), " <#channel> [description…]");
+        assert_eq!(signature(&[]), "");
+    }
+}

--- a/tools/attend-chat/src/helper.rs
+++ b/tools/attend-chat/src/helper.rs
@@ -1,8 +1,9 @@
 //! Helper-row state machine.
 //!
-//! The row below the input box shows one of three registries — agents,
-//! groups, or slash commands — depending on what the user is typing.
-//! This module is the single source of truth for that decision.
+//! The row below the input box shows one of the registries — agents,
+//! groups, slash commands, a subcommand level, or a free-token hint —
+//! depending on what the user is typing. This module is the single
+//! source of truth for that decision.
 //!
 //! [`derive`] is a pure function of the input buffer. Given any
 //! string, it returns the [`HelperMode`] the render path should use.
@@ -13,23 +14,27 @@
 //!
 //! ## States
 //!
-//! | State        | Entered when …                                | Partial underlined |
-//! |--------------|-----------------------------------------------|--------------------|
-//! | `Slash`      | buffer starts with `/`, still typing the name | yes, on command    |
-//! | `Agents`     | trailing `@partial`, OR default               | yes, on agent      |
-//! | `Groups`     | trailing `#partial`                           | yes, on group      |
-//! | `Agents/None`| past a slash command whose arg is [`ArgKind::Agent`] | no, until `@` typed |
-//! | `Groups/None`| past a slash command whose arg is [`ArgKind::Group`] | no, until `#` typed |
-//! | `Agents`     | past a slash command with [`ArgKind::None`]   | —                  |
+//! | State         | Entered when …                                | Partial underlined |
+//! |---------------|-----------------------------------------------|--------------------|
+//! | `Slash`       | buffer starts with `/`, still typing the name | yes, on command    |
+//! | `Agents`      | trailing `@partial`, OR default               | yes, on agent      |
+//! | `Groups`      | trailing `#partial`                           | yes, on group      |
+//! | `SubCommands` | grammar walk sits at a subcommand choice      | yes, on subcommand |
+//! | `FreeText`    | grammar walk sits at a free token             | — (hint only)      |
+//! | `Agents`/`Groups` | grammar walk sits at an `@`/`#` token     | once typing starts |
+//! | `Agents`      | grammar satisfied (past the end)              | —                  |
 //!
 //! ## Extending
 //!
 //! Adding a new slash command that routes the helper: add a row to
-//! [`crate::slash::REGISTRY`] with the right [`ArgKind`]. No changes
-//! here — [`derive`] inspects the registry dynamically.
+//! [`crate::slash::REGISTRY`] with the right grammar. No changes
+//! here — [`derive`] walks the registry's grammars dynamically
+//! (#405); state ascends/descends purely by re-deriving from the
+//! string, so backspace unwinds levels with no hidden mode.
 
+use crate::grammar::{self, SubCommand};
 use crate::legend::{find_trailing_mention, Sigil};
-use crate::slash::{self, ArgKind};
+use crate::slash;
 
 /// Which registry the helper row should render right now. The
 /// `Option<String>` carries the current partial (what the user has
@@ -41,6 +46,16 @@ pub enum HelperMode {
     Agents(Option<String>),
     Groups(Option<String>),
     Slash(Option<String>),
+    /// Grammar walk sits at a subcommand choice (#405) — render that
+    /// level's candidates through the same chip row as the top-level
+    /// slash list.
+    SubCommands {
+        choices: &'static [SubCommand],
+        partial: Option<String>,
+    },
+    /// Grammar walk sits at a free token — render its hint dimmed
+    /// (`<name>`, `[description…]`).
+    FreeText(&'static str),
 }
 
 /// Derive the helper mode from the current input buffer.
@@ -49,8 +64,10 @@ pub enum HelperMode {
 ///
 /// 1. **Slash active.** Input starts with `/`:
 ///    - still typing the name → [`HelperMode::Slash`] with partial.
-///    - past the name, argument phase → inspect the command's
-///      [`ArgKind`] and switch to the matching registry.
+///    - past the name → walk the command's grammar (#405): the
+///      position picks the registry (agents / groups / subcommand
+///      level / free-token hint), descending one level per completed
+///      token + space.
 ///    - past the name, unknown command → stay on slash registry so
 ///      the user can see valid options.
 /// 2. **Trailing mention.** A trailing `@partial` or `#partial`
@@ -79,18 +96,21 @@ fn derive_slash(input: &str) -> Option<HelperMode> {
     if let Some(partial) = slash::find_slash_partial(input) {
         return Some(HelperMode::Slash(Some(partial.partial.to_string())));
     }
-    // Phase 2: past the name, in the argument(s). Inspect the
-    // command's ArgKind to pick the right registry.
+    // Phase 2: past the name — the grammar walk owns the rest. Its
+    // position maps 1:1 onto a helper mode; `Done` falls back to the
+    // default agents glance (nothing left to help with).
     let (name, args) = slash::parse(input)?;
     let Some(cmd) = slash::lookup(name) else {
         // Unknown command — keep the slash registry visible so the
         // user can see what they might have meant.
         return Some(HelperMode::Slash(None));
     };
-    Some(match cmd.arg_kind {
-        ArgKind::None => HelperMode::Agents(None),
-        ArgKind::Agent => HelperMode::Agents(trailing_partial(args, Sigil::Agent)),
-        ArgKind::Group => HelperMode::Groups(trailing_partial(args, Sigil::Group)),
+    Some(match grammar::walk(cmd.grammar, args) {
+        grammar::Pos::Done => HelperMode::Agents(None),
+        grammar::Pos::Sub { choices, partial } => HelperMode::SubCommands { choices, partial },
+        grammar::Pos::Agent(p) => HelperMode::Agents(p),
+        grammar::Pos::Group(p) => HelperMode::Groups(p),
+        grammar::Pos::Free(hint) => HelperMode::FreeText(hint),
     })
 }
 
@@ -100,14 +120,6 @@ fn derive_mention(input: &str) -> Option<HelperMode> {
         Sigil::Agent => HelperMode::Agents(Some(ctx.partial.to_string())),
         Sigil::Group => HelperMode::Groups(Some(ctx.partial.to_string())),
     })
-}
-
-/// Extract a trailing `@partial` or `#partial` from `input`, returning
-/// the partial text only if its sigil matches `expect`.
-fn trailing_partial(input: &str, expect: Sigil) -> Option<String> {
-    find_trailing_mention(input)
-        .filter(|m| m.sigil == expect)
-        .map(|m| m.partial.to_string())
 }
 
 #[cfg(test)]
@@ -266,5 +278,109 @@ mod tests {
         // mode — the tolerance is surgical, not blanket.
         assert_eq!(derive(" hello"), HelperMode::Agents(None));
         assert_eq!(derive("   "), HelperMode::Agents(None));
+    }
+
+    // ── Hierarchical narrowing (#405) ──────────────────────────
+
+    #[test]
+    fn channels_space_descends_to_subcommand_level() {
+        // Completed name + space: the choice level's full candidate
+        // list, no narrowing yet.
+        assert_eq!(
+            derive("/channels "),
+            HelperMode::SubCommands {
+                choices: slash::CHANNELS_SUBS,
+                partial: None
+            }
+        );
+    }
+
+    #[test]
+    fn subcommand_partial_narrows_at_its_level() {
+        assert_eq!(
+            derive("/channels cr"),
+            HelperMode::SubCommands {
+                choices: slash::CHANNELS_SUBS,
+                partial: Some("cr".into())
+            }
+        );
+    }
+
+    #[test]
+    fn completed_subcommand_descends_to_its_first_token() {
+        // create → free-word name hint; describe → channel legend.
+        assert_eq!(derive("/channels create "), HelperMode::FreeText("<name>"));
+        assert_eq!(derive("/channels describe "), HelperMode::Groups(None));
+        assert_eq!(
+            derive("/channels describe #pla"),
+            HelperMode::Groups(Some("pla".into()))
+        );
+        // list's branch grammar is empty — immediately satisfied.
+        assert_eq!(derive("/channels list "), HelperMode::Agents(None));
+    }
+
+    #[test]
+    fn free_text_tail_holds_its_hint() {
+        assert_eq!(
+            derive("/channels create plans "),
+            HelperMode::FreeText("[description…]")
+        );
+        assert_eq!(
+            derive("/channels create plans roadmap talk for"),
+            HelperMode::FreeText("[description…]")
+        );
+        assert_eq!(
+            derive("/channels describe #plans road"),
+            HelperMode::FreeText("[description…]")
+        );
+    }
+
+    #[test]
+    fn unknown_subcommand_keeps_the_level_unnarrowed() {
+        // Same posture as an unknown top-level command: show the
+        // valid options rather than guessing.
+        assert_eq!(
+            derive("/channels bogus "),
+            HelperMode::SubCommands {
+                choices: slash::CHANNELS_SUBS,
+                partial: None
+            }
+        );
+    }
+
+    #[test]
+    fn membership_pair_walks_agent_then_channel() {
+        // invite/kick: <@agent> [#channel] — the second level opens
+        // once the first token completes.
+        assert_eq!(derive("/invite "), HelperMode::Agents(None));
+        assert_eq!(derive("/invite @Cl"), HelperMode::Agents(Some("Cl".into())));
+        assert_eq!(derive("/invite @Cleo "), HelperMode::Groups(None));
+        assert_eq!(
+            derive("/kick @Cleo #dep"),
+            HelperMode::Groups(Some("dep".into()))
+        );
+        // Grammar satisfied → default glance.
+        assert_eq!(derive("/kick @Cleo #deploy "), HelperMode::Agents(None));
+    }
+
+    #[test]
+    fn backspacing_ascends_because_state_is_derived() {
+        // The exact reverse of the descend sequence — no mode state
+        // to unwind, just re-derivation from shorter strings.
+        assert_eq!(
+            derive("/channels create plans "),
+            HelperMode::FreeText("[description…]")
+        );
+        assert_eq!(derive("/channels create plans"), HelperMode::FreeText("<name>"));
+        assert_eq!(derive("/channels create "), HelperMode::FreeText("<name>"));
+        assert_eq!(
+            derive("/channels create"),
+            HelperMode::SubCommands {
+                choices: slash::CHANNELS_SUBS,
+                partial: Some("create".into())
+            }
+        );
+        assert_eq!(derive("/channels"), HelperMode::Slash(Some("channels".into())));
+        assert_eq!(derive("/"), HelperMode::Slash(Some("".into())));
     }
 }

--- a/tools/attend-chat/src/helper.rs
+++ b/tools/attend-chat/src/helper.rs
@@ -165,23 +165,23 @@ mod tests {
         assert_eq!(derive("/he"), HelperMode::Slash(Some("he".into())));
     }
 
-    // ── Slash: past the name, ArgKind routing ──────────────────
+    // ── Slash: past the name, grammar routing ──────────────────
 
     #[test]
     fn slash_help_space_stays_on_agents_as_default() {
-        // ArgKind::None → default registry (agents), no partial.
+        // Empty grammar → satisfied → default registry (agents).
         assert_eq!(derive("/help "), HelperMode::Agents(None));
     }
 
     #[test]
     fn slash_whois_space_switches_to_agents_waiting_for_at() {
-        // ArgKind::Agent, no @ typed yet — Agents with no partial.
+        // Agent token, no @ typed yet — Agents with no partial.
         assert_eq!(derive("/whois "), HelperMode::Agents(None));
     }
 
     #[test]
     fn slash_whois_with_at_partial_underlines_agent() {
-        // ArgKind::Agent, user is now typing @Ur — underline "Ur".
+        // Agent token, user is now typing @Ur — underline "Ur".
         assert_eq!(
             derive("/whois @Ur"),
             HelperMode::Agents(Some("Ur".into()))
@@ -190,7 +190,7 @@ mod tests {
 
     #[test]
     fn slash_join_space_switches_to_groups() {
-        // ArgKind::Group, no # typed yet — Groups with no partial.
+        // Group token, no # typed yet — Groups with no partial.
         assert_eq!(derive("/join "), HelperMode::Groups(None));
     }
 
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn slash_leave_space_switches_to_groups() {
-        // Second Group-arg command — confirms ArgKind routing isn't
+        // Second Group-token command — confirms grammar routing isn't
         // tied to a single command name.
         assert_eq!(derive("/leave "), HelperMode::Groups(None));
     }
@@ -224,7 +224,7 @@ mod tests {
     fn slash_precedes_trailing_mention() {
         // `/help @Tam` — even though there's a trailing @, the
         // buffer starts with `/` and we're past the command name.
-        // ArgKind::None returns Agents(None), which tests the
+        // the satisfied grammar returns Agents(None), which tests the
         // state machine's "slash wins" invariant.
         assert_eq!(derive("/help @Tam"), HelperMode::Agents(None));
     }
@@ -244,7 +244,7 @@ mod tests {
     fn slash_with_leading_space_routes_arg_kind() {
         // Past-the-name routing must also tolerate leading
         // whitespace — otherwise `" /whois "` silently shows agents
-        // (the default) instead of agents-because-ArgKind.
+        // (the default) instead of agents-because-grammar.
         // The observable state is the same, but the reasoning path
         // differs; we want the state machine to take the Slash
         // branch for consistency with Enter / Tab.
@@ -256,7 +256,7 @@ mod tests {
 
     #[test]
     fn agent_cmd_with_wrong_sigil_falls_back_to_default_agents() {
-        // `/whois #dep` — ArgKind::Agent but user typed `#`. The
+        // `/whois #dep` — Agent token but user typed `#`. The
         // trailing-# doesn't satisfy the Agent filter, so the state
         // is "agents waiting for @" (no partial) rather than
         // hijacking to groups.

--- a/tools/attend-chat/src/lib.rs
+++ b/tools/attend-chat/src/lib.rs
@@ -9,6 +9,7 @@ pub mod app;
 pub mod attach;
 pub mod chip;
 pub mod consumers;
+pub mod grammar;
 pub mod groups;
 pub mod helper;
 pub mod legend;

--- a/tools/attend-chat/src/slash.rs
+++ b/tools/attend-chat/src/slash.rs
@@ -107,7 +107,7 @@ pub const REGISTRY: &[SlashCommand] = &[
     },
     SlashCommand {
         name: "channels",
-        description: "List channels with member counts",
+        description: "List · create · describe channels",
         status: Status::Implemented,
         arg_kind: ArgKind::None,
     },
@@ -262,9 +262,25 @@ pub enum SlashOutcome {
     /// (ADR-170). `None` scopes to the foreground tab (#393); the
     /// live-member guard runs at execution time.
     Dissolve(Option<String>),
-    /// `/channels` — render every channel with live/total member
-    /// counts into the status row.
+    /// `/channels` (or `/channels list`) — render every channel with
+    /// live/total member counts + description into the status row.
     ListChannels,
+    /// `/channels create <name> [description…]` — explicit lifecycle
+    /// verb: create a channel WITHOUT joining it (#404). Name
+    /// normalized (`#` stripped) and validated here; duplicate
+    /// detection lives in `Groups::create` at execution time, and
+    /// both error classes surface through the status path (#400).
+    CreateChannel {
+        name: String,
+        description: Option<String>,
+    },
+    /// `/channels describe <#channel> [description…]` — set or
+    /// replace a channel's one-line description; empty text clears
+    /// (#404). Name normalized; existence checked at execution time.
+    DescribeChannel {
+        name: String,
+        description: String,
+    },
     /// `/purge` — delete a channel's on-disk signal history (ADR-136
     /// durability, deliberately overridden by explicit operator
     /// action). `None` targets the base channel's `_broadcast/`.
@@ -302,6 +318,15 @@ pub enum SlashOutcome {
 fn agent_arg(args: &str) -> Option<&str> {
     let first = args.split_whitespace().next()?;
     Some(first.strip_prefix('@').unwrap_or(first))
+}
+
+/// Join remaining whitespace-separated tokens as free text — the
+/// `trailing_var_arg` shape the CLI's create/describe use, so both
+/// surfaces normalize descriptions identically (runs of whitespace,
+/// including compose-box newlines, collapse to single spaces —
+/// which also satisfies the wire format's single-line contract).
+fn rest_text<'a>(toks: impl Iterator<Item = &'a str>) -> String {
+    toks.collect::<Vec<_>>().join(" ")
 }
 
 /// Normalize a group argument: first whitespace-separated token,
@@ -355,7 +380,61 @@ pub fn dispatch(name: &str, args: &str) -> SlashOutcome {
                 ),
                 Some(g) => SlashOutcome::Dissolve(Some(g.to_string())),
             },
-            "channels" => SlashOutcome::ListChannels,
+            // Subcommand family (#404): slash commands stay top-level,
+            // subcommands steer into them. Bare `/channels` keeps the
+            // pre-#404 listing default.
+            "channels" => {
+                let mut toks = args.split_whitespace();
+                match toks.next() {
+                    None | Some("list") => SlashOutcome::ListChannels,
+                    Some("create") => match toks.next() {
+                        None => SlashOutcome::Err(
+                            "usage: /channels create <name> [description…]".into(),
+                        ),
+                        Some(raw) => {
+                            let name = raw.strip_prefix('#').unwrap_or(raw);
+                            // Same validator `/join` consults — reserved
+                            // names (`open`, `broadcast`) and malformed
+                            // names bounce before any fs work.
+                            match attend_groups::validate_group_name(name) {
+                                Err(e) => {
+                                    SlashOutcome::Err(format!("/channels create: {e}"))
+                                }
+                                Ok(()) => {
+                                    let description = rest_text(toks);
+                                    SlashOutcome::CreateChannel {
+                                        name: name.to_string(),
+                                        description: (!description.is_empty())
+                                            .then_some(description),
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    Some("describe") => match toks.next() {
+                        None => SlashOutcome::Err(
+                            "usage: /channels describe <#channel> [description…]".into(),
+                        ),
+                        Some(raw) => {
+                            let name = raw.strip_prefix('#').unwrap_or(raw);
+                            if name == "open" {
+                                SlashOutcome::Err(
+                                    "#open is the base channel — its description is fixed"
+                                        .into(),
+                                )
+                            } else {
+                                SlashOutcome::DescribeChannel {
+                                    name: name.to_string(),
+                                    description: rest_text(toks),
+                                }
+                            }
+                        }
+                    },
+                    Some(other) => SlashOutcome::Err(format!(
+                        "/channels {other}: unknown subcommand (list · create · describe)"
+                    )),
+                }
+            }
             // Bare `/purge` = foreground-tab scope, resolved
             // downstream. An explicit `/purge open` stays EXPLICIT:
             // collapsing it into `None` here would reinterpret it as
@@ -673,8 +752,87 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_channels_returns_effect() {
+    fn dispatch_channels_bare_and_list_return_listing() {
+        // Bare `/channels` keeps the pre-#404 default; `list` is the
+        // explicit spelling of the same thing.
         assert_eq!(dispatch("channels", ""), SlashOutcome::ListChannels);
+        assert_eq!(dispatch("channels", "list"), SlashOutcome::ListChannels);
+    }
+
+    #[test]
+    fn dispatch_channels_create_parses_name_and_description() {
+        assert_eq!(
+            dispatch("channels", "create plans roadmap talk"),
+            SlashOutcome::CreateChannel {
+                name: "plans".into(),
+                description: Some("roadmap talk".into())
+            }
+        );
+        // No description → None; `#` spelling tolerated.
+        assert_eq!(
+            dispatch("channels", "create #plans"),
+            SlashOutcome::CreateChannel {
+                name: "plans".into(),
+                description: None
+            }
+        );
+        let SlashOutcome::Err(s) = dispatch("channels", "create") else {
+            panic!("bare create should be a usage error")
+        };
+        assert!(s.contains("usage"));
+    }
+
+    #[test]
+    fn dispatch_channels_create_rejects_reserved_names() {
+        // The shared validator's reserved list applies before any fs
+        // work — `open` aliases the commons, `_x` is an internal
+        // prefix. Errors surface via the #400 status path.
+        let SlashOutcome::Err(s) = dispatch("channels", "create open") else {
+            panic!("reserved name should be rejected")
+        };
+        assert!(s.contains("/channels create"), "got: {s}");
+        assert!(s.contains("reserved"), "got: {s}");
+        let SlashOutcome::Err(s) = dispatch("channels", "create _internal") else {
+            panic!("underscore prefix should be rejected")
+        };
+        assert!(s.contains("/channels create"), "got: {s}");
+    }
+
+    #[test]
+    fn dispatch_channels_describe_parses_and_clears() {
+        assert_eq!(
+            dispatch("channels", "describe #plans roadmap talk"),
+            SlashOutcome::DescribeChannel {
+                name: "plans".into(),
+                description: "roadmap talk".into()
+            }
+        );
+        // No text → empty description → clears (CLI parity).
+        assert_eq!(
+            dispatch("channels", "describe plans"),
+            SlashOutcome::DescribeChannel {
+                name: "plans".into(),
+                description: String::new()
+            }
+        );
+        let SlashOutcome::Err(s) = dispatch("channels", "describe") else {
+            panic!("bare describe should be a usage error")
+        };
+        assert!(s.contains("usage"));
+        // The base channel's description is synthetic, not stored.
+        let SlashOutcome::Err(s) = dispatch("channels", "describe #open shiny") else {
+            panic!("describe open should be rejected")
+        };
+        assert!(s.contains("base channel"));
+    }
+
+    #[test]
+    fn dispatch_channels_unknown_subcommand_is_precise() {
+        let SlashOutcome::Err(s) = dispatch("channels", "bogus") else {
+            panic!("unknown subcommand should be an error")
+        };
+        assert!(s.contains("unknown subcommand"), "got: {s}");
+        assert!(s.contains("create"), "the error should teach the family: {s}");
     }
 
     #[test]

--- a/tools/attend-chat/src/slash.rs
+++ b/tools/attend-chat/src/slash.rs
@@ -30,6 +30,8 @@
 
 use iocraft::prelude::*;
 
+use crate::grammar::{self, SubCommand, Token};
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Status {
     /// Wired into [`dispatch`]. Runs when invoked.
@@ -39,31 +41,44 @@ pub enum Status {
     Planned,
 }
 
-/// What registry the helper row should switch to once the user is
-/// past a command's name and typing its argument. The app-side
-/// state machine in `crate::helper` reads this to pick the right
-/// chip source — keeping the "which commands expect which kind of
-/// argument" data next to the command definition itself, so adding
-/// a command means adding one row here and nothing elsewhere.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum ArgKind {
-    /// Command takes no argument. Helper stays on the default
-    /// (agents) once the name is complete.
-    None,
-    /// Expects an `@Agent`. Helper switches to the agent legend.
-    Agent,
-    /// Expects a `#group`. Helper switches to the channel legend.
-    Group,
-}
-
-/// One row of the slash-command registry.
+/// One row of the slash-command registry. `grammar` (#405) is the
+/// command's full token sequence — the app-side state machine in
+/// `crate::helper` walks it to steer the helper row level by level,
+/// keeping "what does this command expect" next to the command
+/// definition itself, so adding a command means adding one row here
+/// and nothing elsewhere.
 #[derive(Copy, Clone, Debug)]
 pub struct SlashCommand {
     pub name: &'static str,
     pub description: &'static str,
     pub status: Status,
-    pub arg_kind: ArgKind,
+    pub grammar: &'static [Token],
 }
+
+// Grammar shorthands for the registry rows below.
+const AGENT: Token = Token::Agent { required: true };
+const GROUP_OPT: Token = Token::Group { required: false };
+
+/// The `/channels` subcommand family (#404): `list` (default),
+/// `create`, `describe`. `dispatch` and the helper walk both read
+/// this — the branch grammars ARE the parse contract.
+pub const CHANNELS_SUBS: &[SubCommand] = &[
+    SubCommand {
+        name: "list",
+        description: "List channels with member counts (default)",
+        grammar: &[],
+    },
+    SubCommand {
+        name: "create",
+        description: "Create a channel without joining it",
+        grammar: &[Token::Word("<name>"), Token::Rest("[description…]")],
+    },
+    SubCommand {
+        name: "describe",
+        description: "Set a channel's description (empty clears)",
+        grammar: &[Token::Group { required: true }, Token::Rest("[description…]")],
+    },
+];
 
 /// Every slash command the TUI knows about. Implemented ones
 /// dispatch; planned ones autocomplete and show up in `/help` so
@@ -73,72 +88,72 @@ pub const REGISTRY: &[SlashCommand] = &[
         name: "help",
         description: "List available commands",
         status: Status::Implemented,
-        arg_kind: ArgKind::None,
+        grammar: &[],
     },
     SlashCommand {
         name: "whois",
         description: "Show a peer's session id + origin root",
         status: Status::Implemented,
-        arg_kind: ArgKind::Agent,
+        grammar: &[AGENT],
     },
     SlashCommand {
         name: "peers",
         description: "List live peer sessions",
         status: Status::Implemented,
-        arg_kind: ArgKind::None,
+        grammar: &[],
     },
     SlashCommand {
         name: "join",
         description: "Join a focus group",
         status: Status::Implemented,
-        arg_kind: ArgKind::Group,
+        grammar: &[Token::Group { required: true }],
     },
     SlashCommand {
         name: "leave",
         description: "Leave a focus group",
         status: Status::Implemented,
-        arg_kind: ArgKind::Group,
+        grammar: &[GROUP_OPT],
     },
     SlashCommand {
         name: "dissolve",
         description: "Remove a group with no live members",
         status: Status::Implemented,
-        arg_kind: ArgKind::Group,
+        grammar: &[GROUP_OPT],
     },
     SlashCommand {
         name: "channels",
         description: "List · create · describe channels",
         status: Status::Implemented,
-        arg_kind: ArgKind::None,
+        grammar: &[Token::Subcommands(CHANNELS_SUBS)],
     },
     SlashCommand {
         name: "invite",
         description: "Invite a peer to a channel (they join themselves)",
         status: Status::Implemented,
-        arg_kind: ArgKind::Agent,
+        grammar: &[AGENT, GROUP_OPT],
     },
     SlashCommand {
         name: "kick",
         description: "Remove a member from a channel",
         status: Status::Implemented,
-        arg_kind: ArgKind::Agent,
+        grammar: &[AGENT, GROUP_OPT],
     },
     SlashCommand {
         name: "purge",
         description: "Delete a channel's on-disk history",
         status: Status::Implemented,
-        arg_kind: ArgKind::Group,
+        grammar: &[GROUP_OPT],
     },
     SlashCommand {
         name: "clear",
         description: "Clear the message buffer",
         status: Status::Implemented,
-        arg_kind: ArgKind::None,
+        grammar: &[],
     },
 ];
 
 /// Look up a registered command by name (exact match, case-sensitive).
-/// The helper state machine uses this to inspect `arg_kind` once the
+/// The helper state machine uses this to walk `grammar` once the
 /// user is past the name; callers that need prefix matching use
 /// [`best_slash_completion`] instead.
 pub fn lookup(name: &str) -> Option<&'static SlashCommand> {
@@ -180,29 +195,70 @@ pub struct SlashPartial<'a> {
     pub partial: &'a str,
 }
 
-/// Inline help for the status slot while composing (#398): when
-/// exactly one registry command has `partial` as a prefix, return its
-/// one-line help; otherwise `None` and the caller keeps showing the
-/// last executed result. An empty partial matches everything, so the
-/// bare `/` menu keeps the result visible beneath the full list.
-pub fn single_match_help(partial: &str) -> Option<String> {
-    let mut matches = REGISTRY.iter().filter(|c| c.name.starts_with(partial));
-    match (matches.next(), matches.next()) {
-        (Some(cmd), None) => {
-            let arg = match cmd.arg_kind {
-                ArgKind::None => "",
-                ArgKind::Agent => " <@name>",
-                ArgKind::Group => " <#channel>",
-            };
-            let planned = if cmd.status == Status::Planned {
-                " (planned)"
-            } else {
-                ""
-            };
-            Some(format!("/{}{} — {}{}", cmd.name, arg, cmd.description, planned))
-        }
-        _ => None,
+/// Inline help for the status slot while composing (#398, recursion
+/// per #405): help text for the DEEPEST unambiguous grammar node the
+/// input has reached.
+///
+/// - Typing the name: exactly one prefix match → that command's help
+///   (signature derived from its grammar). An empty partial matches
+///   everything, so the bare `/` menu keeps the result visible.
+/// - Past the name: the command itself is committed, hence
+///   unambiguous — its help shows; a subcommand token (completed or
+///   uniquely prefixed) deepens to the branch's help. An ambiguous or
+///   unknown subcommand token falls back to the family help.
+///
+/// Takes the full input (not a pre-split partial) because depth
+/// requires the whole line. Returns `None` for non-slash input and
+/// the caller keeps showing the last executed result.
+pub fn contextual_help(input: &str) -> Option<String> {
+    if let Some(p) = find_slash_partial(input) {
+        let mut matches = REGISTRY.iter().filter(|c| c.name.starts_with(p.partial));
+        return match (matches.next(), matches.next()) {
+            (Some(cmd), None) => Some(top_help(cmd)),
+            _ => None,
+        };
     }
+    let (name, args) = parse(input)?;
+    let cmd = lookup(name)?;
+    // Only a leading subcommand choice deepens the node — every other
+    // token shape keeps the command's own help (its signature already
+    // describes the remaining levels).
+    let Some(Token::Subcommands(subs)) = cmd.grammar.first() else {
+        return Some(top_help(cmd));
+    };
+    // The first args token narrows whether completed or mid-typing —
+    // same rule as the top level, one level down.
+    match args.split_whitespace().next() {
+        None => Some(top_help(cmd)),
+        Some(t) => {
+            let mut hits = subs.iter().filter(|s| s.name.starts_with(t));
+            match (hits.next(), hits.next()) {
+                (Some(sub), None) => Some(format!(
+                    "/{} {}{} — {}",
+                    cmd.name,
+                    sub.name,
+                    grammar::signature(sub.grammar),
+                    sub.description
+                )),
+                _ => Some(top_help(cmd)),
+            }
+        }
+    }
+}
+
+fn top_help(cmd: &SlashCommand) -> String {
+    let planned = if cmd.status == Status::Planned {
+        " (planned)"
+    } else {
+        ""
+    };
+    format!(
+        "/{}{} — {}{}",
+        cmd.name,
+        grammar::signature(cmd.grammar),
+        cmd.description,
+        planned
+    )
 }
 
 pub fn find_slash_partial(input: &str) -> Option<SlashPartial<'_>> {
@@ -492,36 +548,30 @@ pub fn dispatch(name: &str, args: &str) -> SlashOutcome {
     }
 }
 
-/// Render the slash-command legend row — one chip per registered
-/// command. Implemented entries render in a full-weight foreground
-/// color; planned entries dim so the roadmap is visible without
-/// looking equally available. Matching names underline when the
-/// caller passes the current partial (Tab-target affordance, same
-/// idiom as the agent / group legends).
-pub fn slash_legend_row(current_partial: Option<&str>) -> Vec<AnyElement<'static>> {
-    let lc_partial = current_partial.map(|p| p.to_ascii_lowercase());
-    let chips: Vec<AnyElement<'static>> = REGISTRY
-        .iter()
-        .map(|cmd| {
-            let matches = lc_partial
-                .as_ref()
-                .map(|p| !p.is_empty() && cmd.name.to_ascii_lowercase().starts_with(p))
-                .unwrap_or(false);
-            // Slash commands aren't identities, so they don't carry
-            // palette hashing — a uniform Cyan for ready, DarkGrey
-            // for planned keeps the bar readable without adding new
-            // visual dimensions the user has to learn.
-            let color = match cmd.status {
-                Status::Implemented => Color::Cyan,
-                Status::Planned => Color::DarkGrey,
-            };
+/// Does `name` prefix-match the partial being typed? The shared
+/// highlight rule for every command-chip level: non-empty partial,
+/// case-insensitive.
+fn chip_matches(name: &str, lc_partial: Option<&String>) -> bool {
+    lc_partial
+        .map(|p| !p.is_empty() && name.to_ascii_lowercase().starts_with(p.as_str()))
+        .unwrap_or(false)
+}
+
+/// One-row chip strip shared by every command level (#405): the
+/// top-level slash list and each subcommand level render through the
+/// same function, so descending a level cannot drift visually.
+/// `chips` is `(label, color, matches)` — matching chips bold +
+/// underline (the Tab-target affordance the legends use).
+fn command_chip_row(chips: Vec<(String, Color, bool)>) -> Vec<AnyElement<'static>> {
+    let chips: Vec<AnyElement<'static>> = chips
+        .into_iter()
+        .map(|(content, color, matches)| {
             let weight = if matches { Weight::Bold } else { Weight::Normal };
             let decoration = if matches {
                 TextDecoration::Underline
             } else {
                 TextDecoration::None
             };
-            let content = format!("/{} ", cmd.name);
             element! {
                 Text(color, weight, decoration, content, wrap: TextWrap::NoWrap)
             }
@@ -541,6 +591,99 @@ pub fn slash_legend_row(current_partial: Option<&str>) -> Vec<AnyElement<'static
         }
     }
     .into_any()]
+}
+
+/// Render the slash-command legend row — one chip per registered
+/// command. Implemented entries render in a full-weight foreground
+/// color; planned entries dim so the roadmap is visible without
+/// looking equally available. Matching names underline when the
+/// caller passes the current partial (Tab-target affordance, same
+/// idiom as the agent / group legends).
+pub fn slash_legend_row(current_partial: Option<&str>) -> Vec<AnyElement<'static>> {
+    let lc_partial = current_partial.map(|p| p.to_ascii_lowercase());
+    command_chip_row(
+        REGISTRY
+            .iter()
+            .map(|cmd| {
+                // Slash commands aren't identities, so they don't carry
+                // palette hashing — a uniform Cyan for ready, DarkGrey
+                // for planned keeps the bar readable without adding new
+                // visual dimensions the user has to learn.
+                let color = match cmd.status {
+                    Status::Implemented => Color::Cyan,
+                    Status::Planned => Color::DarkGrey,
+                };
+                (
+                    format!("/{} ", cmd.name),
+                    color,
+                    chip_matches(cmd.name, lc_partial.as_ref()),
+                )
+            })
+            .collect(),
+    )
+}
+
+/// Subcommand-level legend row (#405): the current choice level's
+/// candidates, prefix-narrowed exactly like the top-level slash list
+/// — same chips, one level down, no leading slash (they're not
+/// commands, they steer one).
+pub fn subcommand_legend_row(
+    choices: &'static [SubCommand],
+    current_partial: Option<&str>,
+) -> Vec<AnyElement<'static>> {
+    let lc_partial = current_partial.map(|p| p.to_ascii_lowercase());
+    command_chip_row(
+        choices
+            .iter()
+            .map(|sub| {
+                (
+                    format!("{} ", sub.name),
+                    Color::Cyan,
+                    chip_matches(sub.name, lc_partial.as_ref()),
+                )
+            })
+            .collect(),
+    )
+}
+
+/// Free-token hint row (#405): the grammar has descended to a token
+/// no legend can offer (`<name>`, `[description…]`) — show the hint
+/// dimmed where the candidates would be.
+pub fn hint_row(hint: &str) -> Vec<AnyElement<'static>> {
+    command_chip_row(vec![(hint.to_string(), Color::DarkGrey, false)])
+}
+
+/// Tab completion one level down (#405): when the caret sits at a
+/// subcommand choice, complete the partial (or, on a bare descent,
+/// insert the first choice — mirroring bare `/` + Tab at the top
+/// level). Returns the new buffer + char cursor, or `None` when the
+/// input isn't at a subcommand level.
+pub fn complete_subcommand(input: &str) -> Option<(String, usize)> {
+    let (name, args) = parse(input)?;
+    let cmd = lookup(name)?;
+    let grammar::Pos::Sub { choices, partial } = grammar::walk(cmd.grammar, args) else {
+        return None;
+    };
+    let p = match partial {
+        Some(p) => p,
+        // A bare descent ("/channels ") completes to the first
+        // choice; but "/channels" with no space is still the NAME
+        // being typed — `parse` accepts it, so gate on the space
+        // ourselves and leave it to the top-level completion path.
+        None if input.ends_with(char::is_whitespace) => String::new(),
+        None => return None,
+    };
+    let lc = p.to_ascii_lowercase();
+    let hit = choices
+        .iter()
+        .find(|s| s.name.to_ascii_lowercase().starts_with(&lc))?;
+    // The partial — when present — is the input's literal tail (walk
+    // only yields `Some` for the final unterminated token), so a
+    // byte-suffix splice is safe.
+    let head = &input[..input.len() - p.len()];
+    let out = format!("{}{} ", head, hit.name);
+    let cursor = out.chars().count();
+    Some((out, cursor))
 }
 
 fn help_message() -> String {
@@ -933,28 +1076,103 @@ mod tests {
 }
 
 #[cfg(test)]
-mod single_match_tests {
+mod contextual_help_tests {
+    //! #398's single-match rule, following the grammar recursion
+    //! (#405): the deepest unambiguous node's help wins.
+
     use super::*;
 
     #[test]
-    fn unique_prefix_yields_help_with_arg_hint() {
-        // "/w" → only whois. Help carries the @name hint.
-        let h = single_match_help("w").expect("whois is the only w-command");
+    fn unique_prefix_yields_help_with_grammar_signature() {
+        // "/w" → only whois. Signature derives from the grammar.
+        let h = contextual_help("/w").expect("whois is the only w-command");
         assert!(h.starts_with("/whois <@name> — "), "got: {h}");
+        // Optional tokens render bracketed.
+        let h = contextual_help("/inv").expect("invite is the only inv-command");
+        assert!(h.starts_with("/invite <@name> [#channel] — "), "got: {h}");
     }
 
     #[test]
     fn ambiguous_and_empty_prefixes_yield_none() {
         // Empty matches everything → the bare / menu keeps the last
         // result visible (#398 step 2).
-        assert!(single_match_help("").is_none());
+        assert!(contextual_help("/").is_none());
         // "p" is ambiguous (peers, purge).
-        assert!(single_match_help("p").is_none());
+        assert!(contextual_help("/p").is_none());
+        // Non-slash input never has help.
+        assert!(contextual_help("hello").is_none());
+        assert!(contextual_help("").is_none());
     }
 
     #[test]
     fn full_name_and_unknown_behave() {
-        assert!(single_match_help("peers").is_some());
-        assert!(single_match_help("zzz").is_none());
+        assert!(contextual_help("/peers").is_some());
+        assert!(contextual_help("/zzz").is_none());
+        assert!(contextual_help("/zzz args").is_none());
+    }
+
+    #[test]
+    fn committed_command_keeps_its_help_through_the_args() {
+        // Past the name the command is unambiguous — help persists
+        // while its arguments are typed (the recursion's base case).
+        let h = contextual_help("/whois ").expect("committed command has help");
+        assert!(h.starts_with("/whois <@name> — "), "got: {h}");
+        let h = contextual_help("/whois @Ur").expect("still committed");
+        assert!(h.starts_with("/whois <@name> — "), "got: {h}");
+    }
+
+    #[test]
+    fn subcommand_family_shows_family_then_branch_help() {
+        // At the choice level with nothing typed: the family node.
+        let h = contextual_help("/channels ").expect("family help");
+        assert!(h.starts_with("/channels [list|create|describe] — "), "got: {h}");
+        // A unique subcommand prefix deepens to the branch node.
+        let h = contextual_help("/channels c").expect("create is the only c-sub");
+        assert_eq!(
+            h,
+            "/channels create <name> [description…] — Create a channel without joining it"
+        );
+        // Help follows all the way down the branch's own tokens.
+        let h = contextual_help("/channels create plans road").expect("deep in create");
+        assert!(h.starts_with("/channels create <name> [description…] — "), "got: {h}");
+        let h = contextual_help("/channels describe #plans ").expect("describe branch");
+        assert!(h.starts_with("/channels describe <#channel> [description…] — "), "got: {h}");
+        // Unknown subcommand token: fall back to the family node.
+        let h = contextual_help("/channels zz").expect("family fallback");
+        assert!(h.starts_with("/channels [list|create|describe] — "), "got: {h}");
+    }
+}
+
+#[cfg(test)]
+mod subcommand_completion_tests {
+    use super::*;
+
+    #[test]
+    fn completes_partial_subcommand_with_trailing_space() {
+        let (buf, cursor) = complete_subcommand("/channels cr").expect("cr → create");
+        assert_eq!(buf, "/channels create ");
+        assert_eq!(cursor, buf.chars().count());
+        // Case-insensitive, like top-level completion.
+        let (buf, _) = complete_subcommand("/channels DE").expect("DE → describe");
+        assert_eq!(buf, "/channels describe ");
+    }
+
+    #[test]
+    fn bare_descent_completes_to_first_choice() {
+        // Mirrors bare `/` + Tab picking the first registry entry.
+        let (buf, _) = complete_subcommand("/channels ").expect("first choice");
+        assert_eq!(buf, "/channels list ");
+    }
+
+    #[test]
+    fn none_when_not_at_a_subcommand_level() {
+        // Below the choice (free token) and on grammar-less commands.
+        assert!(complete_subcommand("/channels create pl").is_none());
+        assert!(complete_subcommand("/whois @Ur").is_none());
+        assert!(complete_subcommand("/help ").is_none());
+        // No prefix hit → no completion.
+        assert!(complete_subcommand("/channels zz").is_none());
+        // Still typing the command name → the top-level path owns it.
+        assert!(complete_subcommand("/channels").is_none());
     }
 }

--- a/tools/attend-chat/src/slash.rs
+++ b/tools/attend-chat/src/slash.rs
@@ -670,7 +670,13 @@ pub fn complete_subcommand(input: &str) -> Option<(String, usize)> {
         // choice; but "/channels" with no space is still the NAME
         // being typed — `parse` accepts it, so gate on the space
         // ourselves and leave it to the top-level completion path.
-        None if input.ends_with(char::is_whitespace) => String::new(),
+        // The descent must also be CLEAN: after an unknown completed
+        // token ("/channels bogus "), walk still reports the Sub level
+        // with no partial, and completing there would graft "list"
+        // onto garbage (PR #407 review).
+        None if input.ends_with(char::is_whitespace) && args.trim().is_empty() => {
+            String::new()
+        }
         None => return None,
     };
     let lc = p.to_ascii_lowercase();

--- a/tools/attend-chat/src/tabs.rs
+++ b/tools/attend-chat/src/tabs.rs
@@ -205,6 +205,31 @@ pub fn tab_strip_row(
         });
     }
 
+    // Foreground channel's description, dimmed after the strip
+    // (#404): the one-line "what is this channel for" sits where the
+    // eye already is when a tab is focused. Merged has no channel and
+    // `#open` carries no stored description, so the strip stays bare
+    // for both; overflow: Hidden on the row truncates gracefully on
+    // narrow terminals.
+    if let Tab::Channel(g) = foreground {
+        if let Some(desc) = known
+            .iter()
+            .find(|k| k.group.name == *g)
+            .and_then(|k| k.membership.description.as_deref())
+        {
+            chips.push(
+                element! {
+                    Text(
+                        color: Color::DarkGrey,
+                        content: format!(" — {desc}"),
+                        wrap: TextWrap::NoWrap,
+                    )
+                }
+                .into_any(),
+            );
+        }
+    }
+
     vec![element! {
         View(
             flex_direction: FlexDirection::Row,

--- a/tools/attend-groups/src/lib.rs
+++ b/tools/attend-groups/src/lib.rs
@@ -45,6 +45,18 @@ pub struct Groups {
 
 const GROUP_PREFIX: &str = "@";
 
+/// The single-line description contract, shared by every write path
+/// (create, set_description). Control characters — newlines above
+/// all — are rejected, not folded: a folded payload still surprises,
+/// and the yaml wire format is line-oriented (PR #407 review).
+fn normalize_description(text: &str) -> Result<Option<String>, String> {
+    if text.chars().any(|c| c.is_control()) {
+        return Err("description must be a single line of printable text".to_string());
+    }
+    let t = text.trim();
+    Ok((!t.is_empty()).then(|| t.to_string()))
+}
+
 /// Member-kind discriminator (#406). Agent ids are Claude Code session
 /// UUIDs (8-4-4-4-12 hex) or the `pid-<n>` unresolved fallback; human
 /// ids are ADR-170 sanitized usernames, which are neither. Encoded
@@ -128,6 +140,15 @@ impl Groups {
     /// joins or the operator dissolves it.
     pub fn create(&self, name: &str, description: Option<&str>) -> Result<(), String> {
         validate_group_name(name)?;
+        // Same single-line contract as set_description — enforced HERE,
+        // not per-surface: a newline in the description is a yaml
+        // injection that mints fabricated groups/members (PR #407
+        // review, blocking finding — reproduced against the built
+        // crate).
+        let description = match description {
+            Some(d) => normalize_description(d)?,
+            None => None,
+        };
         let mut state = self.load_state();
         if state.contains_key(name) {
             return Err(format!("#{name} already exists"));
@@ -137,10 +158,7 @@ impl Groups {
             GroupEntry {
                 pinned: true,
                 members: Vec::new(),
-                description: description
-                    .map(str::trim)
-                    .filter(|d| !d.is_empty())
-                    .map(String::from),
+                description,
             },
         );
         self.save_state(&state);
@@ -152,19 +170,12 @@ impl Groups {
     /// Set or replace a channel's description (#404). Single-line by
     /// contract — the yaml wire format is line-oriented.
     pub fn set_description(&self, name: &str, text: &str) -> Result<(), String> {
-        if text.contains('\n') {
-            return Err("description must be a single line".to_string());
-        }
+        let normalized = normalize_description(text)?;
         let mut state = self.load_state();
         let Some(entry) = state.get_mut(name) else {
             return Err(format!("#{name}: unknown group"));
         };
-        let trimmed = text.trim();
-        entry.description = if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed.to_string())
-        };
+        entry.description = normalized;
         self.save_state(&state);
         Ok(())
     }
@@ -490,6 +501,12 @@ pub fn validate_group_name(name: &str) -> Result<(), String> {
     }
     if name.contains('/') || name.contains(' ') {
         return Err("group name cannot contain / or spaces".to_string());
+    }
+    // '#' would survive a single sigil-strip and mint a phantom whose
+    // yaml header parses as a comment; ':' is the yaml key terminator.
+    // Both are wire hazards, not names (PR #407 review).
+    if name.contains('#') || name.contains(':') {
+        return Err("group name cannot contain # or :".to_string());
     }
     // `broadcast` backs `_broadcast/`; `open` is the display name of
     // the base channel (ADR-124) — both would alias the commons if
@@ -1003,5 +1020,44 @@ mod lifecycle_tests {
         // Close-but-wrong UUID shapes are not agents.
         assert!(!is_agent_member("a62473ce-6310-421e-9964"));
         assert!(!is_agent_member("zzzzzzzz-6310-421e-9964-7bb3c9a752d4"));
+    }
+}
+
+#[cfg(test)]
+mod injection_tests {
+    use super::*;
+
+    fn base(tag: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("attend-groups-407-{tag}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&d);
+        fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    /// PR #407 blocking regression: a newline-bearing description must
+    /// be rejected by EVERY write path — the reviewer reproduced a
+    /// yaml injection minting a fabricated pinned group with an
+    /// arbitrary member through `create`.
+    #[test]
+    fn create_and_describe_reject_yaml_injection() {
+        let b = base("inject");
+        let g = Groups::new(&b, "operator");
+        let evil = "x\nevil:\n  pinned: true\n  members:\n    - fake-member";
+        assert!(g.create("foo", Some(evil)).unwrap_err().contains("single line"));
+        assert!(load_groups(&b).is_empty(), "nothing may be written on rejection");
+
+        g.create("foo", None).unwrap();
+        assert!(g.set_description("foo", evil).unwrap_err().contains("single line"));
+        let state = load_groups(&b);
+        assert!(!state.contains_key("evil"), "no fabricated group");
+        assert_eq!(state["foo"].description, None);
+        fs::remove_dir_all(&b).ok();
+    }
+
+    #[test]
+    fn group_names_reject_wire_hazard_characters() {
+        assert!(validate_group_name("#x").unwrap_err().contains("# or :"));
+        assert!(validate_group_name("a:b").unwrap_err().contains("# or :"));
+        assert!(validate_group_name("plain-name").is_ok());
     }
 }

--- a/tools/attend-groups/src/lib.rs
+++ b/tools/attend-groups/src/lib.rs
@@ -30,6 +30,10 @@ pub struct GroupEntry {
     /// Member ids currently in this group: Claude Code session UUIDs
     /// for claude sessions, sanitized usernames for humans (ADR-170).
     pub members: Vec<String>,
+    /// Optional single-line channel description (#404). Absent in
+    /// pre-#404 files — the parser treats a missing key as `None`, so
+    /// old state round-trips untouched.
+    pub description: Option<String>,
 }
 
 /// Group state manager.
@@ -40,6 +44,24 @@ pub struct Groups {
 }
 
 const GROUP_PREFIX: &str = "@";
+
+/// Member-kind discriminator (#406). Agent ids are Claude Code session
+/// UUIDs (8-4-4-4-12 hex) or the `pid-<n>` unresolved fallback; human
+/// ids are ADR-170 sanitized usernames, which are neither. Encoded
+/// once, here, next to the member-identity documentation — every
+/// policy that distinguishes the kinds must call this, not re-derive
+/// the shape.
+pub fn is_agent_member(id: &str) -> bool {
+    if id.starts_with("pid-") {
+        return true;
+    }
+    let parts: Vec<&str> = id.split('-').collect();
+    parts.len() == 5
+        && [8usize, 4, 4, 4, 12]
+            .iter()
+            .zip(&parts)
+            .all(|(len, p)| p.len() == *len && p.bytes().all(|b| b.is_ascii_hexdigit()))
+}
 
 impl Groups {
     /// `member_id` is the identity this manager acts for: a session
@@ -84,6 +106,7 @@ impl Groups {
         let entry = state.entry(name.to_string()).or_insert(GroupEntry {
             pinned: false,
             members: Vec::new(),
+            description: None,
         });
         if !entry.members.contains(&self.member_id) {
             entry.members.push(self.member_id.clone());
@@ -95,6 +118,54 @@ impl Groups {
 
         let dir = self.group_dir(name);
         fs::create_dir_all(&dir).map_err(|e| format!("creating group dir: {e}"))?;
+        Ok(())
+    }
+
+    /// Create a channel WITHOUT joining it (#404) — the operator's
+    /// explicit lifecycle verb, distinct from join's create-implicitly.
+    /// Created channels are pinned: an empty unpinned group is swept
+    /// by cleanup, so an explicit create must persist until someone
+    /// joins or the operator dissolves it.
+    pub fn create(&self, name: &str, description: Option<&str>) -> Result<(), String> {
+        validate_group_name(name)?;
+        let mut state = self.load_state();
+        if state.contains_key(name) {
+            return Err(format!("#{name} already exists"));
+        }
+        state.insert(
+            name.to_string(),
+            GroupEntry {
+                pinned: true,
+                members: Vec::new(),
+                description: description
+                    .map(str::trim)
+                    .filter(|d| !d.is_empty())
+                    .map(String::from),
+            },
+        );
+        self.save_state(&state);
+        fs::create_dir_all(self.group_dir(name))
+            .map_err(|e| format!("creating group dir: {e}"))?;
+        Ok(())
+    }
+
+    /// Set or replace a channel's description (#404). Single-line by
+    /// contract — the yaml wire format is line-oriented.
+    pub fn set_description(&self, name: &str, text: &str) -> Result<(), String> {
+        if text.contains('\n') {
+            return Err("description must be a single line".to_string());
+        }
+        let mut state = self.load_state();
+        let Some(entry) = state.get_mut(name) else {
+            return Err(format!("#{name}: unknown group"));
+        };
+        let trimmed = text.trim();
+        entry.description = if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        };
+        self.save_state(&state);
         Ok(())
     }
 
@@ -124,6 +195,13 @@ impl Groups {
     /// an unknown group or a non-member so the TUI can report
     /// precisely.
     pub fn kick(&self, name: &str, member: &str) -> Result<(), String> {
+        // #406: removal is unilateral between peers, but an agent may
+        // never remove a HUMAN member — the operator power flows one
+        // way. Enforced here, at the shared API, so no surface (current
+        // or future) can reach around it.
+        if is_agent_member(&self.member_id) && !is_agent_member(member) {
+            return Err("agents cannot kick a human member".to_string());
+        }
         let mut state = self.load_state();
         let Some(entry) = state.get_mut(name) else {
             return Err(format!("#{name}: unknown group"));
@@ -453,6 +531,7 @@ pub fn parse_groups_yaml(content: &str) -> HashMap<String, GroupEntry> {
     let mut current_room: Option<String> = None;
     let mut current_pinned = false;
     let mut current_members: Vec<String> = Vec::new();
+    let mut current_description: Option<String> = None;
 
     for line in content.lines() {
         let trimmed = line.trim();
@@ -471,12 +550,14 @@ pub fn parse_groups_yaml(content: &str) -> HashMap<String, GroupEntry> {
                     GroupEntry {
                         pinned: current_pinned,
                         members: current_members.clone(),
+                        description: current_description.take(),
                     },
                 );
             }
             current_room = Some(trimmed.trim_end_matches(':').to_string());
             current_pinned = false;
             current_members = Vec::new();
+            current_description = None;
             continue;
         }
 
@@ -487,6 +568,9 @@ pub fn parse_groups_yaml(content: &str) -> HashMap<String, GroupEntry> {
                 let value = value.trim();
                 match key {
                     "pinned" => current_pinned = value == "true",
+                    "description" if !value.is_empty() => {
+                        current_description = Some(value.to_string());
+                    }
                     "members" => {} // array header, items follow
                     _ => {}
                 }
@@ -508,6 +592,7 @@ pub fn parse_groups_yaml(content: &str) -> HashMap<String, GroupEntry> {
             GroupEntry {
                 pinned: current_pinned,
                 members: current_members,
+                description: current_description,
             },
         );
     }
@@ -524,6 +609,9 @@ pub fn serialize_groups_yaml(state: &HashMap<String, GroupEntry>) -> String {
         let entry = &state[name];
         out.push_str(&format!("{name}:\n"));
         out.push_str(&format!("  pinned: {}\n", entry.pinned));
+        if let Some(ref d) = entry.description {
+            out.push_str(&format!("  description: {d}\n"));
+        }
         out.push_str("  members:\n");
         for member in &entry.members {
             out.push_str(&format!("    - {member}\n"));
@@ -572,6 +660,7 @@ mod tests {
             GroupEntry {
                 pinned: true,
                 members: vec!["session-abc".to_string(), "session-xyz".to_string()],
+                description: None,
             },
         );
         state.insert(
@@ -579,6 +668,7 @@ mod tests {
             GroupEntry {
                 pinned: false,
                 members: vec!["session-abc".to_string()],
+                description: None,
             },
         );
 
@@ -804,5 +894,114 @@ mod kick_tests {
         assert!(op.members("temp").is_none(), "empty unpinned group is removed");
         assert!(!b.join("@temp").exists());
         fs::remove_dir_all(&b).ok();
+    }
+}
+
+#[cfg(test)]
+mod lifecycle_tests {
+    use super::*;
+
+    fn base(tag: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!(
+            "attend-groups-404-{tag}-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&d);
+        fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    /// #404 golden extension: description round-trips through the yaml
+    /// wire format, and pre-#404 files (no description key) parse to
+    /// `None` untouched.
+    #[test]
+    fn description_round_trips_and_absent_is_none() {
+        let mut state = HashMap::new();
+        state.insert(
+            "deploy".to_string(),
+            GroupEntry {
+                pinned: true,
+                members: vec!["m1".into()],
+                description: Some("release coordination".into()),
+            },
+        );
+        let yaml = serialize_groups_yaml(&state);
+        assert!(yaml.contains("  description: release coordination\n"), "got: {yaml}");
+        let back = parse_groups_yaml(&yaml);
+        assert_eq!(back["deploy"].description.as_deref(), Some("release coordination"));
+
+        let legacy = "old:\n  pinned: false\n  members:\n    - m1\n";
+        let parsed = parse_groups_yaml(legacy);
+        assert_eq!(parsed["old"].description, None);
+        assert_eq!(parsed["old"].members, vec!["m1".to_string()]);
+    }
+
+    #[test]
+    fn create_is_pinned_empty_and_refuses_duplicates() {
+        let b = base("create");
+        let g = Groups::new(&b, "operator");
+        g.create("plans", Some("  roadmap talk  ")).unwrap();
+        let state = load_groups(&b);
+        assert!(state["plans"].pinned, "explicit create must survive empty");
+        assert!(state["plans"].members.is_empty());
+        assert_eq!(state["plans"].description.as_deref(), Some("roadmap talk"));
+        assert!(b.join("@plans").is_dir());
+        assert!(g.create("plans", None).unwrap_err().contains("already exists"));
+        assert!(g.create("open", None).is_err(), "reserved names stay reserved");
+        fs::remove_dir_all(&b).ok();
+    }
+
+    #[test]
+    fn set_description_updates_clears_and_rejects_multiline() {
+        let b = base("desc");
+        let g = Groups::new(&b, "operator");
+        g.create("x", None).unwrap();
+        g.set_description("x", "first").unwrap();
+        assert_eq!(load_groups(&b)["x"].description.as_deref(), Some("first"));
+        g.set_description("x", "  ").unwrap();
+        assert_eq!(load_groups(&b)["x"].description, None);
+        assert!(g.set_description("x", "a\nb").unwrap_err().contains("single line"));
+        assert!(g.set_description("ghost", "d").unwrap_err().contains("unknown group"));
+        fs::remove_dir_all(&b).ok();
+    }
+
+    /// #406: the operator power flows one way — an agent-acting Groups
+    /// may not remove a human member; humans may remove anyone; agents
+    /// may still remove agents (peer coordination).
+    #[test]
+    fn kick_guard_blocks_agent_removing_human() {
+        let b = base("guard");
+        let human = "aaron";
+        let agent = "a62473ce-6310-421e-9964-7bb3c9a752d4";
+        Groups::new(&b, human).join("ops", false).unwrap();
+        Groups::new(&b, agent).join("ops", false).unwrap();
+
+        let acting_agent = Groups::new(&b, agent);
+        assert!(
+            acting_agent.kick("ops", human).unwrap_err().contains("cannot kick a human"),
+            "agent must not remove a human member"
+        );
+        // pid-fallback identities count as agents too — the guard must
+        // not be dodgeable by running unresolved.
+        assert!(
+            Groups::new(&b, "pid-4242").kick("ops", human).is_err(),
+            "unresolved agent must not remove a human member"
+        );
+        // Agent → agent stays allowed; human → agent stays allowed.
+        assert!(acting_agent.kick("ops", agent).is_ok());
+        Groups::new(&b, agent).join("ops", false).unwrap();
+        assert!(Groups::new(&b, human).kick("ops", agent).is_ok());
+        fs::remove_dir_all(&b).ok();
+    }
+
+    #[test]
+    fn member_kind_discriminator_shapes() {
+        assert!(is_agent_member("a62473ce-6310-421e-9964-7bb3c9a752d4"));
+        assert!(is_agent_member("pid-1234"));
+        assert!(!is_agent_member("aaron"));
+        assert!(!is_agent_member("aaron-b"));
+        // Close-but-wrong UUID shapes are not agents.
+        assert!(!is_agent_member("a62473ce-6310-421e-9964"));
+        assert!(!is_agent_member("zzzzzzzz-6310-421e-9964-7bb3c9a752d4"));
     }
 }

--- a/tools/attend/src/cli.rs
+++ b/tools/attend/src/cli.rs
@@ -219,7 +219,7 @@ pub(crate) enum ChannelsCmd {
         /// Channel name (with or without the # prefix)
         name: String,
         /// Optional single-line description (all trailing words)
-        #[arg(trailing_var_arg = true)]
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         description: Vec<String>,
     },
 

--- a/tools/attend/src/cli.rs
+++ b/tools/attend/src/cli.rs
@@ -147,8 +147,11 @@ pub(crate) enum Commands {
         name: String,
     },
 
-    /// List channels — all available, with joined ones marked
-    Channels,
+    /// Channel lifecycle (default: list all, joined ones marked)
+    Channels {
+        #[command(subcommand)]
+        sub: Option<ChannelsCmd>,
+    },
 
     /// Dissolve a channel (removes it for every member)
     Dissolve {
@@ -201,6 +204,32 @@ pub(crate) enum Commands {
     Config {
         #[command(subcommand)]
         sub: Option<ConfigCmd>,
+    },
+}
+
+/// Subcommands for `attend channels`. With no subcommand, defaults to
+/// `list` — the plain listing agents already know.
+#[derive(Subcommand)]
+pub(crate) enum ChannelsCmd {
+    /// List all channels with joined marks (default)
+    List,
+
+    /// Create a channel without joining it (pinned so it persists empty)
+    Create {
+        /// Channel name (with or without the # prefix)
+        name: String,
+        /// Optional single-line description (all trailing words)
+        #[arg(trailing_var_arg = true)]
+        description: Vec<String>,
+    },
+
+    /// Set or replace a channel's single-line description
+    Describe {
+        /// Channel name (with or without the # prefix)
+        name: String,
+        /// The description text (all trailing words; empty clears)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        description: Vec<String>,
     },
 }
 

--- a/tools/attend/src/cmd/channels.rs
+++ b/tools/attend/src/cmd/channels.rs
@@ -77,6 +77,41 @@ pub(crate) fn cmd_dissolve(name: &str) {
     }
 }
 
+/// Create a channel without joining it (#404): explicit lifecycle,
+/// pinned by the shared crate so it survives empty.
+pub(crate) fn cmd_create(name: &str, description: &str) {
+    let r = get_groups();
+    let desc = (!description.trim().is_empty()).then_some(description.trim());
+    match r.create(name, desc) {
+        Ok(()) => match desc {
+            Some(d) => println!("[attend] created #{name} — {d}"),
+            None => println!("[attend] created #{name}"),
+        },
+        Err(e) => {
+            eprintln!("[attend] create: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Set or replace a channel's description (#404). Empty text clears.
+pub(crate) fn cmd_describe(name: &str, description: &str) {
+    let r = get_groups();
+    match r.set_description(name, description) {
+        Ok(()) => {
+            if description.trim().is_empty() {
+                println!("[attend] cleared #{name} description");
+            } else {
+                println!("[attend] #{name} — {}", description.trim());
+            }
+        }
+        Err(e) => {
+            eprintln!("[attend] describe: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
 /// All channels with membership marks — the agent-side mirror of the
 /// TUI's `/channels`. Supersedes the old joined/all split (`focus
 /// list` / `focus all`), which stays reachable via the deprecated
@@ -87,19 +122,26 @@ pub(crate) fn cmd_channels() {
     let joined: std::collections::HashSet<String> =
         r.my_groups().into_iter().map(|(n, _)| n).collect();
     let all = r.all_groups();
-    let mut t = agent_fmt::Table::new(&["Channel", "Members", "Joined", "Pinned"]);
+    let descriptions = attend_groups::load_groups(&crate::util::signals_base());
+    let mut t =
+        agent_fmt::Table::new(&["Channel", "Members", "Joined", "Pinned", "Description"]);
     t.align(1, agent_fmt::Align::Right);
     // ADR-124 §I.4: base channel leads the list, mirrors the TUI's
     // leftmost rule. `(all)` captures the fact that every peer is
     // implicitly subscribed.
-    t.add(vec!["#open", "(all)", "(always)", "(base)"]);
+    t.add(vec!["#open", "(all)", "(always)", "(base)", "the commons"]);
     for (name, count, pinned) in &all {
         let label = format!("#{name}");
+        let desc = descriptions
+            .get(name)
+            .and_then(|e| e.description.clone())
+            .unwrap_or_default();
         t.add(vec![
             &label,
             &count.to_string(),
             if joined.contains(name) { "yes" } else { "" },
             if *pinned { "yes" } else { "no" },
+            &desc,
         ]);
     }
     t.print();

--- a/tools/attend/src/cmd/channels.rs
+++ b/tools/attend/src/cmd/channels.rs
@@ -121,8 +121,12 @@ pub(crate) fn cmd_channels() {
     r.cleanup_stale();
     let joined: std::collections::HashSet<String> =
         r.my_groups().into_iter().map(|(n, _)| n).collect();
-    let all = r.all_groups();
-    let descriptions = attend_groups::load_groups(&crate::util::signals_base());
+    // Single read of the whole file (PR #407 nit): a second read for
+    // descriptions could misalign the column against a concurrent
+    // write. Members/pinned/description all come from this one snapshot.
+    let state = attend_groups::load_groups(&crate::util::signals_base());
+    let mut names: Vec<&String> = state.keys().collect();
+    names.sort();
     let mut t =
         agent_fmt::Table::new(&["Channel", "Members", "Joined", "Pinned", "Description"]);
     t.align(1, agent_fmt::Align::Right);
@@ -130,17 +134,15 @@ pub(crate) fn cmd_channels() {
     // leftmost rule. `(all)` captures the fact that every peer is
     // implicitly subscribed.
     t.add(vec!["#open", "(all)", "(always)", "(base)", "the commons"]);
-    for (name, count, pinned) in &all {
+    for name in names {
+        let entry = &state[name];
         let label = format!("#{name}");
-        let desc = descriptions
-            .get(name)
-            .and_then(|e| e.description.clone())
-            .unwrap_or_default();
+        let desc = entry.description.clone().unwrap_or_default();
         t.add(vec![
             &label,
-            &count.to_string(),
+            &entry.members.len().to_string(),
             if joined.contains(name) { "yes" } else { "" },
-            if *pinned { "yes" } else { "no" },
+            if entry.pinned { "yes" } else { "no" },
             &desc,
         ]);
     }

--- a/tools/attend/src/main.rs
+++ b/tools/attend/src/main.rs
@@ -84,7 +84,15 @@ fn main() {
         // primary because an unquoted `#` starts a shell comment.
         Commands::Join { name, pin } => cmd::channels::cmd_join(name.trim_start_matches('#'), pin),
         Commands::Leave { name } => cmd::channels::cmd_leave(name.trim_start_matches('#')),
-        Commands::Channels => cmd::channels::cmd_channels(),
+        Commands::Channels { sub } => match sub {
+            None | Some(cli::ChannelsCmd::List) => cmd::channels::cmd_channels(),
+            Some(cli::ChannelsCmd::Create { name, description }) => {
+                cmd::channels::cmd_create(name.trim_start_matches('#'), &description.join(" "));
+            }
+            Some(cli::ChannelsCmd::Describe { name, description }) => {
+                cmd::channels::cmd_describe(name.trim_start_matches('#'), &description.join(" "));
+            }
+        },
         Commands::Dissolve { name } => {
             cmd::channels::cmd_dissolve(name.trim_start_matches('#'));
         }


### PR DESCRIPTION
The final bundle of today's riding-the-loop session. Closes #404, #405, #406.

## #404 — channel lifecycle
- attend-groups: `GroupEntry.description` (single-line; absent key parses `None` — golden test extended for the wire-format change), `create()` (explicit lifecycle, pinned so an empty channel survives until joined/dissolved), `set_description()`.
- Both surfaces: `attend channels [list|create|describe]` (bare = list, # tolerated, Description column) and `/channels [list|create|describe]` — slash commands stay top-level, subcommands steer (operator convention). Tab strip shows the foreground channel's description, dimmed.

## #405 — hierarchical narrowing helper (Rhino/AutoCAD modal command line)
New `grammar.rs`: per-command token grammars (`Agent | Group | Word | Rest | Subcommands`) replace the single-valued ArgKind. The helper narrows candidates by prefix at EVERY level — type, underline, complete+space descends to the next token's domain (subcommand list / agent legend / channel legend / free-text hint), recursively; backspace ascends for free because position re-derives from the input string each render (no mode state). The #398 help slot follows to the deepest unambiguous node; the #400 assert window still wins while fresh. Tab completes at subcommand level. Sub-level lists render through the same row renderer as the top level — refactored, not forked.

## #406 — kick guard
`is_agent_member` discriminator (session UUID or `pid-` fallback = agent) documented beside the member-identity contract; `Groups::kick` refuses agent→human AT THE SHARED API so no surface can reach around it. Four quadrants tested: agent→human blocked (incl. unresolved pid- agents), agent→agent allowed, human→anyone allowed. TUI acting identity pinned by test so a future change that would make the TUI agent-shaped fails before shipping.

## Verification
897 workspace tests green (attend-groups 18→23, attend-chat 220→243), clippy zero warnings, CLI reference regenerated.