### PR TITLE
fix(scan): emit the canonical hookSpecificOutput envelope on SessionStart

### DIFF
--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -75,11 +75,10 @@ impl WayCandidate {
 /// Match user prompt against ways and emit matched bodies for the agent.
 ///
 /// Wired only from the `UserPromptSubmit` hook (`check-prompt.sh`), so the
-/// envelope event name is hardcoded. The call routes through the canonical
-/// `hookSpecificOutput` default branch of `emit_hook_context`. If this is
-/// ever reused from another hook event, just pass that event's name —
-/// `SessionStart` and `PreToolUse` are the only events that take the
-/// legacy top-level `additionalContext` envelope.
+/// envelope event name is hardcoded. The call routes through
+/// `emit_hook_context`, which emits the canonical `hookSpecificOutput`
+/// envelope for every event. If this is ever reused from another hook
+/// event, just pass that event's name.
 ///
 /// `response_context` (ADR-155 §3) is Claude's last response, stored raw by
 /// the Stop hook. It feeds ONLY the embed input — never the regex lane — so
@@ -1036,34 +1035,25 @@ fn regex_span(pattern: &str, text: &str) -> Option<String> {
     })
 }
 
-/// Emit accumulated context using the envelope shape required by the
-/// invoking hook event. The Claude Code hook contract treats
-/// `hookSpecificOutput` as canonical for all events, and the current hooks
-/// reference documents no other JSON shape. The bare top-level
-/// `additionalContext` this branch once emitted for `SessionStart` was
-/// believed to be a legacy tolerance — session transcripts proved otherwise:
-/// the harness records the stdout in its `hook_success` bookkeeping and
-/// creates no context attachment, so the payload (the ways catalog and the
-/// core posture) never reached the model in any session on record. Canonical
-/// everywhere is what the delivered paths (UserPromptSubmit, PostToolUse,
-/// SubagentStart in the shell emitters) already use.
+/// Emit accumulated context in the canonical `hookSpecificOutput` envelope —
+/// the only JSON shape the current hooks reference documents, for any event.
 ///
-/// `PreToolUse` keeps its `decision`-bearing shape for now: its envelope is
-/// entangled with permission semantics, and transcripts suggest its
-/// `additionalContext` may be dropped too — tracked separately rather than
-/// changed blind here.
+/// A bare top-level `additionalContext` was emitted for `SessionStart` here
+/// until session transcripts proved the harness never delivered it: the
+/// stdout landed in `hook_success` bookkeeping, no context attachment was
+/// created, and the payload (the ways catalog and the core posture) reached
+/// zero sessions on record. Undocumented JSON stdout is dropped silently, so
+/// nothing but the canonical envelope belongs here. The PreToolUse emitters
+/// in [`command`] and [`file`] build their `decision`-bearing shape inline
+/// and never route through this function; whether their `additionalContext`
+/// is delivered is tracked separately.
 pub(super) fn emit_hook_context(hook_event: &str, context: &str) {
-    let payload = match hook_event {
-        "PreToolUse" => {
-            serde_json::json!({ "additionalContext": context })
+    let payload = serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": hook_event,
+            "additionalContext": context,
         }
-        _ => serde_json::json!({
-            "hookSpecificOutput": {
-                "hookEventName": hook_event,
-                "additionalContext": context,
-            }
-        }),
-    };
+    });
     println!("{payload}");
 }
 

