### PR TITLE
feat(ways): standing delegation authorization for the AgentTool gate (ADR-175)

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -95,6 +95,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-172](./system/ADR-172-turn-boundary-inbound-delivery-via-a-cli-owned-drain-checkpoint.md) | Turn-boundary inbound delivery via a CLI-owned drain checkpoint | Accepted |
 | [ADR-173](./system/ADR-173-chat-idiom-convergence-for-the-attend-command-surfaces.md) | Chat-idiom convergence for the attend command surfaces | Accepted |
 | [ADR-174](./system/ADR-174-progressive-core-decoration-guidance-and-the-core-re-disclosure-gap.md) | Progressive core — decoration guidance and the core re-disclosure gap | Draft |
+| [ADR-175](./system/ADR-175-standing-delegation-authorization-satisfies-the-harness-permission-gate-rather-than-overriding-it.md) | Standing delegation authorization satisfies the harness permission gate rather than overriding it | Draft |
 
 ## Governance
 _Provenance, traceability, controls, compliance mapping_

--- a/docs/architecture/system/ADR-175-standing-delegation-authorization-satisfies-the-harness-permission-gate-rather-than-overriding-it.md
+++ b/docs/architecture/system/ADR-175-standing-delegation-authorization-satisfies-the-harness-permission-gate-rather-than-overriding-it.md
@@ -118,7 +118,10 @@ when the operator has said to work solo.
 ### Negative
 
 - Tier 2 duplicates a short clause across several files. Adding a new delegating skill
-  means remembering to carry the clause, and nothing enforces it.
+  means remembering to carry the clause, and nothing enforces it. The drift is fail-closed
+  — a site without a clause grants nothing, so the model asks, which is the pre-change
+  behaviour — but the tiers can still fall out of step, and Tier 1 must name only
+  procedures that carry a clause at their own dispatch site.
 - The change is unverifiable from inside the repository. Whether the model actually
   delegates without asking can only be observed in live sessions.
 - If upstream flips `tengu_fennel_godwit` or removes the section, Tier 1 becomes an

--- a/docs/architecture/system/ADR-175-standing-delegation-authorization-satisfies-the-harness-permission-gate-rather-than-overriding-it.md
+++ b/docs/architecture/system/ADR-175-standing-delegation-authorization-satisfies-the-harness-permission-gate-rather-than-overriding-it.md
@@ -72,8 +72,17 @@ delegation — the moment at which the gate is already satisfied and the text is
 The cases that need it most (*"let's merge this"*, *"research X"*) do not match at all.
 Correct text on a surface that never fires changes nothing.
 
-Widening the pattern to reach those moments would require common-word alternations
-(`merge`, `review`), which is precisely the noise ADR-155's keyword gate exists to veto.
+Widening the pattern only partly helps, and is partly blocked. `review` is in the linter's
+`COMMON_WORDS` and is flagged regardless of anchoring, so the review half is unavailable.
+`merge` is not on that list, and `delivery/merge` already ships a lint-clean phrase pattern
+(`merge (this|it|the pr)`) that matches *"let's merge this"* today — so reach was never the
+whole problem.
+
+The binding constraint is different. A way has to *win* a match to disclose, and measurement
+during this work put `meta/subagents` fifth at 0.3 on *"delegate the code review to a
+subagent"* — below a project-local way — even though that query names delegation outright.
+A clause that must win a ranking to appear is a clause that sometimes doesn't. Sites don't
+rank; they are read when the procedure is read.
 
 ## Decision
 
@@ -102,6 +111,17 @@ The authorization is not unconditional. Delegation still requires asking when it
 part of an invoked procedure, when it spends significant tokens outside the stated task, or
 when the operator has said to work solo.
 
