### PR TITLE
Reconcile the issue tracker before the release tag

### DIFF
--- a/.claude/ways/meta/project-health/project-health.md
+++ b/.claude/ways/meta/project-health/project-health.md
@@ -40,6 +40,24 @@ The default window is feathered: anchored at our last release tag, expanded to i
 - Update ADR status when implementation lands, not when the ADR is written
 - Draft = intent not yet committed to. Accepted = we're building or built it.
 
+## Release Mechanics
+
+Two steps, because `main` is branch-protected (ADR-150):
+
+```bash
+make cut-release COMPONENT=<c> LEVEL=<patch|minor|major>   # opens a version-bump PR
+# after that PR merges:
+make publish-release COMPONENT=<c> PUSH=1                  # tags <c>-vX.Y.Z on main
+```
+
+Components: `ways`, `ways-audit`, `attend`, `attend-chat`. `way-embed` versions through its own Makefile.
+
+Pushing the tag is the one outward step. `build-<c>.yml` then builds every platform and creates the GitHub Release with per-platform binaries and `checksums.txt`.
+
+Tags are GPG-signed, so `publish-release` needs a passphrase from the operator's own terminal. An agent cannot complete it — do everything up to that point and hand over the command.
+
+Bump level follows the commit types, against the *binary*. A corpus-only change with a `fix:` commit is a patch even when it changes what every session sees; the CLI interface is what the version tracks.
+
 ## What to Adopt vs Ignore
 
 Filter upstream changes through what this project cares about:

--- a/hooks/ways/softwaredev/delivery/release/release.md
+++ b/hooks/ways/softwaredev/delivery/release/release.md
@@ -78,13 +78,15 @@ Act through whatever CLI the project already uses — `gh issue`, `glab`, `jira`
 | AUR | Update PKGBUILD, `makepkg --printsrcinfo > .SRCINFO`, push to AUR |
 | Container registry | `docker build -t repo:vX.Y.Z . && docker push` |
 
-For multi-platform binaries (like ways, mmaid), build per-platform, attach all to a single GitHub Release with checksums.
+For multi-platform binaries, build per-platform and attach all of them to a single GitHub Release with a `checksums.txt`.
 
-## This Project
+## Two-Step Release Under Branch Protection
 
-Two steps, because `main` is branch-protected (ADR-150). `make cut-release COMPONENT=<c> LEVEL=<patch|minor|major>` opens a version-bump PR; after it merges, `make publish-release COMPONENT=<c> PUSH=1` tags `<c>-vX.Y.Z` on main and pushes it.
+A protected `main` splits the release in two, and this is common enough to plan for. The bump — version file, lockfile, changelog — goes through a PR like any other change. Only after it merges does the tag land on `main`.
 
-Pushing the tag is the one outward step. CI (`build-<c>.yml`) then builds every platform and creates the GitHub Release with per-platform artifacts and `checksums.txt`. Tags are annotated and GPG-signed, so `publish-release` needs the operator's passphrase — an agent cannot complete that step.
+Tagging is then the single outward step, and CI usually takes it from there: a tag-triggered workflow builds each platform and creates the release. Check for that workflow before hand-building artifacts.
+
+Signed tags stop an agent cold. If the project signs (`tag.gpgsign`, or a `-s` in the release script), the tag command needs a passphrase from a terminal the agent doesn't own. Do everything up to that point, then hand the exact command to the operator rather than retrying into a timeout.
 
 ## Do Not
 

--- a/hooks/ways/softwaredev/delivery/release/release.md
+++ b/hooks/ways/softwaredev/delivery/release/release.md
@@ -48,6 +48,25 @@ From commit messages since last tag:
 
 Detect the version file (package.json, Cargo.toml, pyproject.toml, version.txt) and update it.
 
+## Reconcile the Issue Tracker
+
+A release is the moment "fixed in X" becomes a public claim, so the tracker is reconciled before the tag, not after. This is the release-time sibling of the ADR status flip in `delivery/merge` — same failure, different ledger: nothing breaks while it drifts, and the correction arrives later as a bulk audit.
+
+Find what the release claims:
+
+```bash
+git log $(git describe --tags --abbrev=0)..HEAD --format='%s%n%b' \
+  | grep -oiE '(clos|fix|resolv)(e[sd])? +#?[A-Z]+-?[0-9]+'
+```
+
+The pattern is deliberately tracker-agnostic — it catches `#123` and `PROJ-456` equally. Three things to settle with the hits:
+
+- Items the commits closed get the released version recorded, where the tracker has a fix-version field.
+- Items referenced without a closing keyword get checked against what the release actually does.
+- An item the changelog names as fixed while the tracker shows it open means one of the two is wrong.
+
+Act through whatever CLI the project already uses — `gh issue`, `glab`, `jira`, an MCP tool, a checklist in a file. Detect it from the repo rather than assuming. **A project with no tracker is a valid outcome**: say so and move on.
+
 ## Publishing Artifacts
 
 | Destination | How |
