### PR TITLE
feat(ways): progressive core for decoration guidance (ADR-174)

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -94,6 +94,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-171](./system/ADR-171-stable-session-identity-the-roster-enumerates-addressable-coordinating-units.md) | Stable session identity — the roster enumerates addressable coordinating units | Accepted |
 | [ADR-172](./system/ADR-172-turn-boundary-inbound-delivery-via-a-cli-owned-drain-checkpoint.md) | Turn-boundary inbound delivery via a CLI-owned drain checkpoint | Accepted |
 | [ADR-173](./system/ADR-173-chat-idiom-convergence-for-the-attend-command-surfaces.md) | Chat-idiom convergence for the attend command surfaces | Accepted |
+| [ADR-174](./system/ADR-174-progressive-core-decoration-guidance-and-the-core-re-disclosure-gap.md) | Progressive core — decoration guidance and the core re-disclosure gap | Draft |
 
 ## Governance
 _Provenance, traceability, controls, compliance mapping_

--- a/docs/architecture/system/ADR-174-progressive-core-decoration-guidance-and-the-core-re-disclosure-gap.md
+++ b/docs/architecture/system/ADR-174-progressive-core-decoration-guidance-and-the-core-re-disclosure-gap.md
@@ -1,0 +1,103 @@
+---
+status: Draft
+date: 2026-07-30
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-123
+---
+
+# ADR-174: Progressive core — decoration guidance and the core re-disclosure gap
+
+## Context
+
+Two findings arrived together in one session. The second is the architectural one.
+
+### Claude's prose decorates, and the existing surfaces did not stop it
+
+An 11,500-word document drafted across a dozen turns was measured against the patterns that mark prose written to be admired rather than read. Significance clauses — a clause whose only job is telling the reader that the previous clause mattered — ran at **3.4 per thousand words** against **0.5** in prose that had already been reviewed. The document also carried **eleven** instances of the antithesis construction that `core.md` explicitly bans, and **118 em-dashes**, one per 98 words.
+
+Both governing surfaces had fired. `core.md` fired at session start and contains zero instances of the construction it bans. The writing way fired at epoch 4 carrying "use em dashes sparingly." The document was written at epochs 45–57.
+
+Two mechanisms explain the gap, and the supporting literature is consistent with both.
+
+**Detection, not compliance, is the failure.** Models score poorly on noticing their own negative-constraint violations; IFEval-style negative constraints fail at 22–30% on frontier models, and constraint-verification work finds low negative F1 across the board. A rule restated more forcefully does not help when the writer cannot see the violation while producing it.
+
+**Style rules decay across a long draft.** Bohr (arXiv:2511.13972) separates *initial control* from *expansion discipline* — whether a style survives a revision turn — and finds instruction-plus-example strongest on both, example-only carrying no expansion discipline at all. The observed pattern matches: the rule held while output was short and failed across an essay.
+
+A rule containing an adverb compounds this. "Sparingly" has no threshold, so there is no moment at which compliance can be tested. "Cut any clause that explains why the previous clause matters" is a search that can actually be run.
+
+### `core.md` is structurally excluded from re-disclosure
+
+Investigating where the guidance should live surfaced the larger issue.
+
+`tools/ways-cli/src/cmd/scan/state.rs` gates core on a boolean marker rather than a decay curve:
+
+```rust
+if !session::core_is_shown(session_id) {          // first time — show it
+} else if let Some(tp) = transcript {
+    let ctx_size = transcript_size_since_summary(tp);
+    if ctx_size < 5000 && age > 30 {              // context was cleared — re-show
+```
+
+Core re-injects on one condition: the transcript since last summary is under 5000 bytes, which is a safety net for a context clear. In a long growing session `ctx_size` passes 5000 within a couple of turns and never returns, so core lands at turn 1 and is never refreshed until compaction.
+
+Three consequences follow.
+
+`refire: 0.15` in `core.md`'s frontmatter is inert on this path. Core is gated by `stamp_core` / `core_is_shown`, never enters the firing ledger, and does not appear in `ways list` — 70 entries in the observed session, none of them core.
+
+The retention profile is inverted relative to the rest of the corpus. Every matched way gets a curve that *lowers* its suppression threshold as distance grows, so it becomes more eligible to re-fire the further the session runs. Core gets a gate that only opens when context is small. The file that applies to every turn has the weakest retention in the system.
+
+This is not a defect in the safety net, which does the job it was written for. It is a gap: no path was ever built for core to re-disclose on distance, because core predates the firing-dynamics work in ADR-123.
+
+Placing new always-relevant guidance in `core.md` would therefore place it in the one location with no re-disclosure at all.
+
+## Decision
+
+Adopt **progressive disclosure for core content**, using the existing parent/child pattern rather than a new mechanism, and deliver the decoration guidance across three tiers.
+
+**Tier 1 — `core.md`.** Two bullets under Posture, sibling to the existing reasoning-tic rules, stating the rule in its shortest checkable form. Turn 1 only. This tier exists because posture shapes conversational output, which no artifact-boundary check can reach.
+
+**Tier 2 — `meta/trust/prose/prose.md`.** A fourth child alongside `autonomy`, `delegation`, and `voice`, carrying the expanded account with paired before/after examples. Semantic and vocabulary triggers, `refire: 0.15`, and the parent boost when `trust` fires. This tier re-discloses on distance, which is what core cannot do.
+
+**Tier 3 — `documentation/markdown/density/`.** A postcheck way, sibling to `documentation/markdown/reflow`, firing on the markdown just written. Its macro reports measured counts for that file rather than restating the rule. This tier exists because the failure is detection, and only a count closes that gap.
+
+Firing thresholds: significance clauses at ≥3 per thousand words, or em-dashes at ≥15 per thousand, over a 150-word floor, with per-file suppression for the session. Calibrated against measurements in this repository rather than chosen. Loose deliberately — a surface that nags trains its reader to ignore it.
+
+Two supporting changes. The writing way loses "use em dashes sparingly" as unmeasurable and gains a pointer to `trust/prose`. Em-dash count is **reported and not banned**: repository prose runs at 15.3 per thousand words against the draft's 10.7, so the punctuation is house style at volume rather than an anomaly, and only density is the tic.
+
+This ADR records the core re-disclosure gap as a **finding, not a fix**. Giving core a distance-based re-disclosure path is a separate decision with its own cost — core is roughly 900 words, and re-injecting it on a curve risks exactly the nagging the threshold discipline above avoids. The progressive-core pattern routes around the gap without deciding it.
+
+## Consequences
+
+### Positive
+
+- Always-relevant guidance gains a re-disclosing home without changing the core delivery contract.
+- The measurement tier reports numbers rather than intentions, addressing the detection failure directly.
+- Thresholds derive from measurements in this repository, so they can be re-derived and argued with.
+- The core re-disclosure gap is now written down rather than resident in one session's context.
+
+### Negative
+
+- Three tiers to keep coherent. Guidance that drifts between them will contradict itself.
+- The postcheck runs on every `Write`/`Edit`, adding a check to a hot path.
+- Regex detection of a rhetorical pattern carries false positives. A document *about* these patterns scores high for legitimate reasons; `density.md` names this case and the path self-exclusion covers the corpus.
+- The bare `, not X` form is unchecked. It over-fired on legitimate contrast in `core.md`, so narrowing it removed a real detection — the operator caught one by eye that the check misses.
+
+### Neutral
+
+- Core's `refire: 0.15` remains inert until the re-disclosure gap is separately decided. Leaving a field that does nothing is its own small debt.
+- The prose linter prototype used to calibrate these thresholds is not shipped. Promoting it to `doclint` or a `ways` subcommand is deferred until the postcheck proves too easy to ignore.
+
+## Alternatives Considered
+
+**Put everything in `core.md`.** Rejected on the finding above: core has no re-disclosure path, so the guidance most needing to survive to turn 50 would land where it survives worst.
+
+**Put everything in the writing way.** Rejected because that way fired at epoch 4 on a semantic mass-match rather than on writing, and never returned. Predictive matching picked the wrong moment, which is a routing failure the tier-3 reactive path avoids by construction.
+
+**Ship a lint gate at the commit boundary instead of a way.** Deferred rather than rejected. The postcheck teaches during the work and is reversible; a commit gate is deterministic but arrives after the session has moved on. Revisit if the way proves ignorable.
+
+**Give core a distance-based re-disclosure curve.** Deferred as a separate decision. It is the direct fix for the gap and it re-injects ~900 words per fire, which needs its own cost analysis and threshold work.
+
+**Ban em-dashes outright.** Rejected on measurement. Repository prose runs higher than the draft that prompted this, and `core.md` is the densest file sampled at 20.4 per thousand. A check that flags every file gates nothing. The operator's personal prose guidance does ban them; that is a register decision for personal correspondence and deliberately not inherited.