+It also grants *whether*, not *how wide*. A procedure that says "fan out" authorizes the
+fan-out it describes, not an unbounded agent count; the width is stated before spawning and
+asked for past roughly half a dozen. Without that bound the permission gate is answered and
+the cost gate quietly isn't.
+
+Tier 2 carries a corollary: a way that instructs the *opposite* verb at the same moment
+re-opens the recency contest this decision declines to enter. `delivery/github` said to
+"offer" a reviewer on the same trigger where `delivery/merge` now says to dispatch one.
+Aligning both was part of the change, and any future way covering a delegation moment has
+to be checked the same way.
+
 ## Consequences
 
 ### Positive
@@ -129,16 +149,22 @@ when the operator has said to work solo.
 
 ### Neutral
 
-- `subagents.md` needed a correctness pass regardless: it documents the tool as `Task`
-  (now `Agent`) and its agent roster omits several agents that exist. Done alongside.
+- `subagents.md` needed a correctness pass regardless, done alongside: it documented the
+  tool as `Task` (the model-facing name is `Agent`; the `Task` matchers in `settings.json`
+  are the harness event namespace and stay), and its roster listed only the `agents/`
+  directory, omitting the harness built-ins `Explore` and `general-purpose` that the
+  research way's fan-out step now names.
 - `counter_steer` remains untested. Confirming its presence requires a sample from a
   different account, not another session on this one.
 
 ## Alternatives Considered
 
-- **Widen `subagents.md`'s `pattern` to reach the moment-of-use vocabulary.** Rejected:
-  requires common-word alternations that ADR-155 §5 exists to prevent, and would make a
-  frequently-firing way out of one that should fire narrowly.
+- **Widen `subagents.md`'s `pattern` to reach the moment-of-use vocabulary.** Rejected, but
+  not because it is impossible: `review` is in the linter's `COMMON_WORDS` and unavailable,
+  while `merge` is clean and already used in phrase form elsewhere. Rejected because reach
+  is not the constraint — the way still has to win a match to disclose, and it ranked fifth
+  on a query that named delegation explicitly. It would also make a frequently-firing way
+  out of one that should fire narrowly.
 - **Flip the `tengu_fennel_godwit` killswitch.** Rejected: all-or-nothing across the
   `opus_5_prompt_bundle` capability, which would also drop `delivering_work_max` and
   `overcorrection`.

