### PR TITLE
feat(ways): recovery, gates, integration, hostparity from the Cypress survey

### DIFF
--- a/hooks/ways/softwaredev/code/quality/integration/integration.md
+++ b/hooks/ways/softwaredev/code/quality/integration/integration.md
@@ -1,0 +1,69 @@
+---
+description: fixing a bug, refactoring, or changing existing code so the change integrates into the file instead of being patched on; no v2 wrapper or new-suffix copy of the old function, delete dead code and dangling imports after a removal, treat a rename that crosses an API or wire boundary as a contract change, sweep sibling copies of the same defect
+vocabulary: fix the bug fix refactor patch change existing code modify update legacy old handler callers break compatibility rename wrapper v2 cleanup clean up dead code unused duplicate copy paste additive diff sweep bolted stitched integrate integration siblings copies dangling import removal boundary
+files: \.(rs|py|ts|tsx|js|go|java|rb|sh|c|cpp|h)$
+refire: 0.15
+scope: agent, subagent
+---
+<!-- epistemic: heuristic -->
+# Integration Over Patching
+
+A fix landed as the smallest diff that satisfies the request leaves a seam. The new branch sits beside the old logic, the helper it made redundant stays, and the next reader has to work out which path is current. Six months of such seams and the file records its requests in the order they arrived.
+
+## The unit of work
+
+The unit of work is the whole file or module. A change is complete when the file reads as if the requirement had existed from the beginning. Before editing, state the file's responsibilities, its main abstractions, and its conventions; if you cannot, read until you can. Locate where the change belongs, list what it makes redundant (helpers to merge, branches that go dead, names and comments that go stale, tests it implies), then rewrite the affected regions as a whole. Deletion and consolidation are first-class outcomes.
+
+This governs the code that delivers the requested behavior. It adds no capability nobody asked for.
+
+## Forbidden moves
+
+| Move | Do this instead |
+|---|---|
+| A wrapper around the old function, `handleXNew`, `_v2`, an `Improved` or `Enhanced` suffix | Change the function in place; the name describes what it does now |
+| A boolean flag routing around old behavior | Replace the behavior |
+| An `if` for the new case while the general logic stays untouched | Change the general logic when that is where the requirement lives |
+| Appending at the bottom of the file | Put the code where its abstraction lives |
+| Commented-out code, `TODO remove` markers, dead branches kept to be safe | Delete them; version control holds the history |
+| Fixing the symptom at the call site | Fix the abstraction that owns the defect |
+
+## Self-check before calling the change done
+
+- Is the diff purely additive? If so, justify why nothing needed to change or die.
+- Does anything now exist in two places?
+- After a removal, sweep for what still points at the removed thing: imports, exports, re-exports, type and enum references, docs, and tests. Check these separately from call sites; the call sites can all be gone while the import survives.
+- Do all names, comments, and docs still tell the truth?
+- Could a reader tell where the patch was stitched in?
+
+## Renames
+
+A rename is trivial while the identifier stays inside one compiled unit. It becomes a contract change the moment it crosses a serialization, wire, or process boundary: a persisted field, an enum constant another party reads, a token claim name, an HTTP or RPC path, a queue routing key, a service-discovery name. Some stored record or in-flight message still speaks the old name, and nothing fails at compile time. Version it, migrate it, or dual-read it.
+
+## The class sweep
+
+A defect found in one place is often one defect with N locations: the same wrong path in six pipelines, the same unguarded call in four adapters. The location you were handed holds no privilege.
+
+1. State the defect so a search can find it, then search.
+2. Land the fix once, at the seam that owns it. Collapse the copies into one shared implementation each member invokes. Where the copies cannot collapse in this increment (a generated file per consumer, a library outside the change), fix each site in its local conventions, verify uniformity by diff, and file the collapse as its own increment.
+3. Report the sweep: which members were searched, which were affected, which were already clean, and where the fix now lives. A sweep you cannot enumerate is a claim.
+
+If the class is too large for this increment, fix the instance, name the remaining members, and file them. A silent partial fix reads as a complete one.
+
+## Scope
+
+The sweep is bounded by the defect's identity. The scope rule (do the task asked, file the rest) is bounded by relevance. Both bounds hold at once. A sibling carrying the defect you were sent to fix is the same work; a different defect you noticed on the way gets filed. When integration touches files the request did not name, including the seam that should own the fix, list them before editing.
+
+## Append-only artifacts
+
+Changelogs, ADRs, audit logs, and ledgers are deliberately append-only. A stale entry there is struck or superseded. This way governs code and single-current-truth documents, where two copies of a fact is a defect.
+
+## When it does not apply
+
+A typo, a comment, a lint fix, or a single config value takes the trivial shortcut. The test is the unit of work: "fix this typo" is trivial; "fix this bug" rarely is, because the bug usually lives in an abstraction.
+
+## See Also
+
+- code/quality(softwaredev) — parent: measurable quality thresholds
+- code/quality/versioning(softwaredev) — the `_v2` twin and why the name should say what the thing is
+- code/overbuild(softwaredev) — the other side of scope: no capability nobody asked for
+- code/testing/tdd(softwaredev) — the test that makes restructuring existing code safe

