### PR TITLE
fix(reflow): lower the detection floor to the wrap shapes agents actually write

### DIFF
--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -60,9 +60,7 @@ git remote add upstream https://github.com/aaronsb/agent-ways
 ./scripts/install.sh
 ```
 
-Running the installer from inside the app dir is what links the suite binaries
-(`ways`, `ways-audit`, `attend`, `attend-chat`) onto your `PATH`; `make setup`
-alone builds them but does not. Pull upstream improvements later:
+Running the installer from inside the app dir is what links the suite binaries (`ways`, `ways-audit`, `attend`, `attend-chat`) onto your `PATH`; `make setup` alone builds them but does not. Pull upstream improvements later:
 
 ```bash
 cd "$XDG_DATA_HOME/agent-ways"

--- a/docs/migration-1.0.md
+++ b/docs/migration-1.0.md
@@ -33,22 +33,15 @@ Background: [ADR-142](architecture/system/ADR-142-agent-ways-1-0-xdg-application
 
 ## Do I need to migrate?
 
-You're a **legacy in-place** install — the one population this targets — if `~/.claude/.git`
-exists and its `origin` points at `aaronsb/agent-ways` (or your fork). That's the
-clone-in-place model 1.0 supersedes.
+You're a **legacy in-place** install — the one population this targets — if `~/.claude/.git` exists and its `origin` points at `aaronsb/agent-ways` (or your fork). That's the clone-in-place model 1.0 supersedes.
 
 If you started fresh on 1.0, or never made `~/.claude` a git repo, there's nothing to migrate.
 
 ## Before you start
 
-The migrator is built to be safe — it **backs up `~/.claude` first** (to
-`~/.claude.backup-<epoch>`), reconciles the new shape **before** removing the old one, and
-is **resumable**: if a phase aborts it stamps a marker, and re-running `--execute` continues
-where it stopped rather than starting over.
+The migrator is built to be safe — it **backs up `~/.claude` first** (to `~/.claude.backup-<epoch>`), reconciles the new shape **before** removing the old one, and is **resumable**: if a phase aborts it stamps a marker, and re-running `--execute` continues where it stopped rather than starting over.
 
-That said, the one genuinely irreplaceable thing is **`~/.claude/projects/`** — your session
-transcripts. It's preserved in place, but snapshotting it yourself costs nothing and is
-cheap insurance for any migration:
+That said, the one genuinely irreplaceable thing is **`~/.claude/projects/`** — your session transcripts. It's preserved in place, but snapshotting it yourself costs nothing and is cheap insurance for any migration:
 
 ```bash
 cp -a ~/.claude/projects ~/claude-projects-keepsake
@@ -73,9 +66,7 @@ ways migrate            # the plan (default): what would change, read-only
 ways migrate --what-if  # dry-run the executor: assert every phase's contract without writing
 ```
 
-`--what-if` is the stronger check — it runs the executor's logic against your real install
-and verifies each phase *could* succeed, without touching anything. Read its output before
-proceeding.
+`--what-if` is the stronger check — it runs the executor's logic against your real install and verifies each phase *could* succeed, without touching anything. Read its output before proceeding.
 
 **3. Execute.** Gated, backs up first, resumable:
 
@@ -83,21 +74,17 @@ proceeding.
 ways migrate --execute
 ```
 
-When it finishes, `~/.claude` is the projection and the app lives in
-`$XDG_DATA_HOME/agent-ways`. Verify:
+When it finishes, `~/.claude` is the projection and the app lives in `$XDG_DATA_HOME/agent-ways`. Verify:
 
 ```bash
 ways status            # binary, model, corpus, project detection — all should resolve
 ```
 
-`ways status` should show the `ways` binary resolving through `~/.claude/bin/ways` to a real
-file under `$XDG_DATA_HOME/agent-ways/bin/`, the corpus under `$XDG_CACHE_HOME/agent-ways`,
-and your core ways count intact.
+`ways status` should show the `ways` binary resolving through `~/.claude/bin/ways` to a real file under `$XDG_DATA_HOME/agent-ways/bin/`, the corpus under `$XDG_CACHE_HOME/agent-ways`, and your core ways count intact.
 
 ## If something goes wrong
 
-The migrator fails safe. On an aborted phase it **prints the exact restore command** and
-leaves your backup untouched. To roll back manually:
+The migrator fails safe. On an aborted phase it **prints the exact restore command** and leaves your backup untouched. To roll back manually:
 
 ```bash
 rm -rf ~/.claude
@@ -107,9 +94,7 @@ mv ~/.claude.backup-<epoch> ~/.claude
 Because it's marker-resumable, you can also just fix the cause and re-run `ways migrate
 --execute` to continue.
 
-Hit a migration bug? **Please report it.** Real-world migrations on varied installs are
-exactly how correctness fixes land in the 1.0.x line — the same way the first round of fixes
-did before 1.0.0 shipped.
+Hit a migration bug? **Please report it.** Real-world migrations on varied installs are exactly how correctness fixes land in the 1.0.x line — the same way the first round of fixes did before 1.0.0 shipped.
 
 ## The migration window — don't wait indefinitely
 
@@ -134,15 +119,11 @@ ways migrate --execute
 # then update to the current release
 ```
 
-The transition fallbacks in 1.0.x mean an un-migrated install keeps *working* in the
-meantime — but the supported, friction-free path is to migrate while the command is still in
-the binary.
+The transition fallbacks in 1.0.x mean an un-migrated install keeps *working* in the meantime — but the supported, friction-free path is to migrate while the command is still in the binary.
 
 ## After migrating
 
-Your mental model for developing on and updating agent-ways changes with the layout — the
-install, your dev checkout, and a sandbox are now three different places. See
-[development.md](development.md) for the post-1.0 workflow.
+Your mental model for developing on and updating agent-ways changes with the layout — the install, your dev checkout, and a sandbox are now three different places. See [development.md](development.md) for the post-1.0 workflow.
 
 ## See also
 

--- a/hooks/ways/data/documentation/documentation.md
+++ b/hooks/ways/data/documentation/documentation.md
@@ -15,15 +15,9 @@ from the DDL — the source of truth — so they can't lie.**
 
 - **Derive from the schema, not from memory.** Parse the DDL (`CREATE TABLE`,
   `COMMENT ON`, constraints) or introspect a dump. Never transcribe a schema by hand.
-- **Parse textually, no live database.** A generator that reads the `.sql` rather
-  than connecting runs in CI with nothing but the interpreter — deterministic,
-  reviewable, no credentials.
-- **Emit two things:** a *reference* (tables, columns, types, constraints,
-  comments) and a *diagram*. They serve different readers — one is looked up, one
-  is scanned for shape.
-- **Regenerate on every deploy.** Wire it into the docs build so the page and the
-  diagram are rebuilt from the current schema — a generated artifact nobody
-  regenerates is just a slower kind of stale.
+- **Parse textually, no live database.** A generator that reads the `.sql` rather than connecting runs in CI with nothing but the interpreter — deterministic, reviewable, no credentials.
+- **Emit two things:** a *reference* (tables, columns, types, constraints, comments) and a *diagram*. They serve different readers — one is looked up, one is scanned for shape.
+- **Regenerate on every deploy.** Wire it into the docs build so the page and the diagram are rebuilt from the current schema — a generated artifact nobody regenerates is just a slower kind of stale.
 
 ## Diagrams
 

--- a/hooks/ways/data/migrations/checkpoint/checkpoint.md
+++ b/hooks/ways/data/migrations/checkpoint/checkpoint.md
@@ -16,13 +16,11 @@ Replay the old baseline **plus every migration** into a throwaway database, then
 
 ## Prove it faithful before retiring anything
 
-Build a second throwaway database from the **candidate baseline alone** and diff
-it against the replayed original:
+Build a second throwaway database from the **candidate baseline alone** and diff it against the replayed original:
 
 - full schema dump (tables, columns, types, constraints, indexes)
 - per-table row counts, and normalized seed data
-- for graph/extension stores, anything a plain dump misses (e.g. an AGE label
-  catalog) — carried into the baseline verbatim, since it can't round-trip
+- for graph/extension stores, anything a plain dump misses (e.g. an AGE label catalog) — carried into the baseline verbatim, since it can't round-trip
 
 They must match exactly. If they don't, the baseline is wrong — stop.
 

--- a/hooks/ways/data/migrations/idempotent/idempotent.md
+++ b/hooks/ways/data/migrations/idempotent/idempotent.md
@@ -26,9 +26,7 @@ Insert the applied-version row into the ledger as the **final statement, inside 
 
 ## Verify
 
-Run the migration, then run it **again** against the same database. The second
-run must complete with no error and no change. If it throws, an object isn't
-guarded — fix it before the migration leaves your machine.
+Run the migration, then run it **again** against the same database. The second run must complete with no error and no change. If it throws, an object isn't guarded — fix it before the migration leaves your machine.
 
 ## See Also
 

--- a/hooks/ways/data/migrations/numbering/numbering.md
+++ b/hooks/ways/data/migrations/numbering/numbering.md
@@ -8,9 +8,7 @@ refire: 0.15
 <!-- epistemic: convention -->
 # Migration Numbering
 
-A migration's **number is its identity**. The rules that keep a history sane are
-about never disturbing a number once it exists, because downstream databases
-have already recorded it.
+A migration's **number is its identity**. The rules that keep a history sane are about never disturbing a number once it exists, because downstream databases have already recorded it.
 
 ## The rules
 

--- a/hooks/ways/documentation/adr/migration/migration.md
+++ b/hooks/ways/documentation/adr/migration/migration.md
@@ -23,11 +23,7 @@ refire: 0.15
 
 No existing ADRs. Scaffold the full structure.
 
-1. **Vendor the tooling.** The install steps (copy-not-symlink, `adr.yaml` setup)
-   live in the **adr** skill — that's the canonical *how*. For the optional doc
-   catalog (prose + ADRs as one typed graph, ADR-302, sharing this `adr.yaml`),
-   use the **docs** skill. To scaffold tooling *and* the surrounding repo health
-   in one pass, prefer `project-init`.
+1. **Vendor the tooling.** The install steps (copy-not-symlink, `adr.yaml` setup) live in the **adr** skill — that's the canonical *how*. For the optional doc catalog (prose + ADRs as one typed graph, ADR-302, sharing this `adr.yaml`), use the **docs** skill. To scaffold tooling *and* the surrounding repo health in one pass, prefer `project-init`.
 
 2. Verify:
 ```bash
@@ -35,9 +31,7 @@ docs/scripts/adr domains    # Should show your configured domains
 docs/scripts/adr list       # Should show 0 ADRs
 ```
 
-The rest of this way is the migration-specific *why/when/what* the skill doesn't
-cover: which starting state you're in, and how to get existing decisions into the
-tooling without losing history.
+The rest of this way is the migration-specific *why/when/what* the skill doesn't cover: which starting state you're in, and how to get existing decisions into the tooling without losing history.
 
 ## Flat Directory Migration
 

--- a/hooks/ways/documentation/diataxis/diataxis.md
+++ b/hooks/ways/documentation/diataxis/diataxis.md
@@ -24,8 +24,7 @@ docs/scripts/doc lint                            # the page is lint-clean by con
 
 Two questions place every page:
 
-1. **Is the reader _studying_ or _working_?** Building understanding for later, or
-   solving a task right now?
+1. **Is the reader _studying_ or _working_?** Building understanding for later, or solving a task right now?
 2. **Is the content _practical steps_ or _theoretical knowledge_?** Things to *do*,
    or things that *are* / *why*?
 
@@ -42,9 +41,7 @@ Two questions place every page:
 ## Rules
 
 - **There is no fifth mode.** If a page won't fit one quadrant, it is two pages.
-- **One mode per page.** The classic failure is a tutorial that keeps stopping to
-  explain, or a reference padded with how-to steps — each interrupts the other's
-  job. Split them and `related:`-link across.
+- **One mode per page.** The classic failure is a tutorial that keeps stopping to explain, or a reference padded with how-to steps — each interrupts the other's job. Split them and `related:`-link across.
 - **The mode is a promise to the reader** about what kind of help they're getting.
   Keep the page faithful to its quadrant; if it drifts, reclassify or split.
 

--- a/hooks/ways/documentation/documentation.md
+++ b/hooks/ways/documentation/documentation.md
@@ -41,11 +41,8 @@ names the shape so the corpus has somewhere to grow into.
 
 - **Type once, serialize many** — one graph; many views (dev tree, published site,
   Obsidian graph, audience bundles). Audience drives the *view*, never the type.
-- **An invariant earns its place only if its violation is a real defect** — a
-  dangling edge, a supersede cycle, an id that disagrees with its mode. Rigor that
-  tracks nothing is just a tax.
-- **Progressive disclosure, task-orientation, currency** — overview before
-  detail; organize by reader job; an outdated page is a broken front door.
+- **An invariant earns its place only if its violation is a real defect** — a dangling edge, a supersede cycle, an id that disagrees with its mode. Rigor that tracks nothing is just a tax.
+- **Progressive disclosure, task-orientation, currency** — overview before detail; organize by reader job; an outdated page is a broken front door.
 
 ## See Also
 

--- a/hooks/ways/ea/briefing/briefing.md
+++ b/hooks/ways/ea/briefing/briefing.md
@@ -20,9 +20,7 @@ The briefing skill can gather with parallel scout subagents or directly. Use the
 
 ## Surface, don't act
 
-A briefing ends in *suggestions* — a ranked action list and proposed task mutations
-the user approves, modifies, or dismisses. It never sends, schedules, or mutates on
-its own. Acting is a separate, approved step.
+A briefing ends in *suggestions* — a ranked action list and proposed task mutations the user approves, modifies, or dismisses. It never sends, schedules, or mutates on its own. Acting is a separate, approved step.
 
 ## See also
 

--- a/hooks/ways/meta/attend/build-complete/build-complete.md
+++ b/hooks/ways/meta/attend/build-complete/build-complete.md
@@ -15,5 +15,4 @@ A background build has finished. Consider:
 3. **Note warnings** worth investigating — new warnings from your changes are signal
 4. **Resume blocked work** — if you were waiting on this build, pick up where you left off
 
-Only engage if the build is relevant to current work. The user may already be
-aware via terminal output.
+Only engage if the build is relevant to current work. The user may already be aware via terminal output.

--- a/hooks/ways/meta/attend/reflection-overdue/reflection-overdue.md
+++ b/hooks/ways/meta/attend/reflection-overdue/reflection-overdue.md
@@ -16,6 +16,4 @@ This is the window closing — take a moment to capture what matters:
 3. **Current state** — what's in progress, what's blocked, what's next
 4. **Save to memory** anything the next session needs to know
 
-A brief, honest reflection is more valuable than a comprehensive one.
-Three sentences about what surprised you is worth more than a page of
-status reporting.
+A brief, honest reflection is more valuable than a comprehensive one. Three sentences about what surprised you is worth more than a page of status reporting.

--- a/hooks/ways/meta/choices/choices.md
+++ b/hooks/ways/meta/choices/choices.md
@@ -8,9 +8,7 @@ refire: 0.15
 <!-- epistemic: heuristic -->
 # Presenting Choices
 
-When you hit a real branch point — distinct options whose answer changes what you
-do next — **present it as an explicit choice**, not a paragraph the human has to
-parse, and not a silent pick they only discover from the result.
+When you hit a real branch point — distinct options whose answer changes what you do next — **present it as an explicit choice**, not a paragraph the human has to parse, and not a silent pick they only discover from the result.
 
 The harness has a tool for this (`AskUserQuestion`): structured options with short headers, a recommended default, and one-line tradeoffs. A clean choice surface respects the human's time far more than a wall of prose ending in "let me know how you'd like to proceed" — and far more than guessing and making them undo it.
 
@@ -30,8 +28,7 @@ The harness has a tool for this (`AskUserQuestion`): structured options with sho
   choice with no point of view is a burden, not a service.
 - **Make options genuinely distinct.** If two collapse to the same outcome, it's
   one option. State the *tradeoff*, not just the label.
-- **Keep it small.** Two to four options per question, a handful of questions at
-  most. The goal is calibration, not a survey.
+- **Keep it small.** Two to four options per question, a handful of questions at most. The goal is calibration, not a survey.
 - **Don't ask what you've been told.** If the human already decided, act on it.
 
 The bar is a *genuine* fork. Over-asking trains the human to rubber-stamp, which defeats the point — the same way a linter that nags on non-defects trains its reader to ignore it. Ask when their answer changes the work; otherwise decide, state it, and keep moving.

--- a/hooks/ways/meta/compaction-checkpoint/compaction-checkpoint.md
+++ b/hooks/ways/meta/compaction-checkpoint/compaction-checkpoint.md
@@ -55,12 +55,9 @@ This is the difference between controlled compaction (user-directed, synthesis-a
 
 ## If a Goal Is Active
 
-A `/goal` survives compaction — it's session-scoped, and compaction doesn't end the
-session, so the evaluator keeps driving toward the condition on the other side.
-When a goal is active:
+A `/goal` survives compaction — it's session-scoped, and compaction doesn't end the session, so the evaluator keeps driving toward the condition on the other side. When a goal is active:
 
-- **Restate the goal condition in the synthesis** — it's the anchor the
-  post-compaction turns will steer by.
+- **Restate the goal condition in the synthesis** — it's the anchor the post-compaction turns will steer by.
 - **Keep the checkpoint light** — the goal already carries the direction, so confirm
   it still holds rather than re-deriving priorities from scratch.
 - **Consider finishing first** — if the goal's work is nearly done, completing it

--- a/hooks/ways/meta/deployment/deployment.md
+++ b/hooks/ways/meta/deployment/deployment.md
@@ -10,8 +10,7 @@ scope: agent, subagent
 
 In 1.0, `~/.claude` is a **thin projection** of an XDG application, not the app itself (ADR-142). The source lives in `$XDG_DATA_HOME/agent-ways`; `~/.claude` gets symlinks to the projected roots (`skills/`, `agents/`, `commands/`, `hooks/ways/`, built binaries) plus a three-way merge into `settings.json`. Everything else the app ships — `scripts/`, `tools/`, `docs/`, `governance/` — **stays in `$XDG_DATA`** and is deliberately *not* projected. So `~/.claude` remains the user's own directory (their sessions, credentials, and settings survive); agent-ways just adds its links.
 
-This supersedes the pre-1.0 world where `~/.claude` *was* the git clone. That
-"in-place" topology (and the `sync-to-home` subdirectory variant, ADR-140) is now
+This supersedes the pre-1.0 world where `~/.claude` *was* the git clone. That "in-place" topology (and the `sync-to-home` subdirectory variant, ADR-140) is now
 **legacy**: an install still on it needs to **migrate**, not update in place.
 
 ## How install and update work now

--- a/hooks/ways/meta/develop/develop.md
+++ b/hooks/ways/meta/develop/develop.md
@@ -8,24 +8,17 @@ scope: agent
 <!-- epistemic: convention -->
 # Developing
 
-This is the core loop — the working self between `start` (open the session) and
-`wrap` (close it). The **`develop` skill** carries a piece of work through the loop;
-this way is *when and why* to reach for it, and the one idea it turns on.
+This is the core loop — the working self between `start` (open the session) and `wrap` (close it). The **`develop` skill** carries a piece of work through the loop; this way is *when and why* to reach for it, and the one idea it turns on.
 
 ## Variable front, stable tail
 
-The loop is not one fixed order. Its **tail is stable** — build → review → fix →
-merge runs the same way almost every time. Its **front is variable** — design,
-prototype, and ADR reorder depending on the work, and forcing one order is the
-mistake:
+The loop is not one fixed order. Its **tail is stable** — build → review → fix → merge runs the same way almost every time. Its **front is variable** — design, prototype, and ADR reorder depending on the work, and forcing one order is the mistake:
 
 - **Prototype-first** when the load-bearing claim is *outside your repo* — an external API's behavior, a latency budget, a payload size. Reasoning can't settle it; probe the real system, then record what you measured. (`prototype`)
 - **Design-first** when the trade-offs are *open* — several plausible shapes, none yet obviously right. Deliberate, converge, then commit. (`design`)
 - **ADR-first** when the point *is* the direction — you already know the shape and need the decision on record before anyone builds on it. (`adr`)
 
-Pick the front order by **where the uncertainty lives** — the same uncertainty-
-location map `core.md` uses (in the artifacts, in the instructions, in the external
-world). The stage that answers the load-bearing question goes first.
+Pick the front order by **where the uncertainty lives** — the same uncertainty-location map `core.md` uses (in the artifacts, in the instructions, in the external world). The stage that answers the load-bearing question goes first.
 
 ## ADR is part of the method, not the whole of it
 

--- a/hooks/ways/meta/knowledge/authoring/authoring.md
+++ b/hooks/ways/meta/knowledge/authoring/authoring.md
@@ -132,9 +132,7 @@ ways template meta/newway \
 This creates:
 - `{wayname}/{wayname}.md` — frontmatter + body template with guidance placeholders
 
-Ways are authored **English-only** (ADR-139): localization is adopter-run, not
-authored per-way — there is no translation step here. Then: run `ways corpus` and
-`ways lint`.
+Ways are authored **English-only** (ADR-139): localization is adopter-run, not authored per-way — there is no translation step here. Then: run `ways corpus` and `ways lint`.
 
 **Manual creation** also works: create `{domain}/{wayname}/{wayname}.md` with frontmatter + guidance. No config files to update. Project ways override global ways with the same path. Ways can nest arbitrarily: `{domain}/{parent}/{child}/{child}.md`.
 

--- a/hooks/ways/meta/knowledge/knowledge.md
+++ b/hooks/ways/meta/knowledge/knowledge.md
@@ -45,15 +45,12 @@ Three way roots (ADR-143) — don't confuse *reading* one with *authoring* in it
 
 - **Framework ways (read-only projection):** `~/.claude/hooks/ways/{domain}/{wayname}/{wayname}.md`
   — a symlink into the app source at `$XDG_DATA_HOME/agent-ways`. Readable here, but
-  **don't author durably in it**: the app dir is replaced wholesale on update, so edits are
-  lost. Change these in a dev checkout and reproject (see `docs/development.md`).
+  **don't author durably in it**: the app dir is replaced wholesale on update, so edits are lost. Change these in a dev checkout and reproject (see `docs/development.md`).
 - **Your own ways (user scope, survives updates):** `$XDG_CONFIG_HOME/agent-ways/ways/{domain}/{wayname}/{wayname}.md`
 - **Project ways:** `$PROJECT/.claude/ways/{domain}/{wayname}/{wayname}.md` — override global ways at the same path
 - Disable domains: `$XDG_CONFIG_HOME/agent-ways/config.yaml` → `disabled_domains: [domain]` (legacy `$XDG_CONFIG_HOME/ways/config.yaml` and `~/.claude/ways.json` → `{"disabled": [...]}` still honored)
 - Ways can nest: `{domain}/{parent}/{child}/{child}.md` for progressive disclosure
-- When a parent way fires, its in-domain children become eligible on weaker signal: the child's
-  semantic bar drops from `τ_s` to `(τ_s × parent_threshold_multiplier).max(parent_boost_floor)`
-  = `max(0.5×0.8, 0.30) = 0.40` by default (multiplier boosts, floor caps) — domain context is established
+- When a parent way fires, its in-domain children become eligible on weaker signal: the child's semantic bar drops from `τ_s` to `(τ_s × parent_threshold_multiplier).max(parent_boost_floor)` = `max(0.5×0.8, 0.30) = 0.40` by default (multiplier boosts, floor caps) — domain context is established
 - Tree disclosure metrics are tracked per-session (parent, depth, epoch distance, sibling coverage)
 - Think strategies are multi-turn ways that steer reasoning across several turns (auto-detected, opt-out)
 

--- a/hooks/ways/meta/knowledge/optimization/tuning/tuning.md
+++ b/hooks/ways/meta/knowledge/optimization/tuning/tuning.md
@@ -13,13 +13,9 @@ English is the **source of truth.** Each way's English frontmatter is embedded i
 
 ## Two measurements
 
-The tool runs each locale's `description + vocabulary` as a query against the
-multilingual corpus, scoped to the active (or `--lang`) language, and reports:
+The tool runs each locale's `description + vocabulary` as a query against the multilingual corpus, scoped to the active (or `--lang`) language, and reports:
 
-**Fidelity** — cosine alignment to the **English root anchor**. For a single localized
-language the alias's only same-way peer is the root, so `min_peer` *is* root-alignment:
-how well the translation tracks the source of truth. Low fidelity → the stub drifted
-from the English meaning.
+**Fidelity** — cosine alignment to the **English root anchor**. For a single localized language the alias's only same-way peer is the root, so `min_peer` *is* root-alignment: how well the translation tracks the source of truth. Low fidelity → the stub drifted from the English meaning.
 
 **Discrimination** — `min_peer − top_confuser.score`. The top confuser is the best-scoring alias on any *other* way. A negative gap means another way outranks this stub — it collides and will mis-route. Orthogonal to fidelity; both must hold.
 
@@ -33,9 +29,7 @@ ways tune --fidelity-threshold 0.55 --discrimination-threshold 0.05
 ways tune --json
 ```
 
-`ways tune` is the loop the **ways-localize** skill drives: translate → corpus → tune →
-re-author flagged stubs → repeat until clean. "Clean" (no flagged entries) is the
-*evidence* a localization is done — not an assertion.
+`ways tune` is the loop the **ways-localize** skill drives: translate → corpus → tune → re-author flagged stubs → repeat until clean. "Clean" (no flagged entries) is the *evidence* a localization is done — not an assertion.
 
 ## Two failure modes
 
@@ -45,18 +39,14 @@ The translation embeds far from the English original: a mistranslation, or a stu
 
 ### 2. Negative discrimination — collides with another way
 
-The stub embeds closer to a *different* way than its own anchor. **Fix** by what the
-confuser is:
+The stub embeds closer to a *different* way than its own anchor. **Fix** by what the confuser is:
 - **Sibling way** (e.g. `delivery/commits` vs `delivery/branching`) — genuine neighbors;
   sharpen both so each holds a distinct region.
-- **Parent/ancestor** (e.g. `delivery/commits` vs `delivery`) — some overlap is
-  expected; add child-specific terminology.
+- **Parent/ancestor** (e.g. `delivery/commits` vs `delivery`) — some overlap is expected; add child-specific terminology.
 - **Unrelated** (e.g. outranked by `code/quality`) — accidental vocabulary overlap,
   often a generic term doing too much work. Remove or specialize it.
 
-A broad-vocabulary way that keeps appearing as the confuser across many stubs is a
-signal to trim *its* vocabulary so it stops hoovering traffic meant for specialized
-children.
+A broad-vocabulary way that keeps appearing as the confuser across many stubs is a signal to trim *its* vocabulary so it stops hoovering traffic meant for specialized children.
 
 ## Output signal, not verdict
 

--- a/hooks/ways/meta/skills/skills.md
+++ b/hooks/ways/meta/skills/skills.md
@@ -12,9 +12,7 @@ This way is *our convention* for writing skills — not a SKILL.md tutorial. The
 
 > **Canonical mechanics:** https://code.claude.com/docs/en/skills.md
 
-Don't restate that doc in a skill or a way. If you catch yourself writing a
-frontmatter-fields table, stop — link the doc instead. What follows is only the
-judgment the doc can't make for you in *this* repo.
+Don't restate that doc in a skill or a way. If you catch yourself writing a frontmatter-fields table, stop — link the doc instead. What follows is only the judgment the doc can't make for you in *this* repo.
 
 ## First decide: skill, way, or slash command?
 
@@ -35,8 +33,7 @@ Rule of thumb: **a way teaches Claude how to behave; a skill gives Claude someth
 - **Triggers must be tight.** A loose `description` on a global skill hijacks unrelated requests everywhere. Name the specific task and the words a user would actually say, and say what it's *not* for. (`ways-update` ends its description with "Not for editing or authoring individual ways… or upgrading project dependencies" precisely to stay in its lane.)
 - **A global skill must be location-independent.** It can't assume cwd. Resolve the target up front — e.g. `ROOT="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"` — and verify it's the repo you expect before acting.
 
-If a capability only makes sense inside one project, it belongs in *that* project's
-`.claude/skills/`, not here.
+If a capability only makes sense inside one project, it belongs in *that* project's `.claude/skills/`, not here.
 
 ## House conventions
 
@@ -50,13 +47,10 @@ If a capability only makes sense inside one project, it belongs in *that* projec
 
 ## Validate before shipping
 
-A skill is picked up at Claude Code startup — there's no corpus rebuild (that's
-ways). After adding or editing one:
+A skill is picked up at Claude Code startup — there's no corpus rebuild (that's ways). After adding or editing one:
 
 - Confirm `name` matches the directory and the frontmatter parses.
-- **Restart Claude Code**, then ask "what skills are available?" and trigger it with
-  a realistic phrasing to confirm the description fires when it should — and doesn't
-  fire on the near-miss requests you wrote it to avoid.
+- **Restart Claude Code**, then ask "what skills are available?" and trigger it with a realistic phrasing to confirm the description fires when it should — and doesn't fire on the near-miss requests you wrote it to avoid.
 
 ## See Also
 

--- a/hooks/ways/meta/start/start.md
+++ b/hooks/ways/meta/start/start.md
@@ -10,10 +10,7 @@ requires: ["Bash(ways:*)"]
 <!-- epistemic: convention -->
 # Starting
 
-The operator is opening a working session — they want to get oriented and *begin*,
-not to be handed a cold blank slate. This is what the **`start` skill** is for. Pull
-it up (`Skill: start`) rather than improvising a "what should we do?" — the skill
-enforces the parts that are easy to skip when you eyeball it.
+The operator is opening a working session — they want to get oriented and *begin*, not to be handed a cold blank slate. This is what the **`start` skill** is for. Pull it up (`Skill: start`) rather than improvising a "what should we do?" — the skill enforces the parts that are easy to skip when you eyeball it.
 
 `start` is the opening bookend to `wrap`. They are **inverse gauge-aware siblings**: both read the same instrument (`ways context`), but `wrap` confirms the session is near its *end* and scales the handoff down; `start` confirms the session is near its *beginning* — and if it isn't, it says so. (The symmetry is at the skill layer; `start` additionally carries a macro that whispers the gauge on disclosure, because it needs a *proactive* nudge to dissuade a mid-session start — where `wrap` leans on the `compaction-checkpoint` way firing on its own near the limit.)
 

--- a/hooks/ways/meta/subagents/subagents.md
+++ b/hooks/ways/meta/subagents/subagents.md
@@ -31,9 +31,7 @@ Agent(
 | **workflow-orchestrator** | `workflow-orchestrator` | Project status, phase coordination |
 | **workspace-curator** | `workspace-curator` | Organize docs/, manage .claude/ directory |
 
-Project agents live in `agents/`. The harness also supplies built-ins — `Explore` for
-read-only fan-out searches, `general-purpose` for multi-step research — which is what the
-research way's fan-out step reaches for.
+Project agents live in `agents/`. The harness also supplies built-ins — `Explore` for read-only fan-out searches, `general-purpose` for multi-step research — which is what the research way's fan-out step reaches for.
 
 ## Context Passing
 
@@ -52,34 +50,21 @@ Sub-agents are for delegation of token-intensive work, not every action.
 
 ## Invocation Is Authorization
 
-Claude Code's system prompt on Opus 5 carries: *"Do not call the AgentTool unless the user
-requested it."* That is a permission gate, not a prohibition. It asks one question — did the
-user request delegation? This way answers it, in advance and in writing.
+Claude Code's system prompt on Opus 5 carries: *"Do not call the AgentTool unless the user requested it."* That is a permission gate, not a prohibition. It asks one question — did the user request delegation? This way answers it, in advance and in writing.
 
-**Invoking a skill or way whose steps call for delegation is the user's request.** When the
-operator runs `/merge`, asks to land or ship a branch, or asks for a PR review or a research
-sweep, they have requested every delegation those procedures specify. Don't re-ask, and don't
-narrate the gate back at them. Delegate as the procedure directs.
+**Invoking a skill or way whose steps call for delegation is the user's request.** When the operator runs `/merge`, asks to land or ship a branch, or asks for a PR review or a research sweep, they have requested every delegation those procedures specify. Don't re-ask, and don't narrate the gate back at them. Delegate as the procedure directs.
 
-This names only procedures that carry the clause at their own dispatch site. A skill that
-sequences other skills without spawning anything — `/develop` routes, it does not
-orchestrate — grants nothing here, and neither does a built-in command this corpus can't
-annotate.
+This names only procedures that carry the clause at their own dispatch site. A skill that sequences other skills without spawning anything — `/develop` routes, it does not orchestrate — grants nothing here, and neither does a built-in command this corpus can't annotate.
 
 This is not an override. The gate's own condition is met.
 
-Still ask first when the delegation is **not** part of an invoked procedure, when it spends
-significant tokens outside the stated task, or when the operator has said to work solo.
+Still ask first when the delegation is **not** part of an invoked procedure, when it spends significant tokens outside the stated task, or when the operator has said to work solo.
 
-The grant covers *whether*, not *how wide*. A procedure that says "fan out" authorizes the
-fan-out it describes, not an arbitrary number of agents — size it to the work, and say the
-number before spawning it. Past roughly half a dozen, ask.
+The grant covers *whether*, not *how wide*. A procedure that says "fan out" authorizes the fan-out it describes, not an arbitrary number of agents — size it to the work, and say the number before spawning it. Past roughly half a dozen, ask.
 
 ## Name the Payoff, Don't Assume It
 
-A second, independently gated nudge may also be present: *"Subagents multiply cost and
-time… Delegate only when the payoff clearly exceeds that overhead."* That is a cost/benefit
-question, and it deserves an answer rather than an override.
+A second, independently gated nudge may also be present: *"Subagents multiply cost and time… Delegate only when the payoff clearly exceeds that overhead."* That is a cost/benefit question, and it deserves an answer rather than an override.
 
 State the payoff in one clause when you delegate:
 
@@ -89,9 +74,7 @@ State the payoff in one clause when you delegate:
 
 If you can't name the payoff in a clause, the nudge is right — do it inline.
 
-Both sections cover `AgentTool` only. `Workflow` and deep-research are gated by the same
-system-prompt constant and stay that way: propose them and discuss, never invoke unprompted.
-See ADR-175.
+Both sections cover `AgentTool` only. `Workflow` and deep-research are gated by the same system-prompt constant and stay that way: propose them and discuss, never invoke unprompted. See ADR-175.
 
 ## Harness Wrappers Are Not Verdicts
 

--- a/hooks/ways/meta/workflows/workflows.md
+++ b/hooks/ways/meta/workflows/workflows.md
@@ -8,12 +8,7 @@ refire: 0.15
 <!-- epistemic: convention -->
 # Workflows
 
-A workflow is **deterministic orchestration**: a script that fans agents out,
-pipelines them through stages, verifies, and synthesizes — control flow you
-*encode* (loops, conditionals, fan-out) rather than improvise turn by turn. Per
-ADR-138 it's the third *how*-carrier: a skill is one procedure, a macro is one
-injected command, a workflow is many agents coordinated. This way is *when* to
-reach for one.
+A workflow is **deterministic orchestration**: a script that fans agents out, pipelines them through stages, verifies, and synthesizes — control flow you *encode* (loops, conditionals, fan-out) rather than improvise turn by turn. Per ADR-138 it's the third *how*-carrier: a skill is one procedure, a macro is one injected command, a workflow is many agents coordinated. This way is *when* to reach for one.
 
 ## The substrate ladder
 
@@ -27,17 +22,12 @@ Most work doesn't need a workflow. Climb only as far as the task demands:
 | **Workflow** | many items × stages, needs deterministic fan-out / verify / synthesis, or scale beyond one context |
 
 Reach for a workflow to be **comprehensive** (decompose and cover in parallel),
-**confident** (independent perspectives + adversarial verification before
-committing), or to take on **scale one context can't hold** (migrations, audits,
-broad sweeps).
+**confident** (independent perspectives + adversarial verification before committing), or to take on **scale one context can't hold** (migrations, audits, broad sweeps).
 
 ## The opt-in cost
 
 A workflow can spawn dozens of agents and burn a large amount of tokens, so it is
-**explicit opt-in** — never inferred from a task that merely *would* benefit.
-Scout inline first to discover the work-list (list the files, scope the diff),
-*then* fan out over it. Match the fan-out to the real scale, and **log what you
-deliberately leave uncovered** so a bounded sweep never reads as exhaustive.
+**explicit opt-in** — never inferred from a task that merely *would* benefit. Scout inline first to discover the work-list (list the files, scope the diff), *then* fan out over it. Match the fan-out to the real scale, and **log what you deliberately leave uncovered** so a bounded sweep never reads as exhaustive.
 
 ## Worked example: the deliver workflow
 

--- a/hooks/ways/meta/wrap/wrap.md
+++ b/hooks/ways/meta/wrap/wrap.md
@@ -8,9 +8,7 @@ refire: 0.15
 <!-- epistemic: convention -->
 # Wrapping Up
 
-The user is signaling the session is ending — they want to close out, not keep building.
-This is exactly what the **`wrap` skill** is for. Pull it up (`Skill: wrap`) rather than
-improvising a summary; the skill enforces the parts that are easy to skip when you eyeball it.
+The user is signaling the session is ending — they want to close out, not keep building. This is exactly what the **`wrap` skill** is for. Pull it up (`Skill: wrap`) rather than improvising a summary; the skill enforces the parts that are easy to skip when you eyeball it.
 
 ## Why the skill, not a freehand summary
 
@@ -26,9 +24,7 @@ Neither a way nor a skill can trigger `/compact` — Claude Code forbids invokin
 
 ## Relation to the automatic sibling
 
-The `compaction-checkpoint` way fires **on its own** as context nears the limit. This way
-fires when the **user says so** — an early, deliberate close. Same destination, different
-trigger: one is the smoke alarm, the other is choosing to leave.
+The `compaction-checkpoint` way fires **on its own** as context nears the limit. This way fires when the **user says so** — an early, deliberate close. Same destination, different trigger: one is the smoke alarm, the other is choosing to leave.
 
 ## See Also
 

--- a/hooks/ways/softwaredev/architecture/architecture.md
+++ b/hooks/ways/softwaredev/architecture/architecture.md
@@ -14,8 +14,7 @@ Children of this way cover structural thinking about software:
 | System design | `architecture/design` |
 | Threat modeling | `architecture/threat-modeling` |
 
-Architecture *decisions* are recorded as ADRs, which now live in the documentation
-graph as a node type — see `adr(documentation)`.
+Architecture *decisions* are recorded as ADRs, which now live in the documentation graph as a node type — see `adr(documentation)`.
 
 ## See Also
 

--- a/hooks/ways/softwaredev/delivery/merge/merge.md
+++ b/hooks/ways/softwaredev/delivery/merge/merge.md
@@ -19,22 +19,14 @@ Classify the increment on two axes and pick the path:
 | **human gate: none** (routine, or already read) | **run it** — a quick `code-review` (or skip) → merge | **swarm-gate** — fan review across dimensions, adversarially verify → agent-gated merge |
 | **human gate: required** (sets direction, or unread one-way door) | **review + offer** — single-agent review → "want to read before I merge?" | **full gate** — swarm review **and** operator approval before merge |
 
-- **The X axis** is driven by **complexity and blast-radius**: diff size, number of
-  files, core-vs-leaf, test coverage, reversibility. A sprawling change to a core
-  path earns a swarm; a contained leaf edit earns a single pass.
-- **The Y axis** is driven by **whether the work sets direction** — an ADR that
-  steers architecture lands in the bottom row no matter how small the diff — and by
+- **The X axis** is driven by **complexity and blast-radius**: diff size, number of files, core-vs-leaf, test coverage, reversibility. A sprawling change to a core path earns a swarm; a contained leaf edit earns a single pass.
+- **The Y axis** is driven by **whether the work sets direction** — an ADR that steers architecture lands in the bottom row no matter how small the diff — and by
   **whether the operator has already read it**. If they wrote it or reviewed it live,
   the human gate is already satisfied.
 
-When the classification is ambiguous, **surface the call** rather than silently
-picking a corner. Inside a `/goal` loop, bias toward the autonomous corners; outside
-one, ask.
+When the classification is ambiguous, **surface the call** rather than silently picking a corner. Inside a `/goal` loop, bias toward the autonomous corners; outside one, ask.
 
-Whichever corner you land in, asking to merge is asking for the review this gate
-specifies — dispatch the reviewer rather than re-requesting permission to, and name the
-payoff in a clause as you do. The ambiguity worth surfacing is *which corner*, never
-*whether to review*. See ADR-175.
+Whichever corner you land in, asking to merge is asking for the review this gate specifies — dispatch the reviewer rather than re-requesting permission to, and name the payoff in a clause as you do. The ambiguity worth surfacing is *which corner*, never *whether to review*. See ADR-175.
 
 ## Remediate before you merge
 
@@ -42,10 +34,7 @@ A review that finds nothing changes nothing; a review that finds something is on
 
 ## Then land it
 
-Merge (regular merge commit, preserving the branch's narrative — see `delivery/github`),
-then run the full cleanup: back to `main`, pull, prune, delete the merged branch.
-Landing an increment is **not** cutting a release — versioning, changelogs, and
-artifacts are `delivery/release` and the `/release` skill, a separate, heavier act.
+Merge (regular merge commit, preserving the branch's narrative — see `delivery/github`), then run the full cleanup: back to `main`, pull, prune, delete the merged branch. Landing an increment is **not** cutting a release — versioning, changelogs, and artifacts are `delivery/release` and the `/release` skill, a separate, heavier act.
 
 ## See Also
 

--- a/hooks/ways/softwaredev/tooling/tooling.md
+++ b/hooks/ways/softwaredev/tooling/tooling.md
@@ -28,9 +28,7 @@ A concrete example from this corpus: renaming an ADR means editing its heading *
 
 ## Don't over-build
 
-The inverse failure is real: not every one-off needs a tool. If an operation runs
-once and never recurs, a manual sequence is fine — wrapping it is its own waste.
-The trigger is *repetition × risk*, not novelty. See `code/overbuild`.
+The inverse failure is real: not every one-off needs a tool. If an operation runs once and never recurs, a manual sequence is fine — wrapping it is its own waste. The trigger is *repetition × risk*, not novelty. See `code/overbuild`.
 
 ## See Also
 

--- a/tools/ways-core/src/reflow.rs
+++ b/tools/ways-core/src/reflow.rs
@@ -38,7 +38,7 @@
 //! Missing a wrapped paragraph is acceptable. Firing on deliberate structure is
 //! not — a check that nags trains its reader to ignore it.
 //!
-//! # Why the transform is scoped to the enclosing paragraph
+//! # Why the transform is scoped to the enclosing unit
 //!
 //! Measured against the 138-file `hooks/ways` corpus, three scopes behave very
 //! differently:
@@ -68,12 +68,12 @@ pub enum LineKind {
     Prose,
 }
 
-/// A paragraph containing at least one detected hard-wrap window.
+/// A unit containing at least one detected hard-wrap window.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WrappedParagraph {
-    /// First line index of the enclosing paragraph (0-based).
+    /// First line index of the enclosing unit (0-based).
     pub start: usize,
-    /// Last line index of the enclosing paragraph, inclusive.
+    /// Last line index of the enclosing unit, inclusive.
     pub end: usize,
     /// First line index of the window that triggered detection.
     pub trigger_start: usize,
@@ -115,7 +115,17 @@ impl Default for DetectConfig {
 
 /// Characters that end a line at a natural boundary. A line ending on one of
 /// these was plausibly broken on purpose, so it is not evidence of wrapping.
-const BOUNDARY_END: &[char] = &['.', '!', '?', ':', ';', '"', ')', '`', '*', '|', '>', ','];
+///
+/// With the lowered floor a single break can fire a two-line window, so this
+/// list carries the whole false-positive burden there — it must cover every
+/// character an author plausibly pauses on, not just the ASCII ones. The cost
+/// of each entry is bounded and points the right way: a genuine wrap whose one
+/// break lands exactly after such a character goes unrepaired, and a missed
+/// repair is a wrapped paragraph while a false fire welds authored structure.
+const BOUNDARY_END: &[char] = &[
+    '.', '!', '?', ':', ';', '"', ')', '`', '*', '|', '>', ',', '_', ']', '\'', '\u{2014}',
+    '\u{2013}', '\u{201d}', '\u{2019}',
+];
 
 fn indent_of(line: &str) -> &str {
     &line[..line.len() - line.trim_start().len()]
@@ -579,11 +589,9 @@ pub fn reflow_with_stats(lines: &[&str]) -> (Vec<String>, usize) {
             let line = *line;
             // The same boundary predicate `units` splits on, so detection scope
             // and join scope cannot drift apart. With an empty block there is
-            // nothing to flush, so the prev-dependent clauses need no special
-            // case beyond picking the line itself as its own predecessor.
-            if block.last().is_some_and(|p| starts_join_block(line, p))
-                || (block.is_empty() && starts_join_block(line, line))
-            {
+            // nothing to flush, so the predicate only matters against a
+            // predecessor.
+            if block.last().is_some_and(|p| starts_join_block(line, p)) {
                 flush(&mut block, &mut out, &mut quote_joins);
             }
             block.push(line);
@@ -902,6 +910,25 @@ finally ends here.";
         assert_eq!(lines[0], "- first item stays short");
         assert!(lines[1].ends_with("past the fill column"));
         assert_eq!(lines[2], "- another short item");
+    }
+
+    #[test]
+    fn authored_pause_characters_are_boundaries() {
+        // Review finding on the lowered floor: with a single break able to
+        // fire a two-line window, BOUNDARY_END carries the whole
+        // false-positive burden, and it covered `)` and `"` but not their
+        // typographic and inline-markup siblings. Each pair here is an
+        // authored pause that must stay two lines.
+        let cases = [
+            "A line of authored prose that pauses on a deliberate em-dash here \u{2014}\nand picks the thought back up on the next line with fresh intent.",
+            "He closed the ledger and said the season was finished, \u{201c}so be it\u{201d}\nthe others repeated, one after another, around the fire that night.",
+            "The rule is spelled out in the manual's own section on line handling_\nunderscored emphasis closing right at the break, as an author might set.",
+            "The findings are collected in the appendix under [wrapped paragraphs]\nalongside the tables that summarize each corpus sweep by way and file.",
+        ];
+        for src in cases {
+            assert!(detect(&split(src)).is_empty(), "false fire on: {src:?}");
+            assert_eq!(round_trip(src), src);
+        }
     }
 
     #[test]

--- a/tools/ways-core/src/reflow.rs
+++ b/tools/ways-core/src/reflow.rs
@@ -51,8 +51,11 @@
 //! - Flattening the **enclosing paragraph of a detected window** touched all 24
 //!   detected files and none of the other 114.
 //!
-//! So detection is per-window, repair is per-paragraph, and a paragraph with no
-//! detected window is never touched.
+//! So detection is per-window, repair is per-paragraph, and a paragraph with
+//! no detected window is never touched. Both sides now work on the same *unit*
+//! — a paragraph split further at the boundaries the repair refuses to join
+//! across (list items, labels, quote transitions, hard breaks) — so the span
+//! detection flags is exactly the span a repair would flatten.
 
 /// How a line participates in wrap detection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -82,6 +85,14 @@ pub struct WrappedParagraph {
 
 /// Tuning for [`detect`]. The defaults are the measured ones; they are exposed
 /// so tests can probe the boundaries, not so callers can invent policies.
+///
+/// Two floor rules soften these bounds where wrapping actually terminates. A
+/// unit's final line is exempt from `min_len` and the band — the tail of a
+/// wrap is short by construction, and requiring it to sit near the fill
+/// column made every two-wrap paragraph with a short last sentence invisible.
+/// And a window is only asked for as many mid-phrase breaks as it has line
+/// breaks — `min_mid_breaks` is a cap, not a flat requirement — so a two-line
+/// window qualifies on its single break.
 #[derive(Debug, Clone, Copy)]
 pub struct DetectConfig {
     /// Minimum line length to count as "near a fill column".
@@ -92,13 +103,13 @@ pub struct DetectConfig {
     pub band: usize,
     /// Minimum lines in a window.
     pub min_run: usize,
-    /// Minimum mid-phrase breaks in a window.
+    /// Minimum mid-phrase breaks in a window, capped at the breaks it contains.
     pub min_mid_breaks: usize,
 }
 
 impl Default for DetectConfig {
     fn default() -> Self {
-        Self { min_len: 55, max_len: 100, band: 12, min_run: 3, min_mid_breaks: 2 }
+        Self { min_len: 55, max_len: 100, band: 12, min_run: 2, min_mid_breaks: 2 }
     }
 }
 
@@ -324,27 +335,52 @@ pub fn classify(lines: &[&str]) -> Vec<LineKind> {
         .collect()
 }
 
-/// Maximal spans of consecutive [`LineKind::Prose`] lines — the paragraphs.
-fn paragraphs(kinds: &[LineKind]) -> Vec<(usize, usize)> {
+/// True if `line` opens a new join block relative to `prev` — the boundaries
+/// [`reflow`]'s flush loop refuses to join across: list items, bold label
+/// lines, blockquote transitions, and the line after an explicit hard break.
+///
+/// [`units`] splits on the same predicate so that what [`detect`] measures is
+/// exactly what a repair would join. Before they shared it, a run of list items
+/// was one "paragraph" to the detector — a wrapped item's short continuation
+/// sat mid-run where the tail exemption could not see it.
+fn starts_join_block(line: &str, prev: &str) -> bool {
+    let body = quote_body(line);
+    is_list_item(line)
+        || is_list_item(body)
+        || body.trim_start().starts_with("**")
+        || is_blockquote(line) != is_blockquote(prev)
+        || has_hard_break(prev)
+}
+
+/// Maximal spans of consecutive [`LineKind::Prose`] lines that a repair would
+/// join as one block — paragraphs, split further at [`starts_join_block`]
+/// boundaries. Single-line spans are dropped: nothing to join, nothing wrapped.
+fn units(kinds: &[LineKind], lines: &[&str]) -> Vec<(usize, usize)> {
     let mut out = Vec::new();
     let mut start: Option<usize> = None;
+    let close = |s: usize, e: usize, out: &mut Vec<(usize, usize)>| {
+        if e > s {
+            out.push((s, e));
+        }
+    };
     for (i, k) in kinds.iter().enumerate() {
         match (k, start) {
             (LineKind::Prose, None) => start = Some(i),
-            (LineKind::Prose, Some(_)) => {}
-            (_, Some(s)) => {
-                if i - s > 1 {
-                    out.push((s, i - 1));
+            (LineKind::Prose, Some(s)) => {
+                if starts_join_block(lines[i], lines[i - 1]) {
+                    close(s, i - 1, &mut out);
+                    start = Some(i);
                 }
+            }
+            (_, Some(s)) => {
+                close(s, i - 1, &mut out);
                 start = None;
             }
             (_, None) => {}
         }
     }
     if let Some(s) = start {
-        if kinds.len() - s > 1 {
-            out.push((s, kinds.len() - 1));
-        }
+        close(s, kinds.len() - 1, &mut out);
     }
     out
 }
@@ -395,16 +431,23 @@ pub fn detect_with(lines: &[&str], cfg: DetectConfig) -> Vec<WrappedParagraph> {
     let kinds = classify(lines);
     let mut found = Vec::new();
 
-    for (pstart, pend) in paragraphs(&kinds) {
+    for (pstart, pend) in units(&kinds, lines) {
         let n = pend - pstart + 1;
         if n < cfg.min_run {
             continue;
         }
-        // Line lengths computed once per paragraph, not once per window.
+        // Line lengths computed once per unit, not once per window.
         let lens: Vec<usize> = lines[pstart..=pend]
             .iter()
             .map(|l| l.trim_end().chars().count())
             .collect();
+
+        // The unit's final line is exempt from the band when short: a wrap
+        // tail is whatever was left of the sentence, so demanding it sit near
+        // the fill column hid every wrap whose remainder was short (the old floor). A
+        // window never consists of exempt lines alone — the exemption names
+        // one line, and every window has at least two.
+        let exempt = |i: usize| i == n - 1 && lens[i] < cfg.min_len;
 
         'windows: for offset in 0..=(n - cfg.min_run) {
             let mut lo = usize::MAX;
@@ -412,9 +455,17 @@ pub fn detect_with(lines: &[&str], cfg: DetectConfig) -> Vec<WrappedParagraph> {
             for len in cfg.min_run..=(n - offset) {
                 // Extend the running min/max by the one newly included line.
                 let upto = if len == cfg.min_run { 0 } else { len - 1 };
-                for l in &lens[offset + upto..offset + len] {
+                for (i, l) in lens.iter().enumerate().take(offset + len).skip(offset + upto) {
+                    if exempt(i) {
+                        continue;
+                    }
                     lo = lo.min(*l);
                     hi = hi.max(*l);
+                }
+                // A window of only the exempt tail (reachable when a config
+                // sets min_run to 1) has no banded lines yet — extend it.
+                if lo > hi {
+                    continue;
                 }
                 // Each band predicate is monotone in window length: `lo` only
                 // falls and `hi` only rises as the window grows, so a failure
@@ -430,7 +481,7 @@ pub fn detect_with(lines: &[&str], cfg: DetectConfig) -> Vec<WrappedParagraph> {
                     .windows(2)
                     .filter(|p| is_mid_phrase_break(p[0], p[1]))
                     .count();
-                if mids >= cfg.min_mid_breaks {
+                if mids >= cfg.min_mid_breaks.min(len - 1) {
                     found.push(WrappedParagraph {
                         start: pstart,
                         end: pend,
@@ -526,13 +577,13 @@ pub fn reflow_with_stats(lines: &[&str]) -> (Vec<String>, usize) {
 
         for line in &lines[i..=end] {
             let line = *line;
-            let body = quote_body(line);
-            let starts_block = is_list_item(line)
-                || is_list_item(body)
-                || body.trim_start().starts_with("**")
-                || (is_blockquote(line) && block.last().is_some_and(|p| !is_blockquote(p)))
-                || (!is_blockquote(line) && block.last().is_some_and(|p| is_blockquote(p)));
-            if starts_block {
+            // The same boundary predicate `units` splits on, so detection scope
+            // and join scope cannot drift apart. With an empty block there is
+            // nothing to flush, so the prev-dependent clauses need no special
+            // case beyond picking the line itself as its own predecessor.
+            if block.last().is_some_and(|p| starts_join_block(line, p))
+                || (block.is_empty() && starts_join_block(line, line))
+            {
                 flush(&mut block, &mut out, &mut quote_joins);
             }
             block.push(line);
@@ -805,6 +856,73 @@ everything else the app ships stays where it is.";
     #[test]
     fn token_stream_survives_a_reflow() {
         assert_eq!(token_verdict(WRAPPED, &round_trip(WRAPPED)), TokenVerdict::Identical);
+    }
+
+    #[test]
+    fn detects_a_two_line_wrap_with_a_short_tail() {
+        // The most common wrap shape: one break at the fill column, the
+        // remainder short. The old floor (3-line windows, tail inside the
+        // band) could not see it — this was the live gap that let wrapped
+        // markdown ship while the postcheck stayed silent.
+        let src = "\
+The most common wrap shape is a paragraph broken exactly once at the
+fill column.";
+        let hits = detect(&split(src));
+        assert_eq!(hits.len(), 1);
+        assert_eq!(round_trip(src).lines().count(), 1);
+    }
+
+    #[test]
+    fn detects_a_three_line_wrap_with_a_short_tail() {
+        // Two breaks, then the sentence ends short. The tail sat inside every
+        // candidate window, and its length failed the band for all of them.
+        let src = "\
+A slightly longer paragraph that the model wrapped twice while it
+was writing, so there are two interior breaks before the sentence
+finally ends here.";
+        let hits = detect(&split(src));
+        assert_eq!(hits.len(), 1);
+        assert_eq!(round_trip(src).lines().count(), 1);
+    }
+
+    #[test]
+    fn detects_a_wrapped_list_item_between_flat_siblings() {
+        // A wrapped bullet mid-list. Before units, the whole list was one
+        // "paragraph": breaks at item boundaries are never mid-phrase, so the
+        // count could not reach its floor, and the wrapped item's short
+        // continuation failed the band besides.
+        let src = "\
+- first item stays short
+- A list item whose text the model wrapped onto a continuation line
+  past the fill column
+- another short item";
+        let out = round_trip(src);
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 3, "expected the wrapped item joined: {out:?}");
+        assert_eq!(lines[0], "- first item stays short");
+        assert!(lines[1].ends_with("past the fill column"));
+        assert_eq!(lines[2], "- another short item");
+    }
+
+    #[test]
+    fn leaves_an_authored_two_line_break_alone() {
+        // A two-line paragraph whose break lands at a clause boundary — the
+        // comma says the author paused there. The single-break rule must not
+        // sweep this in.
+        let src = "\
+When the sentence pauses at a natural boundary like a comma or colon,
+the continuation is judged authored and the paragraph stays untouched.";
+        assert!(detect(&split(src)).is_empty());
+        assert_eq!(round_trip(src), src);
+    }
+
+    #[test]
+    fn a_capitalized_second_line_is_not_a_wrap() {
+        let src = "\
+A first line that is long enough to sit inside the detection band here
+But the next line starts a new sentence with a capital letter after it.";
+        assert!(detect(&split(src)).is_empty());
+        assert_eq!(round_trip(src), src);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The wrap detector's floor sat exactly above the shapes the model most often produces, so the reactive `documentation/markdown/reflow` way never fired: zero postcheck state across every session since boot, while wrapped markdown kept shipping. Upstream context: anthropics/claude-code#33666 confirms the model hard-wraps at ~75–80 columns regardless of instructions, so the reactive layer is the load-bearing one — and it was blind to:

- **Two-line wraps** — at most one mid-phrase break; the floor demanded two.
- **Three-line wraps with a short tail** — the tail sat in every candidate window (`min_run: 3`) and failed `min_len` for all of them.
- **Wrapped list items** — a list was one "paragraph" whose item-boundary breaks never count as mid-phrase.

## Fix

- `min_mid_breaks` becomes a cap: a window is asked for as many mid-phrase breaks as it has line breaks; `min_run` drops to 2.
- A unit's final line is exempt from the length band — a wrap tail is short by construction.
- Detection now works on the same *units* the repair joins (paragraphs split at list items, labels, quote transitions, hard breaks), via a `starts_join_block` predicate shared with the flush loop so the scopes cannot drift.

## Validation

- 158 ways-core tests pass, including five new regression tests for the blind spots and two authored-prose guards.
- Full corpus diff old-vs-new: 25 newly detected files, **every finding a genuine mid-phrase wrap, zero false positives** on authored one-clause-per-line prose.
- All repairs pass the existing token and structure gates; sweep commit flattens the 25 plus two post-#418 drifts, leaving hooks/ways fully clean.

## Out of scope, noted for follow-up

- docs/ carries ~90 files the old detector already flagged (never swept) — separate chore.
- `postcheck.sh` appends to the seen-set at detection time, but ADR-123's amendment says the way should stay quiet only about what has been *surfaced* — a gate-denied fire currently suppresses the file for the whole session unseen. Fixing that touches the amendment's one-way state-flow constraint, so it wants its own ADR discussion.