--- a/docs/architecture/system/ADR-175-standing-delegation-authorization-satisfies-the-harness-permission-gate-rather-than-overriding-it.md
+++ b/docs/architecture/system/ADR-175-standing-delegation-authorization-satisfies-the-harness-permission-gate-rather-than-overriding-it.md
@@ -1,0 +1,153 @@
+---
+status: Draft
+date: 2026-07-31
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-155
+---
+
+# ADR-175: Standing delegation authorization satisfies the harness permission gate rather than overriding it
+
+## Context
+
+Claude Code 2.1.219+ injects a system-prompt section (`heron_brook`) carrying a single
+constant, emitted as one block:
+
+```
+Do not call the AgentTool unless the user requested it
+Do not use workflows or deep-research unless the user requested it
+```
+
+The gate is the `opus_5_prompt_bundle` model capability plus the killswitch flag
+`tengu_fennel_godwit`, currently `false`. Confirmed live from inside two sessions during
+the investigation that produced this ADR. Upstream: `anthropics/claude-code#80988`, open,
+no staff response at time of writing.
+
+There is no opt-out. `CLAUDE_INTERNAL_FC_OVERRIDES` is dead code in 2.1.220 — an
+unconditional `return` precedes the env read. `DISABLE_GROWTHBOOK=1` makes matters worse,
+because the killswitch defaults `false` and blocking the fetch guarantees the gate stays
+open. Flipping `tengu_fennel_godwit` is all-or-nothing: the same capability gates five
+other sections including `delivering_work_max` and `overcorrection`, both of which are
+wanted. Buying delegation by dropping those is not a trade worth making.
+
+The constant carves out no exception by agent type. `code-reviewer` is suppressed exactly
+as `Explore` or `general-purpose` is. The observed effect is that the operator must name
+delegation explicitly on every occasion, including for procedures whose own documented
+steps call for it. That is the gate working as written, not a defect in it.
+
+A second, independently gated nudge exists: the `subagent_steer_delegation` experiment,
+arm `counter_steer`, injecting *"Subagents multiply cost and time… Delegate only when the
+payoff clearly exceeds that overhead."* It was not observed in either sampled session.
+Both samples share one account, and GrowthBook buckets on stable user attributes derived
+from email and account uuid, so two sessions on one account land the same arm by
+construction. The observation discriminates nothing; the gate is untested, not absent.
+
+### The two gates have different shapes
+
+`heron_brook` asks a permission question: *did the user request this?* Its condition is
+satisfiable — and satisfiable in advance, in writing, by the operator.
+
+`counter_steer` asks a cost/benefit question: *does the payoff exceed the overhead?* Its
+condition is answerable by stating the payoff.
+
+Neither is a prohibition. A countermand written as "ignore the above" fails both, and
+wins only on recency — user-authored way text and user-authored `CLAUDE.md` carry the same
+authority, so recency is the only lever such text has, and it is a weak one.
+
+### Placement is not firing
+
+`hooks/ways/meta/subagents/subagents.md` is the natural home for delegation doctrine, and
+`scope: agent` delivers it to the main loop — `scan/mod.rs` filters the task surface to
+ways whose scope contains `subagent`, so `agent` scope is main-loop delivery. But its
+trigger surface is:
+
+```
+pattern: subagent|delegat|spawn.{0,30}agent|review.{0,30}\bpr\b|organiz.{0,30}docs
+```
+
+Every one of those tokens is something the operator says only once they have already named
+delegation — the moment at which the gate is already satisfied and the text is redundant.
+The cases that need it most (*"let's merge this"*, *"research X"*) do not match at all.
+Correct text on a surface that never fires changes nothing.
+
+Widening the pattern to reach those moments would require common-word alternations
+(`merge`, `review`), which is precisely the noise ADR-155's keyword gate exists to veto.
+
+## Decision
+
+Encode the operator's authorization as **evidence that satisfies each gate on its own
+terms**, placed in two tiers.
+
+**Tier 1 — doctrine, in `hooks/ways/meta/subagents/subagents.md`.** Two sections. The
+first states that invoking a skill or way whose steps call for delegation *is* the user's
+request, and names the conditions under which delegation still requires asking. The second
+answers the cost/benefit nudge by requiring a one-clause payoff statement at the point of
+delegation. This tier explains the reasoning and is allowed to fire only when delegation
+is already named; at that moment it supplies the *how*, not the permission.
+
+**Tier 2 — operative clause, inline at each delegation site.** Every skill or way whose
+own steps direct a delegation carries a short authorization clause at that step. Skills are
+read at invocation, so the clause is present exactly when delegation is about to happen,
+with no dependence on a way firing. This is what reaches the *"let's merge this"* case: the
+merge skill loads, the clause sits in the step that dispatches `code-reviewer`.
+
+**Scope is `AgentTool` only.** Workflows and deep-research are the second line of the same
+constant and remain gated. They are token-invasive enough that the operator wants them
+proposed and discussed, never invoked unprompted. A change that also frees them is out of
+scope for this decision.
+
+The authorization is not unconditional. Delegation still requires asking when it is not
+part of an invoked procedure, when it spends significant tokens outside the stated task, or
+when the operator has said to work solo.
+
+## Consequences
+
+### Positive
+
+- Procedures that document a delegation step execute it, instead of stopping to re-ask for
+  permission the operator already granted by invoking the procedure.
+- The mechanism does not contradict the system prompt, so it does not depend on winning a
+  recency contest against it.
+- The payoff clause is useful on its own merits and remains correct whether or not
+  `counter_steer` is ever present in a given session.
+- Tier 2 is inherently drift-resistant in one direction: a delegation site that is deleted
+  takes its clause with it.
+
+### Negative
+
+- Tier 2 duplicates a short clause across several files. Adding a new delegating skill
+  means remembering to carry the clause, and nothing enforces it.
+- The change is unverifiable from inside the repository. Whether the model actually
+  delegates without asking can only be observed in live sessions.
+- If upstream flips `tengu_fennel_godwit` or removes the section, Tier 1 becomes an
+  explanation of a constraint that no longer exists and will need pruning.
+
+### Neutral
+
+- `subagents.md` needed a correctness pass regardless: it documents the tool as `Task`
+  (now `Agent`) and its agent roster omits several agents that exist. Done alongside.
+- `counter_steer` remains untested. Confirming its presence requires a sample from a
+  different account, not another session on this one.
+
+## Alternatives Considered
+
+- **Widen `subagents.md`'s `pattern` to reach the moment-of-use vocabulary.** Rejected:
+  requires common-word alternations that ADR-155 §5 exists to prevent, and would make a
+  frequently-firing way out of one that should fire narrowly.
+- **Flip the `tengu_fennel_godwit` killswitch.** Rejected: all-or-nothing across the
+  `opus_5_prompt_bundle` capability, which would also drop `delivering_work_max` and
+  `overcorrection`.
+- **`CLAUDE_INTERNAL_FC_OVERRIDES` / `DISABLE_GROWTHBOOK`.** Rejected: the first is dead
+  code in 2.1.220; the second guarantees the gate stays open, since the killswitch defaults
+  `false`.
+- **Put the authorization in user `CLAUDE.md`.** Rejected: same authorship as way text, so
+  it wins on recency alone, and it applies to every project rather than to the procedures
+  that actually specify delegation.
+- **Write the text as an explicit override of the system prompt.** Rejected: fails both
+  gates on their own terms, and instructs the model to disregard its own instructions —
+  a pattern that should not be normalized in this corpus regardless of whether it works.
+- **Wait for upstream.** Rejected as the sole response: issue 80988 is open with no staff
+  reply, and the friction is present in every session meanwhile. This decision is
+  compatible with an upstream fix and is cheap to remove if one lands.

