### PR TITLE
release(ways): bump to 1.7.3

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "ways"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "agent-fmt",
  "anyhow",

--- a/tools/ways-cli/Cargo.toml
+++ b/tools/ways-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ways"
-version = "1.7.2"
+version = "1.7.3"
 edition = "2021"
 description = "Unified CLI for ways — knowledge guidance for Claude Code"
 license = "MIT"


### PR DESCRIPTION
Version bump for 1.7.3.

Contains #430 — firing-window and session-detection fixes:

- The way-firing curve is no longer latched at first fire. `EngagementState` serializes its `curve`, and `load_engagement` was discarding the freshly-resolved one, so a way whose first fire landed before the transcript named a model kept `half_life = refire x 200_000` for the whole session (closes #426).
- The firing window resolves from the firing session, with both candidates filtered on `window_source` so a defaulted 200k never shadows a real detection.
- `ways list` auto-detect requires a resolvable transcript and distinguishes "no markers" from "markers, no transcript" (closes #427).

Follow-ups tracked in #428 and #429.