### PR TITLE
Add supplychain/maturity: adoption versus presentation, and thin wrappers

### DIFF
--- a/hooks/ways/softwaredev/code/supplychain/maturity/maturity.md
+++ b/hooks/ways/softwaredev/code/supplychain/maturity/maturity.md
@@ -1,0 +1,49 @@
+---
+description: judging whether a candidate package is what it presents itself as — adoption versus presentation, and thin wrappers around a mature library
+vocabulary: package maturity adoption downloads stars wrapper thin wrapper reimplementation candidate library evaluate choose between alternatives which package should we use first order transitive dependency underneath
+scope: agent, subagent
+refire: 0.15
+---
+<!-- epistemic: heuristic -->
+# Is the Package What It Presents Itself As?
+
+The other supply-chain tiers ask whether a package is *safe*. This one asks whether it is *what it appears to be* — which decides whether you should adopt it at all, before safety is even the question.
+
+Two failure modes, and they usually travel together:
+
+- **Presentation outruns adoption.** A polished README, a benchmark table, and a confident feature list are cheap to produce now. They no longer signal that anyone depends on this or that it has met real-world inputs.
+- **The package is a thin wrapper positioned as a first-order tool.** The substantive work happens in a dependency. You can usually take that dependency directly, and get far more adoption and a smaller surface for the same capability.
+
+## The check
+
+Three questions, a minute of work, before adopting anything you found through a search:
+
+| Question | How to check |
+|---|---|
+| How many people actually use this? | Registry API — total downloads, recent downloads, first-published date. Not stars, which reflect attention rather than reliance. |
+| What is underneath it? | Read its manifest. A short dependency list with one substantial entry is the wrapper tell. |
+| How does the wrapped thing compare? | Look up adoption for that dependency too, and put the two numbers side by side. |
+
+An order-of-magnitude gap between a package and the thing it depends on is the finding. It does not automatically disqualify the wrapper — convenience layers earn their keep when the ergonomics are the point — but it moves the burden: the wrapper now has to justify itself over the library, rather than being adopted because it surfaced first.
+
+## Why this needs saying now
+
+Search results increasingly include packages that are competent, well-documented, recently created, and barely used. Coding agents make that combination cheap to produce, so the correlation search rank once carried — polish implies adoption implies maturity — has weakened.
+
+Apply the same skepticism to your own output. A capable library written this afternoon and a capable library with a decade of adversarial inputs behind it read almost identically in a README. They are not the same dependency.
+
+## What the numbers do and don't tell you
+
+- **Low adoption is not a verdict.** New, narrow, and excellent all look alike from the download count. It is a prompt to look at what is underneath, not a rejection.
+- **High adoption is not safety.** Widely used packages are worth *more* attacker attention, not less. This is an appropriateness check; the other tiers stay necessary.
+- **Prefer the layer doing the work.** When a wrapper and its dependency both solve the problem, the dependency is usually the smaller, better-tested, longer-lived choice.
+
+## The same question about building it yourself
+
+Hand-rolling is also a supply-chain choice, with the maintenance and the defect surface landing on you. Reach for a maintained library specifically when the problem has a *specification* — parsing a document format, dates and time zones, character encodings, cryptography, protocol handling. There the defects are not in the logic you wrote but in the parts of the specification you did not know to handle, so they surface one at a time, in review after review, long after the thing looks finished.
+
+## See Also
+
+- code/supplychain(softwaredev) — the trust tiers this precedes
+- code/supplychain/depscan(softwaredev) — known vulnerabilities, once a package is chosen
+- environment/deps(softwaredev) — the pre-adoption checklist this extends

--- a/hooks/ways/softwaredev/code/supplychain/supplychain.md
+++ b/hooks/ways/softwaredev/code/supplychain/supplychain.md
@@ -16,6 +16,7 @@ Work from fast and cheap to slow and thorough. Most repos only need the first tw
 
 | Tier | What | Time | When |
 |------|------|------|------|
+| 0. Maturity | Is the package what it presents itself as? | a minute | Before adopting anything found via search |
 | 1. Repo audit | Git history, size, leaked secrets | seconds | Any unfamiliar repo |
 | 2. Source audit | Dangerous code patterns | minutes | Before running anything |
 | 3. Dep scan | Known vulnerabilities in dependencies | minutes | Before installing |