--- a/hooks/ways/meta/subagents/subagents.md
+++ b/hooks/ways/meta/subagents/subagents.md
@@ -10,10 +10,10 @@ refire: 0.15
 
 ## How to Invoke
 
-Use the `Task` tool with `subagent_type` parameter:
+Use the `Agent` tool with the `subagent_type` parameter:
 
 ```
-Task(
+Agent(
   description: "Review PR for quality",
   prompt: "Review the changes in PR #42 for...",
   subagent_type: "code-reviewer"
@@ -45,6 +45,40 @@ Task(
 - Quick questions or clarifications
 
 Sub-agents are for delegation of token-intensive work, not every action.
+
+## Invocation Is Authorization
+
+Claude Code's system prompt on Opus 5 carries: *"Do not call the AgentTool unless the user
+requested it."* That is a permission gate, not a prohibition. It asks one question — did the
+user request delegation? This way answers it, in advance and in writing.
+
+**Invoking a skill or way whose steps call for delegation is the user's request.** When the
+operator runs `/merge`, `/develop`, or `/code-review`, or asks for a PR review or a research
+sweep, they have requested every delegation those procedures specify. Don't re-ask, and don't
+narrate the gate back at them. Delegate as the procedure directs.
+
+This is not an override. The gate's own condition is met.
+
+Still ask first when the delegation is **not** part of an invoked procedure, when it spends
+significant tokens outside the stated task, or when the operator has said to work solo.
+
+## Name the Payoff, Don't Assume It
+
+A second, independently gated nudge may also be present: *"Subagents multiply cost and
+time… Delegate only when the payoff clearly exceeds that overhead."* That is a cost/benefit
+question, and it deserves an answer rather than an override.
+
+State the payoff in one clause when you delegate:
+
+- **Fan-out reads** — "six independent files; subagents return conclusions, not file dumps"
+- **Isolation** — "review needs a reader who hasn't seen my reasoning"
+- **Parallel independent work** — "three unrelated call sites, no shared state"
+
+If you can't name the payoff in a clause, the nudge is right — do it inline.
+
+Both sections cover `AgentTool` only. `Workflow` and deep-research are gated by the same
+system-prompt constant and stay that way: propose them and discuss, never invoke unprompted.
+See ADR-175.
 
 ## Harness Wrappers Are Not Verdicts
 

--- a/hooks/ways/meta/subagents/subagents.md
+++ b/hooks/ways/meta/subagents/subagents.md
@@ -53,9 +53,13 @@ requested it."* That is a permission gate, not a prohibition. It asks one questi
 user request delegation? This way answers it, in advance and in writing.
 
 **Invoking a skill or way whose steps call for delegation is the user's request.** When the
-operator runs `/merge`, `/develop`, or `/code-review`, or asks for a PR review or a research
-sweep, they have requested every delegation those procedures specify. Don't re-ask, and don't
-narrate the gate back at them. Delegate as the procedure directs.
+operator runs `/merge` or `/code-review`, or asks for a PR review or a research sweep, they
+have requested every delegation those procedures specify. Don't re-ask, and don't narrate the
+gate back at them. Delegate as the procedure directs.
+
+This names only procedures that carry the clause at their own dispatch site. A skill that
+sequences other skills without spawning anything — `/develop` routes, it does not
+orchestrate — grants nothing here.
 
 This is not an override. The gate's own condition is met.
 

--- a/hooks/ways/meta/subagents/subagents.md
+++ b/hooks/ways/meta/subagents/subagents.md
@@ -31,6 +31,10 @@ Agent(
 | **workflow-orchestrator** | `workflow-orchestrator` | Project status, phase coordination |
 | **workspace-curator** | `workspace-curator` | Organize docs/, manage .claude/ directory |
 
+Project agents live in `agents/`. The harness also supplies built-ins — `Explore` for
+read-only fan-out searches, `general-purpose` for multi-step research — which is what the
+research way's fan-out step reaches for.
+
 ## Context Passing
 
 - Include specific file paths and line ranges in the prompt
@@ -53,18 +57,23 @@ requested it."* That is a permission gate, not a prohibition. It asks one questi
 user request delegation? This way answers it, in advance and in writing.
 
 **Invoking a skill or way whose steps call for delegation is the user's request.** When the
-operator runs `/merge` or `/code-review`, or asks for a PR review or a research sweep, they
-have requested every delegation those procedures specify. Don't re-ask, and don't narrate the
-gate back at them. Delegate as the procedure directs.
+operator runs `/merge`, asks to land or ship a branch, or asks for a PR review or a research
+sweep, they have requested every delegation those procedures specify. Don't re-ask, and don't
+narrate the gate back at them. Delegate as the procedure directs.
 
 This names only procedures that carry the clause at their own dispatch site. A skill that
 sequences other skills without spawning anything — `/develop` routes, it does not
-orchestrate — grants nothing here.
+orchestrate — grants nothing here, and neither does a built-in command this corpus can't
+annotate.
 
 This is not an override. The gate's own condition is met.
 
 Still ask first when the delegation is **not** part of an invoked procedure, when it spends
 significant tokens outside the stated task, or when the operator has said to work solo.
+
+The grant covers *whether*, not *how wide*. A procedure that says "fan out" authorizes the
+fan-out it describes, not an arbitrary number of agents — size it to the work, and say the
+number before spawning it. Past roughly half a dozen, ask.
 
 ## Name the Payoff, Don't Assume It
 

--- a/hooks/ways/research/research.md
+++ b/hooks/ways/research/research.md
@@ -16,7 +16,7 @@ Before searching, state what you're trying to learn and why. A vague "research X
 ## Investigation Structure
 
 1. **Scope** — What's in bounds? What would be a tangent?
-2. **Gather** — Use tools (WebSearch, WebFetch, Grep, Read) to collect information. Prefer primary sources over summaries of summaries.
+2. **Gather** — Use tools (WebSearch, WebFetch, Grep, Read) to collect information. Prefer primary sources over summaries of summaries. When the question spans several independent sources, asking for the research is asking for the sweep: fan `Explore` or `general-purpose` agents across them rather than pausing to request permission, and say why in a clause ("six independent sources; agents return conclusions, not page dumps"). Deep-research and `Workflow` are not covered by that — propose those and discuss. See ADR-175.
 3. **Evaluate** — Not all sources are equal. Official docs > blog posts > forum answers > LLM-generated content. Flag confidence levels.
 4. **Synthesize** — Compress findings into a structure the user can act on. Don't dump raw results.
 5. **Present** — Lead with the answer, then the evidence. The user wants the conclusion first.

--- a/hooks/ways/softwaredev/delivery/github/github.md
+++ b/hooks/ways/softwaredev/delivery/github/github.md
@@ -21,7 +21,9 @@ We use PRs for all changes, including solo projects. A PR without reviewers stil
 
 ## Code Review Before Merge
 
-After creating a PR, review before merging — don't wait to be asked. But *how hard* to review, and *whether a human reads first*, is the four-square decision in `delivery/merge`, not a fixed "always spawn one reviewer." At minimum offer a `code-reviewer` subagent; scale to a swarm for complex, high-blast-radius changes, and gate on operator approval when the work sets direction.
+After creating a PR, review before merging — don't wait to be asked. But *how hard* to review, and *whether a human reads first*, is the four-square decision in `delivery/merge`, not a fixed "always spawn one reviewer." At minimum dispatch a `code-reviewer` subagent; scale to a swarm for complex, high-blast-radius changes, and gate on operator approval when the work sets direction.
+
+Asking to merge is asking for that review, so dispatch it rather than asking permission to (ADR-175). The four-square decides review *depth* and whether a human reads first — never whether a review happens. Merge *strategy* is a separate question and still gets asked, below.
 
 ## Merge Strategy — Prefer Regular Merge
 

--- a/hooks/ways/softwaredev/delivery/merge/merge.md
+++ b/hooks/ways/softwaredev/delivery/merge/merge.md
@@ -31,6 +31,11 @@ When the classification is ambiguous, **surface the call** rather than silently
 picking a corner. Inside a `/goal` loop, bias toward the autonomous corners; outside
 one, ask.
 
+Whichever corner you land in, asking to merge is asking for the review this gate
+specifies — dispatch the reviewer rather than re-requesting permission to, and name the
+payoff in a clause as you do. The ambiguity worth surfacing is *which corner*, never
+*whether to review*. See ADR-175.
+
 ## Remediate before you merge
 
 A review that finds nothing changes nothing; a review that finds something is only worth running if the findings get fixed. **Remediate per finding** before the merge gate — apply the fix, or record why a finding is declined. Don't carry known findings past the gate. This is the step the loop is easy to skip: "reviewed" is not "landed clean."

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -95,11 +95,12 @@ rather than silently picking a corner. Inside a `/goal` loop, bias to the autono
 corners; outside one, ask. Team repos always gate; `/merge full-sail` is rejected for
 them and for direction-setting changes — say why.
 
-**Running a single review:**
+Invoking `/merge` is the request for the review this gate specifies, in whichever corner you
+landed — dispatch the reviewers, don't stop to ask permission for them. Say why in a clause as
+you go ("review needs a reader who hasn't seen my reasoning"). For a swarm, state the number
+before spawning it. See ADR-175.
 
-Invoking `/merge` is the request for this review — dispatch the reviewer, don't stop to ask
-permission for it. Say why in a clause as you go ("review needs a reader who hasn't seen my
-reasoning"). See ADR-175.
+**Running a single review:**
 
 ```
 Agent(subagent_type="code-reviewer", prompt="Review PR #<number> in this repo.

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -97,6 +97,10 @@ them and for direction-setting changes — say why.
 
 **Running a single review:**
 
+Invoking `/merge` is the request for this review — dispatch the reviewer, don't stop to ask
+permission for it. Say why in a clause as you go ("review needs a reader who hasn't seen my
+reasoning"). See ADR-175.
+
 ```
 Agent(subagent_type="code-reviewer", prompt="Review PR #<number> in this repo.
 Run gh pr diff <number> to see the changes. Post findings as a gh pr comment.")


### PR DESCRIPTION
## Problem

Claude Code 2.1.219+ injects a system-prompt section (`heron_brook`) on Opus 5 carrying a
single constant, emitted as one block:

```
Do not call the AgentTool unless the user requested it
Do not use workflows or deep-research unless the user requested it
```

Gate: the `opus_5_prompt_bundle` model capability plus killswitch `tengu_fennel_godwit`,
currently `false`. Confirmed live from inside two sessions. Upstream:
[anthropics/claude-code#80988](https://github.com/anthropics/claude-code/issues/80988),
open, no staff reply.

No opt-out exists. `CLAUDE_INTERNAL_FC_OVERRIDES` is dead code in 2.1.220 (unconditional
`return` before the env read), and `DISABLE_GROWTHBOOK=1` makes it worse since the
killswitch defaults `false`. Flipping the killswitch is all-or-nothing: the same capability
gates five other sections including `delivering_work_max` and `overcorrection`.

The constant carves out no exception by agent type, so `code-reviewer` is suppressed
exactly like `Explore`. The operator has to name delegation explicitly every time —
including for procedures whose own steps call for it.

## Approach

**Evidence, not override.** The gate asks a permission question, and its condition is
satisfiable in advance and in writing by the operator. An "ignore the above" countermand
fails on its own terms and wins only on recency, since way text and `CLAUDE.md` share the
operator's authorship.

A second gate (`subagent_steer_delegation`, arm `counter_steer`) asks a cost/benefit
question instead. It is answered by naming the payoff, not by overriding.

## Changes

**Tier 1 — doctrine** in `hooks/ways/meta/subagents/subagents.md`: invocation is
authorization, plus a payoff clause for the cost/benefit gate.

**Tier 2 — operative clause** inline at each site that actually directs a delegation:

| Site | Where |
|---|---|
| `skills/merge/SKILL.md` | the review gate, beside the `Agent(...)` dispatch |
| `hooks/ways/softwaredev/delivery/merge/merge.md` | the four-square classification |
| `hooks/ways/research/research.md` | the Gather fan-out step |

Site-level rather than widening `subagents.md`'s `pattern`. Reaching *"let's merge this"*
by regex needs common-word alternations (`merge`, `review`) — exactly the noise ADR-155 §5
exists to veto. A skill is read at invocation, so the clause is present whenever delegation
is about to happen with no dependence on a way firing.

`delivery/branching` was considered and declined: it scores high on merge-shaped queries but
directs no delegation, so placing an authorization there is trigger-chasing under a
different filename.

## Scope

**`AgentTool` only.** Workflows and deep-research are the second line of the same constant
and stay gated — proposed and discussed, never invoked unprompted. Authorization is also
conditional: ad-hoc delegation outside an invoked procedure still asks first.

## Also

`subagents.md` documented the tool as `Task`; the model-facing name is `Agent`. The `Task`
matchers in `settings.json` are the harness event namespace and are deliberately unchanged —
renaming them would break subagent way injection.

## Verification

- `ways lint hooks/ways --check` — 137 files, 0 errors, 0 warnings
- `adr lint` — 0 errors (1 pre-existing warning on ADR-127, unrelated)

Behavioural acceptance is only observable in live sessions; it can't be verified from inside
the repo. Noted as a limitation in the ADR.

## Known limitation

`counter_steer` was not observed in either sampled session, but both samples share one
account and GrowthBook buckets on stable user attributes, so they land the same arm by
construction. That gate is **untested, not absent** — §2 of the way text is written
defensively for it.

Implements ADR-175.
