### PR TITLE
feat(tools): version-stamped vendored tools with direction-aware drift detection (ADR-177)

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -97,6 +97,7 @@ _Ways architecture, matching, macros, hooks, session lifecycle_
 | [ADR-174](./system/ADR-174-progressive-core-decoration-guidance-and-the-core-re-disclosure-gap.md) | Progressive core — decoration guidance and the core re-disclosure gap | Draft |
 | [ADR-175](./system/ADR-175-standing-delegation-authorization-satisfies-the-harness-permission-gate-rather-than-overriding-it.md) | Standing delegation authorization satisfies the harness permission gate rather than overriding it | Draft |
 | [ADR-176](./system/ADR-176-contract-identification-as-the-develop-loop-front-gate.md) | Contract identification as the develop-loop front gate | Accepted |
+| [ADR-177](./system/ADR-177-version-stamped-vendored-tools-with-direction-aware-drift-detection.md) | Version-stamped vendored tools with direction-aware drift detection | Draft |
 
 ## Governance
 _Provenance, traceability, controls, compliance mapping_

--- a/docs/architecture/system/ADR-177-version-stamped-vendored-tools-with-direction-aware-drift-detection.md
+++ b/docs/architecture/system/ADR-177-version-stamped-vendored-tools-with-direction-aware-drift-detection.md
@@ -1,0 +1,104 @@
+---
+status: Draft
+date: 2026-08-06
+deciders:
+  - aaronsb
+  - claude
+related:
+  - 138
+---
+
+# ADR-177: Version-stamped vendored tools with direction-aware drift detection
+
+## Context
+
+Three tools ship inside ways and get **vendored** — copied, never symlinked —
+into consuming repositories: `adr-tool` (documentation/adr), `doc-tool`
+(documentation/linting), and `chart-tool` (softwaredev/visualization/charts).
+ADR-138 put the vendoring procedure in skills; the copies it produces are
+snapshots that never hear about upstream changes.
+
+None of the three carries a version marker. The one drift check that exists —
+the adr way's macro `diff -q` between the repo copy and the installed
+template — is **direction-blind**: a stale copy and a deliberately customized
+copy produce the same byte difference, and the macro's note ("differs from the
+universal template; expected for customized setups") actively reassures the
+reader in the stale case. As upstream tools grow features (e.g. `adr archive`,
+issue #438), every vendored copy silently falls behind while the disclosure
+says all is well.
+
+## Decision
+
+**Every vendorable tool carries its own version, and drift disclosure reads
+direction from it.**
+
+1. **Per-tool semver constant** — a `TOOL_VERSION = "X.Y.Z"` line near the top
+   of each tool, plus a `--version` flag. The version is per-tool and bumps
+   only when the tool changes. It is deliberately *not* the ways release
+   version: coupling to releases would mark every vendored copy stale on every
+   release even when the tool never moved.
+
+2. **Direction-aware macro disclosure** — a way macro that surfaces a vendored
+   tool extracts `TOOL_VERSION` from both the repo copy and the installed
+   template (a `grep`, not an execution) and compares with `sort -V`. Four
+   states replace the direction-blind diff note:
+
+   | Local copy | Disclosure |
+   |---|---|
+   | no version marker | predates versioning — out of date; re-vendor |
+   | lower than installed | stale — re-vendor to pick up the newer tool |
+   | equal, bytes differ (version line excluded) | customized — expected, say so |
+   | higher than installed | repo is ahead — the agent-ways install is stale; update it |
+
+   The version line is excluded from the customization diff so the stamp
+   cannot trigger the very warning it exists to disambiguate.
+
+3. **Re-vendoring is a documented move** — the skill that owns each tool's
+   vendoring procedure (ADR-138) also documents the update: plain copy when
+   the local tool is unmodified; when customized, diff first so local changes
+   are carried forward rather than clobbered.
+
+The unversioned era is bounded by the rule itself: a copy with no
+`TOOL_VERSION` marker is by definition older than every stamped release, so
+"no marker" needs no special casing beyond "out of date."
+
+## Consequences
+
+### Positive
+
+- Drift disclosure gains direction: stale, customized, and ahead-of-install
+  are distinct states with distinct remedies, instead of one reassuring note.
+- Tool changes (like #438's `adr archive`) propagate — the next session in a
+  consuming repo is told its copy is behind, rather than nobody ever noticing.
+- "Repo ahead of install" is surfaced too, catching the stale-install case the
+  old diff attributed to customization.
+
+### Negative
+
+- Version bumps are a manual discipline — a tool change without a bump defeats
+  the mechanism. Mitigated by review: the stamp lives in the same file as any
+  change to it.
+
+### Neutral
+
+- Requires stamping all three tools, upgrading the adr way's macro, and adding
+  update guidance to the owning skills; other tool-surfacing macros adopt the
+  same comparison as they grow one.
+- Already-vendored copies in the wild have no marker and will read as "out of
+  date" on first contact with the new macro — which is accurate.
+
+## Alternatives Considered
+
+- **Keep the byte-diff note.** Rejected: direction-blind. It cannot
+  distinguish the case that needs action (stale) from the case that needs none
+  (customized), and its wording suppresses the one signal it does emit.
+- **Stamp tools with the ways release version.** Rejected: false staleness —
+  every release would mark every vendored copy out of date even when the tool
+  is byte-identical.
+- **Checksum registry (manifest of known tool hashes per version).** Rejected:
+  heavier machinery for the same answer; requires the installed side to carry
+  history, and any local edit breaks the lookup entirely — exactly the
+  customized case the mechanism must keep distinguishable.
+- **Auto-update on detection.** Rejected: a vendored copy may be deliberately
+  customized; overwriting on sight destroys local changes. Disclosure names
+  the state; the operator (or a skill-guided session) decides.

--- a/docs/architecture/system/ADR-177-version-stamped-vendored-tools-with-direction-aware-drift-detection.md
+++ b/docs/architecture/system/ADR-177-version-stamped-vendored-tools-with-direction-aware-drift-detection.md
@@ -40,18 +40,21 @@ direction from it.**
 
 2. **Direction-aware macro disclosure** — a way macro that surfaces a vendored
    tool extracts `TOOL_VERSION` from both the repo copy and the installed
-   template (a `grep`, not an execution) and compares with `sort -V`. Four
+   template (a `grep`, not an execution) and compares with `sort -V`. Five
    states replace the direction-blind diff note:
 
-   | Local copy | Disclosure |
+   | Local copy vs installed | Disclosure |
    |---|---|
-   | no version marker | predates versioning — out of date; re-vendor |
+   | no version marker, installed stamped | predates versioning — out of date; re-vendor |
    | lower than installed | stale — re-vendor to pick up the newer tool |
    | equal, bytes differ (version line excluded) | customized — expected, say so |
    | higher than installed | repo is ahead — the agent-ways install is stale; update it |
+   | stamped, installed unversioned | same as above — the install is stale |
 
    The version line is excluded from the customization diff so the stamp
-   cannot trigger the very warning it exists to disambiguate.
+   cannot trigger the very warning it exists to disambiguate. The extracted
+   stamp is shape-restricted to a version string — a stamp that doesn't parse
+   as one is treated as unversioned, never echoed into disclosed context.
 
 3. **Re-vendoring is a documented move** — the skill that owns each tool's
    vendoring procedure (ADR-138) also documents the update: plain copy when

--- a/hooks/ways/documentation/adr/adr-tool
+++ b/hooks/ways/documentation/adr/adr-tool
@@ -21,10 +21,6 @@ import argparse
 import re
 import subprocess
 import sys
-
-# Vendored-tool version (ADR-177). Bump when this tool changes — way macros
-# compare it against the installed template to tell stale from customized.
-TOOL_VERSION = "1.0.0"
 from datetime import date
 from pathlib import Path
 from dataclasses import dataclass, field
@@ -37,6 +33,10 @@ except ImportError:
     print("Error: PyYAML is required. Install with: pip install pyyaml", file=sys.stderr)
     print("       Or system-wide: sudo apt install python3-yaml", file=sys.stderr)
     sys.exit(1)
+
+# Vendored-tool version (ADR-177). Bump when this tool changes — way macros
+# compare it against the installed template to tell stale from customized.
+TOOL_VERSION = "1.0.0"
 
 # ============================================================================
 # Configuration

--- a/hooks/ways/documentation/adr/adr-tool
+++ b/hooks/ways/documentation/adr/adr-tool
@@ -21,6 +21,10 @@ import argparse
 import re
 import subprocess
 import sys
+
+# Vendored-tool version (ADR-177). Bump when this tool changes — way macros
+# compare it against the installed template to tell stale from customized.
+TOOL_VERSION = "1.0.0"
 from datetime import date
 from pathlib import Path
 from dataclasses import dataclass, field
@@ -816,6 +820,8 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__
     )
+    parser.add_argument('--version', action='version',
+                        version=f'adr-tool {TOOL_VERSION}')
     subparsers = parser.add_subparsers(dest='command', help='Command')
 
     # list

--- a/hooks/ways/documentation/adr/macro.sh
+++ b/hooks/ways/documentation/adr/macro.sh
@@ -43,14 +43,17 @@ if [[ -n "$ADR_SCRIPT" ]]; then
   # compare TOOL_VERSION stamps to tell stale from customized from ahead.
   UNIVERSAL="${HOME}/.claude/hooks/ways/documentation/adr/adr-tool"
   if [[ -f "$UNIVERSAL" ]]; then
-    local_ver=$(grep -m1 -oP '^TOOL_VERSION = "\K[^"]+' "$PROJECT_DIR/$ADR_SCRIPT" 2>/dev/null || true)
-    univ_ver=$(grep -m1 -oP '^TOOL_VERSION = "\K[^"]+' "$UNIVERSAL" 2>/dev/null || true)
+    # Capture is shape-restricted: a stamp that isn't a plain version string is
+    # treated as unversioned rather than echoed into disclosed context.
+    ver_re='^TOOL_VERSION = "\K[0-9]+(\.[0-9]+)*(-[0-9A-Za-z.]+)?(?=")'
+    local_ver=$(grep -m1 -oP "$ver_re" "$PROJECT_DIR/$ADR_SCRIPT" 2>/dev/null || true)
+    univ_ver=$(grep -m1 -oP "$ver_re" "$UNIVERSAL" 2>/dev/null || true)
     if [[ -z "$local_ver" && -n "$univ_ver" ]]; then
       echo ""
       echo "_The project's copy predates tool versioning (ways ships v${univ_ver}) — it is out of date. Re-vendor via the \`adr\` skill; if it was customized, diff first and carry the changes forward._"
     elif [[ -n "$local_ver" && -z "$univ_ver" ]]; then
       echo ""
-      echo "_The project's copy is v${local_ver} but the installed template is unversioned — the agent-ways install is stale. Update it (\`ways-update\`)._"
+      echo "_The project's copy is v${local_ver} but the installed template is unversioned — the agent-ways install is stale. Update it (\`/ways-update\`)._"
     elif [[ -n "$local_ver" && -n "$univ_ver" && "$local_ver" != "$univ_ver" ]]; then
       newest=$(printf '%s\n%s\n' "$local_ver" "$univ_ver" | sort -V | tail -1)
       if [[ "$newest" == "$univ_ver" ]]; then
@@ -58,7 +61,7 @@ if [[ -n "$ADR_SCRIPT" ]]; then
         echo "_The project's copy is v${local_ver}; ways ships v${univ_ver} — out of date. Re-vendor via the \`adr\` skill; if it was customized, diff first and carry the changes forward._"
       else
         echo ""
-        echo "_The project's copy is v${local_ver}, ahead of the installed template (v${univ_ver}) — the agent-ways install is stale. Update it (\`ways-update\`)._"
+        echo "_The project's copy is v${local_ver}, ahead of the installed template (v${univ_ver}) — the agent-ways install is stale. Update it (\`/ways-update\`)._"
       fi
     elif ! diff -q <(grep -v '^TOOL_VERSION = ' "$PROJECT_DIR/$ADR_SCRIPT") <(grep -v '^TOOL_VERSION = ' "$UNIVERSAL") &>/dev/null; then
       echo ""

--- a/hooks/ways/documentation/adr/macro.sh
+++ b/hooks/ways/documentation/adr/macro.sh
@@ -39,11 +39,31 @@ if [[ -n "$ADR_SCRIPT" ]]; then
   echo ""
   echo "**Always use \`$ADR_SCRIPT new\` to create ADRs** — it handles numbering, domain routing, and templates."
 
-  # Check if project script differs from universal template
+  # Direction-aware drift check against the universal template (ADR-177):
+  # compare TOOL_VERSION stamps to tell stale from customized from ahead.
   UNIVERSAL="${HOME}/.claude/hooks/ways/documentation/adr/adr-tool"
-  if [[ -f "$UNIVERSAL" ]] && ! diff -q "$PROJECT_DIR/$ADR_SCRIPT" "$UNIVERSAL" &>/dev/null; then
-    echo ""
-    echo "_Note: Project script differs from the universal template. This is expected for customized setups._"
+  if [[ -f "$UNIVERSAL" ]]; then
+    local_ver=$(grep -m1 -oP '^TOOL_VERSION = "\K[^"]+' "$PROJECT_DIR/$ADR_SCRIPT" 2>/dev/null || true)
+    univ_ver=$(grep -m1 -oP '^TOOL_VERSION = "\K[^"]+' "$UNIVERSAL" 2>/dev/null || true)
+    if [[ -z "$local_ver" && -n "$univ_ver" ]]; then
+      echo ""
+      echo "_The project's copy predates tool versioning (ways ships v${univ_ver}) — it is out of date. Re-vendor via the \`adr\` skill; if it was customized, diff first and carry the changes forward._"
+    elif [[ -n "$local_ver" && -z "$univ_ver" ]]; then
+      echo ""
+      echo "_The project's copy is v${local_ver} but the installed template is unversioned — the agent-ways install is stale. Update it (\`ways-update\`)._"
+    elif [[ -n "$local_ver" && -n "$univ_ver" && "$local_ver" != "$univ_ver" ]]; then
+      newest=$(printf '%s\n%s\n' "$local_ver" "$univ_ver" | sort -V | tail -1)
+      if [[ "$newest" == "$univ_ver" ]]; then
+        echo ""
+        echo "_The project's copy is v${local_ver}; ways ships v${univ_ver} — out of date. Re-vendor via the \`adr\` skill; if it was customized, diff first and carry the changes forward._"
+      else
+        echo ""
+        echo "_The project's copy is v${local_ver}, ahead of the installed template (v${univ_ver}) — the agent-ways install is stale. Update it (\`ways-update\`)._"
+      fi
+    elif ! diff -q <(grep -v '^TOOL_VERSION = ' "$PROJECT_DIR/$ADR_SCRIPT") <(grep -v '^TOOL_VERSION = ' "$UNIVERSAL") &>/dev/null; then
+      echo ""
+      echo "_Note: Project script differs from the universal template. This is expected for customized setups._"
+    fi
   fi
   exit 0
 fi

--- a/hooks/ways/documentation/linting/doc-tool
+++ b/hooks/ways/documentation/linting/doc-tool
@@ -29,6 +29,10 @@ import sys
 from collections import Counter
 from pathlib import Path
 
+# Vendored-tool version (ADR-177). Bump when this tool changes — way macros
+# compare it against the installed template to tell stale from customized.
+TOOL_VERSION = "1.0.0"
+
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
 import doclint  # noqa: E402  — reuse catalog parsing (single source of truth)
@@ -337,6 +341,8 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description="Librarian for the documentation catalog.",
         formatter_class=argparse.RawDescriptionHelpFormatter, epilog=__doc__)
