### PR TITLE
docs(direnv): bump model examples to Opus 5

### DIFF
--- a/skills/direnv/SKILL.md
+++ b/skills/direnv/SKILL.md
@@ -46,7 +46,7 @@ export CLAUDE_CODE_USE_BEDROCK=1
 export AWS_PROFILE=my-bedrock-profile
 export AWS_REGION=us-east-1
 # Optional: override model
-# export ANTHROPIC_MODEL="us.anthropic.claude-sonnet-4-20250514-v1:0"
+# export ANTHROPIC_MODEL="anthropic.claude-opus-5"
 ```
 
 ### Google Vertex AI
@@ -71,7 +71,7 @@ export ANTHROPIC_FOUNDRY_API_KEY="..."
 
 ```bash
 # .envrc — append to any of the above
-export ANTHROPIC_MODEL="claude-opus-4-8"   # pin a specific model snapshot; update as releases land
+export ANTHROPIC_MODEL="claude-opus-5"     # pin a specific model snapshot; update as releases land
 export CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000
 export CLAUDE_CODE_EFFORT_LEVEL=high
 export CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE=99


### PR DESCRIPTION
## Changes

Two stale model IDs in `skills/direnv/SKILL.md`, both operator-facing examples:

- **Feature flags block** — `claude-opus-4-8` → `claude-opus-5`. This line reads as the recommended pin.
- **Bedrock block** — the commented override named `us.anthropic.claude-sonnet-4-20250514-v1:0` → `anthropic.claude-opus-5`. The shape changes too: the current Bedrock endpoint takes a bare `anthropic.`-prefixed ID; the `us.` region prefix and `-v1:0` suffix are the legacy InvokeModel form.

## Scope

Found while scanning for pinned older model IDs. Two other hits were left alone:

- `scripts/sync-to-home-test.sh` uses `claude-opus-4-8` as a settings-merge fixture — the value is arbitrary, the test asserts key preservation.
- The ADR-166 table in `tools/ways-core/src/context_window.rs` carries 4.6/4.7/4.8 as historical entries. That's a lookup table, and it already resolves `claude-opus-5` to 1M.

Opened via the REST endpoint — GitHub's GraphQL API is 503ing during the current partial outage, so `gh pr create` could not be used.