### PR TITLE
release(ways): v1.6.0

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "ways"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "agent-fmt",
  "anyhow",

--- a/tools/ways-cli/Cargo.toml
+++ b/tools/ways-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ways"
-version = "1.5.1"
+version = "1.6.0"
 edition = "2021"
 description = "Unified CLI for ways — knowledge guidance for Claude Code"
 license = "MIT"


### PR DESCRIPTION
Version bump for the ways 1.6.0 release (ADR-150). After merge, tag with `make publish-release COMPONENT=ways` — that pushes `ways-v1.6.0` and CI builds all platforms and creates the GitHub Release.

## What ships in 1.6.0

### Markdown line handling (#415)

Agents hard-wrap markdown at ~80 columns by habit. That breaks `Edit` — `old_string` has to reproduce interior line breaks exactly, which is where edits *miss* and get retried — and makes diffs non-semantic, since changing three words reflows the paragraph. Four surfaces now address it:

- **`core.md` gains `## Line handling`** — present before the first write of a session, next to `## Language` which is already a mechanical file-output rule of the same class.
- **`documentation/markdown`** carries the convention, including the formats it deliberately excludes: plain `.txt` has no renderer so the wrap *is* the layout, and commit bodies keep 72.
- **`documentation/markdown/reflow`** is a trigger-inert reactive way. Its postcheck inspects the text just written (never the file on disk, so it can't misattribute pre-existing drift), names the file and the paragraph lines, and tells the reader to trust their own prose over the check if a file is flagged twice.
- **`ways reflow`** — a new subcommand. Detection is a heuristic over a real CommonMark parse; repair is scoped to the enclosing paragraph of a detection and leaves everything else byte-identical; and before writing it reparses the result and compares, declining to write if anything moved beyond line breaks inside a paragraph.

The 23 hard-wrapped files in the shipped corpus were flattened, so the ways being injected as guidance no longer contradict the convention they carry.

### ⚠️ Behavior change: `ways lint --fix` now takes its scope from the path

`ways lint --fix` with no path used to rewrite every way in the resolved corpus. It now **refuses**, the way `eslint --fix` gets its scope from the paths you hand it rather than from the flag:

```
ways lint <path> --fix     # fix within that file or directory
ways lint --fix --all      # the whole resolved corpus, deliberately
```

Any script running bare `ways lint --fix` will need one of those. It fails loudly with both alternatives named rather than silently doing something different, and nothing in this repo or its CI used the old form.

Exit codes are also now distinct: `0` clean, `1` findings, `2` the invocation was wrong or the tool failed — kept apart so a caller can tell "the corpus has problems" from "you used the flag wrong."

### New way: `code/supplychain/maturity` (#417)

Tier 0 of the supply-chain assessment, before the safety tiers, because it decides adoption rather than risk: is a candidate package what it presents itself as? Two failure modes — presentation outrunning adoption, and a thin wrapper positioned as a first-order tool while a dependency does the work. The check is registry adoption numbers, read the manifest for the substantial dependency, compare the two.

### Under the hood

`ways-core` gained `pulldown-cmark` (`default-features = false`) — **zero net new packages** in `Cargo.lock`, since its three transitives were already in the graph. It replaced a hand-rolled markdown classifier that had accumulated ten construct bugs, each found one review at a time.

## Verification

- 153 `ways-core` tests and 38 suites green; clippy clean; `ways lint --check` 0/0; `check-portability.sh` passes all gates
- Corpus: **0 hard-wrapped way files remain**
- Two independent review passes, the second building an HTML-render oracle and running ~20k generated cases plus every `.md` in the tree through it — the structural post-condition showed zero false negatives and zero false positives
- All review findings remediated before this bump, each with a regression fixture

## Known limits, stated deliberately

- Welding *authored* line breaks is invisible to any structural check — two joined sentences are the same CommonMark document. That is what the detection heuristic exists to avoid; it cannot be verified after the fact.
- Non-CommonMark syntax (`:::` directives, MDX, Liquid) is paragraph text to any CommonMark parser, and is covered by an explicit delimiter list rather than by the parser.
- `ENABLE_MATH` means a literal `$$` — PostgreSQL dollar-quoting, bash's PID — parses as display math and suppresses repair in that region. Two files in this corpus hit it. Coverage lost, not documents damaged, which is the direction to err in.