@@ -25,6 +26,7 @@ Work from fast and cheap to slow and thorough. Most repos only need the first tw
 ## Principles
 
 - **Scan before you run.** `pip install` and `npm install` execute arbitrary code. Scan first.
+- **Check what a package is before checking whether it is safe.** A thin wrapper around a mature library is usually the wrong adoption even when it is perfectly safe.
 - **Containers aren't a security boundary.** A malicious setup.py in Docker still has network access.
 - **Match the tool to the project.** Manual `osv-scanner` for a hobby project. GitHub Actions for a team repo. Don't skip levels, don't overbuild.
 - **Responsible disclosure over silence.** If you find leaked secrets in someone else's repo, report it — masked values, remediation hints, not a public callout.
@@ -32,6 +34,7 @@ Work from fast and cheap to slow and thorough. Most repos only need the first tw
 ## See Also
 
 - code/security(softwaredev) — supply chain is a security concern
+- code/supplychain/maturity(softwaredev) — adoption versus presentation, before the safety tiers
 - code/supplychain/depscan(softwaredev) — scanning dependencies
 - code/supplychain/sourceaudit(softwaredev) — auditing source before execution
 - environment/deps(softwaredev) — dependency management workflow

--- a/hooks/ways/softwaredev/environment/deps/deps.md
+++ b/hooks/ways/softwaredev/environment/deps/deps.md
@@ -21,6 +21,7 @@ Pause and check:
 | How big is it? | `npm pack --dry-run <pkg>` for size |
 | What's the license? | `npm info <pkg> license` |
 | Is it trivial? | Don't add packages for `is-odd`, `left-pad`, etc. |
+| Is it a wrapper? | Read its manifest — if one dependency does the real work, compare adoption and consider taking that directly. See code/supplychain/maturity(softwaredev). |
 
 ## When Updating
 


### PR DESCRIPTION
## Summary

A new `code/supplychain/maturity` way, plus a tier-0 row in the parent and a wrapper row in `environment/deps`.

The existing supply-chain tiers all ask whether a package is *safe*. None asks whether it is *what it presents itself as* — which decides whether to adopt it at all, before safety is the question.

Two failure modes, usually together:

- **Presentation outruns adoption.** A polished README and a benchmark table are cheap to produce now, and no longer signal that anyone depends on the thing.
- **A thin wrapper positioned as a first-order tool.** The substantive work happens in a dependency you could take directly, usually with far more adoption and a smaller surface.

The check is three questions and about a minute: registry adoption numbers (downloads and first-published date, not stars), read the manifest for the one substantial dependency, then compare the two side by side.

## Why now

The correlation search rank used to carry — polish implies adoption implies maturity — has weakened, because producing a competent, well-documented, barely-used package is now cheap. The way says explicitly that the same skepticism applies to our own output: a capable library written this afternoon and one with a decade of adversarial inputs behind it read almost identically in a README.

## The case that produced it

Evaluating a markdown formatter that surfaced first in search:

| package | total downloads | last 90d | first published |
|---|---:|---:|---|
| the formatter | 386 | 147 | 2025-11 |
| the parser it depends on | 6,458,277 | 1,683,777 | 2017 |
| the parser rustdoc uses | 126,405,557 | 37,855,348 | 2015 |

Its own manifest pointed at the right answer. Three commands, and the conclusion flipped from "adopt this" to "take what it wraps."

## Also recorded

Hand-rolling is a supply-chain choice too, with maintenance and defect surface landing on us. The way names when to prefer a maintained library: when the problem has a *specification* — document formats, dates, encodings, crypto, protocols — because there the defects are the parts of the spec you did not know to handle, and they surface one review at a time rather than all at once.

## Test plan

- `ways lint` — 0 errors, 0 warnings across the corpus, including the ADR-160 positive-prose check on the new embedded alias.
- Cross-references resolve to existing ways in both directions.
- Semantic matching needs a corpus rebuild to pick the new way up; that happens on SessionStart via `ways corpus --if-stale`.