### PR TITLE
feat(ways): environment/container-safety — developer safety in container definitions

### DIFF
--- a/hooks/ways/softwaredev/environment/container-safety/container-safety.check.md
+++ b/hooks/ways/softwaredev/environment/container-safety/container-safety.check.md
@@ -1,0 +1,24 @@
+---
+description: verify a container build/run definition affords developer safety before writing or running it
+vocabulary: dockerfile containerfile compose docker build docker run podman build bind mount volume root user uid gid privileged capability artifact ownership
+files: Dockerfile|Containerfile|(docker-)?compose\.ya?ml|\.devcontainer
+commands: (docker|podman|nerdctl|buildah)\ (build|run|compose)
+scope: agent, subagent
+---
+## anchor
+A container build/run definition is a developer-safety surface. Root in the container plus root-owned artifacts on a bind mount widens the blast radius of ordinary mistakes on the local machine.
+
+## check
+Before writing this definition or running this build:
+- Does the build/run stage set a **non-root `USER`**, or is it silently running as root?
+- Will artifacts land on the host owned by **root**? Match the container uid/gid to the host user so cleanup never needs `sudo`.
+- Any `--privileged`, extra capabilities, or a **docker-socket bind mount** this build doesn't actually need?
+- Is the bind mount scoped to the **narrowest path** (and read-only where it can be) — not `$HOME` or `/`?
+
+## Common Rationalizations
+
+| Rationalization | Counter |
+|---|---|
+| "It's just a local build, root is fine" | Local is exactly where root-owned artifacts turn routine cleanup into a `sudo rm` — the dangerous case. |
+| "Setting up a user is extra work" | `--user $(id -u):$(id -g)` at run time is one flag and needs no image change. |
+| "The base image already runs as root" | That's the default, not a decision. Override it — add a `USER` or pass `--user`. |

--- a/hooks/ways/softwaredev/environment/container-safety/container-safety.md
+++ b/hooks/ways/softwaredev/environment/container-safety/container-safety.md
@@ -1,0 +1,48 @@
+---
+description: developer safety when a build or task runs inside a container — non-root execution, host artifact ownership, least privilege, scoped bind mounts
+vocabulary: container docker podman buildah nerdctl dockerfile containerfile compose image build stage bind mount volume rootless non-root user uid gid privileged capability drop artifact ownership blast radius developer safety
+files: Dockerfile|Containerfile|(docker-)?compose\.ya?ml|\.dockerignore|\.devcontainer
+commands: (docker|podman|nerdctl|buildah)\ (build|run|compose)
+refire: 0.15
+scope: agent, subagent
+---
+<!-- epistemic: heuristic -->
+# Container Safety
+
+When our build or a dev task runs inside a container — Docker, Podman, Buildah, Compose, devcontainers — the definition is a **developer-safety surface**, not just a build recipe. The convenient default (everything as root) quietly widens the blast radius of ordinary mistakes on our *own* machine. This isn't about a remote exploit; it's about not building the setup where a routine cleanup command can do real damage.
+
+The failure mode we're avoiding: a build runs as root, writes root-owned artifacts into a bind-mounted host path, cleaning them up then needs `sudo` — and `sudo` in our muscle memory around build output is one slice of Swiss cheese away from an `rm -rf` landing on the wrong target. Least privilege in the definition keeps ordinary mistakes ordinary.
+
+## What we check in a container definition
+
+| Concern | What to do | Why |
+|---------|-----------|-----|
+| **Who runs** | Set a non-root `USER` for the build/run stage | Root in the container is root on any bind-mounted host path |
+| **Who owns artifacts** | Match the container uid/gid to the host user — `ARG UID`/`GID`, or run with `--user $(id -u):$(id -g)` | Root-owned build output forces `sudo` to clean, escalating blast radius |
+| **How much privilege** | No `--privileged`, drop capabilities you don't need, don't bind-mount the docker socket into a build | A build almost never needs host-level power; grant the minimum |
+| **What's mounted** | Mount the narrowest path, read-only where possible | Never mount `$HOME` or `/` into a build — scope the surface |
+| **What ships** | Multi-stage: build in one stage, copy artifacts into a slim non-root runtime stage | Keeps root and build tooling out of the final image |
+
+## The shape we prefer
+
+```dockerfile
+# build args let the image match the invoking host user
+ARG UID=1000
+ARG GID=1000
+
+FROM builder AS build
+# ... compile ...
+
+FROM runtime AS final
+RUN groupadd -g ${GID} app && useradd -u ${UID} -g ${GID} -m app
+USER app                     # non-root from here on
+COPY --from=build --chown=app:app /out /app
+```
+
+For a throwaway local build, the lighter move is to skip the in-image user and just run as the host identity: `docker run --user "$(id -u):$(id -g)" -v "$PWD/out:/out:rw" …` — artifacts land owned by you, `sudo`-free to clean.
+
+## See Also
+
+- environment/makefile(softwaredev) — the build task runner these commands usually sit behind
+- code/security(softwaredev) — least privilege as a general code concern
+- architecture/threat-modeling(softwaredev) — blast radius and the Swiss-cheese framing this leans on

