### PR TITLE
release(ways): v1.5.1

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "ways"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "agent-fmt",
  "anyhow",

--- a/tools/ways-cli/Cargo.toml
+++ b/tools/ways-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ways"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 description = "Unified CLI for ways — knowledge guidance for Claude Code"
 license = "MIT"


### PR DESCRIPTION
Patch release carrying #410 — `claude-opus-5` pinned at 1M in the ADR-166 context-window table.

Without it, every Opus 5 session resolves through the 200K default (`window_source: "default"`), so `ways context` reports a 1M window as 200K and the gauge crosses 100% about a fifth of the way in. Downstream, `sensor-context` reads that `pct_used` directly, firing compaction-pressure notices ~5x early, and ADR-126 window-relative refire scales way half-lives against a window 5x too small.

`attend` embeds `sensor-peers`, which also resolves through `ways-core`; a matching `attend` patch release follows.