+    parser.add_argument("--version", action="version",
+                        version=f"doc-tool {TOOL_VERSION}")
     sub = parser.add_subparsers(dest="command")
 
     sub.add_parser("coverage", help="domain × mode coverage matrix (default)")

--- a/hooks/ways/softwaredev/visualization/charts/chart-tool
+++ b/hooks/ways/softwaredev/visualization/charts/chart-tool
@@ -37,6 +37,10 @@ import math
 import sys
 from collections import Counter
 
+# Vendored-tool version (ADR-177). Bump when this tool changes — way macros
+# compare it against the installed template to tell stale from customized.
+TOOL_VERSION = "1.0.0"
+
 # ============================================================================
 # Color helpers
 # ============================================================================
@@ -348,6 +352,10 @@ RENDERERS = {
 }
 
 def main():
+    if "--version" in sys.argv[1:]:
+        print(f"chart-tool {TOOL_VERSION}")
+        sys.exit(0)
+
     if sys.stdin.isatty():
         print(__doc__)
         sys.exit(0)

--- a/skills/adr/SKILL.md
+++ b/skills/adr/SKILL.md
@@ -95,6 +95,26 @@ For a full repo scaffold (ADRs + GitHub config + CODEOWNERS + project ways), run
 `/project-init` instead — it vendors this tool as one step of a larger setup. The
 **docs** skill is the catalog half and shares this `adr.yaml`.
 
