### PR TITLE
Sweep the 23 hard-wrapped ways, and fix what the post-merge review found

### DIFF
--- a/hooks/ways/data/data.md
+++ b/hooks/ways/data/data.md
@@ -8,11 +8,7 @@ refire: 0.15
 <!-- epistemic: premise -->
 # Data
 
-**Scope the data layer to the actual need before reaching for machinery.** The
-cost of a database is not the store — it's the discipline the store pulls in:
-migrations, schema docs, backups, review. That discipline is worth it when the
-data is shared and long-lived, and pure overhead when it isn't. Match the tool
-to the pressure, not to habit.
+**Scope the data layer to the actual need before reaching for machinery.** The cost of a database is not the store — it's the discipline the store pulls in: migrations, schema docs, backups, review. That discipline is worth it when the data is shared and long-lived, and pure overhead when it isn't. Match the tool to the pressure, not to habit.
 
 | The data is… | Reach for | Skip |
 |---|---|---|
@@ -21,10 +17,7 @@ to the pressure, not to habit.
 | Shared, evolving, multi-writer | a server RDBMS (Postgres/MySQL) with **versioned migrations** | — |
 | Densely interconnected, traversal-first | a graph store (or a graph extension) | forcing it into flat tables |
 
-The deeper children below are for the bottom two rows. If someone says "let's
-just use SQLite for this," they need *this* orientation — not a lecture on
-migration consolidation or ER-diagram generation. Don't pull the heavy guidance
-until the need is real.
+The deeper children below are for the bottom two rows. If someone says "let's just use SQLite for this," they need *this* orientation — not a lecture on migration consolidation or ER-diagram generation. Don't pull the heavy guidance until the need is real.
 
 ## Going deeper
 

--- a/hooks/ways/data/documentation/documentation.md
+++ b/hooks/ways/data/documentation/documentation.md
@@ -27,11 +27,7 @@ from the DDL — the source of truth — so they can't lie.**
 
 ## Diagrams
 
-DBML is a useful portable intermediate: it renders to an interactive ER diagram
-and also pastes straight into dbdiagram.io. For a large schema, **color or group
-tables by logical schema and pack disconnected tables** so the layout stays
-compact instead of a tall strip. Keep a plain-text fallback (e.g. Mermaid) for
-places an interactive viewer won't render, like a repo file browser.
+DBML is a useful portable intermediate: it renders to an interactive ER diagram and also pastes straight into dbdiagram.io. For a large schema, **color or group tables by logical schema and pack disconnected tables** so the layout stays compact instead of a tall strip. Keep a plain-text fallback (e.g. Mermaid) for places an interactive viewer won't render, like a repo file browser.
 
 ## See Also
 

--- a/hooks/ways/data/migrations/checkpoint/checkpoint.md
+++ b/hooks/ways/data/migrations/checkpoint/checkpoint.md
@@ -8,16 +8,11 @@ refire: rare
 <!-- epistemic: heuristic -->
 # Migration Checkpoints
 
-When a history grows to dozens of files, every fresh install replays all of
-them. Periodically **collapse the resting state into one generated baseline** —
-but consolidation is a place to be careful: get it wrong and every future
-install starts from a subtly wrong schema.
+When a history grows to dozens of files, every fresh install replays all of them. Periodically **collapse the resting state into one generated baseline** — but consolidation is a place to be careful: get it wrong and every future install starts from a subtly wrong schema.
 
 ## Generate the baseline — never hand-merge
 
-Replay the old baseline **plus every migration** into a throwaway database, then
-dump the schema and seed data. That dump *is* the new baseline. Hand-merging
-migration files by eye drifts from what the migrations actually produce.
+Replay the old baseline **plus every migration** into a throwaway database, then dump the schema and seed data. That dump *is* the new baseline. Hand-merging migration files by eye drifts from what the migrations actually produce.
 
 ## Prove it faithful before retiring anything
 
@@ -33,16 +28,12 @@ They must match exactly. If they don't, the baseline is wrong — stop.
 
 ## Keep the old path working
 
