### PR TITLE
Reconcile ADR status at land time in the merge flow

### DIFF
--- a/hooks/ways/softwaredev/delivery/merge/merge.md
+++ b/hooks/ways/softwaredev/delivery/merge/merge.md
@@ -36,6 +36,12 @@ A review that finds nothing changes nothing; a review that finds something is on
 
 Merge (regular merge commit, preserving the branch's narrative — see `delivery/github`), then run the full cleanup: back to `main`, pull, prune, delete the merged branch. Landing an increment is **not** cutting a release — versioning, changelogs, and artifacts are `delivery/release` and the `/release` skill, a separate, heavier act.
 
+## Reconcile the decision ledger
+
+An ADR that authorized the work sits at `Draft` for as long as the work is unmerged. Merging is the moment its claim becomes true, so flip it to `Accepted` in the same pass as the cleanup. An ADR that the merge supersedes, or one the work proved unnecessary, leaves the active set through `adr archive`.
+
+Skipping this costs nothing per merge and compounds. An audit in August 2026 found seventeen ADRs still at `Draft` or `Proposed` with their implementation long shipped — one of them carrying thirteen source references while marked "Proposed" — and four documents that had been abandoned or quietly solved by a neighbour. The archive command had existed for weeks and had never been run. Nothing fails while this drifts; the ledger simply stops describing the system, and the correction arrives as a corpus-wide audit instead of a one-line edit.
+
 ## See Also
 
 - delivery/github(softwaredev) — PR creation, merge strategy, and post-merge cleanup discipline.

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: merge
 description: Land an increment to main through the branch → commit → push → PR → review-gate → merge → cleanup flow. The review gate is a four-square decision (review depth × human gate). Picks up wherever you are in the cycle. Use when the user says "merge this", "land this", "run a review and merge", "ship it", or invokes /merge.
-allowed-tools: Bash, Read, Grep, Glob, Agent
+allowed-tools: Bash, Read, Edit, Grep, Glob, Agent
 ---
 
 # Merge — land an increment
@@ -135,7 +135,37 @@ git branch   # verify only main + active work branches remain
 
 Always run the full sequence — stale branches and dangling refs accumulate fast.
 
-### 9. Release? (only if warranted)
+### 9. Reconcile the ADR status
+
+If the merged work implements an ADR, that ADR is still `Draft` or `Proposed`. Flip it
+now, while you know which one it was.
+
+```bash
+docs/scripts/adr list --status Draft      # implemented by this merge?
+docs/scripts/adr list --status Proposed
+```
+
+Set `status: Accepted` in the frontmatter of each one this merge delivered, then:
+
+```bash
+docs/scripts/adr index -y                 # regenerate the index
+docs/scripts/adr lint                     # 0 errors before committing
+```
+
+If the merge supersedes an ADR, or the work proved one unnecessary, archive it instead
+of leaving it in the active set:
+
+```bash
+docs/scripts/adr archive <n> --superseded-by ADR-<m> --reason "..." --dry-run
+docs/scripts/adr archive <n> --status Rejected --reason "..."    # never built
+```
+
+`adr lint` requires the reciprocal `supersedes:` on the superseding ADR. Add it, or the
+link rots one-directionally.
+
+Commit as `docs(adr): accept ADR-<n> post-merge and regenerate index`.
+
+### 10. Release? (only if warranted)
 
 Landing is not releasing. If the merged change warrants a versioned release (new
 feature, breaking change, artifact-bearing project), **suggest `/release`** — don't
@@ -148,6 +178,8 @@ auto-publish. Publishing is a one-way door.
 - **The four-square drives the gate**, not change size alone — a one-line ADR still
   gates on the operator; a big leaf refactor may not.
 - **Remediate before merge** — findings that aren't fixed aren't findings, they're debt.
+- **Reconcile the ledger at land time** — a Draft ADR whose work just merged is a stale
+  record. The correction costs one line now and a corpus audit later.
 - **If mid-flow**, pick up from current state — don't restart.
 - **Merge ≠ release** — landing an increment is the daily act; releasing is `/release`.
 


### PR DESCRIPTION
## Why

The corpus audit in #446 found the failure this closes:

- **17 ADRs** at `Draft`/`Proposed` with implementation long shipped. ADR-129 carried **13 source references** while marked Proposed.
- **4 documents** abandoned or quietly solved by a neighbour ADR.
- `adr archive` had shipped weeks earlier and had **never been run** — the archive set was empty.

Nothing in the merge flow marks a decision done. The correction therefore arrives as a corpus-wide audit months later, instead of a one-line edit at the moment the author still knows which ADR the work delivered.

## Changes

Split per ADR-138 (skills own the how, ways own the 5W):

**`hooks/ways/softwaredev/delivery/merge/merge.md`** — new "Reconcile the decision ledger" section. When the flip happens, what archiving is for, and the audit numbers as the cost of skipping.

**`skills/merge/SKILL.md`** — new step 9 with the commands: list Draft/Proposed, set `status: Accepted`, `adr index -y`, `adr lint`, plus both archive forms (superseded and never-built). Notes that `adr lint` requires the reciprocal `supersedes:` — it caught exactly that on two files in #446. Release moves to step 10, and a matching key principle is added.

## One thing to flag

`Edit` joins the skill's `allowed-tools`. Status lives in frontmatter and there is no `adr status` subcommand, so the step needs a file edit. The skill already commits, pushes, and merges PRs, so a frontmatter line is well inside its existing blast radius — but it is a permission widening and worth seeing.

## Verification

- `ways lint --check` on the changed way — 0 errors, 0 warnings
- `scripts/check-register.sh` — clean

Related: ADR-138, #446