+## Updating a vendored copy
+
+The tool carries a `TOOL_VERSION` stamp (`docs/scripts/adr --version`), and the
+`adr` way's macro compares it against the installed template — so a disclosure
+saying the copy is *out of date* means ways ships a newer tool (ADR-177).
+
+- **Unmodified copy** (only the `TOOL_VERSION` line differs, if anything):
+  re-run the `cp` from the vendoring steps above. `adr.yaml` is untouched —
+  config and tool update independently.
+- **Customized copy**: diff first, then carry the local changes forward onto
+  the new version — never overwrite on sight:
+
+```bash
+diff docs/scripts/adr ~/.claude/hooks/ways/documentation/adr/adr-tool
+```
+
+If the macro instead says the *installed template* is behind the project's
+copy, the agent-ways install is stale — update it (`/ways-update`), don't
+downgrade the project.
+
 ## Key Rules
 
 - **Always use the CLI** — never create `ADR-*.md` files by hand


### PR DESCRIPTION
## What

ADR-177 (Draft, accept-on-merge) plus its implementation in one change:

- **`TOOL_VERSION` stamp + `--version`** in all three vendorable tools: `adr-tool`, `doc-tool`, `chart-tool` (each at 1.0.0).
- **Direction-aware macro** — the adr way's macro previously ran a bare `diff -q` and answered every difference with *"expected for customized setups"*, which reassures exactly when the copy is stale. It now greps `TOOL_VERSION` from both sides and compares with `sort -V`:

| Local copy | Disclosure |
|---|---|
| no marker | predates versioning — re-vendor |
| older | stale — re-vendor |
| equal, bytes differ (version line excluded) | customized — expected |
| newer / install unversioned | agent-ways install is stale — `ways-update` |

- **adr skill**: new *Updating a vendored copy* section (plain re-copy when unmodified; diff-and-carry-forward when customized).

## Why now

Issue #438 (`adr archive` + supersession parsing) is about to grow the tool. Landing the stamp first means post-#438 vendored copies are born versioned, and "no marker = predates versioning" cleanly bounds the unversioned era.

## Validation

- All six macro states exercised in a sandbox (fake `$HOME` + project dir): unversioned-local, older, newer, equal+customized, identical (silent), install-unversioned — each discloses the right message.
- `py_compile` clean on all three tools; `--version` verified on each.
- `adr lint` clean on ADR-177; index regenerated.