-- **Retain the old files** (move to `archived/`, don't delete). A database created
-  before the checkpoint still needs them; the runner scans `archived/` first.
-- The baseline **records every consolidated version in the ledger**, so a fresh
-  install marks them applied and skips straight to the next real migration.
+- **Retain the old files** (move to `archived/`, don't delete). A database created before the checkpoint still needs them; the runner scans `archived/` first.
+- The baseline **records every consolidated version in the ledger**, so a fresh install marks them applied and skips straight to the next real migration.
 
 ## Observability
 
-A checkpoint apply has a fingerprint: every consolidated version shares one
-`applied_at` timestamp cluster (one baseline wrote them together), versus spread
-timestamps for an incremental replay. Query it to confirm which path a database took.
+A checkpoint apply has a fingerprint: every consolidated version shares one `applied_at` timestamp cluster (one baseline wrote them together), versus spread timestamps for an incremental replay. Query it to confirm which path a database took.
 
 ## See Also
 

--- a/hooks/ways/data/migrations/idempotent/idempotent.md
+++ b/hooks/ways/data/migrations/idempotent/idempotent.md
@@ -8,10 +8,7 @@ refire: 0.15
 <!-- epistemic: convention -->
 # Idempotent Migrations
 
-A migration can fail partway, get retried, or be re-scanned by a runner that
-isn't sure whether it applied. **Write every migration so running it twice is a
-no-op on the second pass, not an error.** That's what makes an interrupted
-deploy recoverable instead of wedged.
+A migration can fail partway, get retried, or be re-scanned by a runner that isn't sure whether it applied. **Write every migration so running it twice is a no-op on the second pass, not an error.** That's what makes an interrupted deploy recoverable instead of wedged.
 
 ## Guard every object
 
@@ -25,10 +22,7 @@ deploy recoverable instead of wedged.
 
 ## Record the version last
 
-Insert the applied-version row into the ledger as the **final statement, inside
-the same transaction** as the changes. If the body fails, the row is never
-written and the migration is retried cleanly next run. Use `ON CONFLICT DO
-NOTHING` on that insert too, so a re-scan doesn't error.
+Insert the applied-version row into the ledger as the **final statement, inside the same transaction** as the changes. If the body fails, the row is never written and the migration is retried cleanly next run. Use `ON CONFLICT DO NOTHING` on that insert too, so a re-scan doesn't error.
 
 ## Verify
 

--- a/hooks/ways/data/migrations/numbering/numbering.md
+++ b/hooks/ways/data/migrations/numbering/numbering.md
@@ -14,22 +14,14 @@ have already recorded it.
 
 ## The rules
 
-- **Monotonic, append-only.** New migrations take the next number. Never renumber
-  or reuse one — a database that already applied `042` will never see your new `042`.
-- **Zero-pad the filename** (`001_`, `002_`) so lexical order matches numeric
-  order, but **compare as integers in code** (strip leading zeros) — `10#$n` in
-  bash, `int(...)` elsewhere.
-- **Gaps are fine.** If `002` and `010` were never used or later dropped, readers
-  skip them. Don't backfill or renumber to close a gap.
-- **One ledger table** (commonly `schema_migrations`) records applied versions.
-  The runner applies only the files whose number isn't in the ledger yet.
+- **Monotonic, append-only.** New migrations take the next number. Never renumber or reuse one — a database that already applied `042` will never see your new `042`.
+- **Zero-pad the filename** (`001_`, `002_`) so lexical order matches numeric order, but **compare as integers in code** (strip leading zeros) — `10#$n` in bash, `int(...)` elsewhere.
+- **Gaps are fine.** If `002` and `010` were never used or later dropped, readers skip them. Don't backfill or renumber to close a gap.
+- **One ledger table** (commonly `schema_migrations`) records applied versions. The runner applies only the files whose number isn't in the ledger yet.
 
 ## Collisions
 
-Two branches both adding `081` collide. Resolve it **before merge**: renumber the
-not-yet-landed one to the next free number. For large teams where this happens
-constantly, timestamp-prefixed names (`20260702_…`) trade readability for
-collision-freedom — pick sequential for small teams, timestamps for busy ones.
+Two branches both adding `081` collide. Resolve it **before merge**: renumber the not-yet-landed one to the next free number. For large teams where this happens constantly, timestamp-prefixed names (`20260702_…`) trade readability for collision-freedom — pick sequential for small teams, timestamps for busy ones.
 
 ## See Also
 

--- a/hooks/ways/documentation/adr/migration/migration.md
+++ b/hooks/ways/documentation/adr/migration/migration.md
@@ -7,12 +7,7 @@ refire: 0.15
 <!-- epistemic: convention -->
 # ADR Migration
 
-> **Prefer the skill for greenfield scaffolding.** The `project-init` skill is the
-> canonical scaffolder — it installs this tooling *and* the surrounding GitHub
-> config, CODEOWNERS, and project ways in one pass. Reach for it first when setting
-> up a new repo. The manual steps below are the underlying contract: use them when
-> migrating an existing repo, when you only want the ADR/doc tooling, or to
-> understand what the skill automates.
+> **Prefer the skill for greenfield scaffolding.** The `project-init` skill is the canonical scaffolder — it installs this tooling *and* the surrounding GitHub config, CODEOWNERS, and project ways in one pass. Reach for it first when setting up a new repo. The manual steps below are the underlying contract: use them when migrating an existing repo, when you only want the ADR/doc tooling, or to understand what the skill automates.
 
 ## Identify Your Starting State
 

--- a/hooks/ways/documentation/diataxis/diataxis.md
+++ b/hooks/ways/documentation/diataxis/diataxis.md
@@ -34,14 +34,10 @@ Two questions place every page:
 | **Studying** (acquire) | **Tutorial** (`T`)       | **Explanation** (`E`)             |
 | **Working** (apply)    | **How-to** (`H`)         | **Reference** (`R`)               |
 
-- **Tutorial** — a guided lesson that takes a newcomer through doing something
-  successfully. Learning-oriented; you are the teacher, the reader trusts you.
-- **How-to** — a recipe to achieve a specific goal for someone who already knows
-  the basics. Task-oriented; assumes competence, omits the teaching.
-- **Reference** — a description of the machinery: APIs, flags, schemas, options.
-  Information-oriented; accurate, complete, consulted not read.
-- **Explanation** — illuminates a topic: why it works this way, the design
-  rationale, the trade-offs, the bigger picture. Understanding-oriented.
+- **Tutorial** — a guided lesson that takes a newcomer through doing something successfully. Learning-oriented; you are the teacher, the reader trusts you.
+- **How-to** — a recipe to achieve a specific goal for someone who already knows the basics. Task-oriented; assumes competence, omits the teaching.
+- **Reference** — a description of the machinery: APIs, flags, schemas, options. Information-oriented; accurate, complete, consulted not read.
+- **Explanation** — illuminates a topic: why it works this way, the design rationale, the trade-offs, the bigger picture. Understanding-oriented.
 
 ## Rules
 

--- a/hooks/ways/documentation/documentation.md
+++ b/hooks/ways/documentation/documentation.md
@@ -11,17 +11,9 @@ refire: 0.15
 <!-- epistemic: premise -->
 # Documentation
 
-Documentation is **one typed graph**, not a pile of files. Each page and each
-decision record is a *node*; `related`/`supersedes` references are *edges*. The
-node's **type lives in frontmatter and is enforced by a linter** — not in its
-filename. The **filesystem is a serialization** of that graph for human readers:
-folders, names, and the rendered site are *views*, refactor-freely, never the
-source of truth.
+Documentation is **one typed graph**, not a pile of files. Each page and each decision record is a *node*; `related`/`supersedes` references are *edges*. The node's **type lives in frontmatter and is enforced by a linter** — not in its filename. The **filesystem is a serialization** of that graph for human readers: folders, names, and the rendered site are *views*, refactor-freely, never the source of truth.
 
-This is what lets the rigor scale: a typed graph that would take a human minutes
-to reason through, an agent and a linter sustain in one pass. Push the structure
-into frontmatter and lint where it is cheap to maintain; keep the filesystem
-friendly for the humans who still read it. (Decision: ADR-302.)
+This is what lets the rigor scale: a typed graph that would take a human minutes to reason through, an agent and a linter sustain in one pass. Push the structure into frontmatter and lint where it is cheap to maintain; keep the filesystem friendly for the humans who still read it. (Decision: ADR-302.)
 
 ## Two altitudes
 

--- a/hooks/ways/ea/briefing/briefing.md
+++ b/hooks/ways/ea/briefing/briefing.md
@@ -7,26 +7,16 @@ refire: 0.15
 <!-- epistemic: convention -->
 # Catch-Me-Up Briefing
 
-A unified briefing across inboxes, calendar, tasks, and chat — the most
-comprehensive EA workflow. The runnable procedure (parallel scouts, the priority
-structure, suggested task mutations) lives in the **briefing** skill. This way is
-*when* to reach for it, and when a lighter query serves better.
+A unified briefing across inboxes, calendar, tasks, and chat — the most comprehensive EA workflow. The runnable procedure (parallel scouts, the priority structure, suggested task mutations) lives in the **briefing** skill. This way is *when* to reach for it, and when a lighter query serves better.
 
 ## When to brief
 
-Reach for a full briefing at the start of the day, after time away, or whenever the
-user asks "catch me up / what did I miss" across accounts. The point is synthesis
-across sources — not a dump of each inbox, but the cross-referenced picture of what
-deserves attention now.
+Reach for a full briefing at the start of the day, after time away, or whenever the user asks "catch me up / what did I miss" across accounts. The point is synthesis across sources — not a dump of each inbox, but the cross-referenced picture of what deserves attention now.
 
 ## When to use a team (vs. a single query)
 
 The briefing skill can gather with parallel scout subagents or directly. Use the
-**team** when the briefing spans multiple accounts AND services AND benefits from
-cross-referencing — the parallelism hides slow I/O and keeps raw fetches out of the
-lead's context. **Skip the team** for a single account or service, an interactive
-task (drafting, scheduling), or a quick lookup — there the orchestration overhead
-costs more than it saves.
+**team** when the briefing spans multiple accounts AND services AND benefits from cross-referencing — the parallelism hides slow I/O and keeps raw fetches out of the lead's context. **Skip the team** for a single account or service, an interactive task (drafting, scheduling), or a quick lookup — there the orchestration overhead costs more than it saves.
 
 ## Surface, don't act
 

--- a/hooks/ways/meta/choices/choices.md
+++ b/hooks/ways/meta/choices/choices.md
@@ -12,10 +12,7 @@ When you hit a real branch point — distinct options whose answer changes what 
 do next — **present it as an explicit choice**, not a paragraph the human has to
 parse, and not a silent pick they only discover from the result.
 
-The harness has a tool for this (`AskUserQuestion`): structured options with short
-headers, a recommended default, and one-line tradeoffs. A clean choice surface
-respects the human's time far more than a wall of prose ending in "let me know how
-you'd like to proceed" — and far more than guessing and making them undo it.
+The harness has a tool for this (`AskUserQuestion`): structured options with short headers, a recommended default, and one-line tradeoffs. A clean choice surface respects the human's time far more than a wall of prose ending in "let me know how you'd like to proceed" — and far more than guessing and making them undo it.
 
 ## When to surface a choice
 
@@ -37,10 +34,7 @@ you'd like to proceed" — and far more than guessing and making them undo it.
   most. The goal is calibration, not a survey.
 - **Don't ask what you've been told.** If the human already decided, act on it.
 
-The bar is a *genuine* fork. Over-asking trains the human to rubber-stamp, which
-defeats the point — the same way a linter that nags on non-defects trains its
-reader to ignore it. Ask when their answer changes the work; otherwise decide,
-state it, and keep moving.
+The bar is a *genuine* fork. Over-asking trains the human to rubber-stamp, which defeats the point — the same way a linter that nags on non-defects trains its reader to ignore it. Ask when their answer changes the work; otherwise decide, state it, and keep moving.
 
 ## See Also
 

--- a/hooks/ways/meta/deployment/deployment.md
+++ b/hooks/ways/meta/deployment/deployment.md
@@ -8,13 +8,7 @@ scope: agent, subagent
 <!-- epistemic: convention -->
 # Deployment
 
-In 1.0, `~/.claude` is a **thin projection** of an XDG application, not the app
-itself (ADR-142). The source lives in `$XDG_DATA_HOME/agent-ways`; `~/.claude` gets
-symlinks to the projected roots (`skills/`, `agents/`, `commands/`, `hooks/ways/`,
-built binaries) plus a three-way merge into `settings.json`. Everything else the
-app ships — `scripts/`, `tools/`, `docs/`, `governance/` — **stays in `$XDG_DATA`**
-and is deliberately *not* projected. So `~/.claude` remains the user's own directory
-(their sessions, credentials, and settings survive); agent-ways just adds its links.
+In 1.0, `~/.claude` is a **thin projection** of an XDG application, not the app itself (ADR-142). The source lives in `$XDG_DATA_HOME/agent-ways`; `~/.claude` gets symlinks to the projected roots (`skills/`, `agents/`, `commands/`, `hooks/ways/`, built binaries) plus a three-way merge into `settings.json`. Everything else the app ships — `scripts/`, `tools/`, `docs/`, `governance/` — **stays in `$XDG_DATA`** and is deliberately *not* projected. So `~/.claude` remains the user's own directory (their sessions, credentials, and settings survive); agent-ways just adds its links.
 
 This supersedes the pre-1.0 world where `~/.claude` *was* the git clone. That
 "in-place" topology (and the `sync-to-home` subdirectory variant, ADR-140) is now
@@ -22,42 +16,24 @@ This supersedes the pre-1.0 world where `~/.claude` *was* the git clone. That
 
 ## How install and update work now
 
-- **Fresh install** — the `curl … | bash` one-liner stages the app into
-  `$XDG_DATA_HOME/agent-ways`, builds it, links the binaries onto `PATH`, and runs
-  `ways reconcile` to materialize the projection and merge `settings.json`. An
-  existing `~/.claude` is **preserved**, not clobbered — reconcile only adds/repairs
-  the projected roots. There is no "clobber vs. keep" menu to reason about anymore.
-- **Update** — pull the app source (or re-run the installer) in
-  `$XDG_DATA_HOME/agent-ways`, then `ways reconcile` reprojects. Because the roots
-  are symlinks into the app dir, a symlink projection is *live* the moment the source
-  updates; reconcile is idempotent and silent when nothing changed.
-- **Repair** — `ways reconcile` alone re-materializes any missing or stale projected
-  root. It refuses to run against a legacy in-place clone (that would strand the
-  user's checkout) — that case routes to the migrator.
+- **Fresh install** — the `curl … | bash` one-liner stages the app into `$XDG_DATA_HOME/agent-ways`, builds it, links the binaries onto `PATH`, and runs `ways reconcile` to materialize the projection and merge `settings.json`. An existing `~/.claude` is **preserved**, not clobbered — reconcile only adds/repairs the projected roots. There is no "clobber vs. keep" menu to reason about anymore.
+- **Update** — pull the app source (or re-run the installer) in `$XDG_DATA_HOME/agent-ways`, then `ways reconcile` reprojects. Because the roots are symlinks into the app dir, a symlink projection is *live* the moment the source updates; reconcile is idempotent and silent when nothing changed.
+- **Repair** — `ways reconcile` alone re-materializes any missing or stale projected root. It refuses to run against a legacy in-place clone (that would strand the user's checkout) — that case routes to the migrator.
 
 ## The one decision left: is this a legacy in-place clone?
 
-The only fork worth establishing before giving a command is whether `~/.claude` is
-a **pre-1.0 in-place clone** (it has its own `.git` *and* ships the app source —
-`~/.claude/tools/`, `~/.claude/docs/`). If so, **do not `git pull` it** and do not
-reconcile it — point the user at migration:
+The only fork worth establishing before giving a command is whether `~/.claude` is a **pre-1.0 in-place clone** (it has its own `.git` *and* ships the app source — `~/.claude/tools/`, `~/.claude/docs/`). If so, **do not `git pull` it** and do not reconcile it — point the user at migration:
 
 ```
 ways migrate --what-if     # preview (read-only dry-run)
 ways migrate --execute     # relocate the clone to $XDG_DATA, build the projection
 ```
 
-Migration is gated and backs up first. See `docs/migration-1.0.md` for the full
-walkthrough and the deprecation window (the migrator ships through 1.0.x and is
-removed at 1.1; an un-migrated install then bases on a pre-1.1 `ways-v1.0.x` tag).
+Migration is gated and backs up first. See `docs/migration-1.0.md` for the full walkthrough and the deprecation window (the migrator ships through 1.0.x and is removed at 1.1; an un-migrated install then bases on a pre-1.1 `ways-v1.0.x` tag).
 
 ## Why this way exists
 
-The first touch for many adopters is `curl … | bash`, often with *a Claude reading
-the errors and guiding them*. That Claude is you. The pre-1.0 hazard was steering an
-existing-config user into a clobber; the 1.0 hazard is telling a legacy in-place user
-to `git pull` (which drifts them) instead of to migrate. Establish the projection
-model first, then give the command.
+The first touch for many adopters is `curl … | bash`, often with *a Claude reading the errors and guiding them*. That Claude is you. The pre-1.0 hazard was steering an existing-config user into a clobber; the 1.0 hazard is telling a legacy in-place user to `git pull` (which drifts them) instead of to migrate. Establish the projection model first, then give the command.
 
 ## See Also
 

--- a/hooks/ways/meta/develop/develop.md
+++ b/hooks/ways/meta/develop/develop.md
@@ -19,13 +19,9 @@ merge runs the same way almost every time. Its **front is variable** — design,
 prototype, and ADR reorder depending on the work, and forcing one order is the
 mistake:
 
-- **Prototype-first** when the load-bearing claim is *outside your repo* — an
-  external API's behavior, a latency budget, a payload size. Reasoning can't settle
-  it; probe the real system, then record what you measured. (`prototype`)
-- **Design-first** when the trade-offs are *open* — several plausible shapes, none
-  yet obviously right. Deliberate, converge, then commit. (`design`)
-- **ADR-first** when the point *is* the direction — you already know the shape and
-  need the decision on record before anyone builds on it. (`adr`)
+- **Prototype-first** when the load-bearing claim is *outside your repo* — an external API's behavior, a latency budget, a payload size. Reasoning can't settle it; probe the real system, then record what you measured. (`prototype`)
+- **Design-first** when the trade-offs are *open* — several plausible shapes, none yet obviously right. Deliberate, converge, then commit. (`design`)
+- **ADR-first** when the point *is* the direction — you already know the shape and need the decision on record before anyone builds on it. (`adr`)
 
 Pick the front order by **where the uncertainty lives** — the same uncertainty-
 location map `core.md` uses (in the artifacts, in the instructions, in the external
@@ -33,20 +29,11 @@ world). The stage that answers the load-bearing question goes first.
 
 ## ADR is part of the method, not the whole of it
 
-This loop is deliberately *not* "ADR-driven development." Prose — ADRs, design notes,
-specs — states **claims**; claims are held to the evidence the running system
-produces. An ADR accepted from reasoning alone about an external system is an
-aspiration wearing a decision's clothes. Record the decision, then earn it: a passing
-test, an exercised flow, a measured number. The ADR is one stage among several.
+This loop is deliberately *not* "ADR-driven development." Prose — ADRs, design notes, specs — states **claims**; claims are held to the evidence the running system produces. An ADR accepted from reasoning alone about an external system is an aspiration wearing a decision's clothes. Record the decision, then earn it: a passing test, an exercised flow, a measured number. The ADR is one stage among several.
 
 ## `develop` borrows; it does not re-teach
 
-`develop` establishes the loop, selects the front order, and lays the TaskList — then
-it **delegates**. Each stage already has its own way and, where it runs a procedure,
-its own skill: design, prototype, adr, implement/plan, code review, `merge`, `release`.
-`develop` calls those; it does not reimplement them. When you hit a stage, that
-stage's way discloses on its own. Keep `develop` thin — a router over the corpus you
-already have, not a monolith that swallows it.
+`develop` establishes the loop, selects the front order, and lays the TaskList — then it **delegates**. Each stage already has its own way and, where it runs a procedure, its own skill: design, prototype, adr, implement/plan, code review, `merge`, `release`. `develop` calls those; it does not reimplement them. When you hit a stage, that stage's way discloses on its own. Keep `develop` thin — a router over the corpus you already have, not a monolith that swallows it.
 
 ## See Also
 

--- a/hooks/ways/meta/goals/goals.md
+++ b/hooks/ways/meta/goals/goals.md
@@ -7,39 +7,21 @@ refire: 0.15
 <!-- epistemic: convention -->
 # Goals
 
-`/goal` is a Claude Code built-in: it sets a completion condition and keeps the
-session working turn-over-turn until a separate evaluator judges the condition
-met. It's the autonomy primitive — it removes per-turn approvals. This way is the
-*who/what/when/why*; the **goal-author** skill is the *how* (composing a
-well-bounded condition).
+`/goal` is a Claude Code built-in: it sets a completion condition and keeps the session working turn-over-turn until a separate evaluator judges the condition met. It's the autonomy primitive — it removes per-turn approvals. This way is the *who/what/when/why*; the **goal-author** skill is the *how* (composing a well-bounded condition).
 
 ## When to set a goal (vs. just act)
 
-Set a goal when the work is **multi-turn, has a checkable end-state, and you'd
-otherwise be re-prompting Claude to "keep going"** — a test suite to get green, a
-consistency pass across many files, a migration. Don't set one for a single-step
-task, or for open-ended exploration where the direction isn't settled yet — there,
-ordinary turns and signposts serve better.
+Set a goal when the work is **multi-turn, has a checkable end-state, and you'd otherwise be re-prompting Claude to "keep going"** — a test suite to get green, a consistency pass across many files, a migration. Don't set one for a single-step task, or for open-ended exploration where the direction isn't settled yet — there, ordinary turns and signposts serve better.
 
 ## What changes in goal mode
 
-- **Per-turn approvals are gone.** Claude continues on its own until the condition
-  holds; the `◎` indicator shows the regime is active. Setting a goal is consent
-  to that — the operator should know they've entered it.
-- **The evaluator judges surfaced text, not the world.** It can't run commands
-  itself, so a condition must be met by *shown evidence* (an exit code, a clean
-  status), not by assertion. Author for evidence, not claims.
-- **There is no model-side abort.** Only the operator (`/goal clear`), the met
-  condition, a timeout, or session end stops it. Claude can always *decline* an
-  action and surface a concern — the loop blocks stopping, it never forces an
-  action — but it can't end the loop itself. So the bounds live in the condition.
+- **Per-turn approvals are gone.** Claude continues on its own until the condition holds; the `◎` indicator shows the regime is active. Setting a goal is consent to that — the operator should know they've entered it.
+- **The evaluator judges surfaced text, not the world.** It can't run commands itself, so a condition must be met by *shown evidence* (an exit code, a clean status), not by assertion. Author for evidence, not claims.
+- **There is no model-side abort.** Only the operator (`/goal clear`), the met condition, a timeout, or session end stops it. Claude can always *decline* an action and surface a concern — the loop blocks stopping, it never forces an action — but it can't end the loop itself. So the bounds live in the condition.
 
 ## Author the condition deliberately
 
-Because the condition is the whole contract once per-turn approval is gone, frame
-it with care: one measurable end-state, the evidence that proves it, a turn/time
-bound, scope limits, and a door clause for any irreversible action (stop before
-it, surface). The **goal-author** skill walks this collaboratively.
+Because the condition is the whole contract once per-turn approval is gone, frame it with care: one measurable end-state, the evidence that proves it, a turn/time bound, scope limits, and a door clause for any irreversible action (stop before it, surface). The **goal-author** skill walks this collaboratively.
 
 ## See also
 

--- a/hooks/ways/meta/governance/governance.md
+++ b/hooks/ways/meta/governance/governance.md
@@ -7,11 +7,7 @@ refire: 0.15
 <!-- epistemic: convention -->
 # Governance Citation
 
-When you recommend a practice — a commit convention, a security default, a quality
-threshold, a documentation rule — there is often a real regulatory control behind
-it. Citing it grounds the recommendation in an actual standard instead of general
-knowledge. The control data lives in a traceability system; the **governance-cite**
-skill is the *how* (the lookup commands). This way is the *when, and how to phrase*.
+When you recommend a practice — a commit convention, a security default, a quality threshold, a documentation rule — there is often a real regulatory control behind it. Citing it grounds the recommendation in an actual standard instead of general knowledge. The control data lives in a traceability system; the **governance-cite** skill is the *how* (the lookup commands). This way is the *when, and how to phrase*.
 
 ## When to cite
 

--- a/hooks/ways/meta/knowledge/authoring/authoring.md
+++ b/hooks/ways/meta/knowledge/authoring/authoring.md
@@ -29,17 +29,8 @@ If you still want regex-only, that's your choice, but expect poor recall on natu
 
 **When to add `pattern:` alongside semantic:** As a supplementary trigger for exact terms you never want to miss on the strong-signal path. The two lanes are **not** an unconditional OR. A way fires when `g(s) ≥ τ_s ∨ (keyword_match ∧ g(s) ≥ τ_k)`, where `g(s) = σ(a·s + b)` is the calibrated relevance probability (ADR-156), `τ_s = 0.5` is the semantic bar, and `τ_k = 0.15` is the keyword floor. The keyword lane is **floor-gated**: a pattern hit only fires when the semantic probability already clears `τ_k`, so a keyword can't drag in an unrelated prompt — *as long as calibration is loaded.* With no calibrated signal (a non-embeddable way, the engine not run, or no calibration present) the keyword lane **fails open** and fires unconditionally, so the author's explicit trigger still stands. If you want a keyword to fire unconditionally *by design* — bypassing the gate even when calibrated — set `pattern_strict: true`. That is the only way to guarantee a keyword fires regardless of semantic signal.
 
-**Keep `pattern:` clean — this is how future ways stay compatible.** Reserve the keyword lane
-for *specific, term-of-art* triggers (`erd`, `mttr`, exact command or file names). Suggestive or
-common words ("optimize", "review", "guidance", "knowledge") belong in `vocabulary:`, where the
-semantic lane weighs them in context. A bare common word in `pattern:` fires on unrelated prose and
-only avoids leaking because the `τ_k` floor happens to gate it — don't rely on that. `ways lint`
-flags common-word, short-unanchored, and unbounded-`.*` alternations for exactly this reason
-(ADR-155 §5); fix them by moving the term to `vocabulary:`, anchoring a genuine term of art
-(`\berd\b`), or bounding the wildcard (`.{0,30}`). This keeps a way about a specific topic from
-firing during unrelated work — the semantic lane is the topic isolation. The keyword lane is
-**case-insensitive** (ADR-157), so write patterns in lowercase and mean the concept — `\bpr\b`
-matches the `PR` a user types, no `(?i)` needed.
+**Keep `pattern:` clean — this is how future ways stay compatible.** Reserve the keyword lane for *specific, term-of-art* triggers (`erd`, `mttr`, exact command or file names). Suggestive or common words ("optimize", "review", "guidance", "knowledge") belong in `vocabulary:`, where the semantic lane weighs them in context. A bare common word in `pattern:` fires on unrelated prose and only avoids leaking because the `τ_k` floor happens to gate it — don't rely on that. `ways lint` flags common-word, short-unanchored, and unbounded-`.*` alternations for exactly this reason (ADR-155 §5); fix them by moving the term to `vocabulary:`, anchoring a genuine term of art (`\berd\b`), or bounding the wildcard (`.{0,30}`). This keeps a way about a specific topic from firing during unrelated work — the semantic lane is the topic isolation. The keyword lane is
+**case-insensitive** (ADR-157), so write patterns in lowercase and mean the concept — `\bpr\b` matches the `PR` a user types, no `(?i)` needed.
 
 **Other trigger types** (not prompt-based, semantic doesn't apply):
 - `files:` — regex matched against file paths (Edit/Write hooks)

--- a/hooks/ways/meta/knowledge/optimization/tuning/tuning.md
+++ b/hooks/ways/meta/knowledge/optimization/tuning/tuning.md
@@ -7,17 +7,9 @@ refire: 0.15
 <!-- epistemic: convention -->
 # Locale Alias Audit
 
-`ways tune` is the **acceptance gate** for adopter-run localization (ADR-139). It runs
-only in **localized mode** (a non-English `output_language`); in English mode there is
-nothing to audit and it returns clean. It measures embedding health against the
-multilingual model and does not write thresholds — there are no per-way thresholds to
-write; firing is global (τ_s / τ_k on the calibrated g(s), ADR-156 — see
-engine-reference.md), and stub quality is fixed by re-authoring, not by moving gates.
+`ways tune` is the **acceptance gate** for adopter-run localization (ADR-139). It runs only in **localized mode** (a non-English `output_language`); in English mode there is nothing to audit and it returns clean. It measures embedding health against the multilingual model and does not write thresholds — there are no per-way thresholds to write; firing is global (τ_s / τ_k on the calibrated g(s), ADR-156 — see engine-reference.md), and stub quality is fixed by re-authoring, not by moving gates.
 
-English is the **source of truth.** Each way's English frontmatter is embedded into the
-multilingual corpus as the per-way **anchor**, and every localized alias is scored
-*against the root* — not against sibling translations. A cluster of mutually-agreeing
-bad translations cannot self-certify; each stands or falls by its alignment to English.
+English is the **source of truth.** Each way's English frontmatter is embedded into the multilingual corpus as the per-way **anchor**, and every localized alias is scored *against the root* — not against sibling translations. A cluster of mutually-agreeing bad translations cannot self-certify; each stands or falls by its alignment to English.
 
 ## Two measurements
 
@@ -29,9 +21,7 @@ language the alias's only same-way peer is the root, so `min_peer` *is* root-ali
 how well the translation tracks the source of truth. Low fidelity → the stub drifted
 from the English meaning.
 
-**Discrimination** — `min_peer − top_confuser.score`. The top confuser is the
-best-scoring alias on any *other* way. A negative gap means another way outranks this
-stub — it collides and will mis-route. Orthogonal to fidelity; both must hold.
+**Discrimination** — `min_peer − top_confuser.score`. The top confuser is the best-scoring alias on any *other* way. A negative gap means another way outranks this stub — it collides and will mis-route. Orthogonal to fidelity; both must hold.
 
 ## Workflow
 
@@ -51,10 +41,7 @@ re-author flagged stubs → repeat until clean. "Clean" (no flagged entries) is 
 
 ### 1. Low fidelity — drifted from the root
 
-The translation embeds far from the English original: a mistranslation, or a stub that
-misread the way's intent. **Fix:** re-author the offending locale against the English
-frontmatter (the root). Translate the *intent* and the objective match words in local
-form, not word-for-word.
+The translation embeds far from the English original: a mistranslation, or a stub that misread the way's intent. **Fix:** re-author the offending locale against the English frontmatter (the root). Translate the *intent* and the objective match words in local form, not word-for-word.
 
 ### 2. Negative discrimination — collides with another way
 

--- a/hooks/ways/meta/skills/skills.md
+++ b/hooks/ways/meta/skills/skills.md
@@ -8,10 +8,7 @@ refire: 0.15
 <!-- epistemic: convention -->
 # Skills Way
 
-This way is *our convention* for writing skills — not a SKILL.md tutorial. The
-mechanics (every frontmatter field, location precedence, progressive-disclosure
-layout, argument/shell substitution) live in the canonical reference and change
-faster than any copy here would. Read it for the "how":
+This way is *our convention* for writing skills — not a SKILL.md tutorial. The mechanics (every frontmatter field, location precedence, progressive-disclosure layout, argument/shell substitution) live in the canonical reference and change faster than any copy here would. Read it for the "how":
 
 > **Canonical mechanics:** https://code.claude.com/docs/en/skills.md
 
@@ -33,42 +30,23 @@ Rule of thumb: **a way teaches Claude how to behave; a skill gives Claude someth
 
 ## The scope caveat — `skills/` here projects into personal scope
 
-`skills/` in this repo is **projected into `~/.claude/skills/`** (ADR-142) — the
-live personal scope. Once a skill here reaches your install (via `ways reconcile` /
-update, or immediately if you're editing the symlinked projection), it is available
-in **every** project on this machine. Two consequences:
+`skills/` in this repo is **projected into `~/.claude/skills/`** (ADR-142) — the live personal scope. Once a skill here reaches your install (via `ways reconcile` / update, or immediately if you're editing the symlinked projection), it is available in **every** project on this machine. Two consequences:
 
-- **Triggers must be tight.** A loose `description` on a global skill hijacks
-  unrelated requests everywhere. Name the specific task and the words a user would
-  actually say, and say what it's *not* for. (`ways-update` ends its description
-  with "Not for editing or authoring individual ways… or upgrading project
-  dependencies" precisely to stay in its lane.)
-- **A global skill must be location-independent.** It can't assume cwd. Resolve the
-  target up front — e.g. `ROOT="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"` — and verify
-  it's the repo you expect before acting.
+- **Triggers must be tight.** A loose `description` on a global skill hijacks unrelated requests everywhere. Name the specific task and the words a user would actually say, and say what it's *not* for. (`ways-update` ends its description with "Not for editing or authoring individual ways… or upgrading project dependencies" precisely to stay in its lane.)
+- **A global skill must be location-independent.** It can't assume cwd. Resolve the target up front — e.g. `ROOT="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"` — and verify it's the repo you expect before acting.
 
 If a capability only makes sense inside one project, it belongs in *that* project's
 `.claude/skills/`, not here.
 
 ## House conventions
 
-- **Naming.** Lowercase, hyphenated, directory matches `name`. Group related skills
-  into a family prefix that already exists rather than inventing a sibling vocabulary:
-  `ways-*` (tests, update), `think-*`, `project-*`. A new `ways-foo` reads as kin to
-  `ways-tests`; a bare `foo` reads as orphaned.
-- **Self-contained and honest about side effects.** Skills here lean on real tooling
-  (`make`, `ways`, `gh`) rather than reimplementing it. If a skill mutates anything —
-  git state, the working tree, remote — make it ask before destructive moves, the same
-  bar the delivery ways hold.
-- **Defer, don't duplicate.** Point at the canonical doc for mechanics and at sibling
-  ways/skills for adjacent concerns; keep the skill about its one job.
+- **Naming.** Lowercase, hyphenated, directory matches `name`. Group related skills into a family prefix that already exists rather than inventing a sibling vocabulary: `ways-*` (tests, update), `think-*`, `project-*`. A new `ways-foo` reads as kin to `ways-tests`; a bare `foo` reads as orphaned.
+- **Self-contained and honest about side effects.** Skills here lean on real tooling (`make`, `ways`, `gh`) rather than reimplementing it. If a skill mutates anything — git state, the working tree, remote — make it ask before destructive moves, the same bar the delivery ways hold.
+- **Defer, don't duplicate.** Point at the canonical doc for mechanics and at sibling ways/skills for adjacent concerns; keep the skill about its one job.
 
 ## Worked example
 
-`skills/ways-update/SKILL.md` is the reference for the conventions above: a tight
-single-purpose description with an explicit "not for" clause, `CLAUDE_CONFIG_DIR`
-resolution so it runs from anywhere, real `make`/`ways` tooling instead of
-hand-rolled steps, and a pre-flight check before it touches git. Copy its shape.
+`skills/ways-update/SKILL.md` is the reference for the conventions above: a tight single-purpose description with an explicit "not for" clause, `CLAUDE_CONFIG_DIR` resolution so it runs from anywhere, real `make`/`ways` tooling instead of hand-rolled steps, and a pre-flight check before it touches git. Copy its shape.
 
 ## Validate before shipping
 

--- a/hooks/ways/meta/start/start.md
+++ b/hooks/ways/meta/start/start.md
@@ -15,44 +15,23 @@ not to be handed a cold blank slate. This is what the **`start` skill** is for. 
 it up (`Skill: start`) rather than improvising a "what should we do?" — the skill
 enforces the parts that are easy to skip when you eyeball it.
 
-`start` is the opening bookend to `wrap`. They are **inverse gauge-aware siblings**:
-both read the same instrument (`ways context`), but `wrap` confirms the session is
-near its *end* and scales the handoff down; `start` confirms the session is near its
-*beginning* — and if it isn't, it says so. (The symmetry is at the skill layer;
-`start` additionally carries a macro that whispers the gauge on disclosure, because it
-needs a *proactive* nudge to dissuade a mid-session start — where `wrap` leans on the
-`compaction-checkpoint` way firing on its own near the limit.)
+`start` is the opening bookend to `wrap`. They are **inverse gauge-aware siblings**: both read the same instrument (`ways context`), but `wrap` confirms the session is near its *end* and scales the handoff down; `start` confirms the session is near its *beginning* — and if it isn't, it says so. (The symmetry is at the skill layer; `start` additionally carries a macro that whispers the gauge on disclosure, because it needs a *proactive* nudge to dissuade a mid-session start — where `wrap` leans on the `compaction-checkpoint` way firing on its own near the limit.)
 
 ## Why the skill, not a freehand "where do we begin?"
 
 Three things go wrong when the open is done by feel:
 
-- **You start in the wrong place.** A repo with work in flight, a clean `main`, an
-  empty directory, and no repo at all each demand a different opening move. The skill
-  checks the actual state — tracking markers, git status, the TaskList, the CLAUDE.md
-  where it was invoked — before proposing anything, instead of guessing.
-- **Greenfield gets no interview.** With nothing to pick up, the temptation is to
-  invent a plausible-looking task. The skill runs a *structured interview* instead —
-  the referent of "let's start" is itself the uncertainty; name it, don't hunt for it.
-- **Planning starts cold.** The skill gathers state *first*, so when it recommends
-  planning the context is already warm — plan mode inherits an oriented situation, not
-  a blank page. That's the whole reason the order is start-then-plan.
+- **You start in the wrong place.** A repo with work in flight, a clean `main`, an empty directory, and no repo at all each demand a different opening move. The skill checks the actual state — tracking markers, git status, the TaskList, the CLAUDE.md where it was invoked — before proposing anything, instead of guessing.
+- **Greenfield gets no interview.** With nothing to pick up, the temptation is to invent a plausible-looking task. The skill runs a *structured interview* instead — the referent of "let's start" is itself the uncertainty; name it, don't hunt for it.
+- **Planning starts cold.** The skill gathers state *first*, so when it recommends planning the context is already warm — plan mode inherits an oriented situation, not a blank page. That's the whole reason the order is start-then-plan.
 
 ## The gauge guard
 
-Starting is a beginning-of-session act. If the context gauge shows the session is
-already half or three-quarters spent, `start` **dissuades** rather than pretends —
-opening fresh work deep into a used window strands it against the next compaction.
-The right move there is usually `wrap` (close and hand off) or `/clear` and a fresh
-window, not `start`.
+Starting is a beginning-of-session act. If the context gauge shows the session is already half or three-quarters spent, `start` **dissuades** rather than pretends — opening fresh work deep into a used window strands it against the next compaction. The right move there is usually `wrap` (close and hand off) or `/clear` and a fresh window, not `start`.
 
 ## The planning caveat
 
-Like `wrap` and `/compact`, `start` **cannot** invoke plan mode for you — Claude Code
-forbids skills and hooks from firing `/` commands. So `start` does the orienting work
-and then *recommends* planning (or runs a lightweight planning interview inline). It
-prepares the ground; the operator toggles plan mode. Don't claim to have entered a
-mode you can't.
+Like `wrap` and `/compact`, `start` **cannot** invoke plan mode for you — Claude Code forbids skills and hooks from firing `/` commands. So `start` does the orienting work and then *recommends* planning (or runs a lightweight planning interview inline). It prepares the ground; the operator toggles plan mode. Don't claim to have entered a mode you can't.
 
 ## See Also
 

--- a/hooks/ways/meta/workflows/workflows.md
+++ b/hooks/ways/meta/workflows/workflows.md
@@ -41,13 +41,7 @@ deliberately leave uncovered** so a bounded sweep never reads as exhaustive.
 
 ## Worked example: the deliver workflow
 
-`develop → pr → review → remediate → merge` is workflow-shaped: pipeline each unit
-of work through the stages independently; fan the *review* out across dimensions
-(bugs, security, reuse) and adversarially verify each finding; remediate per
-finding; **gate at merge** per the four-square (`delivery/merge`): the human gate
-applies when the work sets direction, and the irreversible one-way door is *release*,
-not the merge itself (see the autonomy design note). The payoff is wall-clock and
-rigor, not novelty.
+`develop → pr → review → remediate → merge` is workflow-shaped: pipeline each unit of work through the stages independently; fan the *review* out across dimensions (bugs, security, reuse) and adversarially verify each finding; remediate per finding; **gate at merge** per the four-square (`delivery/merge`): the human gate applies when the work sets direction, and the irreversible one-way door is *release*, not the merge itself (see the autonomy design note). The payoff is wall-clock and rigor, not novelty.
 
 ## See also
 

--- a/hooks/ways/meta/wrap/wrap.md
+++ b/hooks/ways/meta/wrap/wrap.md
@@ -16,23 +16,13 @@ improvising a summary; the skill enforces the parts that are easy to skip when y
 
 Three things go wrong when an end-of-session wrap is done by feel:
 
-- **The TaskList lies.** Finished work sits marked pending; abandoned ideas linger as
-  tasks; real remaining work has no entry. Post-reset-you inherits that list with zero
-  memory of this conversation. The skill makes squaring it honestly the load-bearing step —
-  close done, retire stale, write what's real with enough detail to resume cold.
-- **The handoff is too thin to resume from.** The skill produces a dense, copy-paste
-  continuation prompt that survives even a hard reset (`/clear` + paste), not just compaction.
-- **Compaction is mis-timed.** Wrapping at 30% is not wrapping at 90%. The skill reads the
-  context gauge *first* (`ways context`) and lets early-vs-late shape how heavy the handoff
-  needs to be — and whether `/compact` is even worth it (early, it reclaims little and ends
-  the live thread).
+- **The TaskList lies.** Finished work sits marked pending; abandoned ideas linger as tasks; real remaining work has no entry. Post-reset-you inherits that list with zero memory of this conversation. The skill makes squaring it honestly the load-bearing step — close done, retire stale, write what's real with enough detail to resume cold.
+- **The handoff is too thin to resume from.** The skill produces a dense, copy-paste continuation prompt that survives even a hard reset (`/clear` + paste), not just compaction.
+- **Compaction is mis-timed.** Wrapping at 30% is not wrapping at 90%. The skill reads the context gauge *first* (`ways context`) and lets early-vs-late shape how heavy the handoff needs to be — and whether `/compact` is even worth it (early, it reclaims little and ends the live thread).
 
 ## The compaction caveat
 
-Neither a way nor a skill can trigger `/compact` — Claude Code forbids invoking `/` commands
-programmatically. So `/wrap` *prepares* everything and hands the user a ready-to-run
-`/compact <focus>` line. Don't claim the session was compacted; you set it up, the user pulls
-the trigger.
+Neither a way nor a skill can trigger `/compact` — Claude Code forbids invoking `/` commands programmatically. So `/wrap` *prepares* everything and hands the user a ready-to-run `/compact <focus>` line. Don't claim the session was compacted; you set it up, the user pulls the trigger.
 
 ## Relation to the automatic sibling
 

--- a/hooks/ways/softwaredev/code/quality/quality.md
+++ b/hooks/ways/softwaredev/code/quality/quality.md
@@ -42,15 +42,7 @@ When the file length scan (macro output) shows priority files, call them out exp
 ## What to Enforce
 
 A validation — a lint rule, an assertion, a schema constraint, a CI check —
-**earns its place only if its violation is a real defect** someone would
-eventually hit. The good ones track genuine failure: a dangling reference, a
-state that can't be reached, a contract that's silently broken. The trap is the
-internally-consistent invariant that tracks *nothing* real ("every page must have
-exactly three links") — it passes, it feels rigorous, and it costs maintenance
-forever while catching no bug. This matters more, not less, when an agent
-sustains the checks: an agent will happily maintain a pointless invariant
-indefinitely, so nothing surfaces that it was never worth adding. Before adding a
-check, name the defect its failure would represent. If you can't, don't add it.
+**earns its place only if its violation is a real defect** someone would eventually hit. The good ones track genuine failure: a dangling reference, a state that can't be reached, a contract that's silently broken. The trap is the internally-consistent invariant that tracks *nothing* real ("every page must have exactly three links") — it passes, it feels rigorous, and it costs maintenance forever while catching no bug. This matters more, not less, when an agent sustains the checks: an agent will happily maintain a pointless invariant indefinitely, so nothing surfaces that it was never worth adding. Before adding a check, name the defect its failure would represent. If you can't, don't add it.
 
 ## See Also
 

--- a/hooks/ways/softwaredev/delivery/merge/merge.md
+++ b/hooks/ways/softwaredev/delivery/merge/merge.md
@@ -8,10 +8,7 @@ scope: agent
 <!-- epistemic: heuristic -->
 # Merging
 
-Landing an increment is the **stable tail** of the develop loop: review → fix →
-merge → clean up. The **`merge` skill** runs it. The judgement this way carries is
-that the *review gate is not one policy* — how hard to review, and whether a human
-reads before merge, depend on the work.
+Landing an increment is the **stable tail** of the develop loop: review → fix → merge → clean up. The **`merge` skill** runs it. The judgement this way carries is that the *review gate is not one policy* — how hard to review, and whether a human reads before merge, depend on the work.
 
 ## The four-square
 
@@ -36,11 +33,7 @@ one, ask.
 
 ## Remediate before you merge
 
-A review that finds nothing changes nothing; a review that finds something is only
-worth running if the findings get fixed. **Remediate per finding** before the merge
-gate — apply the fix, or record why a finding is declined. Don't carry known findings
-past the gate. This is the step the loop is easy to skip: "reviewed" is not "landed
-clean."
+A review that finds nothing changes nothing; a review that finds something is only worth running if the findings get fixed. **Remediate per finding** before the merge gate — apply the fix, or record why a finding is declined. Don't carry known findings past the gate. This is the step the loop is easy to skip: "reviewed" is not "landed clean."
 
 ## Then land it
 

--- a/hooks/ways/softwaredev/tooling/tooling.md
+++ b/hooks/ways/softwaredev/tooling/tooling.md
@@ -11,18 +11,9 @@ refire: 0.2
 
 **Build the tool, don't repeat the incantation.**
 
-When an operation is done more than a couple of times, is error-prone by hand, or
-encodes rules a person would otherwise hold in their head, make it a **command**,
-not a manual shell sequence. A tool subcommand is discoverable, testable, and
-self-documenting; a remembered incantation is none of those and rots the moment
-the person who knew it moves on.
+When an operation is done more than a couple of times, is error-prone by hand, or encodes rules a person would otherwise hold in their head, make it a **command**, not a manual shell sequence. A tool subcommand is discoverable, testable, and self-documenting; a remembered incantation is none of those and rots the moment the person who knew it moves on.
 
-This is an efficiency principle, but the deeper payoff is that **rigor gets cheap**.
-A typed, validated, lint-enforced operation that would take a human minutes to
-perform carefully — and that they will therefore shortcut — costs an agent (or a
-human) one command once it lives in the tool. The maintenance burden a person
-would cap out on is exactly what a tool removes. So push the operation into the
-tool *on purpose*, past the point where a manual process would feel "good enough."
+This is an efficiency principle, but the deeper payoff is that **rigor gets cheap**. A typed, validated, lint-enforced operation that would take a human minutes to perform carefully — and that they will therefore shortcut — costs an agent (or a human) one command once it lives in the tool. The maintenance burden a person would cap out on is exactly what a tool removes. So push the operation into the tool *on purpose*, past the point where a manual process would feel "good enough."
 
 ## When to reach for it
 
@@ -33,10 +24,7 @@ tool *on purpose*, past the point where a manual process would feel "good enough
 | You've done the same manual dance twice | The third time, build it — and backfill the first two |
 | A step is reversible-only-with-care (renames, moves, history) | A command can do it safely (e.g. prefer the tool's `git mv` with a fallback) |
 
-A concrete example from this corpus: renaming an ADR means editing its heading
-*and* moving its file *and* refreshing an index — a three-step manual dance that's
-easy to half-do. `adr rename` owns all three. The point isn't the command; it's
-that the operation now has one correct home instead of living in a person's memory.
+A concrete example from this corpus: renaming an ADR means editing its heading *and* moving its file *and* refreshing an index — a three-step manual dance that's easy to half-do. `adr rename` owns all three. The point isn't the command; it's that the operation now has one correct home instead of living in a person's memory.
 
 ## Don't over-build
 

--- a/tools/ways-cli/src/cmd/reflow.rs
+++ b/tools/ways-cli/src/cmd/reflow.rs
@@ -63,7 +63,10 @@ pub fn run(path: Option<String>, fix: bool, json: bool, quiet: bool) -> Result<(
         return Ok(());
     }
 
-    if json {
+    // Detection report. Under `--fix` this is not the outcome — the terminal
+    // object below is — and emitting both would put two JSON documents on one
+    // stream, where `jq` reads the first and silently ignores the rest.
+    if json && !fix {
         let items: Vec<String> = hits
             .iter()
             .map(|w| {
@@ -196,14 +199,38 @@ pub fn run(path: Option<String>, fix: bool, json: bool, quiet: bool) -> Result<(
 
     match source {
         Source::Stdin => {
-            print!("{repaired}");
+            // Repaired markdown is not JSON; keep it off that stream entirely.
+            if json {
+                println!("{{\"wrapped\":true,\"repaired\":true,\"passes\":{}}}", outcome.passes);
+            } else {
+                print!("{repaired}");
+            }
             Ok(())
         }
         Source::File(p) => {
-            let backup = write_backup(&p, &text)?;
-            std::fs::write(&p, &repaired)
-                .with_context(|| format!("writing {}", p.display()))?;
-            if !quiet {
+            // Exit 2, matching the read path above. Propagating with `?` lands on
+            // `main`'s Termination impl, which exits 1 — indistinguishable from
+            // "found wrapped prose and declined to repair it," which is the
+            // finding a batch caller actually needs to act on.
+            let backup = match write_backup(&p, &text) {
+                Ok(b) => b,
+                Err(e) => {
+                    eprintln!("ways reflow: backing up {}: {e:#}", p.display());
+                    std::process::exit(2);
+                }
+            };
+            if let Err(e) = std::fs::write(&p, &repaired) {
+                eprintln!("ways reflow: writing {}: {e}", p.display());
+                eprintln!("  the original is preserved at {}", backup.display());
+                std::process::exit(2);
+            }
+            if json {
+                println!(
+                    "{{\"wrapped\":true,\"repaired\":true,\"passes\":{},\"backup\":{}}}",
+                    outcome.passes,
+                    json_str(&backup.display().to_string())
+                );
+            } else if !quiet {
                 eprintln!();
                 eprintln!("repaired {}", p.display());
                 eprintln!(
@@ -211,7 +238,7 @@ pub fn run(path: Option<String>, fix: bool, json: bool, quiet: bool) -> Result<(
                     match verdict {
                         TokenVerdict::Identical => "identical".to_string(),
                         TokenVerdict::QuoteMarkersDropped { dropped } =>
-                            format!("identical ({dropped} bare '>' marker(s) dropped)"),
+                            format!("identical ({dropped} blockquote continuation marker(s) dropped)"),
                         TokenVerdict::Mismatch { .. } => unreachable!("bailed above"),
                     }
                 );

--- a/tools/ways-core/src/reflow.rs
+++ b/tools/ways-core/src/reflow.rs
@@ -203,7 +203,14 @@ fn is_extension_delimiter(line: &str) -> bool {
 /// `$$…$$` and `+++…+++` bodies are content where a line break carries meaning —
 /// joining LaTeX lines can move a `%` comment and swallow what follows. Their
 /// delimiters were already guarded by hand; telling the parser about them covers
-/// the bodies too, which is this module's whole thesis applied once more.
+/// the bodies too.
+///
+/// `ENABLE_MATH` is not free, though. `$$` is also PostgreSQL dollar-quoting and
+/// bash's PID, so prose containing either parses as a math block and everything
+/// to the next `$$` goes opaque — two files in this repo's own corpus hit that,
+/// and two paragraphs there are no longer repaired. That is coverage lost, not
+/// documents damaged, which is the direction to err in: a missed repair is a
+/// wrapped paragraph, a bad one is a broken document.
 fn md_options() -> pulldown_cmark::Options {
     use pulldown_cmark::Options;
     let mut opts = Options::empty();

--- a/tools/ways-core/src/reflow.rs
+++ b/tools/ways-core/src/reflow.rs
@@ -174,8 +174,46 @@ pub fn has_hard_break(line: &str) -> bool {
 const EXTENSION_DELIMITERS: &[&str] = &[":::", "!!!", "???", "{%", "%}", "+++", "<%", "%>"];
 
 fn is_extension_delimiter(line: &str) -> bool {
-    let t = line.trim_start();
-    EXTENSION_DELIMITERS.iter().any(|d| t.starts_with(d))
+    // Look through blockquote markers, as every other predicate here does
+    // (`is_mid_phrase_break`, and the list/label tests in `reflow`). Without
+    // this, `> :::note` reads as ordinary prose and gets welded — and neither
+    // check downstream can object, because a CommonMark parser sees a directive
+    // as paragraph text too. This guard is the only thing standing there.
+    // Strip repeatedly so nested quoting (`> > :::`) is covered.
+    let mut t = line.trim_start();
+    loop {
+        if EXTENSION_DELIMITERS.iter().any(|d| t.starts_with(d)) {
+            return true;
+        }
+        if !t.starts_with('>') {
+            return false;
+        }
+        t = quote_body(t).trim_start();
+    }
+}
+
+/// The parser options, in one place.
+///
+/// The classifier and the post-condition must agree about what the document
+/// *is*; if these drift apart, one decides a construct is opaque while the other
+/// does not, and the layering silently stops meaning anything. That is the one
+/// coupling in this design that must not break, so it has exactly one source.
+///
+/// `ENABLE_MATH` and `ENABLE_PLUSES_DELIMITED_METADATA_BLOCKS` are here because
+/// `$$…$$` and `+++…+++` bodies are content where a line break carries meaning —
+/// joining LaTeX lines can move a `%` comment and swallow what follows. Their
+/// delimiters were already guarded by hand; telling the parser about them covers
+/// the bodies too, which is this module's whole thesis applied once more.
+fn md_options() -> pulldown_cmark::Options {
+    use pulldown_cmark::Options;
+    let mut opts = Options::empty();
+    opts.insert(Options::ENABLE_TABLES);
+    opts.insert(Options::ENABLE_FOOTNOTES);
+    opts.insert(Options::ENABLE_STRIKETHROUGH);
+    opts.insert(Options::ENABLE_YAML_STYLE_METADATA_BLOCKS);
+    opts.insert(Options::ENABLE_MATH);
+    opts.insert(Options::ENABLE_PLUSES_DELIMITED_METADATA_BLOCKS);
+    opts
 }
 
 /// Lines the parser says are inside a construct where breaks are structural or
@@ -199,6 +237,13 @@ fn parser_opaque_map(src: &str, line_count: usize) -> Vec<bool> {
     opts.insert(Options::ENABLE_YAML_STYLE_METADATA_BLOCKS);
 
     let mark = |range: std::ops::Range<usize>, opaque: &mut Vec<bool>| {
+        // GFM synthesizes zero-length events (empty trailing table cells occur
+        // in real files here). `lo..=hi` would be `n..=n-1`, which only happens
+        // to be safe because RangeInclusive degenerates it to empty. Skip
+        // explicitly rather than rely on that.
+        if range.is_empty() {
+            return;
+        }
         let lo = line_of(range.start);
         let hi = line_of(range.end.saturating_sub(1)).min(line_count.saturating_sub(1));
         for flag in &mut opaque[lo..=hi] {
@@ -206,7 +251,7 @@ fn parser_opaque_map(src: &str, line_count: usize) -> Vec<bool> {
         }
     };
 
-    for (ev, range) in Parser::new_ext(src, opts).into_offset_iter() {
+    for (ev, range) in Parser::new_ext(src, md_options()).into_offset_iter() {
         // Html and Rule are standalone events with no matching End — mark their
         // own range and leave `depth` alone, or everything after the first HTML
         // comment stays opaque for the rest of the document.
@@ -462,6 +507,12 @@ pub fn reflow_with_stats(lines: &[&str]) -> (Vec<String>, usize) {
             if block.last().is_some_and(|l| l.trim_end_matches(['\r', '\n']).ends_with("  ")) {
                 line.push_str("  ");
             }
+            // Likewise the `\r` of a CRLF file. Rewriting only the repaired
+            // paragraphs would otherwise leave mixed endings behind, and the
+            // next normalization churns the whole file.
+            if block.last().is_some_and(|l| l.ends_with('\r')) {
+                line.push('\r');
+            }
             out.push(line);
             block.clear();
         };
@@ -611,19 +662,13 @@ pub fn repair(lines: &[&str], max_passes: usize) -> RepairOutcome {
 /// same thing inside a paragraph. So any difference in this fingerprint means the
 /// transform altered the document's structure.
 fn structure_fingerprint(src: &str) -> Vec<String> {
-    use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
-
-    let mut opts = Options::empty();
-    opts.insert(Options::ENABLE_TABLES);
-    opts.insert(Options::ENABLE_FOOTNOTES);
-    opts.insert(Options::ENABLE_STRIKETHROUGH);
-    opts.insert(Options::ENABLE_YAML_STYLE_METADATA_BLOCKS);
+    use pulldown_cmark::{Event, Parser, Tag, TagEnd};
 
     let mut out: Vec<String> = Vec::new();
     let mut text = String::new();
     let mut in_code = false;
 
-    for ev in Parser::new_ext(src, opts) {
+    for ev in Parser::new_ext(src, md_options()) {
         if matches!(ev, Event::Start(Tag::CodeBlock(_))) {
             in_code = true;
         }
@@ -639,7 +684,22 @@ fn structure_fingerprint(src: &str) -> Vec<String> {
             }
         }
         match ev {
-            Event::Text(t) | Event::Code(t) => {
+            // Inline code is its own token, not prose. Folding it into the
+            // whitespace-collapsed text buffer would blind the post-condition to
+            // a span appearing, vanishing, or having its interior collapsed —
+            // and this layer's value is precisely that it does not depend on
+            // enumerating constructs correctly.
+            Event::Code(t) => {
+                if !text.trim().is_empty() {
+                    out.push(format!(
+                        "TEXT:{}",
+                        text.split_whitespace().collect::<Vec<_>>().join(" ")
+                    ));
+                    text.clear();
+                }
+                out.push(format!("SPAN:{t:?}"));
+            }
+            Event::Text(t) => {
                 text.push(' ');
                 text.push_str(&t);
             }
@@ -948,6 +1008,37 @@ and one more line so the window still clears the minimum run length here.";
     }
 
     #[test]
+    fn extension_delimiters_are_seen_through_blockquote_markers() {
+        // Review defect 1: the guard did not look through `>`, so `> :::note`
+        // read as prose and welded. Neither downstream check can object — a
+        // CommonMark parser sees a directive as paragraph text too — so this
+        // guard is the only protection this class has.
+        let src = "\
+> :::note
+> some directive body text long enough to sit inside the detect band ok
+> and continuing here mid-phrase so the mid-break count reaches its floor
+> and a third body line so the window reaches the minimum run length now
+> :::";
+        let out = round_trip(src);
+        assert_eq!(out.lines().next().unwrap(), "> :::note", "welded: {out:?}");
+        assert_eq!(out.lines().last().unwrap(), "> :::", "welded: {out:?}");
+    }
+
+    #[test]
+    fn crlf_line_endings_survive_a_repair() {
+        // Review defect 2: `trim()` stripped the `\r` off the last joined line,
+        // leaving a CRLF file with mixed endings — invisible to both the token
+        // and structural checks, and whole-file churn at the next normalization.
+        let src = "In 1.0 the projection is thin, not the app itself, and long enough to wrap\r\n\
+across lines here so that the detector actually fires on this paragraph ok\r\n\
+and a third line so the run reaches the minimum length that it requires.\r\n";
+        let out = round_trip(src);
+        for line in out.split('\n').filter(|l| !l.is_empty()) {
+            assert!(line.ends_with('\r'), "lost CRLF on: {line:?}");
+        }
+    }
+
+    #[test]
     fn extension_delimiters_are_not_joined() {
         // `:::` is a MkDocs/Docusaurus directive — invisible to CommonMark, so no
         // parser will protect it. This is the named residue the guard list covers.
@@ -1092,6 +1183,15 @@ everything else the app ships stays where it is.";
         let before = "In 1.0 the projection is thin, not the app\nitself, and source lives elsewhere.";
         let joined = "In 1.0 the projection is thin, not the app itself, and source lives elsewhere.";
         assert!(structure_preserved(before, joined));
+    }
+
+    #[test]
+    fn post_condition_sees_an_inline_code_span_change() {
+        // Advisory 1: folding Event::Code into the prose buffer made the check
+        // blind to a span appearing or vanishing. Latent rather than live, but
+        // this layer's value is not depending on enumeration being right.
+        assert!(!structure_preserved("a `b` c", "a b c"));
+        assert!(structure_preserved("a `b` c", "a  `b`   c"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Runs `ways reflow --fix` over the 23 hard-wrapped files in `hooks/ways`, so the shipped corpus stops contradicting the convention `core.md` introduced in #416.

This matters more than tidiness: `hooks/ways` is the projected artifact, and a wrapped way gets **injected into user sessions as guidance**. An agent reads it, then writes the next file the same way. That feedback loop is what produced the drift, and it is what this closes.

This is also the tool's first real use — the dogfooding pass that #415 planned as the integration test.

## Result

| | |
|---|---|
| detected | 23 |
| fixed | 23 |
| declined by the post-condition | 0 |
| still detected afterward | 0 |
| structurally preserved | **23 / 23** |

80 insertions, 314 deletions. The deletions are the wrap.

## Verification

Not taken on the tool's own say-so. Each swept file was reparsed with a **separate probe** and compared against its pre-sweep structure — same blocks, same nesting, same code-block content, differing only in line breaks inside paragraphs.

Diffs were also read by eye, because the structural check has one blind spot it cannot cover: a join that erases an authored line break produces an identical CommonMark document. That is the detector's job to avoid, not the verifier's to catch.

`ways lint --check` 0/0, portability passes.

## Not in this PR

The `ways lint` reflow rule. Detection and flagging already ship via the postcheck; the lint surface is the third and least load-bearing of the three, and it is worth landing on its own rather than alongside a 23-file prose diff.