### PR TITLE
release(ways): bump to 1.7.4

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "ways"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "agent-fmt",
  "anyhow",

--- a/tools/ways-cli/Cargo.toml
+++ b/tools/ways-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ways"
-version = "1.7.3"
+version = "1.7.4"
 edition = "2021"
 description = "Unified CLI for ways — knowledge guidance for Claude Code"
 license = "MIT"


### PR DESCRIPTION
Patch release carrying ADR-175 — standing delegation authorization for the AgentTool gate (#432).

Ways-corpus content change; no Rust changes. Version bump only.

Tag `ways-v1.7.4` follows the merge and triggers the multi-platform build and release publish.