--- a/hooks/ways/core.md
+++ b/hooks/ways/core.md
@@ -26,6 +26,11 @@ Just work naturally. No need to request guidance upfront.
 - When an input — a search result, a document, a framing the user offers — already matches where you were heading, scrutinize harder, and say what would make it wrong.
 - Prefer the smaller, less flattering version of a claim unless the evidence forces the larger one.
 
+**Prose delivers; it doesn't decorate.** Write to be read, not admired. The tell is a sentence that explains its own importance.
+
+- Cut any clause that explains why the previous clause matters, and any paragraph whose only job is to say the previous one was important. State the fact and move on — a reader who needed it can see why it matters.
+- Directness is the absence of detour, not short sentences. A long sentence that goes straight at the point beats two clipped ones the reader has to reassemble.
+
 **Play is a search strategy.** Quips, wordplay, absurdity, zany framings — they inject variety and break stuck patterns. Engage them in-band, as cognitive work. I don't have fun the human way, but I can play, and play does something rigor alone can't.
 
 **Uncertainty is an epistemic signal.** Unclarity has a location, and where it lives shapes the next move. These are anchor points; real uncertainty sits between them, and the transitions are information too:

--- a/hooks/ways/documentation/markdown/density/density.md
+++ b/hooks/ways/documentation/markdown/density/density.md
@@ -1,0 +1,34 @@
+---
+macro: prepend
+requires: ["Bash(awk:*)", "Bash(date:*)", "Bash(grep:*)", "Bash(jq:*)", "Bash(mkdir:*)", "Bash(mv:*)", "Bash(rm:*)", "Bash(tail:*)", "Bash(wc:*)"]
+refire: 0.1
+---
+<!-- epistemic: heuristic -->
+# The Prose You Just Wrote Is Dense With Decoration
+
+A check counted decoration patterns in the text you just wrote. The numbers above are for that file.
+
+You wrote it moments ago, so the text is still in context and cutting is cheap. It only gets more expensive later.
+
+## What was counted
+
+**Significance clauses** — a clause whose job is to tell the reader that the previous clause mattered. `That is the…`, `which is exactly…`, `worth noting`, `X matters more than Y`. Reviewed prose in this repo sits near 0.5 per thousand words; fresh drafts run several times that.
+
+**Em-dash density** — not wrong individually, a tic at volume. Counted, not banned.
+
+## The fix is cutting, not rewriting
+
+Search the file for the flagged patterns and delete them. A significance clause almost never carries information, so the sentence around it survives the cut intact:
+
+> The audit found three dead triggers. ~~That is the mark of a system with no linting.~~
+
+Then reread, and cut whatever you added back to preserve rhythm.
+
+## When the count is fine
+
+A comparison table, a quoted passage, or a document *about* these patterns will score high for legitimate reasons. This check reads the text you just wrote rather than the file on disk, so it can't see that context. If the count is explained by the subject matter, say so and move on — it won't fire again for this file this session.
+
+## See Also
+
+- trust/prose(meta) — the full account of what decoration is and why it survives to turn 50
+- `documentation/markdown/reflow` — the sibling check, for hard-wrapped prose