--- a/hooks/ways/softwaredev/environment/container-safety/provenance.yaml
+++ b/hooks/ways/softwaredev/environment/container-safety/provenance.yaml
@@ -1,0 +1,31 @@
+policy:
+  - uri: governance/policies/operations.md
+    type: governance-doc
+controls:
+  - id: NIST SP 800-53 AC-6 (Least Privilege)
+    justifications:
+      - Non-root USER required in build/run stages; root-as-default is called out as a decision to override, not a baseline to accept
+      - Privilege table prohibits --privileged, requires dropping unneeded capabilities, and forbids binding the docker socket into builds
+      - Bind mounts scoped to the narrowest path and read-only where possible; mounting $HOME or / into a build is named as the failure case
+    satisfied_when: >
+      Container definitions written or reviewed in the session set a non-root USER
+      (or pass --user at run time), grant no --privileged or unneeded capabilities,
+      and scope bind mounts to the narrowest necessary path. A definition left
+      silently running as root, or a build granted host-level power it does not
+      need, is the failure case.
+  - id: CIS Docker Benchmark 4.1 (Create a user for the container)
+    justifications:
+      - Preferred Dockerfile shape creates a uid/gid-matched user and switches to it before the runtime stage
+      - Lighter path for throwaway builds runs as the host identity via --user $(id -u):$(id -g)
+      - Artifact-ownership check ensures build output lands host-owned, so cleanup never needs sudo
+    satisfied_when: >
+      Images built in the session define and switch to a non-root user (or the run
+      command passes the host uid/gid), and artifacts written to bind-mounted host
+      paths land owned by the invoking user. Root-owned build output on the host is
+      the failure case.
+verified: 2026-08-06
+rationale: >
+  Non-root execution, capability minimization, and scoped mounts implement least
+  privilege at the container-definition level. Uid/gid matching operationalizes the
+  CIS non-root-user benchmark while keeping host artifact cleanup sudo-free, which
+  is the developer-safety blast-radius concern the way exists to bound.

--- a/hooks/ways/softwaredev/environment/environment.md
+++ b/hooks/ways/softwaredev/environment/environment.md
@@ -16,6 +16,7 @@ Children of this way cover the development environment:
 | Debugging | `environment/debugging` |
 | SSH, remote access | `environment/ssh` |
 | Makefile targets | `environment/makefile` |
+| Container build/run safety | `environment/container-safety` |
 | Awareness / attend loop | `environment/attend` |
 
 ## See Also
@@ -25,4 +26,5 @@ Children of this way cover the development environment:
 - environment/debugging(softwaredev) — systematic debugging
 - environment/ssh(softwaredev) — SSH and remote access
 - environment/makefile(softwaredev) — Makefile targets and conventions
+- environment/container-safety(softwaredev) — developer safety in container build/run definitions
 - environment/attend(softwaredev) — the attend awareness sensor loop


### PR DESCRIPTION
## What

New way `softwaredev/environment/container-safety` + check file + provenance, and the parent `environment` way's child table/See Also updated.

## Origin

The second follow-on from the socratic cross-check (see PR #439 / ADR-176's scope note): a developer-safety posture for container build/run definitions — non-root execution, uid/gid-matched artifact ownership, least privilege, scoped bind mounts. The framing is blast-radius on the developer's own machine (root-owned artifacts → sudo cleanup → Swiss-cheese `rm`), not remote exploitation.

## Validation

- `ways lint` on the new directory: 0 errors, 0 warnings
- Sibling vocabulary Jaccard across all `environment` children: container-safety overlaps no sibling above 0.05 (only pre-existing pair is deps↔makefile at 0.108, below the 0.15 warn bar)
- `ways-audit lint` (repo-scoped): all claim checks pass; claims NIST SP 800-53 AC-6 (first implementer in the corpus) and CIS Docker Benchmark 4.1