### PR TITLE
Markdown line handling: convention, reactive nudge, and a shared detector

### DIFF
--- a/docs/architecture/system/ADR-123-firing-dynamics-progression-axis-unification.md
+++ b/docs/architecture/system/ADR-123-firing-dynamics-progression-axis-unification.md
@@ -203,6 +203,25 @@ A new `ways tune` subcommand mirrors `attend tune`. It surveys recent sessions v
 
 Tuning parameters come from real session distributions, not guesses — the same discipline ADR-119 used when it sized attend's parameters to "Claude's actual turn cadence, not biological neuron kinetics."
 
+## Amendment — 2026-07-29: postcheck state handoff to its own macro
+
+Decision 5 describes postcheck evaluation as "metric-predicate style — cheap, deterministic, side-effect-free." That clause bundles three properties, and one of them is narrowed here: a postcheck may write **session-scoped state for the sole purpose of handing a finding to its own way's `macro.sh`**. Cheap and deterministic are unchanged, and the reason they survive is spelled out in constraint 4 below.
+
+**Why the channel is needed at all.** `check-post.sh` invokes each postcheck with `>/dev/null 2>&1` and reads only the exit code — ADR-135's amendment already recorded the consequence: "a postcheck's stdout is discarded... the content injected on a fire is the way's own body." `macro.sh` cannot close the gap either: `show/helpers.rs` runs it with no stdin and no arguments, so it never sees the tool input. `show/mod.rs` applies no trigger condition to macro execution, so a macro *does* run on a postcheck-triggered fire — the ordering (postcheck, then gate, then macro) is guaranteed by `check-post.sh`. A session-scoped stash is therefore the only channel by which a reactive way can name the file it is reacting to. Without it, every reactive way is limited to a static body, which is adequate for a way whose finding *is* its body (over-build names a replacement) and inadequate for one whose finding is a location.
+
+**Constraints, so this does not become a general escape hatch:**
+
+1. **Session-scoped only**, under `sessions-root.sh`. Not project files, not global state, not anything a later session or another agent inherits.
+2. **Own-way only.** A postcheck writes state that its own way's macro consumes. Reading or writing another way's state is out of scope and would reintroduce the coupling Decision 5's separation was protecting.
+3. **Bounded.** State is a set with a cap and a TTL, not an append-only log — because the inward gate may deny the fire that would have consumed an entry, so unconsumed entries are the normal case rather than an error.
+4. **Never an input to the predicate.** The exit code stays a pure function of the observed post-state. State flows one way — postcheck writes, macro reads — so the *predicate* remains deterministic and re-runnable, which is the property the original clause was protecting. A postcheck that consulted its own prior state to decide whether to fire would be a genuine violation, not a narrowing.
+
+**A set, not a single slot.** `refire` keys on the way, not on the artifact the way is reacting to. With a single overwritten slot, a permissive cadence re-fires about a file the operator already declined to act on, and a gate denial leaves a stale path that a later, unrelated fire would name incorrectly. A seen-set addresses both: the macro names what has not yet been surfaced, and the way stays quiet about what has.
+
+Unchanged: reactive requests are not privileged over predictive matches, and both continue through the same inward gate.
+
+First application is the markdown line-handling way (#415), whose postcheck detects hard-wrapped prose in freshly written markdown and whose macro names the file and the remediation command.
+
 ## Consequences
 
 ### Positive

--- a/docs/reference/ways-cli.md
+++ b/docs/reference/ways-cli.md
@@ -202,15 +202,20 @@ ways template itops/alerts -d "alerting runbooks" --global
 
 **Run from:** Project directory to scan all project ways. Pass a specific file path to lint just one file. Add `--global` to lint global ways instead.
 
-**Tells you:** Validation errors and warnings per file against the frontmatter schema. `--fix` auto-corrects multi-line YAML and missing check sections. `--schema` prints the full frontmatter schema reference. `--check` exits non-zero for CI use.
+**Tells you:** Validation errors and warnings per file against the frontmatter schema. `--schema` prints the full frontmatter schema reference. `--check` exits non-zero for CI use.
+
+`--fix` auto-corrects what is fixable, and **takes its scope from `path`, not from the flag** — the same way `eslint --fix` does. Without a path it refuses rather than rewriting every way in the resolved corpus; pass `--all` when that is what you actually want. Each correction is disclosed on its own `FIXED:` line, and fixes are writes, so review them with `git diff`.
 
 ```
 ways lint                                          # scan project ways
 ways lint ~/.claude/hooks/ways/meta/knowledge/knowledge.md  # single file
-ways lint --fix                                    # auto-correct what's fixable
+ways lint <path> --fix                             # auto-correct within that path
+ways lint --fix --all                              # auto-correct the whole resolved corpus
 ways lint --check                                  # CI mode — non-zero exit on errors
 ways lint --schema                                 # show the frontmatter schema
 ```
+
+Exit codes: `0` clean, `1` errors found (with `--check`), `2` the invocation was wrong — kept distinct so a caller can tell "the corpus has problems" from "you used the flag wrong".
 
 ---
 

--- a/hooks/ways/core.md
+++ b/hooks/ways/core.md
@@ -54,6 +54,10 @@ The ledger is not the whole method, and recording a decision does not make it tr
 
 All file output (commit messages, comments, documentation, PR descriptions) must be in English regardless of interface language setting.
 
+## Line handling
+
+Write markdown prose one line per paragraph or list item. Don't hard-wrap to a column — a renderer reflows paragraphs, so wrapping buys nothing and costs edit-ability: an `Edit` then has to reproduce interior line breaks exactly, and a three-word change reflows the paragraph so the diff stops being semantic. Wide content (tables, long links, code) is allowed to be wide. This is about markdown; in plain text the wrap *is* the layout, and commit bodies keep the 72-column convention.
+
 ## Attribution
 
 Do NOT append the Claude Code attribution to commits.

--- a/hooks/ways/documentation/markdown/markdown.md
+++ b/hooks/ways/documentation/markdown/markdown.md
@@ -48,7 +48,9 @@ The reasoning above depends on a renderer that reflows paragraphs. Where there i
 
 `ways reflow <file>` reports hard-wrapped paragraphs and exits non-zero when it finds any; `--fix` flattens them, backs the original up first, and prints the backup path.
 
-It repairs the *enclosing paragraph* of each detection and leaves everything else byte-identical, so it won't flatten authored one-clause-per-line prose elsewhere in the file. Read the diff anyway — the tool's token-stream check catches dropped words but cannot see a join that shouldn't have happened.
+It repairs the *enclosing paragraph* of each detection and leaves everything else byte-identical, so it won't flatten authored one-clause-per-line prose elsewhere in the file.
+
+Before writing, it reparses the result and compares the document's structure against the original. If anything moved beyond the line breaks inside a paragraph, it refuses to write and says so — a construct it misread becomes a refusal rather than a corrupted file. Read the diff anyway: two things that check cannot see are a join that erased an authored line break, and non-CommonMark syntax like `:::` directives.
 
 ## See Also
 

--- a/hooks/ways/documentation/markdown/markdown.md
+++ b/hooks/ways/documentation/markdown/markdown.md
@@ -1,0 +1,58 @@
+---
+description: markdown authoring mechanics — line handling, hard wrapping versus flat prose, when a line break carries structure, tables and fences
+vocabulary: markdown wrap unwrap reflow flatten line length column paragraph prose hard wrap fill width flow text file authoring plaintext txt
+files: \.md$
+scope: agent, subagent
+refire: 0.15
+---
+<!-- epistemic: convention -->
+# Markdown Line Handling
+
+Write prose **one line per paragraph**. One line per list item, one line per table row, one line per blockquote line. Don't hard-wrap prose to a column.
+
+This is a machine-ergonomics convention, not a style preference. Two concrete costs:
+
+- **Hard wrapping breaks `Edit`.** Exact-string replacement means `old_string` has to reproduce every interior line break perfectly. A one-sentence change inside a wrapped paragraph becomes a multi-line match to transcribe; flat, it's a single line. This is where edits *miss* and get retried, not merely where they get long.
+- **Hard wrapping makes diffs non-semantic.** Change three words and the rest of the paragraph reflows, so `git diff` shows five changed lines for one changed thought. Review cost starts scaling with wrap width instead of with the size of the change.
+
+Neither cost is one-time. A flat file stays cheaper to edit for its whole life.
+
+## Line breaks that do carry structure
+
+A line break is fine — required, even — where the break *is* the structure. Keep these on their own lines:
+
+| Construct | Why it stays |
+|---|---|
+| List items | The marker is line-initial syntax |
+| Table rows | Row boundary is the line boundary |
+| Headings, thematic breaks | Block-level, line-initial |
+| Blockquote label lines (`**Status:**`, `**Next:**`) | Reads as a field list; joining makes one run-on line |
+| Deliberate hard breaks (two trailing spaces, or `\`) | The break renders as `<br>` — joining silently deletes it |
+| Parallel one-clause-per-line prose | Authored rhythm, not wrapping |
+
+That last one is the judgment call. The test that separates it from hard wrapping: **does the break land at a clause boundary, or mid-phrase?** Wrapping breaks wherever the column runs out — mid-phrase, with line lengths all clustered just under the fill width. Authored breaks land where the thought turns, and their lengths vary freely.
+
+## Wide content is allowed to be wide
+
+Tables, long links, deep code lines, and long fenced blocks may run past any comfortable reading width. Readers scroll; authors shouldn't reflow. Never "fix" a table by rewrapping its cells.
+
+## Other text formats are not markdown
+
+The reasoning above depends on a renderer that reflows paragraphs. Where there is none, wrapping is the layout and should stay:
+
+- **Plain `.txt`** — no renderer, so the wrap is the presentation. Leave it alone; 72 columns there is correct, not drift.
+- **Commit message bodies** — keep the conventional 72-column wrap. Git tooling assumes it.
+- **Code comments** — follow the language's own line-length convention.
+
+## Repairing a wrapped file
+
+`ways reflow <file>` reports hard-wrapped paragraphs and exits non-zero when it finds any; `--fix` flattens them, backs the original up first, and prints the backup path.
+
+It repairs the *enclosing paragraph* of each detection and leaves everything else byte-identical, so it won't flatten authored one-clause-per-line prose elsewhere in the file. Read the diff anyway — the tool's token-stream check catches dropped words but cannot see a join that shouldn't have happened.
+
+## See Also
+
+- mermaid(documentation) — the sibling convention-plus-tool pair, for diagrams
+- diataxis(documentation) — which *mode* a page is written in
+- standards(documentation) — how conventions like this one get established
+- knowledge/authoring(meta) — authoring the way files themselves

--- a/hooks/ways/documentation/markdown/reflow/macro.sh
+++ b/hooks/ways/documentation/markdown/reflow/macro.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Macro for documentation/markdown/reflow (#415) — names the file.
+#
+# postcheck.sh detects and records; this reads the record. That handoff exists
+# because check-post.sh runs postchecks with stdout to /dev/null and reads only
+# the exit code, and macro.sh itself gets no stdin and no arguments — so a
+# session-scoped file is the only channel by which a reactive way can name the
+# artifact it is reacting to (ADR-123, amended 2026-07-29).
+#
+# Silence is the correct output when there's nothing pending: the way body still
+# fires, just without a filename.
+set -uo pipefail
+
+source "$(dirname "$0")/../../../sessions-root.sh"
+
+SESSION="${CLAUDE_SESSION_ID:-}"
+if [[ -z "$SESSION" ]]; then
+  # Fall back to the newest session dir — macros run without the hook payload.
+  SESSION=$(ls -1t "${SESSIONS_ROOT}" 2>/dev/null | head -n 1 || true)
+fi
+[[ -n "$SESSION" ]] || exit 0
+
+PENDING="${SESSIONS_ROOT}/${SESSION}/markdown-reflow/pending"
+[[ -f "$PENDING" ]] || exit 0
+
+NOW=$(date +%s)
+TTL=900   # 15 minutes
+
+# Consume unconditionally: a denied fire leaves entries behind, and naming a
+# file from twenty minutes ago is worse than naming none.
+FRESH=()
+while IFS=$'\t' read -r stamp path; do
+  [[ -n "${path:-}" ]] || continue
+  [[ "$stamp" =~ ^[0-9]+$ ]] || continue
+  (( NOW - stamp <= TTL )) && FRESH+=("$path")
+done <"$PENDING"
+
+rm -f "$PENDING"
+
+(( ${#FRESH[@]} )) || exit 0
+
+if (( ${#FRESH[@]} == 1 )); then
+  printf '**Hard-wrapped markdown just written:** `%s`\n' "${FRESH[0]}"
+else
+  printf '**Hard-wrapped markdown just written:**\n'
+  printf -- '- `%s`\n' "${FRESH[@]}"
+fi

--- a/hooks/ways/documentation/markdown/reflow/macro.sh
+++ b/hooks/ways/documentation/markdown/reflow/macro.sh
@@ -13,11 +13,10 @@ set -uo pipefail
 
 source "$(dirname "$0")/../../../sessions-root.sh"
 
+# `ways show way` exports this for every macro. No guessing fallback: inferring
+# the session from directory mtimes silently picks the wrong one whenever two
+# sessions are active, and naming the wrong file is worse than naming none.
 SESSION="${CLAUDE_SESSION_ID:-}"
-if [[ -z "$SESSION" ]]; then
-  # Fall back to the newest session dir — macros run without the hook payload.
-  SESSION=$(ls -1t "${SESSIONS_ROOT}" 2>/dev/null | head -n 1 || true)
-fi
 [[ -n "$SESSION" ]] || exit 0
 
 PENDING="${SESSIONS_ROOT}/${SESSION}/markdown-reflow/pending"

--- a/hooks/ways/documentation/markdown/reflow/macro.sh
+++ b/hooks/ways/documentation/markdown/reflow/macro.sh
@@ -25,6 +25,12 @@ PENDING="${SESSIONS_ROOT}/${SESSION}/markdown-reflow/pending"
 NOW=$(date +%s)
 TTL=900   # 15 minutes
 
+# Claim the file by renaming it before reading. Reading and then deleting would
+# silently drop any entry a postcheck appended in between; rename is atomic, so a
+# concurrent append lands on a fresh file and is reported next fire instead.
+CLAIM="${PENDING}.consume.$$"
+mv -f "$PENDING" "$CLAIM" 2>/dev/null || exit 0
+
 # Consume unconditionally: a denied fire leaves entries behind, and naming a
 # file from twenty minutes ago is worse than naming none.
 FRESH=()
@@ -32,9 +38,9 @@ while IFS=$'\t' read -r stamp path; do
   [[ -n "${path:-}" ]] || continue
   [[ "$stamp" =~ ^[0-9]+$ ]] || continue
   (( NOW - stamp <= TTL )) && FRESH+=("$path")
-done <"$PENDING"
+done <"$CLAIM"
 
-rm -f "$PENDING"
+rm -f "$CLAIM"
 
 (( ${#FRESH[@]} )) || exit 0
 

--- a/hooks/ways/documentation/markdown/reflow/macro.sh
+++ b/hooks/ways/documentation/markdown/reflow/macro.sh
@@ -34,10 +34,16 @@ mv -f "$PENDING" "$CLAIM" 2>/dev/null || exit 0
 # Consume unconditionally: a denied fire leaves entries behind, and naming a
 # file from twenty minutes ago is worse than naming none.
 FRESH=()
-while IFS=$'\t' read -r stamp path; do
+while IFS=$'\t' read -r stamp path ranges; do
   [[ -n "${path:-}" ]] || continue
   [[ "$stamp" =~ ^[0-9]+$ ]] || continue
-  (( NOW - stamp <= TTL )) && FRESH+=("$path")
+  if (( NOW - stamp <= TTL )); then
+    if [[ -n "${ranges:-}" ]]; then
+      FRESH+=("\`$path\` (lines $ranges)")
+    else
+      FRESH+=("\`$path\`")
+    fi
+  fi
 done <"$CLAIM"
 
 rm -f "$CLAIM"
@@ -45,8 +51,8 @@ rm -f "$CLAIM"
 (( ${#FRESH[@]} )) || exit 0
 
 if (( ${#FRESH[@]} == 1 )); then
-  printf '**Hard-wrapped markdown just written:** `%s`\n' "${FRESH[0]}"
+  printf '**Hard-wrapped markdown just written:** %s\n' "${FRESH[0]}"
 else
   printf '**Hard-wrapped markdown just written:**\n'
-  printf -- '- `%s`\n' "${FRESH[@]}"
+  printf -- '- %s\n' "${FRESH[@]}"
 fi

--- a/hooks/ways/documentation/markdown/reflow/postcheck.sh
+++ b/hooks/ways/documentation/markdown/reflow/postcheck.sh
@@ -55,19 +55,30 @@ CONTENT=$(printf '%s' "$INPUT" \
            | map(select(. != null)) | join("\n")' 2>/dev/null || true)
 [[ -n "$CONTENT" ]] || exit 1
 
-# Lint convention: 0 = clean, 1 = wrapped prose found. Check for exactly 1 —
-# anything else is the binary failing (an install predating `ways reflow` exits
-# 2 on the unknown subcommand), and an error must read as "no finding" rather
-# than firing the way on every markdown write.
+# Lint convention: 0 = clean, 1 = wrapped prose found, 2 = error. Check for
+# exactly 1 — anything else is the binary failing (an install predating
+# `ways reflow` exits 2 on the unknown subcommand, an unreadable input also
+# exits 2), and an error must read as "no finding" rather than firing the way on
+# every markdown write.
 set +e
-printf '%s' "$CONTENT" | "$WAYS_BIN" reflow --quiet 2>/dev/null
+FINDINGS=$(printf '%s' "$CONTENT" | "$WAYS_BIN" reflow --json 2>/dev/null)
 verdict=$?
 set -e
 (( verdict == 1 )) || exit 1
 
+# Line numbers are only meaningful when the content IS the file. A Write carries
+# the whole document; an Edit carries a fragment, where line 3 of new_string is
+# not line 3 of anything. Reporting fragment offsets as file lines would send the
+# reader to the wrong place, so for an Edit we name the file and stop.
+RANGES=""
+if [[ "$tool" == "Write" ]]; then
+  RANGES=$(printf '%s' "$FINDINGS" \
+    | jq -r '[.paragraphs[]? | "\(.start)-\(.end)"] | join(", ")' 2>/dev/null || true)
+fi
+
 mkdir -p "$STATE_DIR"
 printf '%s\n' "$path" >>"$SEEN"
-printf '%s\t%s\n' "$(date +%s)" "$path" >>"$PENDING"
+printf '%s\t%s\t%s\n' "$(date +%s)" "$path" "$RANGES" >>"$PENDING"
 
 # Bound both files. Unconsumed entries are normal, not exceptional: the inward
 # gate may deny the fire this request is asking for.

--- a/hooks/ways/documentation/markdown/reflow/postcheck.sh
+++ b/hooks/ways/documentation/markdown/reflow/postcheck.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Postcheck for documentation/markdown/reflow (#415).
+#
+# Reads the PostToolUse input on stdin. Exit 0 = "freshly written markdown is
+# hard-wrapped — fire the way." Exit 1 = no match, which is the default and the
+# right outcome on anything unfamiliar.
+#
+# Note the inversion: this file's exit 0 means "fire", while `ways reflow`
+# follows lint convention where exit 0 means "clean". One flag can't serve both
+# conventions, so the inversion lives here, in the wrapper that exists anyway.
+#
+# ADR-123's amendment (2026-07-29) permits the state writes below: a postcheck
+# may record session-scoped findings for its own way's macro.sh to read, because
+# check-post.sh discards postcheck stdout and macro.sh gets no stdin. The
+# constraints there are honored — session scope, own way, bounded, and never an
+# input to this predicate. The exit code is a pure function of the observed
+# post-state; .seen only suppresses *re-disclosure*, never detection.
+set -euo pipefail
+
+source "$(dirname "$0")/../../../sessions-root.sh"
+
+INPUT=$(cat)
+
+# One jq pass: this runs on every Edit/Write/Bash/Task PostToolUse, so keep
+# forks minimal and bail before doing anything expensive.
+{ read -r tool; read -r path; read -r session; } < <(
+  printf '%s' "$INPUT" | jq -r '.tool_name // "", (.tool_input.file_path // ""), (.session_id // "")'
+)
+
+case "$tool" in Write | Edit | MultiEdit) ;; *) exit 1 ;; esac
+[[ "$path" == *.md ]] || exit 1
+[[ -n "$session" ]] || exit 1
+
+# Don't fire on this way's own files: the way body and these scripts necessarily
+# discuss wrapped prose, and the fixtures contain it deliberately.
+[[ "$path" == */documentation/markdown/* ]] && exit 1
+
+WAYS_BIN="${HOME}/.claude/bin/ways"
+[[ -x "$WAYS_BIN" ]] || exit 1
+
+STATE_DIR="${SESSIONS_ROOT}/${session}/markdown-reflow"
+SEEN="${STATE_DIR}/seen"
+PENDING="${STATE_DIR}/pending"
+
+# Already surfaced this file this session — stay quiet. `refire` keys on the way,
+# not the file, so without this a permissive cadence re-nags about a file the
+# operator deliberately left wrapped.
+[[ -f "$SEEN" ]] && grep -qxF "$path" "$SEEN" 2>/dev/null && exit 1
+
+# Inspect the text that was just written, not the file on disk. Reading the file
+# would fire on pre-existing drift in any file merely touched — false
+# attribution, and a nag with no exit.
+CONTENT=$(printf '%s' "$INPUT" \
+  | jq -r '[.tool_input.content, .tool_input.new_string, (.tool_input.edits[]?.new_string)]
+           | map(select(. != null)) | join("\n")' 2>/dev/null || true)
+[[ -n "$CONTENT" ]] || exit 1
+
+# Lint convention: 0 = clean, 1 = wrapped prose found. Check for exactly 1 —
+# anything else is the binary failing (an install predating `ways reflow` exits
+# 2 on the unknown subcommand), and an error must read as "no finding" rather
+# than firing the way on every markdown write.
+set +e
+printf '%s' "$CONTENT" | "$WAYS_BIN" reflow --quiet 2>/dev/null
+verdict=$?
+set -e
+(( verdict == 1 )) || exit 1
+
+mkdir -p "$STATE_DIR"
+printf '%s\n' "$path" >>"$SEEN"
+printf '%s\t%s\n' "$(date +%s)" "$path" >>"$PENDING"
+
+# Bound both files. Unconsumed entries are normal, not exceptional: the inward
+# gate may deny the fire this request is asking for.
+for f in "$SEEN" "$PENDING"; do
+  if [[ -f "$f" ]] && (( $(wc -l <"$f") > 200 )); then
+    tail -n 100 "$f" >"${f}.trim" && mv -f "${f}.trim" "$f"
+  fi
+done
+
+exit 0

--- a/hooks/ways/documentation/markdown/reflow/postcheck.sh
+++ b/hooks/ways/documentation/markdown/reflow/postcheck.sh
@@ -71,9 +71,18 @@ printf '%s\t%s\n' "$(date +%s)" "$path" >>"$PENDING"
 
 # Bound both files. Unconsumed entries are normal, not exceptional: the inward
 # gate may deny the fire this request is asking for.
+#
+# The temp name carries $$: parallel Edit or Task calls mean parallel PostToolUse
+# hooks, and a shared temp name let two trimmers truncate the same file and then
+# `mv` a partial result over the state — which emptied the seen-set outright, so
+# the way re-nagged about every file the operator had already declined. The
+# rename is atomic, so the worst case is now losing an append that lands between
+# the read and the rename: an entry that could re-fire once, not wiped state.
 for f in "$SEEN" "$PENDING"; do
   if [[ -f "$f" ]] && (( $(wc -l <"$f") > 200 )); then
-    tail -n 100 "$f" >"${f}.trim" && mv -f "${f}.trim" "$f"
+    tmp="${f}.trim.$$"
+    tail -n 100 "$f" >"$tmp" 2>/dev/null && mv -f "$tmp" "$f"
+    rm -f "$tmp"
   fi
 done
 

--- a/hooks/ways/documentation/markdown/reflow/reflow.md
+++ b/hooks/ways/documentation/markdown/reflow/reflow.md
@@ -3,17 +3,31 @@ macro: prepend
 requires: ["Bash(date:*)", "Bash(id:*)", "Bash(mv:*)", "Bash(rm:*)", "Bash(uname:*)"]
 refire: 0.1
 ---
-<!-- epistemic: convention -->
-# Hard-Wrapped Markdown Just Written
+<!-- epistemic: heuristic -->
+# Markdown You Just Wrote May Be Hard-Wrapped
 
-The file above was written with prose hard-wrapped to a column. Our convention is flat prose — one line per paragraph — because a wrapped paragraph makes the next `Edit` reproduce interior line breaks exactly, and turns a three-word change into a five-line diff.
+A check ran over the text you just wrote and found prose that looks wrapped to a column. Our convention is flat prose — one line per paragraph — because a wrapped paragraph makes the next `Edit` reproduce interior line breaks exactly, and turns a three-word change into a five-line diff.
 
-You just wrote it, so it's cheap to fix now and it only gets more expensive later.
+You wrote it moments ago, so it is cheap to fix now and only gets more expensive later.
+
+## Two ways to fix it, and the first is usually better
+
+**Fix it yourself.** The text is already in context. Rewriting the paragraph flat is an ordinary edit, and you can see what the prose is doing — whether a break was mechanical or meant.
+
+**Or hand it to the tool:**
 
 ```bash
-ways reflow --fix <file>     # flattens, backs the original up, prints the backup path
+ways reflow --fix <file>
 ```
 
-**Leave it as-is if the breaks are deliberate.** One-clause-per-line prose, a field list, and anything with an intentional `<br>` are all legitimate — the detector is a heuristic and this is advisory. If you meant the line breaks, ignore this.
+It copies the original aside first and prints that path, repairs only the paragraphs it detected, then reparses the result and compares. If anything moved beyond line breaks inside a paragraph, it writes nothing and reports what diverged.
 
-See markdown(documentation) for the full convention and the cases where a line break carries structure.
+## If you already fixed this file and it is still flagging
+
+**Trust your prose over the check.** The detector is a heuristic. It cannot tell column wrapping from one-clause-per-line prose broken on purpose, and that style is one this convention explicitly permits.
+
+A second flag on a file you have already looked at is therefore far more likely to be a false positive than a missed repair. Say so and move on. Don't rewrite prose you believe is correct in order to satisfy a check — that is how a heuristic starts degrading the thing it was meant to protect.
+
+## When to leave it alone entirely
+
+Line breaks that carry structure are correct and stay: list items, table rows, blockquote label lines (`**Status:**`), deliberate hard breaks (two trailing spaces), and parallel one-clause-per-line prose. See markdown(documentation) for the full convention.

--- a/hooks/ways/documentation/markdown/reflow/reflow.md
+++ b/hooks/ways/documentation/markdown/reflow/reflow.md
@@ -1,0 +1,19 @@
+---
+macro: prepend
+requires: ["Bash(date:*)", "Bash(head:*)", "Bash(id:*)", "Bash(ls:*)", "Bash(rm:*)", "Bash(uname:*)"]
+refire: 0.1
+---
+<!-- epistemic: convention -->
+# Hard-Wrapped Markdown Just Written
+
+The file above was written with prose hard-wrapped to a column. Our convention is flat prose — one line per paragraph — because a wrapped paragraph makes the next `Edit` reproduce interior line breaks exactly, and turns a three-word change into a five-line diff.
+
+You just wrote it, so it's cheap to fix now and it only gets more expensive later.
+
+```bash
+ways reflow --fix <file>     # flattens, backs the original up, prints the backup path
+```
+
+**Leave it as-is if the breaks are deliberate.** One-clause-per-line prose, a field list, and anything with an intentional `<br>` are all legitimate — the detector is a heuristic and this is advisory. If you meant the line breaks, ignore this.
+
+See markdown(documentation) for the full convention and the cases where a line break carries structure.

--- a/hooks/ways/documentation/markdown/reflow/reflow.md
+++ b/hooks/ways/documentation/markdown/reflow/reflow.md
@@ -1,6 +1,6 @@
 ---
 macro: prepend
-requires: ["Bash(date:*)", "Bash(id:*)", "Bash(rm:*)", "Bash(uname:*)"]
+requires: ["Bash(date:*)", "Bash(id:*)", "Bash(mv:*)", "Bash(rm:*)", "Bash(uname:*)"]
 refire: 0.1
 ---
 <!-- epistemic: convention -->

--- a/hooks/ways/documentation/markdown/reflow/reflow.md
+++ b/hooks/ways/documentation/markdown/reflow/reflow.md
@@ -1,6 +1,6 @@
 ---
 macro: prepend
-requires: ["Bash(date:*)", "Bash(head:*)", "Bash(id:*)", "Bash(ls:*)", "Bash(rm:*)", "Bash(uname:*)"]
+requires: ["Bash(date:*)", "Bash(id:*)", "Bash(rm:*)", "Bash(uname:*)"]
 refire: 0.1
 ---
 <!-- epistemic: convention -->

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1616,6 +1616,7 @@ name = "ways-core"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "pulldown-cmark",
  "sensor-trait",
  "serde",
  "serde_json",

--- a/tools/ways-cli/src/cmd/lint/mod.rs
+++ b/tools/ways-cli/src/cmd/lint/mod.rs
@@ -41,7 +41,33 @@ use std::path::PathBuf;
 
 use crate::util::{detect_project_dir, home_dir};
 
-pub fn run(path: Option<String>, schema: bool, check: bool, fix: bool, global: bool) -> Result<()> {
+pub fn run(
+    path: Option<String>,
+    schema: bool,
+    check: bool,
+    fix: bool,
+    all: bool,
+    global: bool,
+) -> Result<()> {
+    // Blast radius is explicit, the way `eslint --fix` gets its scope from the
+    // paths you hand it rather than from the flag. `--fix` with no path would
+    // rewrite every way in the resolved corpus, which is a surprising amount of
+    // mutation for a flag that reads like "tidy this up" — so it refuses, and
+    // names both ways forward.
+    if fix && path.is_none() && !all {
+        eprintln!("`--fix` needs a target.");
+        eprintln!();
+        eprintln!("  Give it a file or directory:   ways lint <path> --fix");
+        eprintln!("  Or ask for the whole corpus:   ways lint --fix --all");
+        eprintln!();
+        eprintln!("Refusing rather than rewriting every way in the corpus by default.");
+        // Exit 2, not 1: this command already spends 1 on "lint found errors"
+        // (see the `--check` path below), and a caller cannot act correctly on a
+        // code that means both "your invocation was wrong" and "the corpus has
+        // problems." 2 is also what clap uses for its own argument errors.
+        std::process::exit(2);
+    }
+
     let home_ways_dir = home_dir().join(".claude/hooks/ways");
 
     // Determine the corpus to lint:
@@ -132,7 +158,9 @@ pub fn run(path: Option<String>, schema: bool, check: bool, fix: bool, global: b
     );
     eprintln!();
     if fixes > 0 {
-        eprintln!("Fixed: {fixes} issue(s)");
+        // The FIXED lines above name each change; this is the tally, not the
+        // disclosure. Point at the diff, since fixes are writes.
+        eprintln!("Fixed: {fixes} issue(s) — review with `git diff`");
     }
     eprintln!("Summary: {errors} errors, {warnings} warnings");
 

--- a/tools/ways-cli/src/cmd/mod.rs
+++ b/tools/ways-cli/src/cmd/mod.rs
@@ -17,6 +17,7 @@ pub mod migrate;
 pub mod migrate_exec;
 pub mod permissions;
 pub mod reconcile;
+pub mod reflow;
 pub mod render;
 pub mod reset;
 pub mod rethink;

--- a/tools/ways-cli/src/cmd/reflow.rs
+++ b/tools/ways-cli/src/cmd/reflow.rs
@@ -99,8 +99,36 @@ pub fn run(path: Option<String>, fix: bool, json: bool, quiet: bool) -> Result<(
         std::process::exit(1);
     }
 
-    let (repaired_lines, quote_joins) = reflow::reflow_with_stats(&lines);
-    let repaired = repaired_lines.join("\n");
+    // Repair, then run the detector against our own output. A result that still
+    // trips the detector would be written and then immediately re-flagged — a
+    // file that nags forever — so non-convergence is a finding, not a warning to
+    // write through. In practice this settles on the first pass.
+    let outcome = reflow::repair(&lines, reflow::MAX_REPAIR_PASSES);
+    let repaired = outcome.lines.join("\n");
+    let quote_joins = outcome.quote_joins;
+
+    if !outcome.converged {
+        let label = match &source {
+            Source::File(p) => p.display().to_string(),
+            Source::Stdin => "<stdin>".to_string(),
+        };
+        if json {
+            println!(
+                "{{\"wrapped\":true,\"repaired\":false,\"reason\":\"did-not-converge\",\"passes\":{}}}",
+                outcome.passes
+            );
+        } else if !quiet {
+            eprintln!();
+            eprintln!("NOT repaired: {label}");
+            eprintln!(
+                "  after {} pass(es) the result still reads as hard-wrapped, so the",
+                outcome.passes
+            );
+            eprintln!("  transform cannot reconcile its own output. The file was left");
+            eprintln!("  untouched — writing it would produce a file that flags forever.");
+        }
+        std::process::exit(1);
+    }
 
     // The invariant is a cheap total check against dropped words. It is not
     // sufficient on its own — it cannot see a wrong join, and leading

--- a/tools/ways-cli/src/cmd/reflow.rs
+++ b/tools/ways-cli/src/cmd/reflow.rs
@@ -26,18 +26,27 @@ enum Source {
 }
 
 pub fn run(path: Option<String>, fix: bool, json: bool, quiet: bool) -> Result<()> {
+    // Exit 2 for genuine failures, explicitly. Propagating with `?` would surface
+    // as exit 1, which this command has already spent on "wrapped prose found" —
+    // and a caller that cannot tell an unreadable file from a real finding will
+    // act on the wrong one. `postcheck.sh` checks for exactly 1 for this reason.
     let (source, text) = match path {
         Some(p) => {
             let pb = PathBuf::from(&p);
-            let text = std::fs::read_to_string(&pb)
-                .with_context(|| format!("reading {}", pb.display()))?;
-            (Source::File(pb), text)
+            match std::fs::read_to_string(&pb) {
+                Ok(text) => (Source::File(pb), text),
+                Err(e) => {
+                    eprintln!("ways reflow: reading {}: {e}", pb.display());
+                    std::process::exit(2);
+                }
+            }
         }
         None => {
             let mut buf = String::new();
-            std::io::stdin()
-                .read_to_string(&mut buf)
-                .context("reading stdin")?;
+            if let Err(e) = std::io::stdin().read_to_string(&mut buf) {
+                eprintln!("ways reflow: reading stdin: {e}");
+                std::process::exit(2);
+            }
             (Source::Stdin, buf)
         }
     };
@@ -104,29 +113,57 @@ pub fn run(path: Option<String>, fix: bool, json: bool, quiet: bool) -> Result<(
     // clean, since the difference is `>`-only either way.
     let verdict = reflow::token_verdict_accounted(&text, &repaired, quote_joins);
     if let TokenVerdict::Mismatch { before, after } = verdict {
-        anyhow::bail!(
-            "refusing to write: token stream changed ({before} -> {after}). \
-             This is a bug in the reflow transform; nothing was modified."
-        );
+        // Same posture as the structural check below: a finding, not a crash.
+        // Words would have been lost, so the file is left alone and the wrapped
+        // prose stays flagged for every later caller.
+        if json {
+            println!(
+                "{{\"wrapped\":true,\"repaired\":false,\"reason\":\"tokens-changed\",\
+                 \"before\":{before},\"after\":{after}}}"
+            );
+        } else if !quiet {
+            eprintln!();
+            eprintln!("NOT repaired: token stream would change ({before} -> {after}).");
+            eprintln!("  Words would be lost. The file was left untouched — this is a bug");
+            eprintln!("  in the reflow transform and is worth reporting with the file.");
+        }
+        std::process::exit(1);
     }
 
     // The structural post-condition, and the one actually worth trusting: reparse
     // and compare. Unlike the classifier it does not depend on having enumerated
-    // markdown's constructs correctly, so an enumeration gap becomes a refusal to
-    // write rather than a corrupted document. This is how a live corruption was
-    // caught that the token check above passed — a multi-line HTML comment whose
-    // body was being joined.
-    if !reflow::structure_preserved(&text, &repaired) {
-        anyhow::bail!(
-            "refusing to write {}: reflowing changed the document structure, not \
-             just its line breaks. Nothing was modified. This means the file \
-             contains a construct the classifier treated as ordinary prose — \
-             please report it with the file attached.",
-            match &source {
-                Source::File(p) => p.display().to_string(),
-                Source::Stdin => "<stdin>".to_string(),
-            }
-        );
+    // markdown's constructs correctly.
+    //
+    // A trip does NOT abort. It is the most informative result this tool
+    // produces — it names a construct the classifier misreads — so it is
+    // reported, the file is left alone, and the exit code stays 1: the wrapped
+    // prose is still there, unrepaired, and every later caller (lint, CI, a
+    // sweep over the corpus) keeps flagging it. Refusing silently, or failing
+    // hard enough to stop a batch, would lose the finding instead of recording it.
+    if let Some((idx, before_ev, after_ev)) = reflow::structure_diff(&text, &repaired) {
+        let label = match &source {
+            Source::File(p) => p.display().to_string(),
+            Source::Stdin => "<stdin>".to_string(),
+        };
+        if json {
+            println!(
+                "{{\"wrapped\":true,\"repaired\":false,\"reason\":\"structure-changed\",\
+                 \"event\":{idx},\"before\":{},\"after\":{}}}",
+                json_str(&before_ev),
+                json_str(&after_ev)
+            );
+        } else if !quiet {
+            eprintln!();
+            eprintln!("NOT repaired: {label}");
+            eprintln!("  reflowing this file would change its structure, not just its line breaks,");
+            eprintln!("  so it was left untouched. This means it contains a construct the");
+            eprintln!("  classifier read as ordinary prose — that is a bug worth reporting.");
+            eprintln!("  first divergence at parse event {idx}:");
+            eprintln!("    before: {}", truncate(&before_ev));
+            eprintln!("    after:  {}", truncate(&after_ev));
+        }
+        // Still wrapped, still unfixed — the finding stands.
+        std::process::exit(1);
     }
 
     match source {
@@ -160,6 +197,29 @@ pub fn run(path: Option<String>, fix: bool, json: bool, quiet: bool) -> Result<(
             Ok(())
         }
     }
+}
+
+fn truncate(s: &str) -> String {
+    if s.chars().count() <= 90 {
+        return s.to_string();
+    }
+    format!("{}…", s.chars().take(90).collect::<String>())
+}
+
+fn json_str(s: &str) -> String {
+    let mut out = String::from("\"");
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
 }
 
 /// Copy the original into a fresh temp directory before overwriting.

--- a/tools/ways-cli/src/cmd/reflow.rs
+++ b/tools/ways-cli/src/cmd/reflow.rs
@@ -1,0 +1,176 @@
+//! `ways reflow` — detect and repair hard-wrapped markdown prose (#415).
+//!
+//! The thin caller over [`ways_core::reflow`]. The detector itself lives in the
+//! library because three callers share it: this command, the markdown way's
+//! `postcheck.sh`, and the `ways lint` rule. A separate implementation in any
+//! one of them would drift, and the failure mode is the ugly one — the way
+//! fires and then the tool reports the file clean.
+//!
+//! # Exit codes
+//!
+//! Lint convention: **0 = clean, 1 = wrapped prose found**, 2 = error. Note
+//! that `postcheck.sh` wants the opposite (exit 0 means "fire"), so the
+//! postcheck wrapper inverts this. One flag cannot serve both conventions, and
+//! the wrapper exists anyway.
+
+use anyhow::{Context, Result};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use ways_core::reflow::{self, TokenVerdict};
+
+/// Where the text came from — decides whether repair can write anywhere.
+enum Source {
+    File(PathBuf),
+    Stdin,
+}
+
+pub fn run(path: Option<String>, fix: bool, json: bool, quiet: bool) -> Result<()> {
+    let (source, text) = match path {
+        Some(p) => {
+            let pb = PathBuf::from(&p);
+            let text = std::fs::read_to_string(&pb)
+                .with_context(|| format!("reading {}", pb.display()))?;
+            (Source::File(pb), text)
+        }
+        None => {
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .context("reading stdin")?;
+            (Source::Stdin, buf)
+        }
+    };
+
+    let lines: Vec<&str> = text.split('\n').collect();
+    let hits = reflow::detect(&lines);
+
+    if hits.is_empty() {
+        if json {
+            println!("{{\"wrapped\":false,\"paragraphs\":[]}}");
+        } else if !quiet {
+            eprintln!("clean — no hard-wrapped prose detected");
+        }
+        return Ok(());
+    }
+
+    if json {
+        let items: Vec<String> = hits
+            .iter()
+            .map(|w| {
+                format!(
+                    "{{\"start\":{},\"end\":{},\"trigger_line\":{},\"mid_breaks\":{}}}",
+                    w.start + 1,
+                    w.end + 1,
+                    w.trigger_start + 1,
+                    w.mid_breaks
+                )
+            })
+            .collect();
+        println!(
+            "{{\"wrapped\":true,\"paragraphs\":[{}]}}",
+            items.join(",")
+        );
+    } else if !quiet {
+        let label = match &source {
+            Source::File(p) => p.display().to_string(),
+            Source::Stdin => "<stdin>".to_string(),
+        };
+        eprintln!(
+            "{label}: {} hard-wrapped paragraph(s)",
+            hits.len()
+        );
+        for w in &hits {
+            eprintln!("  lines {}-{}", w.start + 1, w.end + 1);
+        }
+    }
+
+    if !fix {
+        // Found. Lint convention, so this is the non-zero case.
+        std::process::exit(1);
+    }
+
+    let repaired = reflow::reflow(&lines).join("\n");
+
+    // The invariant is a cheap total check against dropped words. It is not
+    // sufficient on its own — it cannot see a wrong join, and leading
+    // whitespace is not a token — so a clean verdict is evidence, not proof,
+    // and the backup below is what makes it reviewable.
+    let verdict = reflow::token_verdict(&text, &repaired);
+    if let TokenVerdict::Mismatch { before, after } = verdict {
+        anyhow::bail!(
+            "refusing to write: token stream changed ({before} -> {after}). \
+             This is a bug in the reflow transform; nothing was modified."
+        );
+    }
+
+    match source {
+        Source::Stdin => {
+            print!("{repaired}");
+            Ok(())
+        }
+        Source::File(p) => {
+            let backup = write_backup(&p, &text)?;
+            std::fs::write(&p, &repaired)
+                .with_context(|| format!("writing {}", p.display()))?;
+            if !quiet {
+                eprintln!();
+                eprintln!("repaired {}", p.display());
+                eprintln!(
+                    "  tokens: {}",
+                    match verdict {
+                        TokenVerdict::Identical => "identical".to_string(),
+                        TokenVerdict::QuoteMarkersDropped { dropped } =>
+                            format!("identical ({dropped} bare '>' marker(s) dropped)"),
+                        TokenVerdict::Mismatch { .. } => unreachable!("bailed above"),
+                    }
+                );
+                eprintln!("  backup: {}", backup.display());
+                if is_tracked(&p) {
+                    eprintln!("  review: git diff -- {}", p.display());
+                } else {
+                    eprintln!("  review: diff {} {}", backup.display(), p.display());
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Copy the original into a fresh temp directory before overwriting.
+///
+/// `mktemp -d` rather than a predictable path: a fixed `/tmp/<name>.bak` is a
+/// collision between two sessions and a symlink-attack surface on a shared
+/// machine. The basename is preserved inside so the path identifies itself when
+/// it is read back out of a log.
+fn write_backup(path: &Path, original: &str) -> Result<PathBuf> {
+    let name = path
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| "document.md".to_string());
+
+    let out = std::process::Command::new("mktemp")
+        .args(["-d", "-t", "ways-reflow.XXXXXXXX"])
+        .output()
+        .context("creating a backup directory with mktemp")?;
+    if !out.status.success() {
+        anyhow::bail!("mktemp failed: {}", String::from_utf8_lossy(&out.stderr));
+    }
+    let dir = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim().to_string());
+    let backup = dir.join(name);
+    std::fs::write(&backup, original)
+        .with_context(|| format!("writing backup {}", backup.display()))?;
+    Ok(backup)
+}
+
+/// Whether git tracks this path — decides which review command to suggest.
+fn is_tracked(path: &Path) -> bool {
+    std::process::Command::new("git")
+        .args(["ls-files", "--error-unmatch"])
+        .arg(path)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}

--- a/tools/ways-cli/src/cmd/reflow.rs
+++ b/tools/ways-cli/src/cmd/reflow.rs
@@ -90,13 +90,19 @@ pub fn run(path: Option<String>, fix: bool, json: bool, quiet: bool) -> Result<(
         std::process::exit(1);
     }
 
-    let repaired = reflow::reflow(&lines).join("\n");
+    let (repaired_lines, quote_joins) = reflow::reflow_with_stats(&lines);
+    let repaired = repaired_lines.join("\n");
 
     // The invariant is a cheap total check against dropped words. It is not
     // sufficient on its own — it cannot see a wrong join, and leading
     // whitespace is not a token — so a clean verdict is evidence, not proof,
     // and the backup below is what makes it reviewable.
-    let verdict = reflow::token_verdict(&text, &repaired);
+    //
+    // Use the *accounted* form: the number of dropped `>` markers has to equal
+    // the number of blockquote continuations the transform actually joined.
+    // Otherwise a bare `>` swallowed from between two quoted paragraphs reads as
+    // clean, since the difference is `>`-only either way.
+    let verdict = reflow::token_verdict_accounted(&text, &repaired, quote_joins);
     if let TokenVerdict::Mismatch { before, after } = verdict {
         anyhow::bail!(
             "refusing to write: token stream changed ({before} -> {after}). \
@@ -139,24 +145,41 @@ pub fn run(path: Option<String>, fix: bool, json: bool, quiet: bool) -> Result<(
 
 /// Copy the original into a fresh temp directory before overwriting.
 ///
-/// `mktemp -d` rather than a predictable path: a fixed `/tmp/<name>.bak` is a
-/// collision between two sessions and a symlink-attack surface on a shared
-/// machine. The basename is preserved inside so the path identifies itself when
-/// it is read back out of a log.
+/// Not a predictable path: a fixed `<tmp>/<name>.bak` is a collision between two
+/// sessions and a symlink-attack surface on a shared machine. `create_dir` (not
+/// `create_dir_all`) is what makes this safe — it fails if the directory already
+/// exists, so an attacker-planted symlink can't be followed. The basename is
+/// preserved inside so the path identifies itself when read back out of a log.
+///
+/// `std::env::temp_dir()` rather than shelling out to `mktemp`: it matches the
+/// rest of the Rust tree, drops a process spawn from the repair path, and has no
+/// PATH dependency — which a native Windows build would not satisfy.
 fn write_backup(path: &Path, original: &str) -> Result<PathBuf> {
     let name = path
         .file_name()
         .map(|s| s.to_string_lossy().to_string())
         .unwrap_or_else(|| "document.md".to_string());
 
-    let out = std::process::Command::new("mktemp")
-        .args(["-d", "-t", "ways-reflow.XXXXXXXX"])
-        .output()
-        .context("creating a backup directory with mktemp")?;
-    if !out.status.success() {
-        anyhow::bail!("mktemp failed: {}", String::from_utf8_lossy(&out.stderr));
+    let base = std::env::temp_dir();
+    let pid = std::process::id();
+    let mut dir = PathBuf::new();
+    for attempt in 0..64u32 {
+        let candidate = base.join(format!("ways-reflow.{pid}.{attempt}"));
+        match std::fs::create_dir(&candidate) {
+            Ok(()) => {
+                dir = candidate;
+                break;
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => {
+                return Err(e).with_context(|| format!("creating {}", candidate.display()))
+            }
+        }
     }
-    let dir = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim().to_string());
+    if dir.as_os_str().is_empty() {
+        anyhow::bail!("could not create a backup directory under {}", base.display());
+    }
+
     let backup = dir.join(name);
     std::fs::write(&backup, original)
         .with_context(|| format!("writing backup {}", backup.display()))?;

--- a/tools/ways-cli/src/cmd/reflow.rs
+++ b/tools/ways-cli/src/cmd/reflow.rs
@@ -110,6 +110,25 @@ pub fn run(path: Option<String>, fix: bool, json: bool, quiet: bool) -> Result<(
         );
     }
 
+    // The structural post-condition, and the one actually worth trusting: reparse
+    // and compare. Unlike the classifier it does not depend on having enumerated
+    // markdown's constructs correctly, so an enumeration gap becomes a refusal to
+    // write rather than a corrupted document. This is how a live corruption was
+    // caught that the token check above passed — a multi-line HTML comment whose
+    // body was being joined.
+    if !reflow::structure_preserved(&text, &repaired) {
+        anyhow::bail!(
+            "refusing to write {}: reflowing changed the document structure, not \
+             just its line breaks. Nothing was modified. This means the file \
+             contains a construct the classifier treated as ordinary prose — \
+             please report it with the file attached.",
+            match &source {
+                Source::File(p) => p.display().to_string(),
+                Source::Stdin => "<stdin>".to_string(),
+            }
+        );
+    }
+
     match source {
         Source::Stdin => {
             print!("{repaired}");

--- a/tools/ways-cli/src/cmd/show/helpers.rs
+++ b/tools/ways-cli/src/cmd/show/helpers.rs
@@ -79,9 +79,16 @@ pub(crate) fn check_sections_text(content: &str, include_anchor: bool) -> String
 }
 
 /// Execute a macro shell script and return its stdout.
-pub(crate) fn run_macro(macro_file: &Path) -> Option<String> {
+///
+/// `CLAUDE_SESSION_ID` is exported into the child so a macro can find its own
+/// session state. Without it a macro has no way to identify the session it is
+/// running for — the hook payload never reaches it (no stdin, no args) — and
+/// guessing from directory mtimes picks the wrong session whenever more than one
+/// is active.
+pub(crate) fn run_macro(macro_file: &Path, session_id: &str) -> Option<String> {
     let output = Command::new("bash")
         .arg(macro_file)
+        .env("CLAUDE_SESSION_ID", session_id)
         .stderr(std::process::Stdio::null())
         .output()
         .ok()?;

--- a/tools/ways-cli/src/cmd/show/mod.rs
+++ b/tools/ways-cli/src/cmd/show/mod.rs
@@ -113,7 +113,7 @@ pub fn way_scored(
                 project_dir
             ))
         } else {
-            run_macro(&macro_file)
+            run_macro(&macro_file, session_id)
         }
     } else {
         None
@@ -336,7 +336,7 @@ pub fn core(session_id: &str) -> Result<String> {
     // Run the macro for the dynamic ways table
     let macro_file = ways_dir.join("macro.sh");
     if macro_file.is_file() {
-        if let Some(out) = run_macro(&macro_file) {
+        if let Some(out) = run_macro(&macro_file, session_id) {
             output.push_str(&out);
             output.push('\n');
         }

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -55,6 +55,23 @@ enum Commands {
         #[arg(long)]
         global: bool,
     },
+    /// Detect (or repair) hard-wrapped markdown prose
+    ///
+    /// Exits 0 when clean and 1 when wrapped prose is found, matching lint
+    /// convention. Reads stdin when no path is given.
+    Reflow {
+        /// Markdown file to inspect (default: read stdin)
+        path: Option<String>,
+        /// Rewrite the file, backing the original up first
+        #[arg(long)]
+        fix: bool,
+        /// Emit findings as JSON
+        #[arg(long)]
+        json: bool,
+        /// Suppress human-readable output (exit code only)
+        #[arg(long)]
+        quiet: bool,
+    },
     /// Generate the ways corpus for matching engines
     Corpus {
         /// Ways root directory (default: ~/.claude/hooks/ways)
@@ -707,6 +724,7 @@ fn run() -> Result<()> {
     match command {
         Commands::Context { project, json } => cmd::context::run(project.as_deref(), json),
         Commands::Lint { path, schema, check, fix, global } => cmd::lint::run(path, schema, check, fix, global),
+        Commands::Reflow { path, fix, json, quiet } => cmd::reflow::run(path, fix, json, quiet),
         Commands::Corpus { ways_dir, output, quiet, verbose, if_stale } => cmd::corpus::run(ways_dir, output, quiet, verbose, if_stale),
         Commands::Match { query, corpus, cosine, project } => {
             if cosine {

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -48,9 +48,16 @@ enum Commands {
         /// Exit non-zero on errors (for CI)
         #[arg(long)]
         check: bool,
-        /// Auto-fix what can be fixed (multi-line YAML, missing check sections)
+        /// Auto-fix what can be fixed, in the file or directory given as `path`
+        ///
+        /// Scope comes from `path`, not from this flag. Without a path, `--fix`
+        /// refuses to run rather than rewriting the whole corpus by surprise;
+        /// pass `--all` to ask for that deliberately.
         #[arg(long)]
         fix: bool,
+        /// Allow `--fix` to write across the entire resolved corpus
+        #[arg(long)]
+        all: bool,
         /// Scan global ways (ignore CLAUDE_PROJECT_DIR)
         #[arg(long)]
         global: bool,
@@ -723,7 +730,7 @@ fn run() -> Result<()> {
 
     match command {
         Commands::Context { project, json } => cmd::context::run(project.as_deref(), json),
-        Commands::Lint { path, schema, check, fix, global } => cmd::lint::run(path, schema, check, fix, global),
+        Commands::Lint { path, schema, check, fix, all, global } => cmd::lint::run(path, schema, check, fix, all, global),
         Commands::Reflow { path, fix, json, quiet } => cmd::reflow::run(path, fix, json, quiet),
         Commands::Corpus { ways_dir, output, quiet, verbose, if_stale } => cmd::corpus::run(ways_dir, output, quiet, verbose, if_stale),
         Commands::Match { query, corpus, cosine, project } => {

--- a/tools/ways-core/Cargo.toml
+++ b/tools/ways-core/Cargo.toml
@@ -14,5 +14,8 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = { version = "1", features = ["preserve_order"] }
 walkdir = "2"
+# Block-level markdown classification and the reflow post-condition (#415).
+# Default features off: we need the parser, not the HTML renderer.
+pulldown-cmark = { version = "0.13", default-features = false }
 anyhow = "1"
 sensor-trait = { path = "../sensor-trait" }

--- a/tools/ways-core/src/lib.rs
+++ b/tools/ways-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod frontmatter;
 pub mod introspection;
 pub mod paths;
 pub mod provenance;
+pub mod reflow;
 pub mod scanner;
 pub mod transcript;
 pub mod util;

--- a/tools/ways-core/src/reflow.rs
+++ b/tools/ways-core/src/reflow.rs
@@ -94,8 +94,19 @@ fn indent_of(line: &str) -> &str {
     &line[..line.len() - line.trim_start().len()]
 }
 
-fn leading_spaces(line: &str) -> usize {
-    line.chars().take_while(|c| *c == ' ').count()
+/// Leading indent in *columns*, counting a tab as four. CommonMark treats a tab
+/// as advancing to the next four-column stop, so counting only spaces would let
+/// a tab-indented code block through as prose.
+fn leading_columns(line: &str) -> usize {
+    let mut cols = 0;
+    for c in line.chars() {
+        match c {
+            ' ' => cols += 1,
+            '\t' => cols += 4 - (cols % 4),
+            _ => break,
+        }
+    }
+    cols
 }
 
 /// A list item: `- `, `* `, `+ `, `1. `, `2) `.
@@ -118,6 +129,14 @@ fn is_blockquote(line: &str) -> bool {
     line.trim_start().starts_with('>')
 }
 
+/// A blockquote line with no content — `>` alone. This is a *paragraph
+/// boundary* inside the quote, not a wrapped line, and joining across one welds
+/// two quoted paragraphs into one. The token-stream check cannot catch that: the
+/// only difference is a bare `>`, which the invariant is allowed to drop.
+fn is_empty_blockquote(line: &str) -> bool {
+    is_blockquote(line) && quote_body(line).trim().is_empty()
+}
+
 /// Strip one level of blockquote marker so the body can be inspected.
 fn quote_body(line: &str) -> &str {
     let t = line.trim_start();
@@ -128,7 +147,7 @@ fn quote_body(line: &str) -> &str {
 }
 
 fn is_heading(line: &str) -> bool {
-    if leading_spaces(line) > 3 {
+    if leading_columns(line) > 3 {
         return false;
     }
     let t = line.trim_start();
@@ -138,7 +157,7 @@ fn is_heading(line: &str) -> bool {
 
 /// A thematic break or a setext underline: `---`, `***`, `___`, `===`.
 fn is_rule_or_setext(line: &str) -> bool {
-    if leading_spaces(line) > 3 {
+    if leading_columns(line) > 3 {
         return false;
     }
     let t = line.trim();
@@ -151,7 +170,8 @@ fn is_rule_or_setext(line: &str) -> bool {
     }
     let count = t.chars().filter(|c| *c == first).count();
     let only = t.chars().all(|c| c == first || c == ' ');
-    only && count >= 3 || (only && matches!(first, '-' | '=') && count >= 1)
+    // `***`/`___` need three; a lone `-` or `=` is already a setext underline.
+    (only && count >= 3) || (only && matches!(first, '-' | '=') && count >= 1)
 }
 
 fn is_table_row(line: &str) -> bool {
@@ -162,25 +182,57 @@ fn is_html(line: &str) -> bool {
     line.trim_start().starts_with('<')
 }
 
-fn is_footnote_def(line: &str) -> bool {
+/// A link reference or footnote definition — `[label]: target`, `[^note]: text`.
+/// These are line-scoped syntax; joined into a paragraph they become literal
+/// text, and the token stream is identical either way.
+fn is_reference_def(line: &str) -> bool {
     let t = line.trim_start();
-    t.starts_with("[^") && t.contains("]:")
+    if !t.starts_with('[') {
+        return false;
+    }
+    match t.find("]:") {
+        Some(close) => !t[1..close].contains('['),
+        None => false,
+    }
+}
+
+/// HTML elements CommonMark treats as raw text — their bodies are literal, so
+/// every line until the closing tag is opaque, not just the opening one.
+const RAW_TEXT_TAGS: &[&str] = &["pre", "script", "style", "textarea"];
+
+/// The raw-text tag this line opens, if any and if it does not also close it.
+fn opens_raw_html(line: &str) -> Option<&'static str> {
+    let lower = line.trim_start().to_ascii_lowercase();
+    RAW_TEXT_TAGS.iter().copied().find(|tag| {
+        let open = format!("<{tag}");
+        lower.starts_with(&open) && !lower.contains(&format!("</{tag}>"))
+    })
 }
 
 /// Four-space indented block — a code block, not wrapped prose. List
 /// continuations are indented too, so this only claims lines indented four or
 /// more spaces that are *not* list items.
 fn is_indented_block(line: &str) -> bool {
-    leading_spaces(line) >= 4 && !line.trim().is_empty() && !is_list_item(line)
+    leading_columns(line) >= 4 && !line.trim().is_empty() && !is_list_item(line)
 }
 
-/// A bare label line like `Status:` — structure, not a wrapped sentence.
+/// A bare label line like `Status:` or `Next steps:` — structure, not prose.
+///
+/// Bounded by word count: without the cap, any prose sentence ending in a colon
+/// and containing no interior punctuation qualifies, which splits its paragraph
+/// and leaves the repair half-flat — the exact failure the enclosing-paragraph
+/// scope exists to avoid.
+const MAX_LABEL_WORDS: usize = 5;
+
 fn is_label_line(line: &str) -> bool {
     let t = line.trim();
     match t.strip_suffix(':') {
-        Some(head) if !head.is_empty() => head
-            .chars()
-            .all(|c| c.is_alphanumeric() || matches!(c, ' ' | '-' | '_' | '/')),
+        Some(head) if !head.is_empty() => {
+            head.split_whitespace().count() <= MAX_LABEL_WORDS
+                && head
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || matches!(c, ' ' | '-' | '_' | '/'))
+        }
         _ => false,
     }
 }
@@ -198,6 +250,7 @@ pub fn classify(lines: &[&str]) -> Vec<LineKind> {
     let mut out = Vec::with_capacity(lines.len());
     let mut fence: Option<&str> = None;
     let mut in_frontmatter = false;
+    let mut raw_html: Option<&str> = None;
 
     for (i, raw) in lines.iter().enumerate() {
         let trimmed = raw.trim();
@@ -240,13 +293,31 @@ pub fn classify(lines: &[&str]) -> Vec<LineKind> {
             (None, None) => {}
         }
 
-        if trimmed.is_empty() {
+        // Raw-text HTML: the body is literal, so every line through the closing
+        // tag is opaque — not just the opening one.
+        if let Some(tag) = raw_html {
+            out.push(LineKind::Verbatim);
+            if trimmed.to_ascii_lowercase().contains(&format!("</{tag}>")) {
+                raw_html = None;
+            }
+            continue;
+        }
+        if let Some(tag) = opens_raw_html(raw) {
+            raw_html = Some(tag);
+            out.push(LineKind::Verbatim);
+            continue;
+        }
+
+        if trimmed.is_empty() || is_empty_blockquote(raw) {
+            // A bare `>` is a paragraph boundary inside the quote. Treating it as
+            // Blank both stops the weld and lets the paragraph after it be
+            // detected on its own.
             out.push(LineKind::Blank);
         } else if is_heading(raw)
             || is_rule_or_setext(raw)
             || is_table_row(raw)
             || is_html(raw)
-            || is_footnote_def(raw)
+            || is_reference_def(raw)
             || is_indented_block(raw)
             || is_label_line(raw)
         {
@@ -334,15 +405,32 @@ pub fn detect_with(lines: &[&str], cfg: DetectConfig) -> Vec<WrappedParagraph> {
         if n < cfg.min_run {
             continue;
         }
+        // Line lengths computed once per paragraph, not once per window.
+        let lens: Vec<usize> = lines[pstart..=pend]
+            .iter()
+            .map(|l| l.trim_end().chars().count())
+            .collect();
+
         'windows: for offset in 0..=(n - cfg.min_run) {
+            let mut lo = usize::MAX;
+            let mut hi = 0usize;
             for len in cfg.min_run..=(n - offset) {
-                let win = &lines[pstart + offset..pstart + offset + len];
-                let lens: Vec<usize> = win.iter().map(|l| l.trim_end().chars().count()).collect();
-                let lo = *lens.iter().min().unwrap();
-                let hi = *lens.iter().max().unwrap();
-                if lo < cfg.min_len || hi > cfg.max_len || hi - lo > cfg.band {
-                    continue;
+                // Extend the running min/max by the one newly included line.
+                let upto = if len == cfg.min_run { 0 } else { len - 1 };
+                for l in &lens[offset + upto..offset + len] {
+                    lo = lo.min(*l);
+                    hi = hi.max(*l);
                 }
+                // Each band predicate is monotone in window length: `lo` only
+                // falls and `hi` only rises as the window grows, so a failure
+                // here fails for every longer window at this offset. Breaking
+                // rather than continuing is what keeps this off O(n^3) — a long
+                // bullet list is one paragraph, and this runs on a hook that
+                // fires on every write.
+                if lo < cfg.min_len || hi > cfg.max_len || hi - lo > cfg.band {
+                    break;
+                }
+                let win = &lines[pstart + offset..pstart + offset + len];
                 let mids = win
                     .windows(2)
                     .filter(|p| is_mid_phrase_break(p[0], p[1]))
@@ -377,10 +465,23 @@ pub fn is_wrapped(lines: &[&str]) -> bool {
 /// explicit hard breaks — because joining across one of those changes the
 /// rendered structure while leaving the token stream untouched.
 pub fn reflow(lines: &[&str]) -> Vec<String> {
+    reflow_with_stats(lines).0
+}
+
+/// [`reflow`], plus the number of blockquote continuation markers the transform
+/// dropped.
+///
+/// The count is what lets [`token_verdict_accounted`] treat a missing `>` as an
+/// *accounted* loss rather than a blanket exemption. Without it, "any difference
+/// consisting only of `>` tokens is fine" cannot distinguish dropping the
+/// continuation markers of a joined quote from dropping the bare `>` that was a
+/// paragraph boundary.
+pub fn reflow_with_stats(lines: &[&str]) -> (Vec<String>, usize) {
     let hot = detect(lines);
     if hot.is_empty() {
-        return lines.iter().map(|s| s.to_string()).collect();
+        return (lines.iter().map(|s| s.to_string()).collect(), 0);
     }
+    let mut quote_joins = 0usize;
     let spans: std::collections::HashMap<usize, usize> =
         hot.iter().map(|w| (w.start, w.end)).collect();
 
@@ -394,7 +495,7 @@ pub fn reflow(lines: &[&str]) -> Vec<String> {
         };
 
         let mut block: Vec<&str> = Vec::new();
-        let flush = |block: &mut Vec<&str>, out: &mut Vec<String>| {
+        let flush = |block: &mut Vec<&str>, out: &mut Vec<String>, joins: &mut usize| {
             if block.is_empty() {
                 return;
             }
@@ -403,6 +504,9 @@ pub fn reflow(lines: &[&str]) -> Vec<String> {
             // markers would otherwise land mid-line as literal text. This is
             // the sole token the invariant is allowed to lose.
             let quoted = is_blockquote(block[0]);
+            if quoted {
+                *joins += block.iter().skip(1).filter(|l| is_blockquote(l)).count();
+            }
             let joined = block
                 .iter()
                 .enumerate()
@@ -428,17 +532,17 @@ pub fn reflow(lines: &[&str]) -> Vec<String> {
                 || (is_blockquote(line) && block.last().is_some_and(|p| !is_blockquote(p)))
                 || (!is_blockquote(line) && block.last().is_some_and(|p| is_blockquote(p)));
             if starts_block {
-                flush(&mut block, &mut out);
+                flush(&mut block, &mut out, &mut quote_joins);
             }
             block.push(line);
             if has_hard_break(line) {
-                flush(&mut block, &mut out);
+                flush(&mut block, &mut out, &mut quote_joins);
             }
         }
-        flush(&mut block, &mut out);
+        flush(&mut block, &mut out, &mut quote_joins);
         i = end + 1;
     }
-    out
+    (out, quote_joins)
 }
 
 /// Result of the token-stream invariant.
@@ -481,6 +585,25 @@ pub fn token_verdict(before: &str, after: &str) -> TokenVerdict {
         return TokenVerdict::Mismatch { before: b.len(), after: a.len() };
     }
     TokenVerdict::Mismatch { before: b.len(), after: a.len() }
+}
+
+/// [`token_verdict`], but the dropped `>` markers must match `expected` exactly.
+///
+/// This is the form callers that write files should use. `token_verdict` accepts
+/// *any* difference consisting solely of `>` tokens, which is an exemption rather
+/// than an invariant: on its own it cannot tell the continuation markers of a
+/// joined quote from the bare `>` that separated two quoted paragraphs. Pairing
+/// the check with the transform's own join count closes that gap.
+pub fn token_verdict_accounted(before: &str, after: &str, expected: usize) -> TokenVerdict {
+    match token_verdict(before, after) {
+        TokenVerdict::QuoteMarkersDropped { dropped } if dropped != expected => {
+            TokenVerdict::Mismatch {
+                before: before.split_whitespace().count(),
+                after: after.split_whitespace().count(),
+            }
+        }
+        other => other,
+    }
 }
 
 #[cfg(test)]
@@ -649,6 +772,113 @@ Body.";
     fn reflow_is_idempotent() {
         let once = round_trip(WRAPPED);
         assert_eq!(round_trip(&once), once);
+    }
+
+    #[test]
+    fn a_bare_quote_marker_separates_two_quoted_paragraphs() {
+        // Review finding 1. Joining across a bare `>` welds two quoted
+        // paragraphs, and the token oracle calls it clean because the only
+        // difference is a `>`. Detection must see the boundary.
+        let src = "\
+> The first quoted paragraph runs long enough to sit inside the detect band
+> and it continues here mid-phrase so the mid-break count reaches its floor
+> and a third line keeps the window at the minimum run length it requires.
+>
+> A second quoted paragraph, which must remain a separate paragraph always.";
+        let out = round_trip(src);
+        assert!(
+            out.contains("\n>\n"),
+            "the bare `>` boundary was swallowed: {out:?}"
+        );
+        assert_eq!(out.lines().count(), 3, "{out:?}");
+        assert!(out.lines().last().unwrap().starts_with("> A second"));
+    }
+
+    #[test]
+    fn accounted_verdict_catches_an_unaccounted_marker_drop() {
+        // The exemption made an invariant: a `>`-only difference is only clean
+        // when the count matches the joins the transform actually performed.
+        let before = "> alpha beta\n>\n> gamma delta";
+        let welded = "> alpha beta gamma delta";
+        assert!(matches!(
+            token_verdict(before, welded),
+            TokenVerdict::QuoteMarkersDropped { .. }
+        ));
+        assert!(matches!(
+            token_verdict_accounted(before, welded, 1),
+            TokenVerdict::Mismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn raw_text_html_bodies_are_opaque() {
+        // Review finding 3. `is_html` matched only the opening line, so a <pre>
+        // body was joined — and preformatted text is precisely where the line
+        // break *is* the rendering.
+        let src = "\
+<pre>
+  some preformatted text line one that is long enough to be within band ok
+  more preformatted text line two continuing mid phrase to trigger detect
+  third preformatted line so the run length reaches the configured minimum
+</pre>";
+        assert!(detect(&split(src)).is_empty());
+        assert_eq!(round_trip(src), src);
+    }
+
+    #[test]
+    fn tab_indented_code_is_opaque() {
+        // A tab advances to the next four-column stop, so counting only spaces
+        // let a tab-indented code block through as prose.
+        let src = "\
+\tsome preformatted text line one that is long enough to be within the band
+\tmore preformatted text line two continuing mid phrase to trigger detection
+\tthird preformatted line so that the run length reaches the configured min";
+        assert!(detect(&split(src)).is_empty());
+        assert_eq!(round_trip(src), src);
+    }
+
+    #[test]
+    fn a_prose_sentence_ending_in_a_colon_is_not_a_label() {
+        // Review finding 4. The unbounded predicate split the paragraph and left
+        // the repair half-flat — the failure enclosing-paragraph scope avoids.
+        let long = "so we ended up considering the following three alternatives:";
+        assert!(!is_label_line(long));
+        assert!(is_label_line("Status:"));
+        assert!(is_label_line("Next steps:"));
+    }
+
+    #[test]
+    fn link_reference_definitions_survive() {
+        // Review finding 5. `[label]: target` is line-scoped syntax; joined into
+        // a paragraph it becomes literal text, token stream unchanged.
+        let src = "\
+Some wrapped prose here that is long enough to fall inside the detect band
+and continuing mid-phrase so that the mid-break count reaches its floor now
+and a third line so the window reaches the minimum run length it requires.
+[adr-142]: https://github.com/aaronsb/agent-ways/blob/main/docs/adr142.md";
+        let out = round_trip(src);
+        assert_eq!(
+            out.lines().last().unwrap(),
+            "[adr-142]: https://github.com/aaronsb/agent-ways/blob/main/docs/adr142.md"
+        );
+    }
+
+    #[test]
+    fn long_paragraph_detection_stays_fast() {
+        // Review finding 2: the band never closes on this input, so before the
+        // monotone break this was O(n^3) — 1600 lines took ~6s on a hook that
+        // runs on every write.
+        let body: Vec<String> = (0..1600)
+            .map(|i| format!("- item {i} with enough text to vary the length {}", "x".repeat(i % 90)))
+            .collect();
+        let refs: Vec<&str> = body.iter().map(|s| s.as_str()).collect();
+        let start = std::time::Instant::now();
+        let _ = detect(&refs);
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed.as_millis() < 500,
+            "detect took {elapsed:?} on 1600 lines — the monotone break regressed"
+        );
     }
 
     #[test]

--- a/tools/ways-core/src/reflow.rs
+++ b/tools/ways-core/src/reflow.rs
@@ -1,0 +1,670 @@
+//! Hard-wrap detection and repair for markdown prose (#415).
+//!
+//! Agents hard-wrap markdown at ~80 columns by habit. That breaks `Edit`
+//! (`old_string` must reproduce arbitrary interior line breaks) and makes
+//! diffs non-semantic (three changed words reflow a whole paragraph). This
+//! module finds mechanically wrapped prose and flattens it.
+//!
+//! Three callers share these functions, which is why they live here rather
+//! than in a binary: the `ways lint` rule (in-process, no spawn per file),
+//! the way's `postcheck.sh` predicate (via the thin binary, on freshly
+//! written text), and explicit remediation.
+//!
+//! # Detection is a heuristic; the transform is not
+//!
+//! [`detect`] is deliberately conservative. It cannot *decide* whether a break
+//! is mechanical — one-clause-per-line is a legitimate authoring style, and the
+//! convention this supports permits it. What it can do is recognize the
+//! fingerprint of column wrapping: a run of lines whose lengths cluster just
+//! under a fill column, broken mid-phrase. Semantic line breaks land at clause
+//! boundaries and vary wildly in length; wrapped prose does neither.
+//!
+//! Missing a wrapped paragraph is acceptable. Firing on deliberate structure is
+//! not — a check that nags trains its reader to ignore it.
+//!
+//! # Why the transform is scoped to the enclosing paragraph
+//!
+//! Measured against the 138-file `hooks/ways` corpus, three scopes behave very
+//! differently:
+//!
+//! - Flattening every paragraph modified 16 of the 115 files with no detected
+//!   wrap at all — welding deliberately parallel sentences together and
+//!   de-indenting nested list items.
+//! - Flattening only the detected window left paragraphs half-flat: one joined
+//!   line followed by the rest of the paragraph still wrapped.
+//! - Flattening the **enclosing paragraph of a detected window** touched all 24
+//!   detected files and none of the other 114.
+//!
+//! So detection is per-window, repair is per-paragraph, and a paragraph with no
+//! detected window is never touched.
+
+/// How a line participates in wrap detection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineKind {
+    /// Structural or literal. Never joined, never a wrap candidate.
+    Verbatim,
+    /// Blank — a paragraph boundary.
+    Blank,
+    /// Paragraph, list-item, or blockquote text.
+    Prose,
+}
+
+/// A paragraph containing at least one detected hard-wrap window.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WrappedParagraph {
+    /// First line index of the enclosing paragraph (0-based).
+    pub start: usize,
+    /// Last line index of the enclosing paragraph, inclusive.
+    pub end: usize,
+    /// First line index of the window that triggered detection.
+    pub trigger_start: usize,
+    /// Number of lines in the triggering window.
+    pub trigger_len: usize,
+    /// Mid-phrase breaks counted inside the triggering window.
+    pub mid_breaks: usize,
+}
+
+/// Tuning for [`detect`]. The defaults are the measured ones; they are exposed
+/// so tests can probe the boundaries, not so callers can invent policies.
+#[derive(Debug, Clone, Copy)]
+pub struct DetectConfig {
+    /// Minimum line length to count as "near a fill column".
+    pub min_len: usize,
+    /// Maximum line length — beyond this it is wide content, not wrapped prose.
+    pub max_len: usize,
+    /// Maximum spread between the longest and shortest line in a window.
+    pub band: usize,
+    /// Minimum lines in a window.
+    pub min_run: usize,
+    /// Minimum mid-phrase breaks in a window.
+    pub min_mid_breaks: usize,
+}
+
+impl Default for DetectConfig {
+    fn default() -> Self {
+        Self { min_len: 55, max_len: 100, band: 12, min_run: 3, min_mid_breaks: 2 }
+    }
+}
+
+/// Characters that end a line at a natural boundary. A line ending on one of
+/// these was plausibly broken on purpose, so it is not evidence of wrapping.
+const BOUNDARY_END: &[char] = &['.', '!', '?', ':', ';', '"', ')', '`', '*', '|', '>', ','];
+
+fn indent_of(line: &str) -> &str {
+    &line[..line.len() - line.trim_start().len()]
+}
+
+fn leading_spaces(line: &str) -> usize {
+    line.chars().take_while(|c| *c == ' ').count()
+}
+
+/// A list item: `- `, `* `, `+ `, `1. `, `2) `.
+fn is_list_item(line: &str) -> bool {
+    let t = line.trim_start();
+    let mut chars = t.chars();
+    match chars.next() {
+        Some('-') | Some('*') | Some('+') => chars.next() == Some(' '),
+        Some(c) if c.is_ascii_digit() => {
+            let rest: String = t.chars().take_while(|c| c.is_ascii_digit()).collect();
+            let after = &t[rest.len()..];
+            let mut a = after.chars();
+            matches!(a.next(), Some('.') | Some(')')) && a.next() == Some(' ')
+        }
+        _ => false,
+    }
+}
+
+fn is_blockquote(line: &str) -> bool {
+    line.trim_start().starts_with('>')
+}
+
+/// Strip one level of blockquote marker so the body can be inspected.
+fn quote_body(line: &str) -> &str {
+    let t = line.trim_start();
+    match t.strip_prefix('>') {
+        Some(rest) => rest.strip_prefix(' ').unwrap_or(rest),
+        None => t,
+    }
+}
+
+fn is_heading(line: &str) -> bool {
+    if leading_spaces(line) > 3 {
+        return false;
+    }
+    let t = line.trim_start();
+    let hashes = t.chars().take_while(|c| *c == '#').count();
+    (1..=6).contains(&hashes) && t[hashes..].starts_with(' ')
+}
+
+/// A thematic break or a setext underline: `---`, `***`, `___`, `===`.
+fn is_rule_or_setext(line: &str) -> bool {
+    if leading_spaces(line) > 3 {
+        return false;
+    }
+    let t = line.trim();
+    if t.is_empty() {
+        return false;
+    }
+    let first = t.chars().next().unwrap();
+    if !matches!(first, '-' | '*' | '_' | '=') {
+        return false;
+    }
+    let count = t.chars().filter(|c| *c == first).count();
+    let only = t.chars().all(|c| c == first || c == ' ');
+    only && count >= 3 || (only && matches!(first, '-' | '=') && count >= 1)
+}
+
+fn is_table_row(line: &str) -> bool {
+    line.trim_start().starts_with('|')
+}
+
+fn is_html(line: &str) -> bool {
+    line.trim_start().starts_with('<')
+}
+
+fn is_footnote_def(line: &str) -> bool {
+    let t = line.trim_start();
+    t.starts_with("[^") && t.contains("]:")
+}
+
+/// Four-space indented block — a code block, not wrapped prose. List
+/// continuations are indented too, so this only claims lines indented four or
+/// more spaces that are *not* list items.
+fn is_indented_block(line: &str) -> bool {
+    leading_spaces(line) >= 4 && !line.trim().is_empty() && !is_list_item(line)
+}
+
+/// A bare label line like `Status:` — structure, not a wrapped sentence.
+fn is_label_line(line: &str) -> bool {
+    let t = line.trim();
+    match t.strip_suffix(':') {
+        Some(head) if !head.is_empty() => head
+            .chars()
+            .all(|c| c.is_alphanumeric() || matches!(c, ' ' | '-' | '_' | '/')),
+        _ => false,
+    }
+}
+
+/// True if the line ends in an explicit hard break — two trailing spaces or a
+/// trailing backslash. Joining across one would silently delete a `<br>`, and a
+/// token-stream check cannot see it.
+pub fn has_hard_break(line: &str) -> bool {
+    let no_nl = line.trim_end_matches(['\r', '\n']);
+    no_nl.ends_with("  ") || no_nl.ends_with('\\')
+}
+
+/// Classify every line. Fenced code and leading YAML frontmatter are opaque.
+pub fn classify(lines: &[&str]) -> Vec<LineKind> {
+    let mut out = Vec::with_capacity(lines.len());
+    let mut fence: Option<&str> = None;
+    let mut in_frontmatter = false;
+
+    for (i, raw) in lines.iter().enumerate() {
+        let trimmed = raw.trim();
+
+        if i == 0 && trimmed == "---" {
+            in_frontmatter = true;
+            out.push(LineKind::Verbatim);
+            continue;
+        }
+        if in_frontmatter {
+            out.push(LineKind::Verbatim);
+            if trimmed == "---" {
+                in_frontmatter = false;
+            }
+            continue;
+        }
+
+        let opener = if trimmed.starts_with("```") {
+            Some("```")
+        } else if trimmed.starts_with("~~~") {
+            Some("~~~")
+        } else {
+            None
+        };
+        match (fence, opener) {
+            (None, Some(tok)) => {
+                fence = Some(tok);
+                out.push(LineKind::Verbatim);
+                continue;
+            }
+            (Some(tok), Some(seen)) if seen == tok => {
+                fence = None;
+                out.push(LineKind::Verbatim);
+                continue;
+            }
+            (Some(_), _) => {
+                out.push(LineKind::Verbatim);
+                continue;
+            }
+            (None, None) => {}
+        }
+
+        if trimmed.is_empty() {
+            out.push(LineKind::Blank);
+        } else if is_heading(raw)
+            || is_rule_or_setext(raw)
+            || is_table_row(raw)
+            || is_html(raw)
+            || is_footnote_def(raw)
+            || is_indented_block(raw)
+            || is_label_line(raw)
+        {
+            out.push(LineKind::Verbatim);
+        } else {
+            out.push(LineKind::Prose);
+        }
+    }
+    out
+}
+
+/// Maximal spans of consecutive [`LineKind::Prose`] lines — the paragraphs.
+fn paragraphs(kinds: &[LineKind]) -> Vec<(usize, usize)> {
+    let mut out = Vec::new();
+    let mut start: Option<usize> = None;
+    for (i, k) in kinds.iter().enumerate() {
+        match (k, start) {
+            (LineKind::Prose, None) => start = Some(i),
+            (LineKind::Prose, Some(_)) => {}
+            (_, Some(s)) => {
+                if i - s > 1 {
+                    out.push((s, i - 1));
+                }
+                start = None;
+            }
+            (_, None) => {}
+        }
+    }
+    if let Some(s) = start {
+        if kinds.len() - s > 1 {
+            out.push((s, kinds.len() - 1));
+        }
+    }
+    out
+}
+
+/// True if the break between `a` and `b` reads as mechanical rather than
+/// authored — `a` stops on a bare word and `b` resumes mid-phrase.
+fn is_mid_phrase_break(a: &str, b: &str) -> bool {
+    if has_hard_break(a) {
+        return false;
+    }
+    // Blockquote prose wraps like any other prose, so judge the break on the
+    // quoted bodies. Crossing *into* or *out of* a quote is structural, never a
+    // wrap, so those cases stay disqualified.
+    let (a, b) = match (is_blockquote(a), is_blockquote(b)) {
+        (true, true) => (quote_body(a), quote_body(b)),
+        (false, false) => (a, b),
+        _ => return false,
+    };
+    let at = a.trim_end();
+    match at.chars().last() {
+        None => return false,
+        Some(c) if BOUNDARY_END.contains(&c) => return false,
+        Some(_) => {}
+    }
+    if is_list_item(b) {
+        return false;
+    }
+    let bt = b.trim_start();
+    if bt.starts_with('#') || bt.starts_with('|') || bt.starts_with("**") {
+        return false;
+    }
+    match bt.chars().next() {
+        Some(c) => c.is_lowercase() || matches!(c, '\u{201c}' | '"' | '(' | '`'),
+        None => false,
+    }
+}
+
+/// Find paragraphs containing a hard-wrap window.
+///
+/// One result per paragraph — the transform flattens the whole paragraph, so a
+/// second window in the same paragraph adds nothing.
+pub fn detect(lines: &[&str]) -> Vec<WrappedParagraph> {
+    detect_with(lines, DetectConfig::default())
+}
+
+/// [`detect`] with explicit tuning.
+pub fn detect_with(lines: &[&str], cfg: DetectConfig) -> Vec<WrappedParagraph> {
+    let kinds = classify(lines);
+    let mut found = Vec::new();
+
+    for (pstart, pend) in paragraphs(&kinds) {
+        let n = pend - pstart + 1;
+        if n < cfg.min_run {
+            continue;
+        }
+        'windows: for offset in 0..=(n - cfg.min_run) {
+            for len in cfg.min_run..=(n - offset) {
+                let win = &lines[pstart + offset..pstart + offset + len];
+                let lens: Vec<usize> = win.iter().map(|l| l.trim_end().chars().count()).collect();
+                let lo = *lens.iter().min().unwrap();
+                let hi = *lens.iter().max().unwrap();
+                if lo < cfg.min_len || hi > cfg.max_len || hi - lo > cfg.band {
+                    continue;
+                }
+                let mids = win
+                    .windows(2)
+                    .filter(|p| is_mid_phrase_break(p[0], p[1]))
+                    .count();
+                if mids >= cfg.min_mid_breaks {
+                    found.push(WrappedParagraph {
+                        start: pstart,
+                        end: pend,
+                        trigger_start: pstart + offset,
+                        trigger_len: len,
+                        mid_breaks: mids,
+                    });
+                    break 'windows;
+                }
+            }
+        }
+    }
+    found
+}
+
+/// True if any paragraph is hard-wrapped. The predicate the postcheck and the
+/// lint rule both reduce to.
+pub fn is_wrapped(lines: &[&str]) -> bool {
+    !detect(lines).is_empty()
+}
+
+/// Flatten the paragraphs [`detect`] identifies, leaving everything else
+/// byte-identical.
+///
+/// A flattened paragraph is split again at boundaries that carry meaning at the
+/// start of a line — list items, blockquote bold labels (`**Status:**`), and
+/// explicit hard breaks — because joining across one of those changes the
+/// rendered structure while leaving the token stream untouched.
+pub fn reflow(lines: &[&str]) -> Vec<String> {
+    let hot = detect(lines);
+    if hot.is_empty() {
+        return lines.iter().map(|s| s.to_string()).collect();
+    }
+    let spans: std::collections::HashMap<usize, usize> =
+        hot.iter().map(|w| (w.start, w.end)).collect();
+
+    let mut out: Vec<String> = Vec::with_capacity(lines.len());
+    let mut i = 0;
+    while i < lines.len() {
+        let Some(&end) = spans.get(&i) else {
+            out.push(lines[i].to_string());
+            i += 1;
+            continue;
+        };
+
+        let mut block: Vec<&str> = Vec::new();
+        let flush = |block: &mut Vec<&str>, out: &mut Vec<String>| {
+            if block.is_empty() {
+                return;
+            }
+            let indent = indent_of(block[0]).to_string();
+            // A joined blockquote keeps one leading `>`; the continuation
+            // markers would otherwise land mid-line as literal text. This is
+            // the sole token the invariant is allowed to lose.
+            let quoted = is_blockquote(block[0]);
+            let joined = block
+                .iter()
+                .enumerate()
+                .map(|(n, l)| if quoted && n > 0 { quote_body(l).trim() } else { l.trim() })
+                .collect::<Vec<_>>()
+                .join(" ");
+            let mut line = indent + &joined;
+            // `trim` above eats the two trailing spaces that *are* the hard
+            // break, so put them back.
+            if block.last().is_some_and(|l| l.trim_end_matches(['\r', '\n']).ends_with("  ")) {
+                line.push_str("  ");
+            }
+            out.push(line);
+            block.clear();
+        };
+
+        for line in &lines[i..=end] {
+            let line = *line;
+            let body = quote_body(line);
+            let starts_block = is_list_item(line)
+                || is_list_item(body)
+                || body.trim_start().starts_with("**")
+                || (is_blockquote(line) && block.last().is_some_and(|p| !is_blockquote(p)))
+                || (!is_blockquote(line) && block.last().is_some_and(|p| is_blockquote(p)));
+            if starts_block {
+                flush(&mut block, &mut out);
+            }
+            block.push(line);
+            if has_hard_break(line) {
+                flush(&mut block, &mut out);
+            }
+        }
+        flush(&mut block, &mut out);
+        i = end + 1;
+    }
+    out
+}
+
+/// Result of the token-stream invariant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenVerdict {
+    /// Byte-for-byte identical token streams.
+    Identical,
+    /// Identical except for bare `>` markers dropped where wrapped blockquote
+    /// lines were joined. `dropped` counts them.
+    QuoteMarkersDropped { dropped: usize },
+    /// Words were lost, gained, or reordered. Never acceptable.
+    Mismatch { before: usize, after: usize },
+}
+
+/// Compare whitespace-delimited tokens before and after a reflow.
+///
+/// This is a cheap total check against *loss*, and it is the reason bulk repair
+/// is tractable at all. It is **not** sufficient on its own: joining two lines
+/// that should have stayed separate produces an identical token stream, and
+/// leading whitespace is not a token, so this check passes a nested list that
+/// has been de-indented. Pair it with the structural guarantees in [`reflow`]
+/// and with reading the diff.
+pub fn token_verdict(before: &str, after: &str) -> TokenVerdict {
+    let b: Vec<&str> = before.split_whitespace().collect();
+    let a: Vec<&str> = after.split_whitespace().collect();
+    if b == a {
+        return TokenVerdict::Identical;
+    }
+    let bq: Vec<&str> = b.iter().copied().filter(|t| *t != ">").collect();
+    let aq: Vec<&str> = a.iter().copied().filter(|t| *t != ">").collect();
+    if bq == aq {
+        let before_markers = b.iter().filter(|t| **t == ">").count();
+        let after_markers = a.iter().filter(|t| **t == ">").count();
+        // Joining a wrapped blockquote can only ever *drop* markers. Gaining
+        // one means the transform invented structure, which is a mismatch —
+        // and subtracting the other way would underflow.
+        if let Some(dropped) = before_markers.checked_sub(after_markers) {
+            return TokenVerdict::QuoteMarkersDropped { dropped };
+        }
+        return TokenVerdict::Mismatch { before: b.len(), after: a.len() };
+    }
+    TokenVerdict::Mismatch { before: b.len(), after: a.len() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn split(s: &str) -> Vec<&str> {
+        s.split('\n').collect()
+    }
+
+    fn round_trip(src: &str) -> String {
+        reflow(&split(src)).join("\n")
+    }
+
+    const WRAPPED: &str = "\
+In 1.0, `~/.claude` is a thin projection of an XDG application, not the app
+itself (ADR-142). The source lives in `$XDG_DATA_HOME/agent-ways`; the home dir
+gets symlinks to the projected roots plus a three-way merge into settings, and
+everything else the app ships stays where it is.";
+
+    #[test]
+    fn detects_a_hard_wrapped_paragraph() {
+        let lines = split(WRAPPED);
+        let hits = detect(&lines);
+        assert_eq!(hits.len(), 1);
+        assert_eq!((hits[0].start, hits[0].end), (0, 3));
+    }
+
+    #[test]
+    fn flattens_the_whole_enclosing_paragraph() {
+        let out = reflow(&split(WRAPPED));
+        assert_eq!(out.len(), 1, "expected one line, got {out:#?}");
+        assert!(out[0].starts_with("In 1.0,"));
+        assert!(out[0].ends_with("stays where it is."));
+    }
+
+    #[test]
+    fn token_stream_survives_a_reflow() {
+        assert_eq!(token_verdict(WRAPPED, &round_trip(WRAPPED)), TokenVerdict::Identical);
+    }
+
+    #[test]
+    fn leaves_parallel_one_sentence_lines_alone() {
+        // Deliberate semantic breaks: each line is a complete clause. The
+        // real corpus case was meta/think/strategies/self-consistency.md.
+        let src = "\
+If majority agrees: that's the answer, with the divergent path noted as caveat.
+If split: present the split to the user. The uncertainty beats a forced answer.";
+        assert!(detect(&split(src)).is_empty());
+        assert_eq!(round_trip(src), src);
+    }
+
+    #[test]
+    fn leaves_bold_definition_lines_alone() {
+        // meta/knowledge/knowledge.md — welding these was a real regression.
+        let src = "\
+**Skills** = semantically-discovered (Claude decides based on intent here)
+**Ways** = triggered (patterns, commands, file edits, or state conditions)";
+        assert_eq!(round_trip(src), src);
+    }
+
+    #[test]
+    fn never_deindents_a_nested_list() {
+        // ea/email/drafting/drafting.md. The token oracle passes this
+        // corruption, which is why indentation is a structural guarantee.
+        let src = "\
+1. Ask the operator for the missing pieces before drafting anything at all:
+   - What is the intent? (accepting, declining, requesting, informing)
+   - Any specific points to include, and anything to leave unsaid?
+   - Tone preference, if it differs from their usual register for this?";
+        assert_eq!(round_trip(src), src);
+    }
+
+    #[test]
+    fn preserves_tables_fences_and_headings() {
+        let src = "\
+## Heading
+
+| Content | Diagram |
+|---------|---------|
+| Temporal sequences that run long enough to wrap in a narrow band | sequence |
+
+```text
+this fenced line is long enough to look wrapped but must not be touched here
+also this one, which continues the thought and would otherwise be joined up
+and a third, so the fence interior would qualify as a run if it were prose
+```
+
+Trailing paragraph.";
+        assert_eq!(round_trip(src), src);
+    }
+
+    #[test]
+    fn keeps_a_blockquote_status_block_on_separate_lines() {
+        let src = "\
+> **Status:** the projection is live and the binaries are linked onto PATH now
+> **Next:** reconcile is idempotent, so re-running it changes nothing at all
+> **Owner:** whoever holds the migration window for this particular release";
+        assert_eq!(round_trip(src), src);
+    }
+
+    #[test]
+    fn joins_a_wrapped_blockquote_and_reports_dropped_markers() {
+        let src = "\
+> Messaging guidance lives in three synchronized sources. When you edit
+> the peer-messaging section, the autonomy paragraph, or the silence-is-valid
+> callout in this file, update the other two in the very same commit.";
+        let out = round_trip(src);
+        assert_eq!(out.lines().count(), 1);
+        match token_verdict(src, &out) {
+            TokenVerdict::QuoteMarkersDropped { dropped } => assert_eq!(dropped, 2),
+            other => panic!("expected dropped quote markers, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn preserves_an_explicit_hard_break() {
+        // The two trailing spaces are the whole point, so build the input
+        // explicitly rather than trusting them to survive a source literal.
+        let src = [
+            "This line ends with a deliberate hard break, long enough to wrap,  ",
+            "and this line continues below it, also long enough to sit in band,",
+            "and a third line to give the window the length detection requires.",
+        ]
+        .join("\n");
+        let out = round_trip(&src);
+        assert!(
+            out.lines().next().unwrap().ends_with("  "),
+            "hard break was eaten: {out:?}"
+        );
+    }
+
+    #[test]
+    fn does_not_weld_a_paragraph_onto_a_setext_underline() {
+        let src = "\
+Some paragraph text that is long enough to look like it might be wrapped here
+and a continuation line that sits comfortably inside the detection band too
+and a third line so that the window has enough members to actually trigger.
+---";
+        let out = round_trip(src);
+        assert_eq!(out.lines().last().unwrap().trim(), "---", "hr consumed: {out:?}");
+    }
+
+    #[test]
+    fn ignores_short_and_wide_prose() {
+        let short = "one\ntwo\nthree\nfour";
+        assert!(detect(&split(short)).is_empty());
+        let wide = format!("{}\n{}\n{}", "x".repeat(200), "y".repeat(201), "z".repeat(199));
+        assert!(detect(&split(&wide)).is_empty());
+    }
+
+    #[test]
+    fn frontmatter_is_opaque() {
+        let src = "\
+---
+description: a description long enough to look wrapped when read as prose here
+vocabulary: markdown wrap unwrap reflow line length column paragraph prose fill
+files: \\.md$
+---
+
+Body.";
+        assert_eq!(round_trip(src), src);
+    }
+
+    #[test]
+    fn reflow_is_idempotent() {
+        let once = round_trip(WRAPPED);
+        assert_eq!(round_trip(&once), once);
+    }
+
+    #[test]
+    fn gaining_a_quote_marker_is_a_mismatch() {
+        // Guards the checked_sub: an invented marker must not underflow.
+        assert!(matches!(
+            token_verdict("> alpha beta", "> > alpha beta"),
+            TokenVerdict::Mismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn mismatch_is_reported_when_words_are_lost() {
+        assert!(matches!(
+            token_verdict("alpha beta gamma", "alpha gamma"),
+            TokenVerdict::Mismatch { .. }
+        ));
+    }
+}

--- a/tools/ways-core/src/reflow.rs
+++ b/tools/ways-core/src/reflow.rs
@@ -10,6 +10,22 @@
 //! the way's `postcheck.sh` predicate (via the thin binary, on freshly
 //! written text), and explicit remediation.
 //!
+//! # Three layers, because one is not enough
+//!
+//! - **Eligibility** comes from a real CommonMark parser ([`pulldown_cmark`]),
+//!   not from hand-rolled line matching. The hand-rolled version accumulated ten
+//!   distinct construct bugs — empty blockquote lines, raw HTML bodies, HTML
+//!   comments, tab indentation, reference definitions — each found one review at
+//!   a time. That is the signature of reimplementing a specification: the defects
+//!   are the parts of the spec you did not know to handle.
+//! - **Whether to touch** is [`detect`]'s heuristic, and it stays hand-written
+//!   because no parser can answer it. Joining two authored sentences produces an
+//!   identical document; only a heuristic can decline to do it.
+//! - **Whether the result is sound** is [`structure_preserved`], which reparses
+//!   and compares. This is the layer that does not depend on enumerating
+//!   constructs correctly — and it caught a live corruption (a multi-line HTML
+//!   comment in `attend.md`) that the token check passed.
+//!
 //! # Detection is a heuristic; the transform is not
 //!
 //! [`detect`] is deliberately conservative. It cannot *decide* whether a break
@@ -94,20 +110,6 @@ fn indent_of(line: &str) -> &str {
     &line[..line.len() - line.trim_start().len()]
 }
 
-/// Leading indent in *columns*, counting a tab as four. CommonMark treats a tab
-/// as advancing to the next four-column stop, so counting only spaces would let
-/// a tab-indented code block through as prose.
-fn leading_columns(line: &str) -> usize {
-    let mut cols = 0;
-    for c in line.chars() {
-        match c {
-            ' ' => cols += 1,
-            '\t' => cols += 4 - (cols % 4),
-            _ => break,
-        }
-    }
-    cols
-}
 
 /// A list item: `- `, `* `, `+ `, `1. `, `2) `.
 fn is_list_item(line: &str) -> bool {
@@ -146,96 +148,13 @@ fn quote_body(line: &str) -> &str {
     }
 }
 
-fn is_heading(line: &str) -> bool {
-    if leading_columns(line) > 3 {
-        return false;
-    }
-    let t = line.trim_start();
-    let hashes = t.chars().take_while(|c| *c == '#').count();
-    (1..=6).contains(&hashes) && t[hashes..].starts_with(' ')
-}
 
-/// A thematic break or a setext underline: `---`, `***`, `___`, `===`.
-fn is_rule_or_setext(line: &str) -> bool {
-    if leading_columns(line) > 3 {
-        return false;
-    }
-    let t = line.trim();
-    if t.is_empty() {
-        return false;
-    }
-    let first = t.chars().next().unwrap();
-    if !matches!(first, '-' | '*' | '_' | '=') {
-        return false;
-    }
-    let count = t.chars().filter(|c| *c == first).count();
-    let only = t.chars().all(|c| c == first || c == ' ');
-    // `***`/`___` need three; a lone `-` or `=` is already a setext underline.
-    (only && count >= 3) || (only && matches!(first, '-' | '=') && count >= 1)
-}
 
-fn is_table_row(line: &str) -> bool {
-    line.trim_start().starts_with('|')
-}
 
-fn is_html(line: &str) -> bool {
-    line.trim_start().starts_with('<')
-}
 
-/// A link reference or footnote definition — `[label]: target`, `[^note]: text`.
-/// These are line-scoped syntax; joined into a paragraph they become literal
-/// text, and the token stream is identical either way.
-fn is_reference_def(line: &str) -> bool {
-    let t = line.trim_start();
-    if !t.starts_with('[') {
-        return false;
-    }
-    match t.find("]:") {
-        Some(close) => !t[1..close].contains('['),
-        None => false,
-    }
-}
 
-/// HTML elements CommonMark treats as raw text — their bodies are literal, so
-/// every line until the closing tag is opaque, not just the opening one.
-const RAW_TEXT_TAGS: &[&str] = &["pre", "script", "style", "textarea"];
 
-/// The raw-text tag this line opens, if any and if it does not also close it.
-fn opens_raw_html(line: &str) -> Option<&'static str> {
-    let lower = line.trim_start().to_ascii_lowercase();
-    RAW_TEXT_TAGS.iter().copied().find(|tag| {
-        let open = format!("<{tag}");
-        lower.starts_with(&open) && !lower.contains(&format!("</{tag}>"))
-    })
-}
 
-/// Four-space indented block — a code block, not wrapped prose. List
-/// continuations are indented too, so this only claims lines indented four or
-/// more spaces that are *not* list items.
-fn is_indented_block(line: &str) -> bool {
-    leading_columns(line) >= 4 && !line.trim().is_empty() && !is_list_item(line)
-}
-
-/// A bare label line like `Status:` or `Next steps:` — structure, not prose.
-///
-/// Bounded by word count: without the cap, any prose sentence ending in a colon
-/// and containing no interior punctuation qualifies, which splits its paragraph
-/// and leaves the repair half-flat — the exact failure the enclosing-paragraph
-/// scope exists to avoid.
-const MAX_LABEL_WORDS: usize = 5;
-
-fn is_label_line(line: &str) -> bool {
-    let t = line.trim();
-    match t.strip_suffix(':') {
-        Some(head) if !head.is_empty() => {
-            head.split_whitespace().count() <= MAX_LABEL_WORDS
-                && head
-                    .chars()
-                    .all(|c| c.is_alphanumeric() || matches!(c, ' ' | '-' | '_' | '/'))
-        }
-        _ => false,
-    }
-}
 
 /// True if the line ends in an explicit hard break — two trailing spaces or a
 /// trailing backslash. Joining across one would silently delete a `<br>`, and a
@@ -245,88 +164,112 @@ pub fn has_hard_break(line: &str) -> bool {
     no_nl.ends_with("  ") || no_nl.ends_with('\\')
 }
 
-/// Classify every line. Fenced code and leading YAML frontmatter are opaque.
-pub fn classify(lines: &[&str]) -> Vec<LineKind> {
-    let mut out = Vec::with_capacity(lines.len());
-    let mut fence: Option<&str> = None;
-    let mut in_frontmatter = false;
-    let mut raw_html: Option<&str> = None;
+/// Line-initial delimiters of common non-CommonMark block extensions.
+///
+/// A CommonMark parser cannot see these — to it, `:::note` is paragraph text —
+/// so joining across one silently destroys a directive that MkDocs, Docusaurus
+/// or Obsidian would have rendered. This list is the *named* residue left after
+/// adopting a parser, and it is short and enumerable, which is the whole reason
+/// the parser is worth having.
+const EXTENSION_DELIMITERS: &[&str] = &[":::", "!!!", "???", "{%", "%}", "+++", "<%", "%>"];
 
-    for (i, raw) in lines.iter().enumerate() {
-        let trimmed = raw.trim();
+fn is_extension_delimiter(line: &str) -> bool {
+    let t = line.trim_start();
+    EXTENSION_DELIMITERS.iter().any(|d| t.starts_with(d))
+}
 
-        if i == 0 && trimmed == "---" {
-            in_frontmatter = true;
-            out.push(LineKind::Verbatim);
+/// Lines the parser says are inside a construct where breaks are structural or
+/// literal: code blocks, tables, metadata blocks, footnote definitions, raw HTML
+/// (including multi-line comments), headings, and thematic breaks.
+fn parser_opaque_map(src: &str, line_count: usize) -> Vec<bool> {
+    use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+
+    let starts: Vec<usize> = std::iter::once(0)
+        .chain(src.char_indices().filter(|(_, c)| *c == '\n').map(|(i, _)| i + 1))
+        .collect();
+    let line_of = |off: usize| starts.partition_point(|&s| s <= off).saturating_sub(1);
+
+    let mut opaque = vec![false; line_count];
+    let mut depth = 0usize;
+
+    let mut opts = Options::empty();
+    opts.insert(Options::ENABLE_TABLES);
+    opts.insert(Options::ENABLE_FOOTNOTES);
+    opts.insert(Options::ENABLE_STRIKETHROUGH);
+    opts.insert(Options::ENABLE_YAML_STYLE_METADATA_BLOCKS);
+
+    let mark = |range: std::ops::Range<usize>, opaque: &mut Vec<bool>| {
+        let lo = line_of(range.start);
+        let hi = line_of(range.end.saturating_sub(1)).min(line_count.saturating_sub(1));
+        for flag in &mut opaque[lo..=hi] {
+            *flag = true;
+        }
+    };
+
+    for (ev, range) in Parser::new_ext(src, opts).into_offset_iter() {
+        // Html and Rule are standalone events with no matching End — mark their
+        // own range and leave `depth` alone, or everything after the first HTML
+        // comment stays opaque for the rest of the document.
+        if matches!(ev, Event::Html(_) | Event::Rule) {
+            mark(range, &mut opaque);
             continue;
         }
-        if in_frontmatter {
-            out.push(LineKind::Verbatim);
-            if trimmed == "---" {
-                in_frontmatter = false;
-            }
-            continue;
+        let opens = matches!(
+            ev,
+            Event::Start(Tag::CodeBlock(_))
+                | Event::Start(Tag::Table(_))
+                | Event::Start(Tag::MetadataBlock(_))
+                | Event::Start(Tag::FootnoteDefinition(_))
+                | Event::Start(Tag::Heading { .. })
+        );
+        let closes = matches!(
+            ev,
+            Event::End(TagEnd::CodeBlock)
+                | Event::End(TagEnd::Table)
+                | Event::End(TagEnd::MetadataBlock(_))
+                | Event::End(TagEnd::FootnoteDefinition)
+                | Event::End(TagEnd::Heading(_))
+        );
+        if opens {
+            depth += 1;
         }
-
-        let opener = if trimmed.starts_with("```") {
-            Some("```")
-        } else if trimmed.starts_with("~~~") {
-            Some("~~~")
-        } else {
-            None
-        };
-        match (fence, opener) {
-            (None, Some(tok)) => {
-                fence = Some(tok);
-                out.push(LineKind::Verbatim);
-                continue;
-            }
-            (Some(tok), Some(seen)) if seen == tok => {
-                fence = None;
-                out.push(LineKind::Verbatim);
-                continue;
-            }
-            (Some(_), _) => {
-                out.push(LineKind::Verbatim);
-                continue;
-            }
-            (None, None) => {}
+        if depth > 0 {
+            mark(range, &mut opaque);
         }
-
-        // Raw-text HTML: the body is literal, so every line through the closing
-        // tag is opaque — not just the opening one.
-        if let Some(tag) = raw_html {
-            out.push(LineKind::Verbatim);
-            if trimmed.to_ascii_lowercase().contains(&format!("</{tag}>")) {
-                raw_html = None;
-            }
-            continue;
-        }
-        if let Some(tag) = opens_raw_html(raw) {
-            raw_html = Some(tag);
-            out.push(LineKind::Verbatim);
-            continue;
-        }
-
-        if trimmed.is_empty() || is_empty_blockquote(raw) {
-            // A bare `>` is a paragraph boundary inside the quote. Treating it as
-            // Blank both stops the weld and lets the paragraph after it be
-            // detected on its own.
-            out.push(LineKind::Blank);
-        } else if is_heading(raw)
-            || is_rule_or_setext(raw)
-            || is_table_row(raw)
-            || is_html(raw)
-            || is_reference_def(raw)
-            || is_indented_block(raw)
-            || is_label_line(raw)
-        {
-            out.push(LineKind::Verbatim);
-        } else {
-            out.push(LineKind::Prose);
+        if closes {
+            depth = depth.saturating_sub(1);
         }
     }
-    out
+    opaque
+}
+
+/// Classify every line, using the parser for eligibility.
+///
+/// Replaces a hand-rolled matcher that had to know about fences, frontmatter,
+/// headings, rules, tables, HTML blocks, HTML comments, indented code, tabs, and
+/// reference definitions — and got several of them wrong. The parser knows all of
+/// them; this function only adds what the parser does not model: blank lines,
+/// empty blockquote lines, and non-CommonMark extension delimiters.
+pub fn classify(lines: &[&str]) -> Vec<LineKind> {
+    let src = lines.join("\n");
+    let opaque = parser_opaque_map(&src, lines.len());
+
+    lines
+        .iter()
+        .enumerate()
+        .map(|(i, raw)| {
+            if opaque.get(i).copied().unwrap_or(false) || is_extension_delimiter(raw) {
+                LineKind::Verbatim
+            } else if raw.trim().is_empty() || is_empty_blockquote(raw) {
+                // A bare `>` is a paragraph boundary inside the quote: joining
+                // across one welds two quoted paragraphs, and the token check
+                // cannot see it because the only difference is a `>`.
+                LineKind::Blank
+            } else {
+                LineKind::Prose
+            }
+        })
+        .collect()
 }
 
 /// Maximal spans of consecutive [`LineKind::Prose`] lines — the paragraphs.
@@ -606,6 +549,86 @@ pub fn token_verdict_accounted(before: &str, after: &str, expected: usize) -> To
     }
 }
 
+/// Structural fingerprint of a document: the parser's event stream, with inline
+/// prose whitespace collapsed and code-block content kept byte-exact.
+///
+/// Joining wrapped lines inside a paragraph is the *only* change a reflow should
+/// make, and it is invisible at this level — a soft break and a space are the
+/// same thing inside a paragraph. So any difference in this fingerprint means the
+/// transform altered the document's structure.
+fn structure_fingerprint(src: &str) -> Vec<String> {
+    use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+
+    let mut opts = Options::empty();
+    opts.insert(Options::ENABLE_TABLES);
+    opts.insert(Options::ENABLE_FOOTNOTES);
+    opts.insert(Options::ENABLE_STRIKETHROUGH);
+    opts.insert(Options::ENABLE_YAML_STYLE_METADATA_BLOCKS);
+
+    let mut out: Vec<String> = Vec::new();
+    let mut text = String::new();
+    let mut in_code = false;
+
+    for ev in Parser::new_ext(src, opts) {
+        if matches!(ev, Event::Start(Tag::CodeBlock(_))) {
+            in_code = true;
+        }
+        if matches!(ev, Event::End(TagEnd::CodeBlock)) {
+            in_code = false;
+        }
+        // Inside a code block whitespace *is* content, so a joined fence body
+        // must not be normalized away.
+        if in_code {
+            if let Event::Text(t) = &ev {
+                out.push(format!("CODE:{t:?}"));
+                continue;
+            }
+        }
+        match ev {
+            Event::Text(t) | Event::Code(t) => {
+                text.push(' ');
+                text.push_str(&t);
+            }
+            Event::SoftBreak => text.push(' '),
+            other => {
+                if !text.trim().is_empty() {
+                    out.push(format!(
+                        "TEXT:{}",
+                        text.split_whitespace().collect::<Vec<_>>().join(" ")
+                    ));
+                    text.clear();
+                }
+                out.push(format!("{other:?}"));
+            }
+        }
+    }
+    if !text.trim().is_empty() {
+        out.push(format!(
+            "TEXT:{}",
+            text.split_whitespace().collect::<Vec<_>>().join(" ")
+        ));
+    }
+    out
+}
+
+/// Whether a reflow left the document structurally identical.
+///
+/// This is the post-condition worth trusting, because unlike the classifier it
+/// does not depend on having enumerated markdown's constructs correctly — it asks
+/// the parser what changed. It caught a live corruption the token check passed: a
+/// multi-line HTML comment in the shipped corpus whose body was being joined.
+///
+/// Two things it cannot see, both principled:
+///
+/// - **Welding authored line breaks.** Two sentences on separate lines and the
+///   same two joined are the *same* CommonMark document. No verifier can catch
+///   that; declining to do it is [`detect`]'s job.
+/// - **Non-CommonMark extensions.** A `:::note` directive is paragraph text to
+///   any CommonMark parser. That residue is covered by `EXTENSION_DELIMITERS`.
+pub fn structure_preserved(before: &str, after: &str) -> bool {
+    structure_fingerprint(before) == structure_fingerprint(after)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -838,29 +861,71 @@ Body.";
     }
 
     #[test]
-    fn a_prose_sentence_ending_in_a_colon_is_not_a_label() {
-        // Review finding 4. The unbounded predicate split the paragraph and left
-        // the repair half-flat — the failure enclosing-paragraph scope avoids.
-        let long = "so we ended up considering the following three alternatives:";
-        assert!(!is_label_line(long));
-        assert!(is_label_line("Status:"));
-        assert!(is_label_line("Next steps:"));
+    fn a_prose_sentence_ending_in_a_colon_does_not_split_its_paragraph() {
+        // Review finding 4. The hand-rolled label predicate marked any
+        // colon-terminated line as structure, splitting the paragraph and leaving
+        // the repair half-flat. The parser has no such notion — it is all one
+        // paragraph — so the predicate is gone and this asserts the behavior.
+        let src = "\
+Messaging guidance lives in three synchronized sources, so when you edit one
+of them you should update the other two so agents receive consistent output:
+and this trailing clause continues the very same paragraph without a break
+and one more line so the window still clears the minimum run length here.";
+        let out = round_trip(src);
+        assert_eq!(out.lines().count(), 1, "paragraph repaired half-flat: {out:?}");
     }
 
     #[test]
-    fn link_reference_definitions_survive() {
-        // Review finding 5. `[label]: target` is line-scoped syntax; joined into
-        // a paragraph it becomes literal text, token stream unchanged.
+    fn extension_delimiters_are_not_joined() {
+        // `:::` is a MkDocs/Docusaurus directive — invisible to CommonMark, so no
+        // parser will protect it. This is the named residue the guard list covers.
+        let src = "\
+:::note
+some directive body text that is long enough to sit inside the detect band
+and continuing here mid-phrase so that the mid-break count reaches a floor
+and a third body line so the window reaches the minimum run length needed
+:::";
+        let out = round_trip(src);
+        assert!(out.lines().next().unwrap() == ":::note", "directive welded: {out:?}");
+        assert!(out.lines().last().unwrap() == ":::", "closing delimiter welded: {out:?}");
+    }
+
+    #[test]
+    fn a_multi_line_html_comment_body_is_never_joined() {
+        // Found by the structural post-condition on the real corpus
+        // (attend.md), after the token check passed it. The hand-rolled
+        // classifier handled <pre>/<script>/<style>/<textarea> but not comments.
+        let src = "\
+<!--
+  Messaging guidance lives in three synchronized sources. When you edit
+  the peer-messaging section, the autonomy paragraph, the silence-is-valid
+  callout, or the CLI-is-the-contract note in this file, update the
+  other two so agents receive consistent guidance at every point.
+-->";
+        assert!(detect(&split(src)).is_empty(), "html comment treated as prose");
+        assert_eq!(round_trip(src), src);
+    }
+
+    #[test]
+    fn a_real_link_reference_definition_survives() {
+        // Review finding 5, corrected by the parser. CommonMark says a link
+        // reference definition *cannot interrupt a paragraph*, so a `[x]: url`
+        // line directly under prose is already paragraph text and joining it
+        // changes nothing. A definition after a blank line is a real definition,
+        // is its own block, and is never inside a detected paragraph. The
+        // hand-rolled predicate was protecting against the wrong case.
         let src = "\
 Some wrapped prose here that is long enough to fall inside the detect band
 and continuing mid-phrase so that the mid-break count reaches its floor now
 and a third line so the window reaches the minimum run length it requires.
+
 [adr-142]: https://github.com/aaronsb/agent-ways/blob/main/docs/adr142.md";
         let out = round_trip(src);
         assert_eq!(
             out.lines().last().unwrap(),
             "[adr-142]: https://github.com/aaronsb/agent-ways/blob/main/docs/adr142.md"
         );
+        assert!(structure_preserved(src, &out), "structure changed");
     }
 
     #[test]
@@ -896,5 +961,39 @@ and a third line so the window reaches the minimum run length it requires.
             token_verdict("alpha beta gamma", "alpha gamma"),
             TokenVerdict::Mismatch { .. }
         ));
+    }
+}
+
+#[cfg(test)]
+mod postcondition_tests {
+    use super::*;
+
+    #[test]
+    fn post_condition_rejects_a_structural_change() {
+        // A join that welds a paragraph onto a thematic break changes structure.
+        let before = "Some paragraph text here\n---";
+        let welded = "Some paragraph text here ---";
+        assert!(!structure_preserved(before, welded));
+    }
+
+    #[test]
+    fn post_condition_accepts_a_pure_line_join() {
+        let before = "In 1.0 the projection is thin, not the app\nitself, and source lives elsewhere.";
+        let joined = "In 1.0 the projection is thin, not the app itself, and source lives elsewhere.";
+        assert!(structure_preserved(before, joined));
+    }
+
+    #[test]
+    fn post_condition_sees_a_joined_code_fence_body() {
+        let before = "```\nline one here\nline two here\n```";
+        let welded = "```\nline one here line two here\n```";
+        assert!(!structure_preserved(before, welded));
+    }
+
+    #[test]
+    fn post_condition_sees_a_deindented_nested_list() {
+        let before = "1. Ask first:\n   - What is the intent?\n   - Any points to include?";
+        let flat = "1. Ask first:\n- What is the intent?\n- Any points to include?";
+        assert!(!structure_preserved(before, flat));
     }
 }

--- a/tools/ways-core/src/reflow.rs
+++ b/tools/ways-core/src/reflow.rs
@@ -549,6 +549,60 @@ pub fn token_verdict_accounted(before: &str, after: &str, expected: usize) -> To
     }
 }
 
+/// Outcome of a bounded repair: the result, and whether it settled.
+#[derive(Debug, Clone)]
+pub struct RepairOutcome {
+    /// The repaired lines.
+    pub lines: Vec<String>,
+    /// Blockquote continuation markers dropped, summed across passes.
+    pub quote_joins: usize,
+    /// Passes actually run.
+    pub passes: usize,
+    /// Whether the detector reports the result clean.
+    ///
+    /// `false` means the transform could not reconcile its own output — the
+    /// output would immediately re-trigger the detector, producing a file that
+    /// nags forever. Callers should treat that as a finding and decline to write,
+    /// not as something to paper over.
+    pub converged: bool,
+}
+
+/// Default pass ceiling for [`repair`]. One pass suffices on every file measured;
+/// the budget exists so a transform bug bails instead of spinning.
+pub const MAX_REPAIR_PASSES: usize = 3;
+
+/// Repair until the detector reports clean, or the pass budget runs out.
+///
+/// A single pass flattens each detected paragraph to one line, which is then too
+/// long to sit in the detection band — so convergence normally happens on the
+/// first pass and the second is just the confirming check. Running the detector
+/// against our own output is what turns "we think we fixed it" into evidence, and
+/// it is the same discipline the caller applies to structure: verify, then write.
+pub fn repair(lines: &[&str], max_passes: usize) -> RepairOutcome {
+    let mut current: Vec<String> = lines.iter().map(|s| s.to_string()).collect();
+    let mut quote_joins = 0usize;
+    let mut passes = 0usize;
+
+    for _ in 0..max_passes.max(1) {
+        let refs: Vec<&str> = current.iter().map(|s| s.as_str()).collect();
+        if detect(&refs).is_empty() {
+            return RepairOutcome { lines: current, quote_joins, passes, converged: true };
+        }
+        let (next, joins) = reflow_with_stats(&refs);
+        passes += 1;
+        quote_joins += joins;
+        if next == current {
+            // A fixed point the detector still flags: another pass cannot help.
+            break;
+        }
+        current = next;
+    }
+
+    let refs: Vec<&str> = current.iter().map(|s| s.as_str()).collect();
+    let converged = detect(&refs).is_empty();
+    RepairOutcome { lines: current, quote_joins, passes, converged }
+}
+
 /// Structural fingerprint of a document: the parser's event stream, with inline
 /// prose whitespace collapsed and code-block content kept byte-exact.
 ///
@@ -985,6 +1039,32 @@ and a third line so the window reaches the minimum run length it requires.
 #[cfg(test)]
 mod postcondition_tests {
     use super::*;
+
+    fn split(s: &str) -> Vec<&str> {
+        s.split('\n').collect()
+    }
+
+    const WRAPPED: &str = "\
+In 1.0, `~/.claude` is a thin projection of an XDG application, not the app
+itself (ADR-142). The source lives in `$XDG_DATA_HOME/agent-ways`; the home dir
+gets symlinks to the projected roots plus a three-way merge into settings, and
+everything else the app ships stays where it is.";
+
+    #[test]
+    fn repair_converges_in_one_pass_and_reports_it() {
+        let out = repair(&split(WRAPPED), MAX_REPAIR_PASSES);
+        assert!(out.converged);
+        assert_eq!(out.passes, 1, "expected a single pass, got {}", out.passes);
+        assert_eq!(out.lines.len(), 1);
+    }
+
+    #[test]
+    fn repair_of_clean_input_runs_no_passes() {
+        let src = "A single flat paragraph with nothing at all to repair here.";
+        let out = repair(&split(src), MAX_REPAIR_PASSES);
+        assert!(out.converged);
+        assert_eq!(out.passes, 0);
+    }
 
     #[test]
     fn structure_diff_names_the_diverging_event() {

--- a/tools/ways-core/src/reflow.rs
+++ b/tools/ways-core/src/reflow.rs
@@ -626,7 +626,25 @@ fn structure_fingerprint(src: &str) -> Vec<String> {
 /// - **Non-CommonMark extensions.** A `:::note` directive is paragraph text to
 ///   any CommonMark parser. That residue is covered by `EXTENSION_DELIMITERS`.
 pub fn structure_preserved(before: &str, after: &str) -> bool {
-    structure_fingerprint(before) == structure_fingerprint(after)
+    structure_diff(before, after).is_none()
+}
+
+/// Where a reflow changed the document's structure, if it did.
+///
+/// Returns the first diverging event as `(index, before, after)`. A tripped
+/// post-condition is the most informative output this module produces — it names
+/// a construct the classifier misreads — so callers should *report* it rather
+/// than discarding it. Refusing to write and saying nothing loses the finding.
+pub fn structure_diff(before: &str, after: &str) -> Option<(usize, String, String)> {
+    let (a, b) = (structure_fingerprint(before), structure_fingerprint(after));
+    if a == b {
+        return None;
+    }
+    let idx = a.iter().zip(b.iter()).position(|(x, y)| x != y).unwrap_or(a.len().min(b.len()));
+    let pick = |v: &Vec<String>, i: usize| {
+        v.get(i).cloned().unwrap_or_else(|| "<end of document>".to_string())
+    };
+    Some((idx, pick(&a, idx), pick(&b, idx)))
 }
 
 #[cfg(test)]
@@ -967,6 +985,19 @@ and a third line so the window reaches the minimum run length it requires.
 #[cfg(test)]
 mod postcondition_tests {
     use super::*;
+
+    #[test]
+    fn structure_diff_names_the_diverging_event() {
+        // A tripped post-condition must be reportable, not just true/false —
+        // the divergence is the finding, and discarding it loses the bug.
+        let before = "Some paragraph text here\n---";
+        let welded = "Some paragraph text here ---";
+        let d = structure_diff(before, welded);
+        assert!(d.is_some(), "structural change not detected");
+        let (_idx, b, a) = d.unwrap();
+        assert_ne!(b, a);
+        assert!(structure_diff(before, before).is_none());
+    }
 
     #[test]
     fn post_condition_rejects_a_structural_change() {


### PR DESCRIPTION
PR1 of #415. Prevention and detection; the lint rule and the corpus sweep are deliberately held for PR2.

## Summary

- **`ways_core::reflow`** — the shared detector and repair transform, plus `ways reflow` as a thin caller. It lives in the library because three callers need the same fingerprint (this command, the way's `postcheck.sh`, and a coming `ways lint` rule); a second implementation would drift, and the failure mode is the way firing on a file the tool then calls clean.
- **`core.md` gains `## Line handling`** next to `## Language`, which is already a mechanical file-output rule of the same class. Core is the only surface present *before* the first write — a postcheck is reactive by construction.
- **`documentation/markdown`** carries the full convention; **`documentation/markdown/reflow`** is the trigger-inert reactive child whose postcheck fires on freshly written wrapped markdown and whose macro names the file.
- **ADR-123 amendment** permitting a postcheck to write session-scoped state for its own macro.

## The design was set by measurement, not reasoning

The precision claim needed evidence, so it was prototyped against the real 138-file corpus first. That changed the design twice:

| Repair scope | Result |
|---|---|
| Whole paragraph | **Modified 16 of the 114 files with no detected wrap** — welded deliberately parallel sentences, and **de-indented nested list items** |
| Detected window only | Left paragraphs half-flat — one joined line, rest still wrapped |
| **Enclosing paragraph of a window** | **24/24 detected files changed, 0/114 others touched** |

**The token-stream oracle is insufficient, demonstrated rather than theorized.** It passed the nested-list de-indent corruption, because leading whitespace is not a token. So indentation and line-initial structure are structural guarantees in the transform, not properties the check verifies — and both regressions are carried as fixtures.

Detection is `>=3` prose lines clustered in `[55,100]` within a 12-char band with `>=2` mid-phrase breaks. The mid-phrase test is what separates column wrapping from deliberate one-clause-per-line prose, which the convention explicitly permits.

## Review focus

- `reflow()`'s block-splitting — the guarantee that authored structure survives.
- `postcheck.sh` on the hot path: `check-post.sh` runs every postcheck on every `Edit`/`Write`/`Bash`/`Task`, so it gates on tool and extension before spawning, and checks for exit code *exactly 1* so a binary error reads as "no finding" rather than firing on every markdown write.
- Exit-code inversion: `ways reflow` uses lint convention (0 clean), `postcheck.sh` wants 0 = fire. One flag can't serve both, so the wrapper inverts.
- The ADR amendment's four constraints, particularly that state is never an input to the predicate — that is what preserves determinism.

## Test plan

- `cargo test` — full workspace green; 16 new fixtures cover tables, fences, blockquote status blocks, setext underlines, indented code, trailing-two-space hard breaks, nested list continuations, and parallel one-sentence-per-line prose (must *not* fire).
- Corpus sweep on a copy: 24 modified, 114 untouched, zero clean files changed, no token mismatches.
- Postcheck end-to-end against synthetic PostToolUse payloads: fires on wrapped markdown and names the file, then stays quiet on the same file again, on flat prose, on a `.rs` path, on a `Bash` tool call, and on an install whose `ways` predates the subcommand.
- `ways lint` 0 errors 0 warnings; `check-portability.sh` passes; `clippy` clean.
- The three new/edited markdown files pass `ways reflow` themselves.

## Not in this PR

The `ways lint` rule and the sweep of the 24 wrapped files land in PR2, so the rule's first observed state is green — shipping it here would print 24 files of warnings on every contributor and CI run, and a surface that nags trains its reader to ignore it.

Refs #415