--- a/hooks/ways/softwaredev/code/quality/quality.md
+++ b/hooks/ways/softwaredev/code/quality/quality.md
@@ -46,6 +46,7 @@ A validation — a lint rule, an assertion, a schema constraint, a CI check —
 
 ## See Also
 
+- code/quality/integration(softwaredev) — a change integrates into the whole file; forbidden patch moves, the class sweep
 - code/testing(softwaredev) — quality requires test coverage
 - code/errors(softwaredev) — error handling is a quality signal
 - tooling(softwaredev) — encode enforced conventions in tooling

--- a/hooks/ways/softwaredev/code/testing/gates/assertions/assertions.md
+++ b/hooks/ways/softwaredev/code/testing/gates/assertions/assertions.md
@@ -1,0 +1,51 @@
+---
+description: the shape of a test assertion, composition versus a bare count, expected values independent of the subject, failure messages that name what drifted, mock call counts, snapshot and golden baselines, a named known-bug marker that expires when the bug is fixed
+vocabulary: assert assertion expect expected mock called toHaveBeenCalled snapshot golden baseline known bug xfail known_bug marker tautological witness drift composition count
+scope: agent, subagent
+refire: 0.15
+---
+<!-- epistemic: heuristic -->
+# Assertion Shape
+
+A gate that executes and asserts can still prove nothing. The assertion compares a count that offsetting errors restore, or an expected value computed from the very thing under test, or a mock call tally that goes vacuous the moment the code stops calling the collaborator. Each of these stays green through the bug it was written to catch.
+
+## Three questions
+
+**Does it assert composition, or only a count?** A total passes again the moment two errors cancel. A count of three returns to three while the set holds the wrong three. Assert what the result is made of: the names, the keys, the ordered members. Where completeness matters, take the full set difference. A spot check of the newest items is a sample. Report new coverage as a delta from the previous run, and establish "no regression" on a red baseline by comparing the names of failing tests before and after.
+
+**Is the expected value independent of the subject?** An expectation derived from the value under test agrees with every mutation of it. Spell expected values as literals. Verify a derived value by a join across independently maintained sources. The test for any duplicate is the same: if one coordinated edit could change both copies with nothing failing, the copy is an echo. A copy that would fail is a witness, kept on purpose.
+
+**Does a failure say what drifted?** Assert each dimension under its own name so a red identifies the property that moved. One assertion over a serialized blob says "different" and stops. Choose a witness sensitive to the change you guard against. A projection only witnesses what it projects.
+
+## The mock invocation count
+
+The canonical vacuous assertion is `expect(mock).toHaveBeenCalledTimes(1)`. It passes for the right call, and it keeps passing when the code calls the collaborator once for an unrelated, wrong reason. Assert on the destination, the content, or the argument passed:
+
+```js
+expect(send).toHaveBeenCalledWith({ to: "ops@example.com", subject: "Disk 91%" });
+```
+
+A count is the behavior only when the count is what the code promises, such as exactly one charge per order. The mocking way holds the wider rule on call counts. This way covers what to assert instead.
+
+## The self-expiring known-bug marker
+
+When a suite must stay green while a confirmed bug still lives, do not weaken or skip the gate. Assert today's broken behavior on purpose, under a named marker:
+
+```python
+def test_KNOWN_BUG_1432_unauthenticated_read_returns_500(client):
+    # Owed: require 401 once the auth middleware handles a missing token.
+    assert client.get("/admin", auth=None).status_code == 500
+```
+
+The assertion passes while the bug lives and flips red the moment the bug is fixed without the assertion being tightened. The debt is named in the suite and retires itself. A skipped or relaxed test hides the same hole. An `xfail` without a reason and a ticket hides it more quietly.
+
+## Golden and snapshot assertions
+
+A snapshot is an assertion whose expected side was captured from the subject. It becomes a witness once a person has reviewed the baseline and the review is on record. Capture it before the change, with volatile leaves masked (timestamps, ids, tokens). After the change, allow only an enumerated list of intended deltas, each with its reason. An unexplained diff is a red to explain before the gate is green. Re-recording the snapshot to make it pass turns the baseline back into an echo.
+
+## See Also
+
+- code/testing/gates(softwaredev) — parent: gate states, positive controls, and the report format
+- code/testing/mocking(softwaredev) — call counts are asserted only when the count is the behavior
+- freshness/groundtruth(softwaredev) — the golden-master oracle captured before a refactor or migration
+- code/testing/tdd(softwaredev) — a test must be seen red before its green means anything