--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -1038,15 +1038,23 @@ fn regex_span(pattern: &str, text: &str) -> Option<String> {
 
 /// Emit accumulated context using the envelope shape required by the
 /// invoking hook event. The Claude Code hook contract treats
-/// `hookSpecificOutput` as canonical for all events; the simpler top-level
-/// `additionalContext` is a legacy tolerance accepted only on
-/// `SessionStart` and `PreToolUse` (where it surfaces as a visible
-/// attachment). Defaulting to canonical means new event wirings
-/// (`Stop`, `PreCompact`, ...) get the right shape automatically rather
-/// than silently re-hitting the bug PR #80 fixed.
+/// `hookSpecificOutput` as canonical for all events, and the current hooks
+/// reference documents no other JSON shape. The bare top-level
+/// `additionalContext` this branch once emitted for `SessionStart` was
+/// believed to be a legacy tolerance — session transcripts proved otherwise:
+/// the harness records the stdout in its `hook_success` bookkeeping and
+/// creates no context attachment, so the payload (the ways catalog and the
+/// core posture) never reached the model in any session on record. Canonical
+/// everywhere is what the delivered paths (UserPromptSubmit, PostToolUse,
+/// SubagentStart in the shell emitters) already use.
+///
+/// `PreToolUse` keeps its `decision`-bearing shape for now: its envelope is
+/// entangled with permission semantics, and transcripts suggest its
+/// `additionalContext` may be dropped too — tracked separately rather than
+/// changed blind here.
 pub(super) fn emit_hook_context(hook_event: &str, context: &str) {
     let payload = match hook_event {
-        "SessionStart" | "PreToolUse" => {
+        "PreToolUse" => {
             serde_json::json!({ "additionalContext": context })
         }
         _ => serde_json::json!({

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -608,14 +608,13 @@ enum ScanCommand {
         /// Transcript path (for context-threshold)
         #[arg(long)]
         transcript: Option<String>,
-        /// Hook event that invoked this scan (drives output envelope shape).
-        /// `hookSpecificOutput` is canonical for all events; `PreToolUse`
-        /// is the only event still taking the legacy top-level
-        /// `additionalContext` shape. When omitted, falls back to
+        /// Hook event that invoked this scan (recorded as the envelope's
+        /// `hookEventName`; the `hookSpecificOutput` shape itself is
+        /// canonical for every event). When omitted, falls back to
         /// `SessionStart` and emits a stderr trace — `check-state.sh` already
         /// applies the same fallback via jq, so a missing value here means
-        /// neither layer received `hook_event_name` and the envelope shape
-        /// may be wrong for the actual invoking event.
+        /// neither layer received `hook_event_name` and the recorded event
+        /// name may be wrong for the actual invoking event.
         #[arg(long)]
         hook_event: Option<String>,
     },
@@ -814,8 +813,8 @@ fn run() -> Result<()> {
                 let event = hook_event.unwrap_or_else(|| {
                     eprintln!(
                         "[ways] scan state invoked without --hook-event; defaulting to SessionStart. \
-                         If the invoking hook is not SessionStart/PreToolUse, the output envelope \
-                         shape will be wrong and the agent will silently receive nothing."
+                         The envelope shape is canonical for every event, but the recorded \
+                         hookEventName will be wrong if the invoking hook is a different event."
                     );
                     "SessionStart".to_string()
                 });

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -609,9 +609,9 @@ enum ScanCommand {
         #[arg(long)]
         transcript: Option<String>,
         /// Hook event that invoked this scan (drives output envelope shape).
-        /// `hookSpecificOutput` is canonical for all events; `SessionStart`
-        /// and `PreToolUse` are the only events that take the legacy
-        /// top-level `additionalContext` shape. When omitted, falls back to
+        /// `hookSpecificOutput` is canonical for all events; `PreToolUse`
+        /// is the only event still taking the legacy top-level
+        /// `additionalContext` shape. When omitted, falls back to
         /// `SessionStart` and emits a stderr trace — `check-state.sh` already
         /// applies the same fallback via jq, so a missing value here means
         /// neither layer received `hook_event_name` and the envelope shape

--- a/tools/ways-cli/tests/session_sim.rs
+++ b/tools/ways-cli/tests/session_sim.rs
@@ -577,8 +577,10 @@ fn scenario_10_state_triggers() {
     let s = Session::new("s10");
 
     // Turn 1: state scan should fire session-start trigger
-    // (state scan doesn't bump epoch — it runs alongside prompt scan)
-    let output = s.scan_state();
+    // (state scan doesn't bump epoch — it runs alongside prompt scan).
+    // Pass --hook-event explicitly — this is what check-state.sh actually
+    // sends; the fallback path is scenario 11's job.
+    let (output, _) = s.scan_state_full(Some("SessionStart"));
     assert_marker_exists("testdomain/state-trigger", &s.id);
     assert!(
         output.contains("State Trigger Test Way"),
@@ -611,9 +613,10 @@ fn scenario_11_hook_event_misroute_warning() {
     // `ways scan state` invoked without `--hook-event` falls back to
     // SessionStart, which is also the shell's jq fallback in
     // `check-state.sh` — two layers of the same default mean a misrouted
-    // hook would silently emit the wrong envelope shape. The fallback
-    // itself is preserved (behavior unchanged) but a defensive stderr
-    // trace surfaces the misroute in hook-execution logs.
+    // hook would silently record the wrong hookEventName (the envelope
+    // shape itself is canonical for every event). The fallback itself is
+    // preserved (behavior unchanged) but a defensive stderr trace surfaces
+    // the misroute in hook-execution logs.
     let s = Session::new("s11");
 
     // Without --hook-event: stderr trace must surface, stdout must still

--- a/tools/ways-cli/tests/session_sim.rs
+++ b/tools/ways-cli/tests/session_sim.rs
@@ -584,19 +584,16 @@ fn scenario_10_state_triggers() {
         output.contains("State Trigger Test Way"),
         "Expected state trigger content in output"
     );
-    // Envelope guard: SessionStart is the explicit legacy branch in
-    // emit_hook_context — it must emit `{"additionalContext": "..."}` at
-    // top level, not the canonical `hookSpecificOutput` wrapper. Locks in
-    // the legacy tolerance after the canonical-by-default discriminator
-    // flip; the inverse guard for the canonical default lives in
-    // scenario_1's scan_prompt assertion.
+    // Envelope guard: SessionStart must emit the canonical
+    // `hookSpecificOutput` wrapper. The bare top-level `additionalContext`
+    // this test previously locked in was believed to be a harness-accepted
+    // legacy shape; session transcripts showed the harness never delivered
+    // it — the SessionStart payload (ways catalog + core posture) reached
+    // zero sessions. Undocumented shapes are dropped silently, so this
+    // guard now points the other way.
     assert!(
-        output.contains("additionalContext"),
-        "scan_state on SessionStart must emit legacy additionalContext envelope; got: {output:?}"
-    );
-    assert!(
-        !output.contains("hookSpecificOutput"),
-        "scan_state on SessionStart must NOT use canonical hookSpecificOutput envelope; got: {output:?}"
+        output.contains("hookSpecificOutput"),
+        "scan_state on SessionStart must emit the canonical hookSpecificOutput envelope; got: {output:?}"
     );
 
     // Turn 2: second state scan — idempotent, marker prevents re-fire


### PR DESCRIPTION
## Problem

The base posture (`core.md`) and ways catalog have never reached the model. Transcript evidence across every session in `~/.claude/projects/-home-aaron-Projects-ai-agent-ways/`:

- The SessionStart hook chain runs and `hook_success` records its stdout (the full ~19KB payload) — on every session.
- Zero `hook_additional_context` attachments for SessionStart, and the payload appears in zero model-visible messages (`grep` across all user/system message content: no hits).
- Canonical-envelope paths (UserPromptSubmit, PostToolUse, SubagentStart) all deliver, same sessions.

The felt symptom — "core way doesn't carry the same weight as CLAUDE.md" — was total non-delivery, not attention decay. CLAUDE.md is re-supplied by the harness every context window with authority framing; the ways posture was arriving via zero paths.

## Cause

`emit_hook_context` emitted a bare top-level `{"additionalContext": ...}` on SessionStart, believed to be a legacy tolerance. The current hooks reference (code.claude.com/docs/en/hooks.md) documents exactly two SessionStart output shapes: plain text, or `{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": ...}}`. Undocumented JSON stdout is dropped silently.

## Fix

- SessionStart joins the canonical branch; scenario 10's envelope guard flipped to lock canonical in.
- `--hook-event` doc comment updated.
- PreToolUse deliberately untouched: its legacy shape carries `decision: approve` (permission semantics), and transcripts suggest its `additionalContext` may also be dropped — follow-up investigation, not a blind flip.

## Verification

`ways scan state --hook-event=SessionStart` emits valid canonical JSON with the full catalog + posture (18.6KB); all session_sim scenarios pass; clippy clean. Real-world confirmation lands on the next session start after the installed binary rebuilds: the transcript should show a SessionStart `hook_additional_context` attachment for the first time.