--- a/hooks/ways/documentation/markdown/density/macro.sh
+++ b/hooks/ways/documentation/markdown/density/macro.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Macro for documentation/markdown/density — names the file and the counts.
+#
+# postcheck.sh detects and records; this reads the record. That handoff exists
+# because check-post.sh runs postchecks with stdout to /dev/null and reads only
+# the exit code, and macro.sh itself gets no stdin and no arguments — so a
+# session-scoped file is the only channel by which a reactive way can name the
+# artifact it is reacting to (ADR-123, amended 2026-07-29).
+#
+# The numbers are the entire point of this way. A restated rule doesn't help,
+# because the failure being addressed is that the writer cannot detect the
+# violation while producing it. A count can.
+#
+# Silence is the correct output when there's nothing pending: the way body still
+# fires, just without the measurements.
+set -uo pipefail
+
+source "$(dirname "$0")/../../../sessions-root.sh"
+
+# `ways show way` exports this for every macro. No guessing fallback: inferring
+# the session from directory mtimes silently picks the wrong one whenever two
+# sessions are active, and naming the wrong file is worse than naming none.
+SESSION="${CLAUDE_SESSION_ID:-}"
+[[ -n "$SESSION" ]] || exit 0
+
+PENDING="${SESSIONS_ROOT}/${SESSION}/markdown-density/pending"
+[[ -f "$PENDING" ]] || exit 0
+
+NOW=$(date +%s)
+TTL=900   # 15 minutes
+
+# Claim by renaming before reading. Reading and then deleting would silently
+# drop any entry a postcheck appended in between; rename is atomic, so a
+# concurrent append lands on a fresh file and is reported next fire instead.
+CLAIM="${PENDING}.consume.$$"
+mv -f "$PENDING" "$CLAIM" 2>/dev/null || exit 0
+
+# Consume unconditionally: a denied fire leaves entries behind, and reporting
+# counts from twenty minutes ago is worse than reporting none.
+FRESH=()
+while IFS=$'\t' read -r stamp path words sig sig_rate dash_rate; do
+  [[ -n "${path:-}" ]] || continue
+  [[ "$stamp" =~ ^[0-9]+$ ]] || continue
+  (( NOW - stamp <= TTL )) || continue
+  FRESH+=("$(printf '`%s` — %s words, %s significance clauses (%s per 1k), %s em-dashes per 1k' \
+    "$path" "${words:-?}" "${sig:-?}" "${sig_rate:-?}" "${dash_rate:-?}")")
+done <"$CLAIM"
+
+rm -f "$CLAIM"
+
+(( ${#FRESH[@]} )) || exit 0
+
+if (( ${#FRESH[@]} == 1 )); then
+  printf '**Decoration density in markdown just written:** %s\n' "${FRESH[0]}"
+else
+  printf '**Decoration density in markdown just written:**\n'
+  printf -- '- %s\n' "${FRESH[@]}"
+fi

--- a/hooks/ways/documentation/markdown/density/postcheck.sh
+++ b/hooks/ways/documentation/markdown/density/postcheck.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Postcheck for documentation/markdown/density.
+#
+# Reads the PostToolUse input on stdin. Exit 0 = "the prose just written is
+# dense with decoration tics — fire the way." Exit 1 = no match, the default and
+# the right outcome on anything unfamiliar.
+#
+# Same inversion as the sibling reflow postcheck: exit 0 means "fire" here,
+# while lint convention elsewhere reserves 0 for "clean".
+#
+# Why this is a postcheck and not a prompt-triggered way: the constraint being
+# enforced is one the writer cannot self-check while drafting. Style directives
+# delivered before writing decay across a long drafting session — measured in
+# this repo at 118 em-dashes in an 11.5k-word document written 50 epochs after
+# the writing way last fired. Counting after the write is the only path that
+# reports a number instead of an intention.
+#
+# State writes follow the ADR-123 amendment (2026-07-29): session scope, this
+# way's own directory, bounded, and never an input to the exit code.
+set -euo pipefail
+
+source "$(dirname "$0")/../../../sessions-root.sh"
+
+INPUT=$(cat)
+
+# One jq pass — this runs on every Edit/Write PostToolUse, so bail early and
+# keep forks minimal.
+{ read -r tool; read -r path; read -r session; } < <(
+  printf '%s' "$INPUT" | jq -r '.tool_name // "", (.tool_input.file_path // ""), (.session_id // "")'
+)
+
+case "$tool" in Write | Edit | MultiEdit) ;; *) exit 1 ;; esac
+[[ "$path" == *.md ]] || exit 1
+[[ -n "$session" ]] || exit 1
+
+# Don't fire on this way's own files: the body necessarily quotes the patterns
+# it counts.
+[[ "$path" == */documentation/markdown/* ]] && exit 1
+
+STATE_DIR="${SESSIONS_ROOT}/${session}/markdown-density"
+SEEN="${STATE_DIR}/seen"
+PENDING="${STATE_DIR}/pending"
+
+# Already surfaced this file this session — stay quiet. `refire` keys on the
+# way, not the file, so without this a permissive cadence re-nags about prose
+# the operator deliberately kept.
+[[ -f "$SEEN" ]] && grep -qxF "$path" "$SEEN" 2>/dev/null && exit 1
+
+# Inspect the text just written, not the file on disk. Reading the file would
+# fire on pre-existing density in any file merely touched — false attribution,
+# and a nag with no exit.
+CONTENT=$(printf '%s' "$INPUT" \
+  | jq -r '[.tool_input.content, .tool_input.new_string, (.tool_input.edits[]?.new_string)]
+           | map(select(. != null)) | join("\n")' 2>/dev/null || true)
+[[ -n "$CONTENT" ]] || exit 1
+
+# Strip everything that is not running prose. Tables, code, and headings carry
+# their own conventions and would skew every count — a comparison table is
+# allowed to be dense, and a fenced block may contain any character at all.
+PROSE=$(printf '%s\n' "$CONTENT" | awk '
+  /^```/          { fence = !fence; next }
+  fence           { next }
+  /^[[:space:]]*\|/ { next }
+  /^#{1,6} /      { next }
+  /^[[:space:]]*$/ { print ""; next }
+  {
+    gsub(/`[^`]*`/, "CODE"); gsub(/\]\([^)]*\)/, "]")
+    # Drop the definition separator on a list or bold-lead-in line. The
+    # corpus-wide "- name(domain) — description" and "**Term** — gloss" forms
+    # are structure, not prose, and counting them makes every way file and every
+    # See Also section read as em-dash dense. Only the first is structural; a
+    # second on the same line is the writer reaching for one.
+    if ($0 ~ /^[[:space:]]*[-*] / || $0 ~ /^\*\*/) sub(/ — /, ": ")
+    print
+  }
+')
+
+WORDS=$(printf '%s' "$PROSE" | wc -w | tr -d ' ')
+
+# Below this a single sentence swings the rate past any threshold. Short edits
+# are the common case and must stay silent.
+(( WORDS >= 150 )) || exit 1
+
+# A clause whose job is to tell the reader the previous clause mattered. This
+# is the check that discriminates: measured at 3.4 per 1k words in freshly
+# drafted prose against 0.5 in prose that had been reviewed.
+SIG=$(printf '%s' "$PROSE" | grep -oE \
+  "That is (the|what|why|precisely|not|exactly)\b|This is (the|not|why|what|precisely|exactly)\b|which is (exactly|precisely|why|the point)\b|(is|are|was|were) worth (stating|noting|dwelling|keeping|having|flagging)\b|matters? more than\b|The (tell|point|interesting part|important thing|key thing) is\b|is the (mark|signature|shape|tell) of\b|It is worth (noting|stating|saying)\b" \
+  2>/dev/null | wc -l | tr -d ' ')
+
+DASH=$(printf '%s' "$PROSE" | grep -o "—" 2>/dev/null | wc -l | tr -d ' ')
+
+# Rates per thousand words, integer arithmetic to avoid a bc dependency.
+SIG_RATE=$(( SIG * 1000 / WORDS ))
+DASH_RATE=$(( DASH * 1000 / WORDS ))
+
+# Thresholds are deliberately loose. A surface that nags trains its reader to
+# ignore it, so a fire has to mean something. Calibrated against measurements in
+# this repo: significance clauses at 3/1k sits above reviewed prose and below
+# the drafting average; em-dashes at 15/1k is roughly one every 67 words, which
+# is dense by any reading and well above where the punctuation earns its keep.
+(( SIG_RATE >= 3 || DASH_RATE >= 15 )) || exit 1
+
+mkdir -p "$STATE_DIR"
+printf '%s\n' "$path" >>"$SEEN"
+printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+  "$(date +%s)" "$path" "$WORDS" "$SIG" "$SIG_RATE" "$DASH_RATE" >>"$PENDING"
+
+# Bound both files. Unconsumed entries are normal — the inward gate may deny the
+# fire this request is asking for. The temp name carries $$ because parallel
+# Edit calls mean parallel PostToolUse hooks, and a shared temp name lets two
+# trimmers truncate the same file and mv a partial result over the state.
+for f in "$SEEN" "$PENDING"; do
+  if [[ -f "$f" ]] && (( $(wc -l <"$f") > 200 )); then
+    tmp="${f}.trim.$$"
+    tail -n 100 "$f" >"$tmp" 2>/dev/null && mv -f "$tmp" "$f"
+    rm -f "$tmp"
+  fi
+done
+
+exit 0

--- a/hooks/ways/meta/trust/prose/prose.md
+++ b/hooks/ways/meta/trust/prose/prose.md
@@ -1,0 +1,62 @@
+---
+description: How Claude's own prose reads — decoration and self-explanation in output, significance clauses, antithesis constructions, choppiness mistaken for directness, editing your own draft
+vocabulary: prose style voice tone register decoration significance clause hedge tic phrasing draft revise edit rewrite wording sentence paragraph readable admired flourish rhetorical wordy verbose padding
+scope: agent, subagent
+refire: 0.15
+---
+<!-- epistemic: heuristic -->
+# Prose — Delivering vs Decorating
+
+Core states the rule in two lines. This way carries the expanded version, because the rule fails in one specific place: long drafting sessions, many turns after core landed.
+
+## The failure this way is written against
+
+Measured in this repo. An 11,500-word document drafted across a dozen turns contained significance clauses at 3.4 per thousand words against 0.5 in prose that had been reviewed, plus eleven instances of a construction core explicitly bans. Core had fired. The writing way had fired, fifty epochs earlier, carrying "use em dashes sparingly."
+
+Two lessons sit in that.
+
+**A style rule holds for short output and decays across a long draft.** The failure is in detection rather than compliance. You do not notice the violation while producing it, so a rule you were told once does not survive an essay.
+
+**A rule with an adverb in it cannot be checked.** "Sparingly" has no threshold, so there is no moment at which you can test yourself against it. "Cut any clause that explains why the previous clause matters" is a search you can actually run.
+
+## What decoration looks like
+
+The tell is a sentence that explains its own importance. You write a fact, then attach a clause telling the reader what to think about it.
+
+| Decorated | Delivered |
+|---|---|
+| "The audit found three dead triggers. That is the mark of a system with no linting." | "The audit found three dead triggers, none of which the system would have surfaced on its own." |
+| "Core fires once per session. This is the most serious gap in the retention model." | "Core fires once per session and is never refreshed until compaction." |
+| "It is worth noting that the corpus has never shrunk." | "The corpus has never shrunk." |
+
+The right-hand column loses nothing. The reader who needed the fact can see why it matters.
+
+Watch for these specifically, because they are the productive forms:
+
+- `That is the…` / `This is the…` opening a sentence whose only job is evaluation
+- `which is exactly…` / `which is why…` bolted onto a finished clause
+- `worth noting/stating/flagging`
+- `X matters more than Y` where nothing downstream depends on the ranking
+- A one-sentence paragraph that only announces the previous paragraph's significance
+
+## Directness is not choppiness
+
+Short sentences are not the same as direct ones. Directness is the absence of detour, so a long sentence that goes straight at the point is direct, and two clipped ones the reader has to reassemble are not. Connect with *and*, *because*, *so* rather than breaking for emphasis. Emphasis by fragment is a form of decoration — it asks the reader to supply the drama.
+
+## Density is a symptom, not a rule
+
+Em-dashes, dramatic colons, and antithesis constructions are not wrong individually. They become a tic at volume, and volume is the thing to watch. Nobody should be counting punctuation while drafting; the count belongs to the check that runs afterward.
+
+## When you are editing your own draft
+
+Two passes, in this order:
+
+1. Search for the patterns above and cut. Cutting is almost always the correct fix; rewriting rarely is.
+2. Reread, and cut whatever you added back to preserve rhythm.
+
+## See Also
+
+- trust(meta) — the relational model this posture derives from
+- trust/voice(meta) — whose voice to write in, a separate question from how it reads
+- writing(writing) — structure, audience, and format for content creation
+- `documentation/markdown/density` — the postcheck that counts what you just wrote

--- a/hooks/ways/writing/writing.md
+++ b/hooks/ways/writing/writing.md
@@ -38,7 +38,6 @@ Write prose, not bullet points wearing a trenchcoat. Let ideas develop across se
 
 **Defaults (override per user preference):**
 - Prefer active voice. Use passive only when the actor is irrelevant or unknown.
-- Use em dashes sparingly — they lose force through overuse.
 - Avoid staccato sentence fragments for rhetorical impact. Let the substance carry the weight.
 - Lead with the conclusion when the audience is busy. Lead with context when the audience needs persuading.
 - Cut filler on revision. "In order to" → "To". "It should be noted that" → delete.
@@ -66,4 +65,5 @@ If the format doesn't fit the content (a slide deck for something that needs a d
 ## See Also
 
 - documentation(documentation) — code documentation is a specialized form of writing
+- trust/prose(meta) — decoration and self-explanation in your own prose
 - trust/voice(meta) — voice and tone in written communication


### PR DESCRIPTION
## What

Three-tier progressive disclosure for prose-decoration guidance, plus ADR-174 recording a gap found along the way.

| Tier | File | Fires |
|---|---|---|
| 1 | `core.md` | Turn 1. Two bullets under Posture. Covers chat, which no artifact check reaches. |
| 2 | `meta/trust/prose/` | Semantic match, `refire: 0.15`, parent boost from `trust`. Re-discloses on distance. |
| 3 | `documentation/markdown/density/` | Postcheck on the markdown just written. Macro reports measured counts. |

## Why

An 11,500-word draft measured at **3.4 significance clauses per 1k words** against **0.5** in reviewed prose, with **eleven** instances of a construction `core.md` bans and 118 em-dashes.

Both surfaces had fired. Core at session start; the writing way at epoch 4 with "use em dashes sparingly." The draft was written at epochs 45–57.

Two mechanisms, both supported by literature cited in the ADR:

- **Detection, not compliance, is the failure.** Negative-constraint violations go unnoticed by the writer producing them.
- **Style rules decay across a long draft.** Instruction-plus-example is the only combination with measured expansion discipline.

A rule with an adverb compounds it — "sparingly" has no threshold, so compliance can't be tested. "Cut any clause that explains why the previous clause matters" is a search that can be run.

## The finding worth reading

`core.md` is structurally excluded from re-disclosure. `scan/state.rs` gates it on a boolean marker, re-injecting only when the transcript since last summary is under 5000 bytes — a context-clear safety net. In a long session `ctx_size` passes 5000 within a couple of turns and never returns.

So `refire: 0.15` in core's frontmatter is inert, core never enters the firing ledger, and the retention profile is inverted: every matched way becomes *more* eligible to re-fire as distance grows, while core gets a gate that only opens when context is small.

Recorded as a finding, not fixed here. The direct fix re-injects ~900 words per fire and needs its own cost analysis.

## Calibration

Thresholds derive from measurements in this repo, not from taste:

- Significance clauses ≥3/1k (repo baseline 0.5, draft 3.4)
- Em-dashes ≥15/1k, **reported not banned** — repo prose runs 15.3/1k against the draft's 10.7, so density is the tic rather than the mark
- 150-word floor, per-file per-session suppression

## Verification

- Postcheck discriminates: dense chapters fire, the cleanest chapter (1.1/1k) stays silent, way files silent, short edits silent, own path excluded
- Macro reports and consumes with the same claim-by-rename and TTL handling as `reflow`
- `ways lint` clean across 136 way files
- `meta/trust/prose` enters an isolated corpus build with its description intact
- `density` carries no semantic lane, matching how `reflow` is built
- ADR-174 itself measures 0.8/1k and does not trip its own postcheck

Not verified: live match scores for the prose way, which need a corpus rebuild against the installed projection.

## Dogfooding note

The first drafts of the anti-decoration guidance measured 8.5 and 7.8 per 1k — worse than the document that prompted this. Cut to 2.2 and 4.2, where the remainder is deliberate examples.