@@ -63,10 +82,9 @@ For multi-platform binaries (like ways, mmaid), build per-platform, attach all t
 
 ## This Project
 
-- Annotated tags: `git tag -a vX.Y.Z -m "summary"`
-- Push tags explicitly: `git push origin main --tags`
-- No CI release pipeline — tagging is the release
-- Binary tools: GitHub Releases with per-platform artifacts + `checksums.txt`
+Two steps, because `main` is branch-protected (ADR-150). `make cut-release COMPONENT=<c> LEVEL=<patch|minor|major>` opens a version-bump PR; after it merges, `make publish-release COMPONENT=<c> PUSH=1` tags `<c>-vX.Y.Z` on main and pushes it.
+
+Pushing the tag is the one outward step. CI (`build-<c>.yml`) then builds every platform and creates the GitHub Release with per-platform artifacts and `checksums.txt`. Tags are annotated and GPG-signed, so `publish-release` needs the operator's passphrase — an agent cannot complete that step.
 
 ## Do Not
 

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -47,14 +47,35 @@ Detect and update: `package.json`, `Cargo.toml`, `pyproject.toml`, `version.txt`
 
 Keep a Changelog format, grouped Added / Changed / Fixed / Removed.
 
-### 4. Tag
+### 4. Reconcile the issue tracker
+
+A release is when "fixed in X" becomes a true statement. Find what this release claims
+to close, before the tag makes the claim public:
+
+```bash
+git log $(git describe --tags --abbrev=0)..HEAD --format='%s%n%b' \
+  | grep -oiE '(clos|fix|resolv)(e[sd])? +#?[A-Z]+-?[0-9]+'
+```
+
+That catches `#123` and `PROJ-456` alike. What to do with the hits depends on what the
+project's tracker offers:
+
+- Items the commits closed — stamp the released version, if there's a fix-version field.
+- Items referenced without a closing keyword — check whether this release resolves them.
+- An item named in the changelog that the tracker still shows open — one of the two is wrong.
+
+Use whatever CLI the project already uses (`gh issue`, `glab`, `jira`, an MCP tool, a
+`TODO.md`). Detect it; don't assume one. **No tracker is a valid answer** — say so and
+move on rather than inventing one.
+
+### 5. Tag
 
 ```bash
 git tag -a vX.Y.Z -m "summary"
 git push origin main --tags
 ```
 
-### 5. Publish artifacts (confirm first — one-way door)
+### 6. Publish artifacts (confirm first — one-way door)
 
 | Destination | How |
 |---|---|


### PR DESCRIPTION
## Why

The release-time sibling of #447. Same failure, different ledger: a release publishes *"fixed in X"* as a claim, and nothing checks the claim against whatever tracks the issues.

## Kept generalized

The step names no tracker. Detection is one grep for closing keywords plus an identifier:

```bash
git log $(git describe --tags --abbrev=0)..HEAD --format='%s%n%b' \
  | grep -oiE '(clos|fix|resolv)(e[sd])? +#?[A-Z]+-?[0-9]+'
```

That catches `#123` and `PROJ-456` equally. The action routes through whatever CLI the repo already uses — `gh issue`, `glab`, `jira`, an MCP tool, a checklist in a file — detected rather than assumed. **A project with no tracker is a stated valid outcome**, so the step no-ops instead of inventing one.

Three things to settle with the hits: stamp the fix version where the field exists, check unclosed references against what the release actually does, and treat a changelog entry whose issue is still open as a contradiction.

Placed **before** the tag. That contradiction is worth catching on this side of the one-way door.

## Also: stale content in the release way

`## This Project` read *"No CI release pipeline — tagging is the release."* That has been wrong since `build-<c>.yml` landed, and we used the pipeline it denies exists an hour ago cutting `ways-v1.8.1`. Replaced with the actual two-step flow (ADR-150): `make cut-release` opens a bump PR, `make publish-release` tags and CI builds every platform.

Also records that tags are GPG-signed, so `publish-release` needs the operator's passphrase and an agent cannot complete it — which is exactly how it failed today.

## Verification

- `ways lint --check` on the changed way — 0 errors, 0 warnings
- `scripts/check-register.sh` — clean

Related: #447, ADR-150