--- a/hooks/ways/softwaredev/code/testing/gates/gates.md
+++ b/hooks/ways/softwaredev/code/testing/gates/gates.md
@@ -1,0 +1,86 @@
+---
+description: verification gates before merge, whether the tests and checks actually ran, reporting each gate as executed, discovered, or absent, positive controls for empty results, gate depth by change class
+vocabulary: gate gates ci check checks verification verify verified tests ran coverage scanner scan lint pass green ready merge executed discovered absent positive control null result zero findings clean instrument report
+commands: (npm|pnpm|yarn)\ test|pytest|cargo\ test|go\ test|make\ test|make\ check
+scope: agent, subagent
+refire: 0.15
+---
+<!-- epistemic: heuristic -->
+# Verification Gates
+
+A change gets called verified when the checks that cover it ran and reported. The failure this way prevents is quieter than a red build: a suite that was never invoked, a step that skipped itself and exited zero, a scanner aimed at the wrong path, and a report that lists none of it. The reader takes the silence for a pass.
+
+## Every gate reports one of three states
+
+A gate is any check that stands between a change and merge: formatter, linter, type check, unit or integration suite, contract test, build, security scan, smoke test, manual review. Each gate you considered lands in exactly one state, and the report says which.
+
+| State | Meaning | What the line carries |
+|---|---|---|
+| **executed** | Run on this change, prerequisites held, assertions ran | The command and the result |
+| **discovered** | Known to exist, deliberately left unrun | Why it was skipped |
+| **absent** | No such gate exists | The date and the reason |
+
+An exit code of zero counts as executed only when the check did its work. A step that skipped itself, a suite that collected zero tests, a tool configured but inert, a run whose test count came back short: record these as discovered, whatever the runner printed. A failing gate is fixed or handed back. Never record a pass that did not happen. A new gate earns trust once a planted violation has turned it red and the plant's removal has turned it green again.
+
+An inherited codebase with no test infrastructure still gets a full report: each standard gate on its own line as absent with a date. A blank report reads the same as one nobody wrote.
+
+## A zero needs a positive control
+
+A scan with no findings, a grep with no hits, a discovery run that collected nothing, and a port check that saw nothing open all return exactly what a broken probe returns. The result alone cannot tell the two apart.
+
+Report a zero only alongside a positive control the same run detected. Point the scanner at a fixture known to trip it, grep for a string you know is present, assert the suite collected the tests you know exist. Then state the coverage the control establishes. "No secrets found by <tool> across <paths>, control fixture detected" is a finding. "No secrets" is a hope with a command history.
+
+A check you author counts what it examined and fails when that count is zero inside its own perimeter. A glob that matched nothing is an environment fault. Reserve the empty result for a genuine empty success.
+
+## Gate depth follows the change class
+
+| Change class | Minimum gate depth |
+|---|---|
+| Trivial edit, no behavior or contract surface | The one focused check that covers it (formatter, linter, build) |
+| Leaf logic, contracts unchanged, affected path known | Cheap static gates plus the focused unit or integration tests on that path |
+| Shared module | Static gates, the module's own suite, and the suites of its callers |
+| Public interface or persisted format | The full battery on the boundary: contract tests, integration, neighboring regression suites |
+| Auth, security, data migration, concurrency, central abstraction | Broad system gates: the full suite, security scan, end-to-end on critical flows, manual review |
+| Affected scope uncertain | The row above your best guess. Uncertainty buys breadth. |
+
+Escalate one row the moment a local change turns out to touch a shared surface. Run the cheap syntactic gates first and proceed to slower ones only when they pass. A broad battery on a provably local change spends attention and wall clock for nothing.
+
+## The instrument is the first suspect
+
+When a check and its subject disagree, read the raw source at the cited location before recording the finding. Two contradictory measurements of your own indict the method. A line-oriented scan over a multi-line construct produces a number that looks like evidence. A tool that produced a false positive is fixed or deleted in the same change that retracts its output. A discredited tool left in place will be quoted again.
+
+Never satisfy a check by changing what it measures. Do not remove the value it observes, do not edit the declaration it reads, and do not revert the change that tripped it. When an assertion fails because the product deliberately changed, update the assertion. When it fails because it found a defect, fix the defect or pin the broken behavior under a named marker (see the assertions child way).
+
+A gate measures the effective state, read back through the path a real client takes. A check that reaches the service by a shortcut cannot see faults in the path it skipped. A control's presence in the code says nothing about its wiring. Verify the flag value on every path that can produce the outcome.
+
+## Report format
+
+One line per gate, state first:
+
+```
+- Linter: executed, `make lint`, PASS (2 warnings, both in docs/)
+- Unit tests: executed, `cargo test`, PASS (47 cases)
+- Secret scan: executed, `gitleaks detect`, 0 findings, control fixture detected
+- End-to-end: discovered, left unrun, suite exists under e2e/, out of scope for this change
+- Smoke test: absent (2026-09-09), no deploy target yet
+```
+
+Close the report with what was deliberately left unverified, blocked distinguished from skipped. A partial pass must never read as completion.
+
+## Common Rationalizations
+
+| Rationalization | Counter |
+|---|---|
+| "All gates green, I just disabled the flaky one" | Fix the flake or record the gate as discovered with the reason. Silent disabling is a hidden absent. |
+| "Tests pass locally, CI can wait" | Record where it ran. A gate that ran nowhere is a hope. |
+| "No time for the full suite this round" | Merge a smaller change. Depth follows the change class. |
+| "The scan came back clean" | Clean against what? Without a control the zero is unread. |
+| "The check was wrong, so I fixed the file it reads" | The declaration now records a bug. Fix the instrument. |
+| "The step exited zero" | An exit code says a process ended. Did its assertions run? |
+
+## See Also
+
+- code/testing/gates/assertions(softwaredev) — whether an executed assertion can have proved anything
+- code/testing(softwaredev) — parent: what to cover and what to assert
+- delivery/merge(softwaredev) — review depth and gate depth are chosen together
+- environment/recovery(softwaredev) — a gate red twice means the increment is wrong-sized

