### PR TITLE
release(attend): v0.12.1

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attend"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "agent-fmt",
  "agent-identity",

--- a/tools/attend/Cargo.toml
+++ b/tools/attend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "attend"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 description = "Active awareness module — adaptive sensing and disclosure for Claude Code sessions"
 license = "MIT"


### PR DESCRIPTION
Companion to `ways` v1.5.1 (#411), carrying #410 — `claude-opus-5` pinned at 1M in the ADR-166 context-window table.

`attend` links `sensor-peers`, which resolves *peer* session windows through `ways_core::resolve_for_foreign_session`. Until this rebuild, an Opus 5 peer was reported as a 200K session, so its context pressure read 5x higher than reality.

The operator's own gauge and the compaction-pressure bands come from `sensor-context`, which shells out to `ways context --json` — those are fixed by the `ways` binary in #411, not this one.