### PR TITLE
fix(ways-core): pin claude-opus-5 at 1M in the context-window table

### DIFF
--- a/tools/ways-core/src/context_window.rs
+++ b/tools/ways-core/src/context_window.rs
@@ -68,6 +68,7 @@ const MODEL_WINDOWS: &[(&str, u64)] = &[
     ("claude-fable-5", 1_000_000),
     ("claude-mythos-5", 1_000_000),
     ("claude-mythos-preview", 1_000_000),
+    ("claude-opus-5", 1_000_000),
     ("claude-opus-4-8", 1_000_000),
     ("claude-opus-4-7", 1_000_000),
     ("claude-opus-4-6", 1_000_000),
@@ -240,6 +241,7 @@ mod tests {
     /// exists to prevent was a model that matched no branch and silently defaulted.
     #[test]
     fn pins_every_model_seen_in_transcripts() {
+        assert_eq!(window_for_model("claude-opus-5"), Some(1_000_000));
         assert_eq!(window_for_model("claude-opus-4-8"), Some(1_000_000));
         assert_eq!(window_for_model("claude-fable-5"), Some(1_000_000));
         assert_eq!(window_for_model("claude-sonnet-4-6"), Some(1_000_000));
@@ -265,6 +267,20 @@ mod tests {
         let w = resolve(Some("claude-fable-5"));
         assert_eq!(w.tokens, 1_000_000);
         assert_eq!(w.source, WindowSource::ModelTable);
+    }
+
+    /// The failure ADR-166 predicted, arriving on schedule: Opus 5 shipped, the
+    /// table still ended at 4.8, and a live 1M session read `pct_used: 106` against
+    /// a 200K denominator — firing compaction pressure that was not there.
+    #[test]
+    fn opus_5_is_a_1m_model() {
+        let w = resolve(Some("claude-opus-5"));
+        assert_eq!(w.tokens, 1_000_000);
+        assert_eq!(w.source, WindowSource::ModelTable);
+
+        // The harness names this model `claude-opus-5[1m]` in the system prompt;
+        // component matching resolves that form too.
+        assert_eq!(window_for_model("claude-opus-5[1m]"), Some(1_000_000));
     }
 
     /// `sonnet` used to swallow `sonnet-5` and call it 200K. Substring matching is


### PR DESCRIPTION
## What

Adds `("claude-opus-5", 1_000_000)` to the ADR-166 model table, plus a regression test pinning both the bare id and the `claude-opus-5[1m]` form.

## Why

Opus 5 shipped; the table still ended at 4.8. Observed live in an Opus 5 session:

```json
{ "tokens_total": 200000, "model": "claude-opus-5", "window_source": "default" }
```

A 1M window measured against a 200K denominator. The gauge crosses 100% about a fifth of the way in.

The bad denominator propagates:

- `sensor-context` reads `pct_used` straight out of `ways context --json`, so its 60/75/85/90 bands fire ~5x early — compaction-pressure notices and the `attend context-pressure` affordance surface on a window that is nearly empty. This is the symptom that surfaced the bug.
- ADR-126 refire is window-relative, so way half-lives were scaled against a window 5x smaller than the real one.

Exactly the failure mode ADR-166 named as its accepted maintenance obligation — and `window_source: "default"` is what made it diagnosable in one command instead of silent.

## Verification

`cargo test -p ways-core context_window` — 15 passed.

Live installs need a rebuild (`/ways-update` or `make ways-rebuild`) before the resolver picks this up.