### PR TITLE
release(ways): v1.9.1

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "ways"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "agent-fmt",
  "anyhow",

--- a/tools/ways-cli/Cargo.toml
+++ b/tools/ways-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ways"
-version = "1.9.0"
+version = "1.9.1"
 edition = "2021"
 description = "Unified CLI for ways — knowledge guidance for Claude Code"
 license = "MIT"


### PR DESCRIPTION
Version bump for the ways 1.9.1 release (ADR-150). After merge, tag it: `make publish-release COMPONENT=ways` — that pushes `ways-v1.9.1` and CI builds all platforms + creates the GitHub Release.