--- a/hooks/ways/softwaredev/code/testing/testing.md
+++ b/hooks/ways/softwaredev/code/testing/testing.md
@@ -37,4 +37,5 @@ Detect the test framework from project files (package.json, requirements.txt, Ca
 
 - code/testing/mocking(softwaredev) — when and how to mock
 - code/testing/tdd(softwaredev) — test-driven development cycle
+- code/testing/gates(softwaredev) — every gate reports executed, discovered, or absent; a zero needs a positive control
 - code/quality(softwaredev) — tests enforce quality thresholds

--- a/hooks/ways/softwaredev/environment/environment.md
+++ b/hooks/ways/softwaredev/environment/environment.md
@@ -17,7 +17,9 @@ Children of this way cover the development environment:
 | SSH, remote access | `environment/ssh` |
 | Makefile targets | `environment/makefile` |
 | Container build/run safety | `environment/container-safety` |
+| Authoring host versus target host | `environment/hostparity` |
 | Awareness / attend loop | `environment/attend` |
+| Recovering from a failed attempt | `environment/recovery` |
 
 ## See Also
 
@@ -27,4 +29,6 @@ Children of this way cover the development environment:
 - environment/ssh(softwaredev) — SSH and remote access
 - environment/makefile(softwaredev) — Makefile targets and conventions
 - environment/container-safety(softwaredev) — developer safety in container build/run definitions
+- environment/hostparity(softwaredev) — a green result on the authoring host is evidence about the authoring host only
 - environment/attend(softwaredev) — the attend awareness sensor loop
+- environment/recovery(softwaredev) — classify a failure, take its one allowed move, escalate after three attempts

--- a/hooks/ways/softwaredev/environment/hostparity/hostparity.md
+++ b/hooks/ways/softwaredev/environment/hostparity/hostparity.md
@@ -1,0 +1,52 @@
+---
+description: a green result on the authoring host is evidence about the authoring host only; the CI runner, container, staging box, or other OS is a separate host until exercised there, and untracked or unpushed files do not exist for it
+vocabulary: works locally fails in ci on my machine passes here ci red workflow runner container differs github actions pipeline job target host authoring host parity unpushed untracked uncommitted reproduce ci locally act same image verified unverified
+files: \.github/workflows/.*\.ya?ml$|Dockerfile|\.gitlab-ci\.yml
+commands: git push
+scope: agent, subagent
+refire: 0.15
+---
+<!-- epistemic: heuristic -->
+# Host Parity
+
+The build passes on the laptop, the report says "tests pass", and CI goes red an hour later. The laptop and the runner are different systems with different shells, tool versions, path layouts, environment variables, and privileges. A green result on the authoring host is evidence about the authoring host. Claims about the target come from the target.
+
+## Two rules
+
+**Validate where it runs, or say that you did not.** Exercise the change on the target: the CI runner, a container built from the CI image, the staging box, the other OS. When the target can be run locally (`act` for GitHub Actions, a container matching the runner, the same base image), run it there before claiming parity. When no target is reachable, name each one as unverified.
+
+**Untracked means absent.** A file the build resolves from the working tree but that is untracked, ignored, or unpushed does not exist for CI, for a teammate, or for the deployed artifact. A build that passes locally on an uncommitted file is unverified. Before claiming delivery, read `git status` and confirm the artifact sits where the consumer will look for it.
+
+## What differs between hosts
+
+| Difference | Typical symptom |
+|---|---|
+| OS and shell | `bash` versus `sh`, GNU versus BSD flags, path separators, line endings |
+| Tool versions | a flag the runner's older compiler, node, or python lacks |
+| Env vars and secrets | a value set in the shell rc that the runner never receives |
+| File case sensitivity | `Readme.md` resolves on macOS and fails on Linux |
+| Network access | a fetch the runner's egress rules block |
+| Working directory | a relative path that assumes the repo root or the home directory |
+| Clock and locale | timezone-dependent dates, sort order, number formatting |
+
+## The report shape
+
+Name the hosts. "Verified on the authoring host only; unverified on <target>" is the sentence, written once per target. "Tests pass" with the host unnamed reads as verified everywhere. When a target has been exercised, say which one and how (the CI run URL, the container image tag).
+
+A local model, service, or credential standing in for a remote one falls under the same rule. The substitute serves iteration, and the remote supplies the evidence.
+
+## Common Rationalizations
+
+| Rationalization | Counter |
+|---|---|
+| "It's the same code" | Same code, different host. Run it there. |
+| "CI will catch it" | CI catches it after the push. Report it as unverified until then. |
+| "I ran the tests" | Where? Name the host in the report. |
+| "The file is right there" | `git status` says whether the runner will see it. |
+
+## See Also
+
+- environment/container-safety(softwaredev) — the container definition the target build runs inside
+- environment/config(softwaredev) — env vars and dotenv files that differ per host
+- delivery/github(softwaredev) — reading CI checks on the pull request
+- freshness/groundtruth(softwaredev) — the executing system is authoritative over descriptions of it

--- a/hooks/ways/softwaredev/environment/recovery/recovery.md
+++ b/hooks/ways/softwaredev/environment/recovery/recovery.md
@@ -1,0 +1,52 @@
+---
+description: what to do when something keeps failing, a flaky test, a command that fails again after a retry, a gate that went red twice, a subagent that came back wrong; classify the failure before retrying, three attempts total, then escalate to the user with evidence
+vocabulary: retry retries retrying flaky flake intermittent still failing fails again keeps failing tried three times same error try again try once more gate red red gate stuck loop spinning going in circles subagent came back wrong delegation handback escalate escalation give up attempt attempts backoff transient deterministic reclassify fallback wrong-sized
+pattern: \bflaky\b|\bintermittent\b
+scope: agent, subagent
+refire: 0.15
+---
+<!-- epistemic: heuristic -->
+# Recovery
+
+A failed attempt invites a reflex: run the same thing again, brief the same worker harder, or feed it more context. Each of those spends a turn on the class of failure least likely to yield to it. Classify the failure first, then take the one move the class allows.
+
+## Classify before you react
+
+| Class | Recognize it by | The one allowed move |
+|---|---|---|
+| **Transient** | Environment flake: network, rate limit, race, resource exhaustion | Retry unchanged, max 2, with backoff. A third failure is reclassified. |
+| **Deterministic** | The same input reproduces the same failure: compile error, failing assertion, lint, schema rejection | Never retry unchanged. Change the input (code, test, config) and re-run. |
+| **Capability** | The instrument is wrong for the job: wrong specialist, missing expertise, a handback that stayed outside the domain | Change the instrument: a different agent, tool, or approach. Re-briefing the same one harder spends an attempt on the same gap. |
+| **Ambiguity** | The worker asked the brief a question, guessed, or two artifacts contradict each other (spec against code, task against brief) | Fix the cheapest upstream artifact that owns the confusion: the brief first, then the task, then the spec or ADR. Re-delegate from there. Widening the worker's context leaves the contradiction in place. |
+| **Systemic** | The harness itself: a wedged delegation, a missing tool, broken gate infrastructure, a hard cap hit | Stop and report to the operator with the exact evidence. A workaround hides the fault. |
+
+Diagnosis precedes classification. Before trusting a timing comparison across two processes, confirm the clocks agree from a log line that carries both processes' own timestamps, and anchor conclusions to absolute timestamps.
+
+## Three attempts, then escalate
+
+A unit of work gets three attempts across all strategies combined. The fourth move is escalation: record the class history, mark the increment as in progress in the handoff, and hand the decision to the operator with the evidence. A fallback chain that spends growing resources on a falling chance of success counts against the same three.
+
+An attempt that ends with no new artifact, no new evidence, and no narrowed hypothesis is a failed attempt, usually deterministic or ambiguity, and it consumes one of the three. Spinning without progress is how a runaway loop gets past every error-shaped check.
+
+## A gate red twice
+
+A gate that fails twice on the same increment is reporting that the increment is wrong-sized or the plan is wrong. Split or rescope the increment and come back through a failing test.
+
+## Intermittent defects
+
+An intermittent or probabilistic failure is confirmed fixed only on mechanism-level evidence: a trace or observation showing the causal path is gone. A lower observed failure rate after a change proves nothing. Any change that reduces exposure to the defect, an unrelated speedup of the racing path for example, improves the rate while fixing nothing. Capture the diagnostic evidence before making any exposure-reducing change.
+
+## Preserve the partial work
+
+A failed attempt still produced evidence: a failing test that stands, a file that was authored, the exact error, the classification itself. The handback carries it (status, failure class, what survives) so the next attempt or the operator starts from the frontier.
+
+## Substitutions are plan changes
+
+Substituting a weaker gate, a smaller scope, or a different agent is a plan change. Record it where the plan lives, with the failure that prompted it. Record the recoveries that worked as well; two successful transient retries in one session are a reliability signal.
+
+## See Also
+
+- environment/debugging(softwaredev) — root-causing a deterministic failure before changing the input
+- subagents(meta) — briefing a subagent so its handback carries status and partial work
+- code/testing/tdd(softwaredev) — the failing test a rescoped increment comes back through
+- delivery/merge(softwaredev) — where a rescoped increment lands

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -85,7 +85,9 @@ The gate is **not one policy**. Classify the increment on two axes and pick the 
 | **human gate: required** | single `code-reviewer` → offer to read before merge | swarm review **and** operator approval before merge |
 
 - **X (review depth)** ← complexity and blast-radius: diff size, files touched,
-  core-vs-leaf, test coverage, reversibility.
+  core-vs-leaf, test coverage, reversibility. The same change class sets the gate
+  depth (`code/testing/gates` way): choose review depth and gate depth together, and
+  report each gate as executed, discovered, or absent.
 - **Y (human gate)** ← does the work set direction (an ADR, an architecture change →
   human gate required, however small), and has the operator already read it (wrote it
   or reviewed it live → gate already satisfied).


### PR DESCRIPTION
## Summary
- Four new ways plus one child under softwaredev, each a verdict row from `docs/design-notes/cypress-survey.md`, rewritten to plain register
- Parent ways gained See Also lines; the merge skill's four-square names gate depth beside review depth
- Closes #461, #462, #464, #467

## Test plan
- `ways lint --check hooks/ways`: 145 files, 0 errors, 0 warnings
- `scripts/check-register.sh`: clean; register grep on the new files hits only See Also lines
- Isolated corpus built with `ways corpus --ways-dir hooks/ways --output <scratch>` and scored with `way-embed match` (the `ways embed --corpus` flag is ignored, filed as #478). Each new way wins its target prompt: recovery 0.50 on "the test is flaky, retry?", gates 0.58 on "did the tests actually run before we merge", integration 0.45 on "add a v2 wrapper", hostparity 0.46 on "workflow is red but the build passes locally". "write a haiku" matches nothing.