### PR TITLE
fix(ways): resolve firing window by session id, unlatch the persisted curve

### DIFF
--- a/tools/sensor-trait/src/engagement.rs
+++ b/tools/sensor-trait/src/engagement.rs
@@ -126,6 +126,19 @@ impl EngagementState {
         &self.curve
     }
 
+    /// Replace the curve, preserving fire history.
+    ///
+    /// The curve is part of the serialized state, so a state reloaded from disk
+    /// carries whatever curve was current at first fire. When the curve is
+    /// derived from something that can change within a session — a `refire:`
+    /// fraction resolved against the context window, which is unknown until the
+    /// first assistant turn names a model — the persisted copy is stale and the
+    /// caller's freshly resolved one is authoritative. History stays: only the
+    /// decay shape is being corrected, not the record of what fired when.
+    pub fn set_curve(&mut self, curve: Curve) {
+        self.curve = curve;
+    }
+
     /// Whether any fire has been recorded. Useful for first-fire vs
     /// re-fire discrimination in the caller.
     pub fn has_fired(&self) -> bool {
@@ -174,6 +187,41 @@ impl EngagementState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn set_curve_replaces_decay_shape_and_keeps_history() {
+        // The curve is serialized with the state, so a state reloaded from disk
+        // carries whatever window was resolvable at first fire. Callers re-apply
+        // the current curve on load; that must not discard what already fired.
+        let mut state = EngagementState::new(Curve::Exponential { half_life: 30_000 });
+        state.record_fire(500, 1.0);
+
+        state.set_curve(Curve::Exponential { half_life: 150_000 });
+
+        assert!(matches!(
+            state.curve(),
+            Curve::Exponential {
+                half_life: 150_000
+            }
+        ));
+        assert!(state.has_fired(), "history dropped when the curve was swapped");
+        assert_eq!(state.last_fire_tick(), Some(500));
+    }
+
+    #[test]
+    fn a_widened_curve_suppresses_where_the_stale_one_would_refire() {
+        // Why the swap matters: at tick 40_000 a latched 30k half-life has
+        // decayed past REFIRE_FLOOR (0.5) and would re-disclose, while the
+        // correctly-resolved 150k curve has not.
+        let mut stale = EngagementState::new(Curve::Exponential { half_life: 30_000 });
+        stale.record_fire(0, 1.0);
+        assert!(stale.current_salience(40_000) < 0.5);
+
+        let mut fresh = EngagementState::new(Curve::Exponential { half_life: 30_000 });
+        fresh.record_fire(0, 1.0);
+        fresh.set_curve(Curve::Exponential { half_life: 150_000 });
+        assert!(fresh.current_salience(40_000) >= 0.5);
+    }
 
     fn ap_curve() -> Curve {
         Curve::ActionPotential {

--- a/tools/ways-cli/src/cmd/context.rs
+++ b/tools/ways-cli/src/cmd/context.rs
@@ -333,8 +333,10 @@ pub(crate) fn find_transcript_by_session_in(
     session_id: &str,
 ) -> Option<PathBuf> {
     let filename = format!("{session_id}.jsonl");
-    for entry in std::fs::read_dir(projects_root).ok()? {
-        let entry = entry.ok()?;
+    // `flatten` rather than `?` on each entry: one unreadable directory must not
+    // abort the scan. This gates `session_is_live`, so a single I/O error while
+    // iterating ~/.claude/projects would otherwise make every session look dead.
+    for entry in std::fs::read_dir(projects_root).ok()?.flatten() {
         let candidate = entry.path().join(&filename);
         if candidate.is_file() {
             return Some(candidate);

--- a/tools/ways-cli/src/cmd/context.rs
+++ b/tools/ways-cli/src/cmd/context.rs
@@ -313,17 +313,25 @@ fn read_token_usage(content: &str) -> (u64, String) {
     (estimated, "bytes".to_string())
 }
 
+/// The root every session transcript lives under, one directory per project.
+pub(crate) fn projects_root() -> PathBuf {
+    home_dir().join(".claude/projects")
+}
+
 /// Find a transcript by session id, searching every project dir under
 /// `~/.claude/projects/`. Session ids are globally unique, so we don't
 /// need to know which project the session is rooted in.
 pub(crate) fn find_transcript_by_session(session_id: &str) -> Option<PathBuf> {
-    find_transcript_by_session_in(&home_dir().join(".claude/projects"), session_id)
+    find_transcript_by_session_in(&projects_root(), session_id)
 }
 
 /// Search `projects_root/*/<session_id>.jsonl`. Split out from
 /// `find_transcript_by_session` so the lookup is testable against a temp
 /// projects root instead of the real `~/.claude/projects`.
-fn find_transcript_by_session_in(projects_root: &Path, session_id: &str) -> Option<PathBuf> {
+pub(crate) fn find_transcript_by_session_in(
+    projects_root: &Path,
+    session_id: &str,
+) -> Option<PathBuf> {
     let filename = format!("{session_id}.jsonl");
     for entry in std::fs::read_dir(projects_root).ok()? {
         let entry = entry.ok()?;

--- a/tools/ways-cli/src/cmd/list.rs
+++ b/tools/ways-cli/src/cmd/list.rs
@@ -5,6 +5,7 @@
 use anyhow::Result;
 use serde_json::json;
 use std::collections::HashMap;
+use std::path::Path;
 
 use crate::cmd::context;
 use crate::cmd::render::{self, WayRow};
@@ -46,9 +47,16 @@ pub fn run(session: Option<&str>, sort: &str, json_out: bool) -> Result<()> {
     let session_id = match session {
         Some(s) => s.to_string(),
         None => match detect_session() {
-            Some(s) => s,
-            None => {
+            Ok(s) => s,
+            Err(NoSession::NoMarkers) => {
                 println!("No session markers found. Ways will appear after the first hook fires.");
+                return Ok(());
+            }
+            Err(NoSession::AllOrphaned) => {
+                println!(
+                    "Session markers found, but no matching transcript. Pass --session <id> to \
+                     inspect one directly."
+                );
                 return Ok(());
             }
         },
@@ -231,62 +239,80 @@ fn load_metrics(session_id: &str) -> HashMap<String, MetricEntry> {
 /// created. Downstream, `get_context_for_session` then fails and the caller
 /// silently drops to marker-derived token positions, so the render looks
 /// plausible while describing a session that is not this one.
-fn session_is_live(session_id: &str) -> bool {
-    session_is_live_in(
-        std::path::Path::new(&crate::session::sessions_root()),
-        &crate::cmd::context::projects_root(),
-        session_id,
-    )
-}
-
-/// Pure core of [`session_is_live`]: both roots passed in. Split out because
-/// `sessions_root()` reads `XDG_RUNTIME_DIR`, and env vars are process-global
-/// while Rust tests run in parallel — a test that set it would race every other
-/// test resolving a session.
+/// Pure core of the liveness check: both roots passed in. Split out because
+/// `sessions_root()` reads `XDG_RUNTIME_DIR` and can shell out to `id -u`,
+/// and env vars are process-global while Rust tests run in parallel — a test
+/// that set it would race every other test resolving a session.
 fn session_is_live_in(
-    sessions_root: &std::path::Path,
-    projects_root: &std::path::Path,
+    sessions_root: &Path,
+    projects_root: &Path,
     session_id: &str,
 ) -> bool {
     sessions_root.join(session_id).is_dir()
         && crate::cmd::context::find_transcript_by_session_in(projects_root, session_id).is_some()
 }
 
-fn detect_session() -> Option<String> {
+/// Why auto-detection found nothing, so the caller can say which of the two
+/// it was rather than always blaming missing markers.
+enum NoSession {
+    /// No state dirs at all — no way has fired yet anywhere.
+    NoMarkers,
+    /// State dirs exist, but none of them has a transcript still on disk.
+    AllOrphaned,
+}
+
+fn detect_session() -> Result<String, NoSession> {
+    let sessions_root = crate::session::sessions_root();
+    let sessions_root = Path::new(&sessions_root);
+    let projects_root = crate::cmd::context::projects_root();
+    detect_session_in(sessions_root, &projects_root)
+}
+
+/// Pure core of [`detect_session`]: roots passed in, so the precedence is
+/// testable against temp dirs instead of the live `~/.claude`.
+///
+/// Both roots are resolved once by the caller — `session_is_live_in` runs per
+/// candidate, and re-deriving `sessions_root()` inside the loop would shell out
+/// to `id -u` once per session on platforms without `XDG_RUNTIME_DIR`.
+fn detect_session_in(sessions_root: &Path, projects_root: &Path) -> Result<String, NoSession> {
     let project = std::env::var("CLAUDE_PROJECT_DIR")
         .ok()
         .or_else(detect_project_dir);
 
     if let Some(ref proj) = project {
         if let Some(sid) = latest_session_for_project(proj) {
-            if session_is_live(&sid) {
-                return Some(sid);
+            if session_is_live_in(sessions_root, projects_root, &sid) {
+                return Ok(sid);
             }
         }
     }
 
-    let sessions: Vec<String> = session::list_sessions()
+    let all = session::list_sessions();
+    if all.is_empty() {
+        return Err(NoSession::NoMarkers);
+    }
+
+    let sessions: Vec<String> = all
         .into_iter()
-        .filter(|sid| session_is_live(sid))
+        .filter(|sid| session_is_live_in(sessions_root, projects_root, sid))
         .collect();
     if sessions.is_empty() {
-        return None;
+        return Err(NoSession::AllOrphaned);
     }
     if sessions.len() == 1 {
-        return Some(sessions.into_iter().next().unwrap());
+        return Ok(sessions.into_iter().next().unwrap());
     }
 
     let mut newest: Option<(std::time::SystemTime, String)> = None;
     for sid in sessions {
-        let dir = format!("{}/{sid}", crate::session::sessions_root());
-        if let Ok(meta) = std::fs::metadata(&dir) {
+        if let Ok(meta) = std::fs::metadata(sessions_root.join(&sid)) {
             let mtime = meta.modified().unwrap_or(std::time::UNIX_EPOCH);
             if newest.as_ref().is_none_or(|(t, _)| mtime > *t) {
                 newest = Some((mtime, sid));
             }
         }
     }
-    newest.map(|(_, s)| s)
+    newest.map(|(_, s)| s).ok_or(NoSession::AllOrphaned)
 }
 
 fn latest_session_for_project(project: &str) -> Option<String> {
@@ -388,9 +414,9 @@ mod tests {
 
     #[test]
     fn orphaned_state_dir_is_not_live() {
-        // The bug: auto-detect accepted a session on `is_dir()` alone. A state
-        // dir outlives its transcript, so an orphan won detection and the
-        // gauge silently fell back to marker-derived token positions.
+        // A state dir outlives its transcript. Pre-fix, `detect_session` took
+        // `is_dir()` as sufficient, so an orphan won detection and the gauge
+        // silently fell back to marker-derived token positions.
         let (sessions, projects) = temp_roots(line!(), &["orphan-sid"], &[]);
         assert!(!session_is_live_in(&sessions, &projects, "orphan-sid"));
         std::fs::remove_dir_all(sessions.parent().unwrap()).ok();

--- a/tools/ways-cli/src/cmd/list.rs
+++ b/tools/ways-cli/src/cmd/list.rs
@@ -223,6 +223,35 @@ fn load_metrics(session_id: &str) -> HashMap<String, MetricEntry> {
     map
 }
 
+/// A session id is only usable here if its transcript still exists.
+///
+/// The state dir under `sessions_root()` outlives the transcript it describes,
+/// so `is_dir()` alone happily returns an orphan — a session whose markers were
+/// written once and whose transcript has since been removed or was never
+/// created. Downstream, `get_context_for_session` then fails and the caller
+/// silently drops to marker-derived token positions, so the render looks
+/// plausible while describing a session that is not this one.
+fn session_is_live(session_id: &str) -> bool {
+    session_is_live_in(
+        std::path::Path::new(&crate::session::sessions_root()),
+        &crate::cmd::context::projects_root(),
+        session_id,
+    )
+}
+
+/// Pure core of [`session_is_live`]: both roots passed in. Split out because
+/// `sessions_root()` reads `XDG_RUNTIME_DIR`, and env vars are process-global
+/// while Rust tests run in parallel — a test that set it would race every other
+/// test resolving a session.
+fn session_is_live_in(
+    sessions_root: &std::path::Path,
+    projects_root: &std::path::Path,
+    session_id: &str,
+) -> bool {
+    sessions_root.join(session_id).is_dir()
+        && crate::cmd::context::find_transcript_by_session_in(projects_root, session_id).is_some()
+}
+
 fn detect_session() -> Option<String> {
     let project = std::env::var("CLAUDE_PROJECT_DIR")
         .ok()
@@ -230,14 +259,16 @@ fn detect_session() -> Option<String> {
 
     if let Some(ref proj) = project {
         if let Some(sid) = latest_session_for_project(proj) {
-            let dir = format!("{}/{sid}", crate::session::sessions_root());
-            if std::path::Path::new(&dir).is_dir() {
+            if session_is_live(&sid) {
                 return Some(sid);
             }
         }
     }
 
-    let sessions = session::list_sessions();
+    let sessions: Vec<String> = session::list_sessions()
+        .into_iter()
+        .filter(|sid| session_is_live(sid))
+        .collect();
     if sessions.is_empty() {
         return None;
     }
@@ -322,4 +353,66 @@ fn print_json(ways: &[FiredWay], current_epoch: u64, current_tokens_k: u64, cont
     });
 
     println!("{}", serde_json::to_string_pretty(&output).unwrap_or_default());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::session_is_live_in;
+    use std::path::PathBuf;
+
+    /// Build a sessions root holding a state dir per id, and a projects root
+    /// holding a transcript per (slug, id). Passing an id to one and not the
+    /// other is how a half-present session is staged.
+    fn temp_roots(
+        unique: u32,
+        state_dirs: &[&str],
+        transcripts: &[(&str, &str)],
+    ) -> (PathBuf, PathBuf) {
+        let base =
+            std::env::temp_dir().join(format!("ways_list_test_{}_{}", std::process::id(), unique));
+        let _ = std::fs::remove_dir_all(&base);
+        let sessions_root = base.join("sessions");
+        let projects_root = base.join("projects");
+        std::fs::create_dir_all(&sessions_root).unwrap();
+        std::fs::create_dir_all(&projects_root).unwrap();
+        for sid in state_dirs {
+            std::fs::create_dir_all(sessions_root.join(sid)).unwrap();
+        }
+        for (slug, sid) in transcripts {
+            let dir = projects_root.join(slug);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join(format!("{sid}.jsonl")), "{}\n").unwrap();
+        }
+        (sessions_root, projects_root)
+    }
+
+    #[test]
+    fn orphaned_state_dir_is_not_live() {
+        // The bug: auto-detect accepted a session on `is_dir()` alone. A state
+        // dir outlives its transcript, so an orphan won detection and the
+        // gauge silently fell back to marker-derived token positions.
+        let (sessions, projects) = temp_roots(line!(), &["orphan-sid"], &[]);
+        assert!(!session_is_live_in(&sessions, &projects, "orphan-sid"));
+        std::fs::remove_dir_all(sessions.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn state_dir_plus_transcript_is_live() {
+        // The positive case must still resolve, in any project dir — session
+        // ids are globally unique, so the slug is irrelevant.
+        let (sessions, projects) =
+            temp_roots(line!(), &["real-sid"], &[("-home-aaron-someproj", "real-sid")]);
+        assert!(session_is_live_in(&sessions, &projects, "real-sid"));
+        std::fs::remove_dir_all(sessions.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn transcript_without_state_dir_is_not_live() {
+        // The other half-present shape: a transcript exists but the session
+        // never wrote markers, so there is no fired-way state to render.
+        let (sessions, projects) =
+            temp_roots(line!(), &[], &[("-home-aaron-someproj", "no-state-sid")]);
+        assert!(!session_is_live_in(&sessions, &projects, "no-state-sid"));
+        std::fs::remove_dir_all(sessions.parent().unwrap()).ok();
+    }
 }

--- a/tools/ways-cli/src/cmd/list.rs
+++ b/tools/ways-cli/src/cmd/list.rs
@@ -54,8 +54,8 @@ pub fn run(session: Option<&str>, sort: &str, json_out: bool) -> Result<()> {
             }
             Err(NoSession::AllOrphaned) => {
                 println!(
-                    "Session markers found, but no matching transcript. Pass --session <id> to \
-                     inspect one directly."
+                    "Session markers found, but no matching transcript. List candidates with \
+                     `ways rethink list`, then pass --session <id> to inspect one directly."
                 );
                 return Ok(());
             }
@@ -268,12 +268,16 @@ fn detect_session() -> Result<String, NoSession> {
     detect_session_in(sessions_root, &projects_root)
 }
 
-/// Pure core of [`detect_session`]: roots passed in, so the precedence is
-/// testable against temp dirs instead of the live `~/.claude`.
+/// Core of [`detect_session`], with both roots passed in.
 ///
-/// Both roots are resolved once by the caller — `session_is_live_in` runs per
-/// candidate, and re-deriving `sessions_root()` inside the loop would shell out
-/// to `id -u` once per session on platforms without `XDG_RUNTIME_DIR`.
+/// Resolved once by the caller: `session_is_live_in` runs per candidate, and
+/// re-deriving `sessions_root()` inside the loop would shell out to `id -u`
+/// once per session on platforms without `XDG_RUNTIME_DIR`.
+///
+/// **Not yet fully injectable.** Enumeration and liveness both honor the passed
+/// roots, but `latest_session_for_project` still reads the global events log via
+/// `paths::events_log()`, so the project-scoped branch escapes them. Closing
+/// that is what stands between this and a temp-dir test of the full precedence.
 fn detect_session_in(sessions_root: &Path, projects_root: &Path) -> Result<String, NoSession> {
     let project = std::env::var("CLAUDE_PROJECT_DIR")
         .ok()
@@ -287,7 +291,7 @@ fn detect_session_in(sessions_root: &Path, projects_root: &Path) -> Result<Strin
         }
     }
 
-    let all = session::list_sessions();
+    let all = session::list_sessions_in(sessions_root);
     if all.is_empty() {
         return Err(NoSession::NoMarkers);
     }

--- a/tools/ways-cli/src/cmd/show/mod.rs
+++ b/tools/ways-cli/src/cmd/show/mod.rs
@@ -19,6 +19,33 @@ pub fn way(id: &str, session_id: &str, trigger: &str) -> Result<String> {
     way_scored(id, session_id, trigger, None, None, None)
 }
 
+/// Whether a resolved context actually detected its window, rather than falling
+/// back to `DEFAULT_WINDOW`. `EnvOverride` and `ModelTable` are detections;
+/// `Default` is the absence of one (ADR-166).
+fn window_detected(ctx: &crate::cmd::context::ContextInfo) -> bool {
+    ctx.window_source != ways_core::context_window::WindowSource::Default
+}
+
+/// Choose the window a firing way's `refire:` fraction resolves against.
+///
+/// Prefers the session-pinned lookup, but only when it detected a window —
+/// a transcript with no assistant turn yet returns `Ok` carrying a defaulted
+/// window, and accepting that would be worse than the project heuristic it
+/// replaced. `fallback` is lazy: the heuristic scans every project dir, and
+/// this runs on every way fire.
+fn resolve_firing_window(
+    pinned: Option<crate::cmd::context::ContextInfo>,
+    fallback: impl FnOnce() -> Option<crate::cmd::context::ContextInfo>,
+) -> u64 {
+    if let Some(ctx) = pinned.filter(window_detected) {
+        return ctx.tokens_total;
+    }
+    if let Some(ctx) = fallback().filter(window_detected) {
+        return ctx.tokens_total;
+    }
+    ways_core::context_window::resolve(None).tokens
+}
+
 /// Bound a matched surface to a single readable line for the `surface` telemetry
 /// field: collapse all whitespace to single spaces and truncate to ~200 chars on
 /// a char boundary (appending `…`). The snippet is a human read-side aid — a
@@ -93,17 +120,18 @@ pub fn way_scored(
     // other's windows, and a way firing in a 200k session against a 1M sibling's
     // transcript re-fires five times too slowly (or the reverse).
     //
-    // The curve itself is not persisted — `record_way_fire` stores tick and
-    // salience only, and every fire decision recomputes the curve from the
-    // window resolved here. So a window that is briefly wrong (the launch race,
-    // before the first assistant turn names a model) self-corrects on the next
-    // fire rather than sticking for the run. The project heuristic stays as the
-    // fallback for callers whose session has no transcript on disk.
+    // A *successful* lookup is not automatically a good one: a transcript that
+    // exists but has no assistant turn yet resolves to DEFAULT_WINDOW and still
+    // returns `Ok`. Accepting that would hand a launching subagent a defaulted
+    // window where the project heuristic would have found a real one, so both
+    // candidates are filtered on `window_source` — the field ADR-166 added so a
+    // default is never mistaken for a detection. `EnvOverride` counts as
+    // detected, keeping CLAUDE_CONTEXT_WINDOW authoritative on this path.
     let fm = frontmatter::parse(&way_file)?;
-    let window = crate::cmd::context::get_context_for_session(session_id)
-        .or_else(|_| crate::cmd::context::get_context(Some(&project_dir)))
-        .map(|c| c.tokens_total)
-        .unwrap_or_else(|_| ways_core::context_window::resolve(None).tokens);
+    let window = resolve_firing_window(
+        crate::cmd::context::get_context_for_session(session_id).ok(),
+        || crate::cmd::context::get_context(Some(&project_dir)).ok(),
+    );
     let curve = fm.resolved_curve(window).ok_or_else(|| {
         anyhow::anyhow!(
             "way {} is missing a `refire:` field in its frontmatter (ADR-126)",
@@ -471,6 +499,76 @@ fn normalize_way_id(id: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ways_core::context_window::WindowSource;
+
+    fn ctx(tokens_total: u64, window_source: WindowSource) -> crate::cmd::context::ContextInfo {
+        crate::cmd::context::ContextInfo {
+            tokens_used: 0,
+            tokens_total,
+            tokens_remaining: tokens_total,
+            pct_used: 0,
+            pct_remaining: 100,
+            model: "test".to_string(),
+            method: "test".to_string(),
+            session: "test".to_string(),
+            window_source,
+        }
+    }
+
+    #[test]
+    fn firing_window_prefers_the_pinned_session() {
+        // The fix: the firing session's own window wins over whatever the
+        // project heuristic's newest-transcript scan happens to land on.
+        let got = resolve_firing_window(Some(ctx(200_000, WindowSource::ModelTable)), || {
+            Some(ctx(1_000_000, WindowSource::ModelTable))
+        });
+        assert_eq!(got, 200_000);
+    }
+
+    #[test]
+    fn defaulted_pinned_window_yields_to_the_fallback() {
+        // The regression this guards: a subagent transcript exists but has no
+        // assistant turn yet, so the pinned lookup returns Ok carrying
+        // DEFAULT_WINDOW. Accepting it would latch a 200k curve on a 1M
+        // session; the project heuristic's real detection must win instead.
+        let got = resolve_firing_window(Some(ctx(200_000, WindowSource::Default)), || {
+            Some(ctx(1_000_000, WindowSource::ModelTable))
+        });
+        assert_eq!(got, 1_000_000);
+    }
+
+    #[test]
+    fn env_override_counts_as_detected() {
+        // ADR-166 keeps CLAUDE_CONTEXT_WINDOW authoritative, so an override on
+        // the pinned lookup must not be treated as a miss.
+        let got = resolve_firing_window(Some(ctx(500_000, WindowSource::EnvOverride)), || {
+            Some(ctx(1_000_000, WindowSource::ModelTable))
+        });
+        assert_eq!(got, 500_000);
+    }
+
+    #[test]
+    fn both_defaulted_falls_through_to_the_resolver() {
+        // Neither candidate detected anything: fall through to the single
+        // resolver rather than propagating either defaulted number.
+        let got = resolve_firing_window(Some(ctx(123, WindowSource::Default)), || {
+            Some(ctx(456, WindowSource::Default))
+        });
+        assert_eq!(got, ways_core::context_window::resolve(None).tokens);
+    }
+
+    #[test]
+    fn fallback_is_not_evaluated_when_pinned_is_detected() {
+        // The heuristic scans every project dir and this runs on every fire,
+        // so a usable pinned answer must short-circuit it.
+        let mut called = false;
+        let got = resolve_firing_window(Some(ctx(1_000_000, WindowSource::ModelTable)), || {
+            called = true;
+            None
+        });
+        assert_eq!(got, 1_000_000);
+        assert!(!called, "fallback ran despite a detected pinned window");
+    }
 
     #[test]
     fn surface_snippet_collapses_whitespace() {

--- a/tools/ways-cli/src/cmd/show/mod.rs
+++ b/tools/ways-cli/src/cmd/show/mod.rs
@@ -85,8 +85,23 @@ pub fn way_scored(
     // When the transcript can't be read at all, fall back through the one resolver
     // (ADR-166) rather than a second hardcoded constant, so the operator's
     // CLAUDE_CONTEXT_WINDOW is still honored on this path.
+    //
+    // Pin the lookup to the *firing* session. Resolving by `project_dir` alone
+    // sends `resolve_transcript` down its newest-transcript-in-project branch,
+    // which reads whichever session in that project wrote last — not necessarily
+    // this one. Concurrent sessions under one project therefore resolve each
+    // other's windows, and a way firing in a 200k session against a 1M sibling's
+    // transcript re-fires five times too slowly (or the reverse).
+    //
+    // The curve itself is not persisted — `record_way_fire` stores tick and
+    // salience only, and every fire decision recomputes the curve from the
+    // window resolved here. So a window that is briefly wrong (the launch race,
+    // before the first assistant turn names a model) self-corrects on the next
+    // fire rather than sticking for the run. The project heuristic stays as the
+    // fallback for callers whose session has no transcript on disk.
     let fm = frontmatter::parse(&way_file)?;
-    let window = crate::cmd::context::get_context(Some(&project_dir))
+    let window = crate::cmd::context::get_context_for_session(session_id)
+        .or_else(|_| crate::cmd::context::get_context(Some(&project_dir)))
         .map(|c| c.tokens_total)
         .unwrap_or_else(|_| ways_core::context_window::resolve(None).tokens);
     let curve = fm.resolved_curve(window).ok_or_else(|| {

--- a/tools/ways-cli/src/session.rs
+++ b/tools/ways-cli/src/session.rs
@@ -728,12 +728,20 @@ fn find_check_in_dir(dir: &Path) -> Option<PathBuf> {
 
 /// List all session IDs that have state directories.
 pub fn list_sessions() -> Vec<String> {
-    let root = PathBuf::from(sessions_root());
+    list_sessions_in(Path::new(&sessions_root()))
+}
+
+/// List session IDs under an explicit state root. Split out from
+/// [`list_sessions`] so callers that already resolved a root enumerate and
+/// test against *that* root — enumerating the real `~/.claude` while checking
+/// liveness against an injected one is internally inconsistent, and silently
+/// makes every injected root look empty.
+pub fn list_sessions_in(root: &Path) -> Vec<String> {
     if !root.is_dir() {
         return Vec::new();
     }
     let mut sessions = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(&root) {
+    if let Ok(entries) = std::fs::read_dir(root) {
         for entry in entries.flatten() {
             if entry.path().is_dir() {
                 if let Some(name) = entry.file_name().to_str() {

--- a/tools/ways-cli/src/session/engagement.rs
+++ b/tools/ways-cli/src/session/engagement.rs
@@ -55,12 +55,32 @@ fn engagement_path(way_id: &str, session_id: &str) -> PathBuf {
         .join(format!("{}.json", way_id.replace('/', "__")))
 }
 
+/// Load a way's engagement state, with the caller's curve taking precedence
+/// over the persisted one.
+///
+/// `EngagementState` serializes its curve, so a state written at first fire
+/// carries the curve resolved *then*. Under ADR-126 the curve comes from
+/// `refire:` resolved against the session's context window — and that window is
+/// `DEFAULT_WINDOW` until the first assistant turn names a model. Honoring the
+/// persisted copy latched that launch-race default for the rest of the session:
+/// a 1M session whose first fire landed early kept `half_life = 0.15 × 200_000`
+/// and re-fired five times too often, permanently.
+///
+/// Re-applying the caller's curve keeps the frontmatter the single source of
+/// truth for decay shape, and lets a mis-resolved window self-correct on the
+/// next fire. Fire history is preserved — only the curve is replaced.
 fn load_engagement(way_id: &str, session_id: &str, curve: &Curve) -> EngagementState {
     let path = engagement_path(way_id, session_id);
-    std::fs::read_to_string(&path)
+    match std::fs::read_to_string(&path)
         .ok()
         .and_then(|s| serde_json::from_str::<EngagementState>(&s).ok())
-        .unwrap_or_else(|| EngagementState::new(curve.clone()))
+    {
+        Some(mut state) => {
+            state.set_curve(curve.clone());
+            state
+        }
+        None => EngagementState::new(curve.clone()),
+    }
 }
 
 fn save_engagement(way_id: &str, session_id: &str, state: &EngagementState) {

--- a/tools/ways-cli/src/session/engagement.rs
+++ b/tools/ways-cli/src/session/engagement.rs
@@ -69,6 +69,18 @@ fn engagement_path(way_id: &str, session_id: &str) -> PathBuf {
 /// Re-applying the caller's curve keeps the frontmatter the single source of
 /// truth for decay shape, and lets a mis-resolved window self-correct on the
 /// next fire. Fire history is preserved — only the curve is replaced.
+///
+/// This cuts both ways. When the window *narrows* mid-session — `/model` from a
+/// 1M model to a 200k one — every way's half-life drops at once, and any way
+/// whose last fire is further back than the new half-life falls below
+/// `REFIRE_FLOOR` and re-discloses on its next trigger. In a long session that
+/// is most of them. This is intended: the window really did shrink, so the
+/// cadence really should tighten. It is self-limiting, since each way re-records
+/// at the current tick under the new curve and normalizes immediately after.
+///
+/// One consequence for readers of the on-disk state: the `curve` field in
+/// `way-engagement/*.json` is still written but no longer read by this path.
+/// It is diagnostic only — the gating curve always comes from frontmatter.
 fn load_engagement(way_id: &str, session_id: &str, curve: &Curve) -> EngagementState {
     let path = engagement_path(way_id, session_id);
     match std::fs::read_to_string(&path)


### PR DESCRIPTION
Closes #426. Closes #427.

Found while verifying that `meta/trust/prose/sustain` (1.7.2) actually re-discloses as context grows. It does — but the curve it decays on was being computed against the wrong window, and then frozen.

## What was broken

**The curve was latched at first fire.** `EngagementState` serializes its `curve`, and `load_engagement` discarded the caller's freshly-resolved one whenever the JSON parsed. Under ADR-126 the curve is `refire:` resolved against the context window — and that window is `DEFAULT_WINDOW` until the first assistant turn names a model. A way firing in that launch race latched `half_life = refire x 200_000` for the whole session: on a 1M session, re-firing five times too often, permanently. Confirmed on disk (`way-engagement/*.json` carry a baked `half_life`).

**The window came from the wrong session.** `show/mod.rs` resolved it via `get_context(Some(&project_dir))`, which forces `resolve_transcript` down its newest-transcript-in-project branch — whichever session in that project wrote last, not the one firing.

**`ways list` auto-detect accepted orphans.** A session state dir outlives its transcript, and `is_dir()` alone was the whole test.

## What changed

- `EngagementState::set_curve`; `load_engagement` re-applies the caller's curve, preserving fire history. Frontmatter is now the single source of truth for decay shape.
- `resolve_firing_window(pinned, fallback)` prefers the firing session but filters **both** candidates on `window_source != Default`. This matters: `get_context_for_session` returns `Ok` whenever the transcript file exists, even with no assistant turn — so pinning alone would have handed a launching subagent a defaulted 200k where the project heuristic finds a real 1M. `EnvOverride` still counts as detected, keeping `CLAUDE_CONTEXT_WINDOW` authoritative (ADR-166). The fallback is lazy; it scans every project dir and runs on every fire.
- Session detection requires a resolvable transcript, and returns `Result<String, NoSession>` so "markers exist but no transcript" stops reporting as "no markers found".
- `list_sessions_in(root)` added so enumeration and liveness agree on one root.
- `find_transcript_by_session_in` uses `flatten()` — it now gates liveness, so one unreadable directory would have made every session look dead.

## Side effect worth knowing

`ways list` renders its threshold from `way_refire_threshold_k`, which builds a fresh curve from frontmatter. Pre-fix the displayed cadence could disagree with the enforced one whenever the persisted curve was latched. They now agree by construction.

Narrowing the window mid-session (`/model` from 1M to 200k) now drops every way's half-life at once, so ways whose last fire is further back than the new half-life re-disclose on their next trigger. Intended and self-limiting; documented at `load_engagement`.

## Verification

Full workspace `cargo test` passes (38 suites). `cargo clippy --workspace --all-targets -- -D warnings` clean. `scripts/check-portability.sh` passes.

New tests: 5 on window precedence including that a detected pinned window short-circuits the fallback; 2 on the curve swap, one showing a stale 30k curve re-firing at a tick where the correct 150k suppresses; 3 on session liveness.

## Follow-ups filed

- #428 — `detect_session_in` still not fully injectable; `latest_session_for_project` scans the global events log unbounded.
- #429 — auto-detect can fall through to a session in a different project. Diagnostic only; firing is unaffected.

Reviewed by the `code-reviewer` agent over two rounds. First round found the curve-persistence claim in my original comment was backwards and that pinning alone regressed subagents — both fixed in 78d188a. Second round approved with the follow-ups above.